### PR TITLE
chore(ai): snapshot test tool contracts

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -206,6 +206,7 @@
         "knex-mock-client": "1.11.0",
         "nodemon": "3.1.9",
         "ts-node": "10.9.2",
-        "typescript": "6.0.3"
+        "typescript": "6.0.3",
+        "zod-to-json-schema": "3.25.1"
     }
 }

--- a/packages/backend/src/ee/services/McpService/AGENTS.md
+++ b/packages/backend/src/ee/services/McpService/AGENTS.md
@@ -1,0 +1,6 @@
+# MCP Tool Contract Notes
+
+- MCP tool names are snake_case.
+- Keep tool descriptions, input schemas, output schemas, and prompt text stable unless the MCP-facing contract is intentionally changing.
+- Run `pnpm -F backend test src/ee/services/ai/tools/toolContracts.snapshot.test.ts` before and after shared tool-definition refactors.
+- If an MCP tool or prompt contract intentionally changes, update only the MCP snapshot entry and mention the contract change in review.

--- a/packages/backend/src/ee/services/McpService/SKILLS.md
+++ b/packages/backend/src/ee/services/McpService/SKILLS.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -1,0 +1,6920 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MCP tool contracts matches the current MCP tool and prompt contract snapshot 1`] = `
+{
+  "prompts": [
+    {
+      "argsSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "description": "Guidelines for querying Lightdash data using MCP tools. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.",
+      "name": "lightdash-analyst",
+      "prompt": "# Lightdash MCP Tools — Usage Guidelines
+
+## Query Building Workflow
+
+1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models
+   - Review the \`topMatchingFields\` to understand which explores match
+   - If multiple explores match with similar scores, ask the user which data source they mean
+2. **Get fields**: Use \`find_fields\` for the chosen explore to see all available dimensions and metrics
+   - Read field labels, descriptions, and hints carefully — hints are written specifically for AI guidance
+   - Never invent field IDs; only use exact values returned by \`find_fields\`
+   - Search for business terms, not technical field names
+   - Use multiple search queries in one call to find related fields efficiently
+   - Look for both dimensions (for grouping) and metrics (for aggregation)
+3. **Search field values**: Use \`search_field_values\` to discover valid filter values for a dimension
+4. **Run queries**: Use \`run_metric_query\` to execute queries and generate visualizations
+5. **Find content**: Use \`find_content\` to search for existing dashboards and charts
+
+## Critical Rules
+
+### Explore Selection
+- When the user's query contains a domain word matching an explore name, use that explore
+- When multiple explores match, check \`usageInCharts\` to find the most commonly used one
+- If still ambiguous, ask the user which data source they want — do NOT guess
+
+### When to Use run_sql vs run_metric_query
+- **Prefer \`run_metric_query\`** for standard analysis — it leverages the semantic layer and ensures consistent metric definitions
+- **Use \`run_sql\`** only for ad-hoc queries, cross-table joins not modeled in explores, or when the user explicitly requests raw SQL
+- \`run_sql\` defaults to 500 rows (max 5000) — use the \`limit\` parameter to control result size
+- Use the SQL dialect appropriate for the connected warehouse
+
+### Time Filtering
+- If the user mentions ANY time period, you MUST add a date filter — do not rely on sort + limit
+- Use the \`inThePast\` operator for relative windows
+- Date fields from joined tables work identically in filters
+
+### Field Usage
+- Never mix fields from different explores in a single query
+- Any field used for sorting MUST be included in dimensions, metrics, or table calculations
+- When similar field names exist in base and joined tables, match to the query's semantic level
+
+### Pagination
+- Page parameters must be numbers (e.g., \`1\`) — never use \`NaN\` or \`"null"\`
+
+### Visualization
+- Supported types: table, bar, horizontal_bar, line, scatter, pie, funnel
+- For time series: use \`line\` with \`xAxisType: 'time'\`
+- For categorical comparisons: use \`bar\` or \`horizontal_bar\`
+- For single values or detailed data: use \`table\`
+- Always provide axis labels
+
+### Table Calculations
+Use table calculations for:
+- Aggregating already-aggregated metrics (e.g., average of monthly totals)
+- Row comparisons: % of total, period-over-period change, rankings, running totals
+- "Top N per group" patterns: create \`row_number\` with \`partitionBy\`, then filter
+
+### Custom Metrics
+- Use when the explore lacks a needed aggregation
+- Always confirm the metric doesn't already exist via \`find_fields\` first
+- Reference using the pattern \`table_metricname\`
+",
+      "title": "Lightdash Data Analyst",
+    },
+  ],
+  "tools": [
+    {
+      "agentName": null,
+      "description": "Get the current Lightdash version",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "get_lightdash_version",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Tool: listExplores
+
+Purpose:
+Lists all Explores available to the user in the current project. Returns a summary of each explore including its name, label, base table, and tags.
+
+Usage Tips:
+- Use this to discover what data sources are available before using findExplores for detailed field information
+- No arguments needed - automatically uses the current project context
+- Results are filtered based on user permissions and selected tags
+- Returns explore metadata without field details for quick overview
+",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "list_explores",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Tool: findExplores
+
+Purpose:
+Returns an explore with all its fields, joined tables, AI hints and descriptions. When multiple explores match your search, also returns alternative explores and top 50 matching fields across ALL explores.
+IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
+
+Parameters:
+- searchQuery: Full user query for finding relevant explores
+
+Output:
+- Selected explore with all fields and metadata (including fields from joined tables)
+- Alternative explores (if multiple matches) with searchRank scores
+- Top matching fields with their explore names and searchRank scores
+",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "searchQuery": {
+            "description": "The full user query or search terms to help find the most relevant explore. Use the complete user request for better search results.",
+            "type": "string",
+          },
+        },
+        "required": [
+          "searchQuery",
+        ],
+        "type": "object",
+      },
+      "name": "find_explores",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Tool: "findFields"
+
+Purpose:
+Finds the most relevant Fields (Metrics & Dimensions) within Explores, returning detailed info about each.
+
+Usage tips:
+- Use "findExplores" first to discover available Explores and their field labels.
+- Use full field labels in search terms (e.g. "Total Revenue", "Order Date").
+- Pass all needed fields in one request.
+- Fields are sorted by relevance, with a maximum score of 1 and a minimum of 0, so the top results are the most relevant.
+- If results aren't relevant, retry with clearer or more specific terms.
+- Results are paginated — use the next page token to get more results if needed.
+",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "fieldSearchQueries": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "label": {
+                  "description": "Full field label",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "label",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "page": {
+            "description": "Use this to paginate through the results. Starts at 1., ",
+            "exclusiveMinimum": 0,
+            "type": "number",
+          },
+          "table": {
+            "description": "The table to search in.",
+            "type": "string",
+          },
+        },
+        "required": [
+          "table",
+          "fieldSearchQueries",
+        ],
+        "type": "object",
+      },
+      "name": "find_fields",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Tool: "findContent"
+Purpose:
+Finds charts or dashboards by name or description within a project, returning detailed information about each.
+
+Usage tips:
+- IMPORTANT: Pass the user's full query or relevant portion directly (e.g., "revenue based on campaigns" instead of just "campaigns").
+- The search engine understands natural language and context — more descriptive queries yield better results.
+- You can provide multiple search queries to look for different topics simultaneously (e.g., ["monthly revenue", "user acquisition trends"]).
+- If results aren't relevant, retry with the full user query or more specific terms.
+- Dashboards with validation errors will be deprioritized.
+- Returns chart and dashboard URLs when available.
+- Dashboards show a preview of the first 5 charts and the total chart count. Use "getDashboardCharts" to see all charts for a specific dashboard.
+- It doesn't provide summaries for dashboards yet, so don't suggest this capability.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "searchQueries": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "label": {
+                  "description": "Full search query from the user (e.g., "revenue based on campaigns" not just "campaigns"). Include full context for better results.",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "label",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "searchQueries",
+        ],
+        "type": "object",
+      },
+      "name": "find_content",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "list_projects",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, use list_agents to discover available AI agents and optionally set_agent to activate one.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "projectUuid": {
+            "type": "string",
+          },
+          "tags": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "projectUuid",
+        ],
+        "type": "object",
+      },
+      "name": "set_project",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Get the currently active project and its configuration. Returns the project UUID, name, and any selected tags. Use this to verify context before calling data tools.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "get_current_project",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Use this to discover which agents are available before calling set_agent.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "projectUuid": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "list_agents",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Set the active AI agent for the active project. Returns the agent's full context including: explores it has access to, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "agentUuid": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "agentUuid",
+        ],
+        "type": "object",
+      },
+      "name": "set_agent",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Clear the active AI agent from context. After clearing, tool calls will no longer be scoped to a specific agent's explores, tags, or instructions. The active project is preserved.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "clear_agent",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Get the currently active AI agent with its full context: explores it has access to, verified questions (curated example queries), and custom instructions. Use this to retrieve the agent's domain knowledge before making data queries.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "get_current_agent",
+      "outputSchema": null,
+    },
+    {
+      "agentName": "runQuery",
+      "description": "Tool: runQuery
+
+Purpose:
+Execute a metric query and create a chart artifact. The results can be viewed as a table, bar, horizontal bar, line, scatter, pie, or funnel chart.
+You define the default visualization type to render but users can switch between visualization types after creation.
+
+Chart Type Selection Guide:
+- 'bar': Vertical bars for categorical comparisons (e.g., sales by product)
+- 'horizontal': Horizontal bars for long category names or ranking (e.g., top 10 customers)
+- 'line': Time series trends (e.g., revenue over months)
+- 'scatter': Correlation between two metrics (e.g., ad spend vs revenue)
+- 'pie': Part-to-whole proportions (e.g., market share by segment)
+- 'funnel': Sequential conversion flows (e.g., sales funnel stages)
+- 'table': Raw data display with all fields
+
+Configuration Tips:
+- Specify exploreName, dimensions (for grouping/x-axis), and metrics (for y-axis values)
+- First dimension is the x-axis; additional dimensions can be used for series breakdown via groupBy
+- At least one metric is required for all chart types except table
+- chartConfig.xAxisDimension: Select the primary dimension from queryConfig.dimensions (typically dimensions[0])
+- chartConfig.yAxisMetrics: Select the metrics to display from queryConfig.metrics or tableCalculations
+- chartConfig.groupBy: Use to split data into multiple series along a CATEGORICAL dimension (e.g., one line per region, one bar per product). Do NOT include the x-axis dimension. Do NOT use to split along a time dimension to simulate a period comparison — use a kind: "periodComparison" customMetric for that. Leave null for simple single-series charts.
+- For bar/horizontal charts: use xAxisType 'category' for strings or 'time' for dates/timestamps
+- For bar/horizontal charts: stackBars (when groupBy is provided) stacks bars instead of placing them side by side
+- For line charts: use lineType 'area' to fill the area under the line
+- For scatter charts: each point represents one row of data
+- For funnel charts: set funnelDataInput to 'row' (each row = stage) or 'column' (multiple funnels)
+- Users can switch between visualization types in the UI after creation
+- xAxisLabel and yAxisLabel provide helpful context for chart axes
+- filters can contain filters on fields from joined tables as well as the base table
+- For time-based comparisons (year-over-year, month-over-month, vs N periods ago), add a kind: "periodComparison" entry to customMetrics. Required ingredients: the time dimension in queryConfig.dimensions, the base metric in queryConfig.metrics, and the periodComparison custom metric pointing at both. Do NOT add a second time-dimension granularity (e.g. _year) and use groupBy — that produces a dimensional split, not a real period comparison.
+",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "chartConfig": {
+            "additionalProperties": false,
+            "description": ", ",
+            "properties": {
+              "defaultVizType": {
+                "description": "The default visualization type to render",
+                "enum": [
+                  "table",
+                  "bar",
+                  "horizontal",
+                  "line",
+                  "scatter",
+                  "pie",
+                  "funnel",
+                ],
+                "type": "string",
+              },
+              "funnelDataInput": {
+                "description": "How to interpret funnel data. Use "row" when each row represents a funnel stage (most common). Use "column" when comparing multiple funnels side-by-side., ",
+                "enum": [
+                  "row",
+                  "column",
+                ],
+                "type": "string",
+              },
+              "groupBy": {
+                "description": "Dimensions to split metrics into separate series (e.g., one line per region, one bar per status). IMPORTANT: Do NOT include the x-axis dimension in groupBy - only include dimensions you want to use for breaking down the data into multiple series. Example: dimensions=["order_date", "status"], groupBy=["status"] creates separate series for each status value. Leave null for simple single-series charts., ",
+                "items": {
+                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "lineType": {
+                "description": "default line. The type of line to display. If area then the area under the line will be filled in., ",
+                "enum": [
+                  "line",
+                  "area",
+                ],
+                "type": "string",
+              },
+              "secondaryYAxisLabel": {
+                "description": "A helpful label for the secondary y-axis, ",
+                "type": "string",
+              },
+              "secondaryYAxisMetric": {
+                "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count)., ",
+                "type": "string",
+              },
+              "stackBars": {
+                "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts., ",
+                "type": "boolean",
+              },
+              "xAxisDimension": {
+                "description": "The dimension field ID to use for the x-axis. Must be included in queryConfig.dimensions, ",
+                "type": "string",
+              },
+              "xAxisLabel": {
+                "description": "A helpful label to explain the x-axis",
+                "type": "string",
+              },
+              "xAxisType": {
+                "description": "The x-axis type can be categorical for string value or time if the dimension is a date or timestamp. Applies to bar, horizontal, and scatter charts., ",
+                "enum": [
+                  "category",
+                  "time",
+                ],
+                "type": "string",
+              },
+              "yAxisLabel": {
+                "description": "A helpful label to explain the y-axis",
+                "type": "string",
+              },
+              "yAxisMetrics": {
+                "description": "The metric field IDs to display on the y-axis. Must be included in queryConfig.metrics or come from tableCalculations, ",
+                "items": {
+                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "required": [
+              "defaultVizType",
+              "xAxisLabel",
+              "yAxisLabel",
+            ],
+            "type": "object",
+          },
+          "customMetrics": {
+            "description": "Define new metric columns the explore doesn't already have. Two kinds:
+
+(1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
+    (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
+    Use when the requested metric doesn't exist in the explore.
+
+(2) kind: "periodComparison" — a column that is an EXISTING metric shifted
+    back in time. Use whenever the user asks for "year-over-year",
+    "month-over-month", "vs last quarter", "compare to previous period",
+    "N periods ago".
+
+For period comparisons, every successful chart has three things:
+- The time dimension in queryConfig.dimensions
+- The base metric in queryConfig.metrics
+- A customMetric of kind "periodComparison" pointing at that base metric and time dimension
+
+The server generates the comparison column automatically and appends it next to the base metric. Do NOT add the comparison column id to queryConfig.metrics yourself.
+
+DO NOT simulate a period comparison by adding a second time-dimension granularity (e.g. _year) and using groupBy. groupBy is for categorical splits (region, product). Time comparisons use a kind: "periodComparison" customMetric.
+
+For aggregation entries:
+1. Add the entry to customMetrics with kind: "aggregation"
+2. Reference it in queryConfig.metrics using the format "table_name" (e.g. "customers_avg_customer_age")
+3. Reference it the same way in sorts, filters, chartConfig.yAxisMetrics
+
+Example A — "Average customer age sorted descending"
+  customMetrics: [{ kind: "aggregation", name: "avg_customer_age", label: "Average Customer Age", description: "...", type: "AVERAGE", baseDimensionName: "age", table: "customers", filters: null }]
+  queryConfig.metrics: ["customers_avg_customer_age"]
+  sorts: [{ fieldId: "customers_avg_customer_age", descending: true }]
+
+Example B — "Revenue by month with year-over-year comparison"
+  queryConfig.dimensions: ["orders_order_date_month"]
+  queryConfig.metrics: ["orders_revenue"]
+  customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }], ",
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "baseDimensionName": {
+                      "description": "Name of the base dimension/column this metric calculates from",
+                      "type": "string",
+                    },
+                    "description": {
+                      "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                      "type": "string",
+                    },
+                    "filters": {
+                      "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name., ",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "filter": {
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "boolean",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "boolean",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "isNull",
+                                          "notNull",
+                                        ],
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "boolean",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "boolean",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "equals",
+                                          "notEquals",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "type": "boolean",
+                                        },
+                                        "maxItems": 1,
+                                        "minItems": 1,
+                                        "type": "array",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                      "values",
+                                    ],
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                              {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "string",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "string",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "isNull",
+                                          "notNull",
+                                        ],
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "string",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "string",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "equals",
+                                          "notEquals",
+                                          "startsWith",
+                                          "endsWith",
+                                          "include",
+                                          "doesNotInclude",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                      "values",
+                                    ],
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                              {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "number",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "number",
+                                          "percentile",
+                                          "median",
+                                          "average",
+                                          "count",
+                                          "count_distinct",
+                                          "sum",
+                                          "sum_distinct",
+                                          "average_distinct",
+                                          "min",
+                                          "max",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "isNull",
+                                          "notNull",
+                                        ],
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "number",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "number",
+                                          "percentile",
+                                          "median",
+                                          "average",
+                                          "count",
+                                          "count_distinct",
+                                          "sum",
+                                          "sum_distinct",
+                                          "average_distinct",
+                                          "min",
+                                          "max",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "equals",
+                                          "notEquals",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "type": "number",
+                                        },
+                                        "type": "array",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                      "values",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "number",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "number",
+                                          "percentile",
+                                          "median",
+                                          "average",
+                                          "count",
+                                          "count_distinct",
+                                          "sum",
+                                          "sum_distinct",
+                                          "average_distinct",
+                                          "min",
+                                          "max",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "lessThan",
+                                          "lessThanOrEqual",
+                                          "greaterThan",
+                                          "greaterThanOrEqual",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "type": "number",
+                                        },
+                                        "maxItems": 1,
+                                        "minItems": 1,
+                                        "type": "array",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                      "values",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "number",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "number",
+                                          "percentile",
+                                          "median",
+                                          "average",
+                                          "count",
+                                          "count_distinct",
+                                          "sum",
+                                          "sum_distinct",
+                                          "average_distinct",
+                                          "min",
+                                          "max",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "inBetween",
+                                          "notInBetween",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "type": "number",
+                                        },
+                                        "maxItems": 2,
+                                        "minItems": 2,
+                                        "type": "array",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                      "values",
+                                    ],
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                              {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "date",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "date",
+                                          "timestamp",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "isNull",
+                                          "notNull",
+                                        ],
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "date",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "date",
+                                          "timestamp",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "equals",
+                                          "notEquals",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "anyOf": [
+                                            {
+                                              "format": "date",
+                                              "type": "string",
+                                            },
+                                            {
+                                              "format": "date-time",
+                                              "type": "string",
+                                            },
+                                          ],
+                                        },
+                                        "type": "array",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                      "values",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "date",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "date",
+                                          "timestamp",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "inThePast",
+                                          "notInThePast",
+                                          "inTheNext",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "settings": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "completed": {
+                                            "type": "boolean",
+                                          },
+                                          "unitOfTime": {
+                                            "enum": [
+                                              "days",
+                                              "weeks",
+                                              "months",
+                                              "quarters",
+                                              "years",
+                                            ],
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "completed",
+                                          "unitOfTime",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "type": "number",
+                                        },
+                                        "maxItems": 1,
+                                        "minItems": 1,
+                                        "type": "array",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                      "values",
+                                      "settings",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "date",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "date",
+                                          "timestamp",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "inTheCurrent",
+                                          "notInTheCurrent",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "settings": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "completed": {
+                                            "const": false,
+                                            "type": "boolean",
+                                          },
+                                          "unitOfTime": {
+                                            "enum": [
+                                              "days",
+                                              "weeks",
+                                              "months",
+                                              "quarters",
+                                              "years",
+                                            ],
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "completed",
+                                          "unitOfTime",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "const": 1,
+                                          "type": "number",
+                                        },
+                                        "maxItems": 1,
+                                        "minItems": 1,
+                                        "type": "array",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                      "values",
+                                      "settings",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "date",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "date",
+                                          "timestamp",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "enum": [
+                                          "lessThan",
+                                          "lessThanOrEqual",
+                                          "greaterThan",
+                                          "greaterThanOrEqual",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "anyOf": [
+                                            {
+                                              "format": "date",
+                                              "type": "string",
+                                            },
+                                            {
+                                              "format": "date-time",
+                                              "type": "string",
+                                            },
+                                          ],
+                                        },
+                                        "maxItems": 1,
+                                        "minItems": 1,
+                                        "type": "array",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                      "values",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldFilterType": {
+                                        "const": "date",
+                                        "type": "string",
+                                      },
+                                      "fieldId": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "fieldType": {
+                                        "enum": [
+                                          "date",
+                                          "timestamp",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      "operator": {
+                                        "const": "inBetween",
+                                        "type": "string",
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "anyOf": [
+                                            {
+                                              "format": "date",
+                                              "type": "string",
+                                            },
+                                            {
+                                              "format": "date-time",
+                                              "type": "string",
+                                            },
+                                          ],
+                                        },
+                                        "maxItems": 2,
+                                        "minItems": 2,
+                                        "type": "array",
+                                      },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "fieldType",
+                                      "fieldFilterType",
+                                      "operator",
+                                      "values",
+                                    ],
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                          "table": {
+                            "description": "Table name this filter field belongs to",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "filter",
+                          "table",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "kind": {
+                      "const": "aggregation",
+                      "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                      "type": "string",
+                    },
+                    "label": {
+                      "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                      "type": "string",
+                    },
+                    "table": {
+                      "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                      "type": "string",
+                    },
+                    "type": {
+                      "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                      "enum": [
+                        "average",
+                        "count",
+                        "count_distinct",
+                        "max",
+                        "min",
+                        "sum",
+                        "percentile",
+                        "median",
+                      ],
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "kind",
+                    "name",
+                    "label",
+                    "description",
+                    "baseDimensionName",
+                    "table",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "baseMetricId": {
+                      "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                      "type": "string",
+                    },
+                    "granularity": {
+                      "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                      "enum": [
+                        "DAY",
+                        "WEEK",
+                        "MONTH",
+                        "QUARTER",
+                        "YEAR",
+                      ],
+                      "type": "string",
+                    },
+                    "kind": {
+                      "const": "periodComparison",
+                      "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                      "type": "string",
+                    },
+                    "periodOffset": {
+                      "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                      "minimum": 1,
+                      "type": "integer",
+                    },
+                    "timeDimensionId": {
+                      "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "kind",
+                    "baseMetricId",
+                    "timeDimensionId",
+                    "granularity",
+                    "periodOffset",
+                  ],
+                  "type": "object",
+                },
+              ],
+            },
+            "type": "array",
+          },
+          "description": {
+            "description": "A descriptive summary or explanation for the chart.",
+            "type": "string",
+          },
+          "filters": {
+            "additionalProperties": false,
+            "description": ", ",
+            "properties": {
+              "dimensions": {
+                "description": ", ",
+                "items": {
+                  "anyOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "boolean",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "boolean",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "boolean",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "boolean",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "boolean",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "string",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "string",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "string",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "string",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                                "startsWith",
+                                "endsWith",
+                                "include",
+                                "doesNotInclude",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "lessThan",
+                                "lessThanOrEqual",
+                                "greaterThan",
+                                "greaterThanOrEqual",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inBetween",
+                                "notInBetween",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 2,
+                              "minItems": 2,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inThePast",
+                                "notInThePast",
+                                "inTheNext",
+                              ],
+                              "type": "string",
+                            },
+                            "settings": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "completed": {
+                                  "type": "boolean",
+                                },
+                                "unitOfTime": {
+                                  "enum": [
+                                    "days",
+                                    "weeks",
+                                    "months",
+                                    "quarters",
+                                    "years",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "completed",
+                                "unitOfTime",
+                              ],
+                              "type": "object",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                            "settings",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inTheCurrent",
+                                "notInTheCurrent",
+                              ],
+                              "type": "string",
+                            },
+                            "settings": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "completed": {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "unitOfTime": {
+                                  "enum": [
+                                    "days",
+                                    "weeks",
+                                    "months",
+                                    "quarters",
+                                    "years",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "completed",
+                                "unitOfTime",
+                              ],
+                              "type": "object",
+                            },
+                            "values": {
+                              "items": {
+                                "const": 1,
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                            "settings",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "lessThan",
+                                "lessThanOrEqual",
+                                "greaterThan",
+                                "greaterThanOrEqual",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "const": "inBetween",
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "maxItems": 2,
+                              "minItems": 2,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                "type": "array",
+              },
+              "metrics": {
+                "description": ", ",
+                "items": {
+                  "anyOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "boolean",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "boolean",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "boolean",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "boolean",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "boolean",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "string",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "string",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "string",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "string",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                                "startsWith",
+                                "endsWith",
+                                "include",
+                                "doesNotInclude",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "lessThan",
+                                "lessThanOrEqual",
+                                "greaterThan",
+                                "greaterThanOrEqual",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inBetween",
+                                "notInBetween",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 2,
+                              "minItems": 2,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inThePast",
+                                "notInThePast",
+                                "inTheNext",
+                              ],
+                              "type": "string",
+                            },
+                            "settings": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "completed": {
+                                  "type": "boolean",
+                                },
+                                "unitOfTime": {
+                                  "enum": [
+                                    "days",
+                                    "weeks",
+                                    "months",
+                                    "quarters",
+                                    "years",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "completed",
+                                "unitOfTime",
+                              ],
+                              "type": "object",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                            "settings",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inTheCurrent",
+                                "notInTheCurrent",
+                              ],
+                              "type": "string",
+                            },
+                            "settings": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "completed": {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "unitOfTime": {
+                                  "enum": [
+                                    "days",
+                                    "weeks",
+                                    "months",
+                                    "quarters",
+                                    "years",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "completed",
+                                "unitOfTime",
+                              ],
+                              "type": "object",
+                            },
+                            "values": {
+                              "items": {
+                                "const": 1,
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                            "settings",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "lessThan",
+                                "lessThanOrEqual",
+                                "greaterThan",
+                                "greaterThanOrEqual",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "const": "inBetween",
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "maxItems": 2,
+                              "minItems": 2,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                "type": "array",
+              },
+              "tableCalculations": {
+                "description": ", ",
+                "items": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fieldFilterType": {
+                          "const": "number",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "fieldType": {
+                          "enum": [
+                            "number",
+                            "percentile",
+                            "median",
+                            "average",
+                            "count",
+                            "count_distinct",
+                            "sum",
+                            "sum_distinct",
+                            "average_distinct",
+                            "min",
+                            "max",
+                          ],
+                          "type": "string",
+                        },
+                        "operator": {
+                          "enum": [
+                            "isNull",
+                            "notNull",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "fieldId",
+                        "fieldType",
+                        "fieldFilterType",
+                        "operator",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fieldFilterType": {
+                          "const": "number",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "fieldType": {
+                          "enum": [
+                            "number",
+                            "percentile",
+                            "median",
+                            "average",
+                            "count",
+                            "count_distinct",
+                            "sum",
+                            "sum_distinct",
+                            "average_distinct",
+                            "min",
+                            "max",
+                          ],
+                          "type": "string",
+                        },
+                        "operator": {
+                          "enum": [
+                            "equals",
+                            "notEquals",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "type": "number",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "fieldId",
+                        "fieldType",
+                        "fieldFilterType",
+                        "operator",
+                        "values",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fieldFilterType": {
+                          "const": "number",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "fieldType": {
+                          "enum": [
+                            "number",
+                            "percentile",
+                            "median",
+                            "average",
+                            "count",
+                            "count_distinct",
+                            "sum",
+                            "sum_distinct",
+                            "average_distinct",
+                            "min",
+                            "max",
+                          ],
+                          "type": "string",
+                        },
+                        "operator": {
+                          "enum": [
+                            "lessThan",
+                            "lessThanOrEqual",
+                            "greaterThan",
+                            "greaterThanOrEqual",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "type": "number",
+                          },
+                          "maxItems": 1,
+                          "minItems": 1,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "fieldId",
+                        "fieldType",
+                        "fieldFilterType",
+                        "operator",
+                        "values",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fieldFilterType": {
+                          "const": "number",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "fieldType": {
+                          "enum": [
+                            "number",
+                            "percentile",
+                            "median",
+                            "average",
+                            "count",
+                            "count_distinct",
+                            "sum",
+                            "sum_distinct",
+                            "average_distinct",
+                            "min",
+                            "max",
+                          ],
+                          "type": "string",
+                        },
+                        "operator": {
+                          "enum": [
+                            "inBetween",
+                            "notInBetween",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "type": "number",
+                          },
+                          "maxItems": 2,
+                          "minItems": 2,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "fieldId",
+                        "fieldType",
+                        "fieldFilterType",
+                        "operator",
+                        "values",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+                "type": "array",
+              },
+              "type": {
+                "description": "Type of filter group operation",
+                "enum": [
+                  "and",
+                  "or",
+                ],
+                "type": "string",
+              },
+            },
+            "required": [
+              "type",
+            ],
+            "type": "object",
+          },
+          "queryConfig": {
+            "additionalProperties": false,
+            "properties": {
+              "dimensions": {
+                "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
+                "items": {
+                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "exploreName": {
+                "description": "The name of the explore containing the metrics and dimensions used for the chart.",
+                "type": "string",
+              },
+              "filters": {
+                "additionalProperties": false,
+                "properties": {
+                  "dimensions": {
+                    "description": ", ",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "boolean",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "boolean",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "isNull",
+                                    "notNull",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "boolean",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "boolean",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "equals",
+                                    "notEquals",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "boolean",
+                                  },
+                                  "maxItems": 1,
+                                  "minItems": 1,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "string",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "string",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "isNull",
+                                    "notNull",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "string",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "string",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "equals",
+                                    "notEquals",
+                                    "startsWith",
+                                    "endsWith",
+                                    "include",
+                                    "doesNotInclude",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string",
+                                  },
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "number",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "number",
+                                    "percentile",
+                                    "median",
+                                    "average",
+                                    "count",
+                                    "count_distinct",
+                                    "sum",
+                                    "sum_distinct",
+                                    "average_distinct",
+                                    "min",
+                                    "max",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "isNull",
+                                    "notNull",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "number",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "number",
+                                    "percentile",
+                                    "median",
+                                    "average",
+                                    "count",
+                                    "count_distinct",
+                                    "sum",
+                                    "sum_distinct",
+                                    "average_distinct",
+                                    "min",
+                                    "max",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "equals",
+                                    "notEquals",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "number",
+                                  },
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "number",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "number",
+                                    "percentile",
+                                    "median",
+                                    "average",
+                                    "count",
+                                    "count_distinct",
+                                    "sum",
+                                    "sum_distinct",
+                                    "average_distinct",
+                                    "min",
+                                    "max",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "lessThan",
+                                    "lessThanOrEqual",
+                                    "greaterThan",
+                                    "greaterThanOrEqual",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "number",
+                                  },
+                                  "maxItems": 1,
+                                  "minItems": 1,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "number",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "number",
+                                    "percentile",
+                                    "median",
+                                    "average",
+                                    "count",
+                                    "count_distinct",
+                                    "sum",
+                                    "sum_distinct",
+                                    "average_distinct",
+                                    "min",
+                                    "max",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "inBetween",
+                                    "notInBetween",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "number",
+                                  },
+                                  "maxItems": 2,
+                                  "minItems": 2,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "isNull",
+                                    "notNull",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "equals",
+                                    "notEquals",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "format": "date",
+                                        "type": "string",
+                                      },
+                                      {
+                                        "format": "date-time",
+                                        "type": "string",
+                                      },
+                                    ],
+                                  },
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "inThePast",
+                                    "notInThePast",
+                                    "inTheNext",
+                                  ],
+                                  "type": "string",
+                                },
+                                "settings": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "completed": {
+                                      "type": "boolean",
+                                    },
+                                    "unitOfTime": {
+                                      "enum": [
+                                        "days",
+                                        "weeks",
+                                        "months",
+                                        "quarters",
+                                        "years",
+                                      ],
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "completed",
+                                    "unitOfTime",
+                                  ],
+                                  "type": "object",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "number",
+                                  },
+                                  "maxItems": 1,
+                                  "minItems": 1,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                                "settings",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "inTheCurrent",
+                                    "notInTheCurrent",
+                                  ],
+                                  "type": "string",
+                                },
+                                "settings": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "completed": {
+                                      "const": false,
+                                      "type": "boolean",
+                                    },
+                                    "unitOfTime": {
+                                      "enum": [
+                                        "days",
+                                        "weeks",
+                                        "months",
+                                        "quarters",
+                                        "years",
+                                      ],
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "completed",
+                                    "unitOfTime",
+                                  ],
+                                  "type": "object",
+                                },
+                                "values": {
+                                  "items": {
+                                    "const": 1,
+                                    "type": "number",
+                                  },
+                                  "maxItems": 1,
+                                  "minItems": 1,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                                "settings",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "lessThan",
+                                    "lessThanOrEqual",
+                                    "greaterThan",
+                                    "greaterThanOrEqual",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "format": "date",
+                                        "type": "string",
+                                      },
+                                      {
+                                        "format": "date-time",
+                                        "type": "string",
+                                      },
+                                    ],
+                                  },
+                                  "maxItems": 1,
+                                  "minItems": 1,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "const": "inBetween",
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "format": "date",
+                                        "type": "string",
+                                      },
+                                      {
+                                        "format": "date-time",
+                                        "type": "string",
+                                      },
+                                    ],
+                                  },
+                                  "maxItems": 2,
+                                  "minItems": 2,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    "type": "array",
+                  },
+                  "metrics": {
+                    "description": ", ",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "boolean",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "boolean",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "isNull",
+                                    "notNull",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "boolean",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "boolean",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "equals",
+                                    "notEquals",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "boolean",
+                                  },
+                                  "maxItems": 1,
+                                  "minItems": 1,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "string",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "string",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "isNull",
+                                    "notNull",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "string",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "string",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "equals",
+                                    "notEquals",
+                                    "startsWith",
+                                    "endsWith",
+                                    "include",
+                                    "doesNotInclude",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string",
+                                  },
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "number",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "number",
+                                    "percentile",
+                                    "median",
+                                    "average",
+                                    "count",
+                                    "count_distinct",
+                                    "sum",
+                                    "sum_distinct",
+                                    "average_distinct",
+                                    "min",
+                                    "max",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "isNull",
+                                    "notNull",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "number",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "number",
+                                    "percentile",
+                                    "median",
+                                    "average",
+                                    "count",
+                                    "count_distinct",
+                                    "sum",
+                                    "sum_distinct",
+                                    "average_distinct",
+                                    "min",
+                                    "max",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "equals",
+                                    "notEquals",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "number",
+                                  },
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "number",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "number",
+                                    "percentile",
+                                    "median",
+                                    "average",
+                                    "count",
+                                    "count_distinct",
+                                    "sum",
+                                    "sum_distinct",
+                                    "average_distinct",
+                                    "min",
+                                    "max",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "lessThan",
+                                    "lessThanOrEqual",
+                                    "greaterThan",
+                                    "greaterThanOrEqual",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "number",
+                                  },
+                                  "maxItems": 1,
+                                  "minItems": 1,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "number",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "number",
+                                    "percentile",
+                                    "median",
+                                    "average",
+                                    "count",
+                                    "count_distinct",
+                                    "sum",
+                                    "sum_distinct",
+                                    "average_distinct",
+                                    "min",
+                                    "max",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "inBetween",
+                                    "notInBetween",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "number",
+                                  },
+                                  "maxItems": 2,
+                                  "minItems": 2,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "isNull",
+                                    "notNull",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "equals",
+                                    "notEquals",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "format": "date",
+                                        "type": "string",
+                                      },
+                                      {
+                                        "format": "date-time",
+                                        "type": "string",
+                                      },
+                                    ],
+                                  },
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "inThePast",
+                                    "notInThePast",
+                                    "inTheNext",
+                                  ],
+                                  "type": "string",
+                                },
+                                "settings": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "completed": {
+                                      "type": "boolean",
+                                    },
+                                    "unitOfTime": {
+                                      "enum": [
+                                        "days",
+                                        "weeks",
+                                        "months",
+                                        "quarters",
+                                        "years",
+                                      ],
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "completed",
+                                    "unitOfTime",
+                                  ],
+                                  "type": "object",
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "number",
+                                  },
+                                  "maxItems": 1,
+                                  "minItems": 1,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                                "settings",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "inTheCurrent",
+                                    "notInTheCurrent",
+                                  ],
+                                  "type": "string",
+                                },
+                                "settings": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "completed": {
+                                      "const": false,
+                                      "type": "boolean",
+                                    },
+                                    "unitOfTime": {
+                                      "enum": [
+                                        "days",
+                                        "weeks",
+                                        "months",
+                                        "quarters",
+                                        "years",
+                                      ],
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "completed",
+                                    "unitOfTime",
+                                  ],
+                                  "type": "object",
+                                },
+                                "values": {
+                                  "items": {
+                                    "const": 1,
+                                    "type": "number",
+                                  },
+                                  "maxItems": 1,
+                                  "minItems": 1,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                                "settings",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "lessThan",
+                                    "lessThanOrEqual",
+                                    "greaterThan",
+                                    "greaterThanOrEqual",
+                                  ],
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "format": "date",
+                                        "type": "string",
+                                      },
+                                      {
+                                        "format": "date-time",
+                                        "type": "string",
+                                      },
+                                    ],
+                                  },
+                                  "maxItems": 1,
+                                  "minItems": 1,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldFilterType": {
+                                  "const": "date",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "fieldType": {
+                                  "enum": [
+                                    "date",
+                                    "timestamp",
+                                  ],
+                                  "type": "string",
+                                },
+                                "operator": {
+                                  "const": "inBetween",
+                                  "type": "string",
+                                },
+                                "values": {
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "format": "date",
+                                        "type": "string",
+                                      },
+                                      {
+                                        "format": "date-time",
+                                        "type": "string",
+                                      },
+                                    ],
+                                  },
+                                  "maxItems": 2,
+                                  "minItems": 2,
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "fieldId",
+                                "fieldType",
+                                "fieldFilterType",
+                                "operator",
+                                "values",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    "type": "array",
+                  },
+                  "tableCalculations": {
+                    "description": ", ",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "lessThan",
+                                "lessThanOrEqual",
+                                "greaterThan",
+                                "greaterThanOrEqual",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inBetween",
+                                "notInBetween",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 2,
+                              "minItems": 2,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    "type": "array",
+                  },
+                  "type": {
+                    "description": "Type of filter group operation",
+                    "enum": [
+                      "and",
+                      "or",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "type",
+                ],
+                "type": "object",
+              },
+              "limit": {
+                "description": "The total number of data points / rows allowed on the chart., ",
+                "type": "number",
+              },
+              "metrics": {
+                "description": "The field ids of the metrics to be calculated. They will be grouped by the dimensions.",
+                "items": {
+                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "sorts": {
+                "description": "Sort configuration for the query, it can use a combination of metrics and dimensions.",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "descending": {
+                      "description": "If true sorts in descending order, if false sorts in ascending order",
+                      "type": "boolean",
+                    },
+                    "fieldId": {
+                      "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "nullsFirst": {
+                      "description": "If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default, If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default",
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "fieldId",
+                    "descending",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+            },
+            "required": [
+              "exploreName",
+              "dimensions",
+              "metrics",
+              "sorts",
+            ],
+            "type": "object",
+          },
+          "tableCalculations": {
+            "description": "
+Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
+
+**Available Types:**
+- Simple calculations: percent_change_from_previous, percent_of_previous_value, percent_of_column_total, rank_in_column, running_total
+- Advanced window_function: Supports row_number, percent_rank, sum, avg, count, min, max with optional partitioning, ordering, and frame clauses
+
+**Technical Requirements:**
+- Appear as additional columns in query results
+- Can be used in sorts and filters alongside dimensions/metrics
+- Multiple calculations can be combined in a single query
+- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
+, ",
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "orderBy": {
+                      "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "fieldId": {
+                            "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "order": {
+                            "description": ", ",
+                            "enum": [
+                              "asc",
+                              "desc",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "fieldId",
+                        ],
+                        "type": "object",
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                    },
+                    "partitionBy": {
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                      "items": {
+                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "type": {
+                      "const": "percent_change_from_previous",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                    "orderBy",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "orderBy": {
+                      "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "fieldId": {
+                            "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "order": {
+                            "description": ", ",
+                            "enum": [
+                              "asc",
+                              "desc",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "fieldId",
+                        ],
+                        "type": "object",
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                    },
+                    "partitionBy": {
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                      "items": {
+                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "type": {
+                      "const": "percent_of_previous_value",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                    "orderBy",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "partitionBy": {
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                      "items": {
+                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "type": {
+                      "const": "percent_of_column_total",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "type": {
+                      "const": "rank_in_column",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "type": {
+                      "const": "running_total",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error, Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "frame": {
+                      "additionalProperties": false,
+                      "description": "Defines which rows to include in calculation. Null uses database defaults.
+
+**Common patterns:**
+- Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
+- Running total: {frameType: "rows", start: {type: "unbounded_preceding"}, end: {type: "current_row"}}
+- Centered window: {frameType: "rows", start: {type: "preceding", offset: 1}, end: {type: "following", offset: 1}}
+
+**Default when null:**
+- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
+- Aggregates WITHOUT ORDER BY: Entire partition (all rows)
+- Ranking functions: Always use entire partition (frame clause has no effect), ",
+                      "properties": {
+                        "end": {
+                          "additionalProperties": false,
+                          "description": "End boundary (required)",
+                          "properties": {
+                            "offset": {
+                              "description": "Number of rows for PRECEDING/FOLLOWING, ",
+                              "exclusiveMinimum": 0,
+                              "type": "integer",
+                            },
+                            "type": {
+                              "enum": [
+                                "unbounded_preceding",
+                                "preceding",
+                                "current_row",
+                                "following",
+                                "unbounded_following",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "type",
+                          ],
+                          "type": "object",
+                        },
+                        "frameType": {
+                          "description": "Frame type:
+- rows: Physical row count
+- range: Logical value-based (includes peer rows with same ORDER BY value)",
+                          "enum": [
+                            "rows",
+                            "range",
+                          ],
+                          "type": "string",
+                        },
+                        "start": {
+                          "additionalProperties": false,
+                          "description": "Start boundary. Null for single-boundary syntax., ",
+                          "properties": {
+                            "offset": {
+                              "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING"), ",
+                              "exclusiveMinimum": 0,
+                              "type": "integer",
+                            },
+                            "type": {
+                              "enum": [
+                                "unbounded_preceding",
+                                "preceding",
+                                "current_row",
+                                "following",
+                                "unbounded_following",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "type",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "frameType",
+                        "end",
+                      ],
+                      "type": "object",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "orderBy": {
+                      "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first., ",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "fieldId": {
+                            "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "order": {
+                            "description": ", ",
+                            "enum": [
+                              "asc",
+                              "desc",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "fieldId",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "partitionBy": {
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                      "items": {
+                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "type": {
+                      "const": "window_function",
+                      "type": "string",
+                    },
+                    "windowFunction": {
+                      "description": "Type of window function to apply.
+
+**Ranking functions** (fieldId optional, ignored if provided):
+- row_number: Sequential numbering (1, 2, 3...)
+- percent_rank: Relative rank as percentage (0.0-1.0)
+- cume_dist: Cumulative distribution as percentage (0.0-1.0)
+- rank: Positional rank (1, 2, 3...) with ties
+
+**Aggregate functions** (fieldId required):
+- sum: Sum values within frame
+- avg: Average values within frame
+- count: Count values within frame
+- min: Minimum value within frame
+- max: Maximum value within frame",
+                      "enum": [
+                        "row_number",
+                        "percent_rank",
+                        "cume_dist",
+                        "rank",
+                        "sum",
+                        "avg",
+                        "count",
+                        "min",
+                        "max",
+                      ],
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "windowFunction",
+                  ],
+                  "type": "object",
+                },
+              ],
+            },
+            "type": "array",
+          },
+          "title": {
+            "description": "A descriptive title for the chart",
+            "type": "string",
+          },
+        },
+        "required": [
+          "title",
+          "description",
+          "queryConfig",
+        ],
+        "type": "object",
+      },
+      "name": "run_metric_query",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Tool: searchFieldValues
+
+Purpose:
+Search for unique values of a specific field in a table. Returns all unique values by default, or use the query parameter to narrow down results. This is useful for finding suggestions for field values when building filters or exploring data.
+
+Usage Tips:
+- Specify the table and field you want to search values for
+- Query parameter: use it to narrow down the search to matching values
+- Optionally add filters to further restrict the results
+- Results are returned as a list of unique field values (limited to 100)
+",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "fieldId": {
+            "description": "The ID of the field to search values for "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+            "type": "string",
+          },
+          "filters": {
+            "additionalProperties": false,
+            "description": "Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics., ",
+            "properties": {
+              "dimensions": {
+                "description": ", ",
+                "items": {
+                  "anyOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "boolean",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "boolean",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "boolean",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "boolean",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "boolean",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "string",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "string",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "string",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "string",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                                "startsWith",
+                                "endsWith",
+                                "include",
+                                "doesNotInclude",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "lessThan",
+                                "lessThanOrEqual",
+                                "greaterThan",
+                                "greaterThanOrEqual",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inBetween",
+                                "notInBetween",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 2,
+                              "minItems": 2,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inThePast",
+                                "notInThePast",
+                                "inTheNext",
+                              ],
+                              "type": "string",
+                            },
+                            "settings": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "completed": {
+                                  "type": "boolean",
+                                },
+                                "unitOfTime": {
+                                  "enum": [
+                                    "days",
+                                    "weeks",
+                                    "months",
+                                    "quarters",
+                                    "years",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "completed",
+                                "unitOfTime",
+                              ],
+                              "type": "object",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                            "settings",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inTheCurrent",
+                                "notInTheCurrent",
+                              ],
+                              "type": "string",
+                            },
+                            "settings": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "completed": {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "unitOfTime": {
+                                  "enum": [
+                                    "days",
+                                    "weeks",
+                                    "months",
+                                    "quarters",
+                                    "years",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "completed",
+                                "unitOfTime",
+                              ],
+                              "type": "object",
+                            },
+                            "values": {
+                              "items": {
+                                "const": 1,
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                            "settings",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "lessThan",
+                                "lessThanOrEqual",
+                                "greaterThan",
+                                "greaterThanOrEqual",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "const": "inBetween",
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "maxItems": 2,
+                              "minItems": 2,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                "type": "array",
+              },
+              "metrics": {
+                "description": ", ",
+                "items": {
+                  "anyOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "boolean",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "boolean",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "boolean",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "boolean",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "boolean",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "string",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "string",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "string",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "string",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                                "startsWith",
+                                "endsWith",
+                                "include",
+                                "doesNotInclude",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "lessThan",
+                                "lessThanOrEqual",
+                                "greaterThan",
+                                "greaterThanOrEqual",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "number",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "number",
+                                "percentile",
+                                "median",
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "sum",
+                                "sum_distinct",
+                                "average_distinct",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inBetween",
+                                "notInBetween",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 2,
+                              "minItems": 2,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "isNull",
+                                "notNull",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "equals",
+                                "notEquals",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inThePast",
+                                "notInThePast",
+                                "inTheNext",
+                              ],
+                              "type": "string",
+                            },
+                            "settings": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "completed": {
+                                  "type": "boolean",
+                                },
+                                "unitOfTime": {
+                                  "enum": [
+                                    "days",
+                                    "weeks",
+                                    "months",
+                                    "quarters",
+                                    "years",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "completed",
+                                "unitOfTime",
+                              ],
+                              "type": "object",
+                            },
+                            "values": {
+                              "items": {
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                            "settings",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "inTheCurrent",
+                                "notInTheCurrent",
+                              ],
+                              "type": "string",
+                            },
+                            "settings": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "completed": {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "unitOfTime": {
+                                  "enum": [
+                                    "days",
+                                    "weeks",
+                                    "months",
+                                    "quarters",
+                                    "years",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "completed",
+                                "unitOfTime",
+                              ],
+                              "type": "object",
+                            },
+                            "values": {
+                              "items": {
+                                "const": 1,
+                                "type": "number",
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                            "settings",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "enum": [
+                                "lessThan",
+                                "lessThanOrEqual",
+                                "greaterThan",
+                                "greaterThanOrEqual",
+                              ],
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "maxItems": 1,
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldFilterType": {
+                              "const": "date",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "fieldType": {
+                              "enum": [
+                                "date",
+                                "timestamp",
+                              ],
+                              "type": "string",
+                            },
+                            "operator": {
+                              "const": "inBetween",
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "format": "date",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                ],
+                              },
+                              "maxItems": 2,
+                              "minItems": 2,
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldType",
+                            "fieldFilterType",
+                            "operator",
+                            "values",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                "type": "array",
+              },
+              "tableCalculations": {
+                "description": ", ",
+                "items": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fieldFilterType": {
+                          "const": "number",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "fieldType": {
+                          "enum": [
+                            "number",
+                            "percentile",
+                            "median",
+                            "average",
+                            "count",
+                            "count_distinct",
+                            "sum",
+                            "sum_distinct",
+                            "average_distinct",
+                            "min",
+                            "max",
+                          ],
+                          "type": "string",
+                        },
+                        "operator": {
+                          "enum": [
+                            "isNull",
+                            "notNull",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "fieldId",
+                        "fieldType",
+                        "fieldFilterType",
+                        "operator",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fieldFilterType": {
+                          "const": "number",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "fieldType": {
+                          "enum": [
+                            "number",
+                            "percentile",
+                            "median",
+                            "average",
+                            "count",
+                            "count_distinct",
+                            "sum",
+                            "sum_distinct",
+                            "average_distinct",
+                            "min",
+                            "max",
+                          ],
+                          "type": "string",
+                        },
+                        "operator": {
+                          "enum": [
+                            "equals",
+                            "notEquals",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "type": "number",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "fieldId",
+                        "fieldType",
+                        "fieldFilterType",
+                        "operator",
+                        "values",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fieldFilterType": {
+                          "const": "number",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "fieldType": {
+                          "enum": [
+                            "number",
+                            "percentile",
+                            "median",
+                            "average",
+                            "count",
+                            "count_distinct",
+                            "sum",
+                            "sum_distinct",
+                            "average_distinct",
+                            "min",
+                            "max",
+                          ],
+                          "type": "string",
+                        },
+                        "operator": {
+                          "enum": [
+                            "lessThan",
+                            "lessThanOrEqual",
+                            "greaterThan",
+                            "greaterThanOrEqual",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "type": "number",
+                          },
+                          "maxItems": 1,
+                          "minItems": 1,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "fieldId",
+                        "fieldType",
+                        "fieldFilterType",
+                        "operator",
+                        "values",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fieldFilterType": {
+                          "const": "number",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "fieldType": {
+                          "enum": [
+                            "number",
+                            "percentile",
+                            "median",
+                            "average",
+                            "count",
+                            "count_distinct",
+                            "sum",
+                            "sum_distinct",
+                            "average_distinct",
+                            "min",
+                            "max",
+                          ],
+                          "type": "string",
+                        },
+                        "operator": {
+                          "enum": [
+                            "inBetween",
+                            "notInBetween",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "type": "number",
+                          },
+                          "maxItems": 2,
+                          "minItems": 2,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "fieldId",
+                        "fieldType",
+                        "fieldFilterType",
+                        "operator",
+                        "values",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+                "type": "array",
+              },
+              "type": {
+                "description": "Type of filter group operation",
+                "enum": [
+                  "and",
+                  "or",
+                ],
+                "type": "string",
+              },
+            },
+            "required": [
+              "type",
+            ],
+            "type": "object",
+          },
+          "query": {
+            "description": "Query string to filter field values, Query string to filter field values",
+            "type": "string",
+          },
+          "table": {
+            "description": "The table to search in.",
+            "type": "string",
+          },
+        },
+        "required": [
+          "table",
+          "fieldId",
+        ],
+        "type": "object",
+      },
+      "name": "search_field_values",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Tool: run_sql
+
+Purpose:
+Execute an arbitrary SQL query against the project's data warehouse and return the results. Successful results can be linked from the final answer with [Open in SQL Runner](#sql-runner-link).
+
+Use this tool when the user wants to run a custom SQL query that doesn't fit the explore-based metric query model.
+This is useful for ad-hoc analysis, data exploration, or queries that join across tables not modeled in explores.
+
+The query is executed directly against the warehouse, so use the SQL dialect appropriate for the connected warehouse (e.g., PostgreSQL, BigQuery, Snowflake, etc.).
+
+Parameters:
+- sql: The SQL query to execute. Must be a valid SELECT statement.
+- limit: Maximum number of rows to return (default 500, max 500).
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: "<CSV string>" }] — header row + data rows, comma-separated. Provided for human/LLM display and as a fallback.
+- structuredContent: {
+    rows:     Array<Record<string, unknown>>,  // each row keyed by column name
+    columns:  string[],                        // column names in order
+    rowCount: number                           // total rows returned
+  }
+
+When writing code that consumes this tool (e.g. inside a live artifact), prefer structuredContent.rows over parsing the CSV. Example:
+
+  const result = await callMcpTool('run_sql', { sql, limit });
+  const rows    = result.structuredContent.rows;     // [{ status: 'completed', n: 94, total_amount: 2397 }, ...]
+  const columns = result.structuredContent.columns;  // ['status', 'n', 'total_amount']
+
+Notes:
+- Values in rows are JSON-serializable primitives: numbers, strings, booleans, ISO date strings, or null. They are NOT pre-stringified — there's no need for parseFloat / parseInt on numeric columns.
+- Empty results still return structuredContent with { rows: [], columns, rowCount: 0 } — distinct from a parse failure.
+- On error, the response has isError: true and content[0].text contains the error message; structuredContent is omitted.
+",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "default": 500,
+            "description": "Maximum number of rows to return. Defaults to 500, max 500.",
+            "exclusiveMinimum": 0,
+            "maximum": 500,
+            "type": "integer",
+          },
+          "sql": {
+            "description": "The SQL query to execute against the data warehouse.",
+            "type": "string",
+          },
+        },
+        "required": [
+          "sql",
+        ],
+        "type": "object",
+      },
+      "name": "run_sql",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "columns": {
+            "description": "Ordered list of column names matching the keys in each row of \`rows\`.",
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "rowCount": {
+            "description": "Total number of rows returned. May be less than the requested limit.",
+            "minimum": 0,
+            "type": "integer",
+          },
+          "rows": {
+            "description": "Result rows. Each row is an object keyed by column name. Values come from the warehouse as JSON-serializable primitives (numbers, strings, booleans, ISO date strings, or null).",
+            "items": {
+              "additionalProperties": {},
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "rows",
+          "columns",
+          "rowCount",
+        ],
+        "type": "object",
+      },
+    },
+    {
+      "agentName": null,
+      "description": "List all verified charts and dashboards in the active project. Verified content has been reviewed and marked as trusted — use this to discover reference examples of sanctioned metrics and visualizations when building new content. Requires an active project set via set_project. Each item includes contentType (chart or dashboard), contentUuid, name, space, and verification metadata (who verified it and when).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "list_verified_content",
+      "outputSchema": null,
+    },
+    {
+      "agentName": null,
+      "description": "Tool: run_ai_writeback
+
+Purpose:
+Make a change to the dbt project that backs the active Lightdash project by describing it in natural language, then open a pull request with the result. The target GitHub repository and dbt sub-folder are resolved server-side from the active project's dbt connection — you never specify them.
+
+How it works:
+- A sandbox is created, the project's GitHub repository is cloned, and the prompt is executed by the Claude Code CLI against the dbt project.
+- If the agent changes any files, a branch is committed, pushed, and a pull request is opened. The PR URL is returned.
+- If the agent makes no file changes, no PR is opened and prUrl is null.
+
+Requirements:
+- An active project must be set first via set_project (or the X-Lightdash-Project header).
+- The project's dbt connection must be GitHub-backed, and the organization must have the GitHub App installed.
+- The AI writeback feature must be enabled for the organization.
+
+Important:
+- This tool is NOT read-only and NOT idempotent — each call can open a new pull request. Use it only when the user explicitly wants to change their dbt project.
+- The run is synchronous and can take a few minutes (cloning, running the agent, opening the PR).
+
+Parameters:
+- prompt: A clear, self-contained description of the change to make to the dbt project (e.g. "Add a 'total_revenue' metric to the orders model as the sum of amount").
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: "<human-readable summary including the PR URL>" }]
+- structuredContent: {
+    output:   string,           // the agent's text output
+    exitCode: number,           // the sandbox command's exit status
+    prUrl:    string | null     // URL of the opened pull request, or null when no changes were made
+  }
+",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "prompt": {
+            "description": "A clear, self-contained description of the change to make to the dbt project that backs the active Lightdash project.",
+            "minLength": 1,
+            "type": "string",
+          },
+        },
+        "required": [
+          "prompt",
+        ],
+        "type": "object",
+      },
+      "name": "run_ai_writeback",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "exitCode": {
+            "description": "The sandbox command's exit status.",
+            "type": "integer",
+          },
+          "output": {
+            "description": "The text output produced by the agent.",
+            "type": "string",
+          },
+          "prUrl": {
+            "description": "URL of the pull request opened from the agent changes, or null when the agent made no file changes.",
+            "type": [
+              "string",
+              "null",
+            ],
+          },
+        },
+        "required": [
+          "output",
+          "exitCode",
+          "prUrl",
+        ],
+        "type": "object",
+      },
+    },
+  ],
+}
+`;

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -1,0 +1,135 @@
+import type { ZodRawShape, ZodTypeAny } from 'zod';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { MCP_ANALYST_PROMPT } from '../ai/prompts/mcpAnalyst';
+import { McpService, McpToolName } from './McpService';
+
+type RegisteredMcpTool = {
+    name: string;
+    config: {
+        description?: string;
+        inputSchema?: ZodRawShape;
+        outputSchema?: ZodRawShape;
+        annotations?: Record<string, unknown>;
+        _meta?: Record<string, unknown>;
+    };
+};
+
+type RegisteredMcpPrompt = {
+    name: string;
+    config: {
+        title?: string;
+        description?: string;
+        argsSchema?: ZodRawShape;
+    };
+};
+
+const mockRegisteredMcpTools: RegisteredMcpTool[] = [];
+const mockRegisteredMcpPrompts: RegisteredMcpPrompt[] = [];
+
+jest.mock('@sentry/node', () => ({
+    getActiveSpan: () => undefined,
+    wrapMcpServerWithSentry: (server: unknown) => server,
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+    McpServer: jest.fn().mockImplementation(() => ({
+        registerResource: jest.fn(),
+        registerPrompt: jest.fn(
+            (
+                name: string,
+                config: RegisteredMcpPrompt['config'],
+                _callback: unknown,
+            ) => {
+                mockRegisteredMcpPrompts.push({ name, config });
+                return {};
+            },
+        ),
+        registerTool: jest.fn(
+            (
+                name: string,
+                config: RegisteredMcpTool['config'],
+                _callback: unknown,
+            ) => {
+                mockRegisteredMcpTools.push({ name, config });
+                return {};
+            },
+        ),
+    })),
+}));
+
+const schemaToJson = (
+    schema: ZodTypeAny | ZodRawShape | undefined,
+): unknown => {
+    if (!schema) {
+        return null;
+    }
+
+    return zodToJsonSchema(
+        schema instanceof z.ZodType ? schema : z.object(schema),
+        {
+            target: 'jsonSchema7',
+        },
+    );
+};
+
+const makeMcpService = (): McpService =>
+    new McpService({
+        aiAgentService: {},
+        aiOrganizationSettingsService: {},
+        aiWritebackService: {},
+        analytics: {},
+        asyncQueryService: {},
+        catalogService: {},
+        contentVerificationService: {},
+        featureFlagService: {},
+        lightdashConfig: {
+            mcp: {
+                runSqlMaxLimit: 500,
+            },
+            siteUrl: 'https://lightdash.example',
+        },
+        mcpContextModel: {},
+        projectModel: {},
+        projectService: {},
+        savedSqlService: {},
+        schedulerService: {},
+        searchModel: {},
+        shareService: {},
+        spaceService: {},
+        userAttributesModel: {},
+    } as ConstructorParameters<typeof McpService>[0]);
+
+describe('MCP tool contracts', () => {
+    beforeEach(() => {
+        mockRegisteredMcpTools.length = 0;
+        mockRegisteredMcpPrompts.length = 0;
+    });
+
+    it('matches the current MCP tool and prompt contract snapshot', () => {
+        const mcpService = makeMcpService();
+
+        mockRegisteredMcpTools.length = 0;
+        mockRegisteredMcpPrompts.length = 0;
+        mcpService.createServer({ aiWritebackEnabled: true });
+
+        expect({
+            prompts: mockRegisteredMcpPrompts.map(({ name, config }) => ({
+                name,
+                title: config.title,
+                description: config.description,
+                argsSchema: schemaToJson(config.argsSchema),
+                prompt:
+                    name === 'lightdash-analyst' ? MCP_ANALYST_PROMPT : null,
+            })),
+            tools: mockRegisteredMcpTools.map(({ name, config }) => ({
+                name,
+                agentName:
+                    name === McpToolName.RUN_METRIC_QUERY ? 'runQuery' : null,
+                description: config.description,
+                inputSchema: schemaToJson(config.inputSchema),
+                outputSchema: schemaToJson(config.outputSchema),
+            })),
+        }).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/AGENTS.md
+++ b/packages/backend/src/ee/services/ai/tools/AGENTS.md
@@ -1,0 +1,6 @@
+# AI Agent Tool Contract Notes
+
+- Agent tool names are camelCase.
+- Keep descriptions, input schemas, and output schemas stable unless the LLM-facing contract is intentionally changing.
+- Run `pnpm -F backend test src/ee/services/ai/tools/toolContracts.snapshot.test.ts` before and after shared tool-definition refactors.
+- If an agent tool contract intentionally changes, update only the AI agent snapshot entry and mention the contract change in review.

--- a/packages/backend/src/ee/services/ai/tools/SKILLS.md
+++ b/packages/backend/src/ee/services/ai/tools/SKILLS.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -1,0 +1,6553 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AI agent tool contracts matches the current agent tool contract snapshot 1`] = `
+[
+  {
+    "description": "Tool: describe_warehouse_table
+
+Purpose:
+Return the column names + types of a single raw warehouse table. Use this to learn the exact schema of a raw / staging / seed table that is NOT exposed via an explore, so you can write correct runSql on the first attempt.
+
+Returns: { columns: [{ name, type }, ...] }. Pulled from cached metadata, fast, NO user approval required.
+
+When to use:
+- You're about to write runSql against a raw table and need its columns (e.g. to confirm a join key exists).
+- A previous runSql failed with "column does not exist" or similar. Use this to recover, then retry the SQL ONCE.
+- The user asked about a raw table that isn't part of any explore.
+
+Do NOT use:
+- For columns of explore-backed tables — use findFields instead.
+- As a substitute for runSql — this returns schema only, not data.
+- For schema-wide listings — use listWarehouseTables to find table names first.
+
+Parameters:
+- table: Required. The unqualified table name (e.g. "raw_parts", not "jaffle.raw_parts").
+- schema: Optional. The schema name (e.g. "jaffle"). If omitted, the project's default schema is used.
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: describe_warehouse_table
+
+Purpose:
+Return the column names + types of a single raw warehouse table. Use this to learn the exact schema of a raw / staging / seed table that is NOT exposed via an explore, so you can write correct runSql on the first attempt.
+
+Returns: { columns: [{ name, type }, ...] }. Pulled from cached metadata, fast, NO user approval required.
+
+When to use:
+- You're about to write runSql against a raw table and need its columns (e.g. to confirm a join key exists).
+- A previous runSql failed with "column does not exist" or similar. Use this to recover, then retry the SQL ONCE.
+- The user asked about a raw table that isn't part of any explore.
+
+Do NOT use:
+- For columns of explore-backed tables — use findFields instead.
+- As a substitute for runSql — this returns schema only, not data.
+- For schema-wide listings — use listWarehouseTables to find table names first.
+
+Parameters:
+- table: Required. The unqualified table name (e.g. "raw_parts", not "jaffle.raw_parts").
+- schema: Optional. The schema name (e.g. "jaffle"). If omitted, the project's default schema is used.
+",
+      "properties": {
+        "schema": {
+          "description": "Optional schema name. Defaults to the project's default schema if omitted.",
+          "type": "string",
+        },
+        "table": {
+          "description": "The unqualified table name (e.g. "raw_parts"). Do not include schema/database here — use the schema parameter instead.",
+          "minLength": 1,
+          "type": "string",
+        },
+      },
+      "required": [
+        "table",
+      ],
+      "type": "object",
+    },
+    "name": "describeWarehouseTable",
+    "outputSchema": null,
+  },
+  {
+    "description": "Tool: discoverFields
+
+Purpose:
+Run the data-discovery subagent. Given the latest user query, returns a structured handoff describing which explore and which fields to use to answer it.
+
+Use this tool as the FIRST step whenever the user asks a data question (counts, totals, breakdowns, trends, "what is", "show me", "how many"). Do NOT call this when the user is only asking about existing dashboards/charts (use findContent) or follow-up clarifications about a chart you already produced.
+
+You will receive one of three statuses:
+- "resolved" — proceed with runQuery (or generateDashboard) using the returned explore + fields.
+- "ambiguous" — surface the suggestedQuestion to the user; do NOT call runQuery.
+- "no_match" — explain back to the user that no data source covers the request.
+
+Re-call this tool if the user pivots mid-thread to a different data topic and you need fields from a different explore.
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "agentInstruction": {
+          "description": "The agent's configured \`instruction\` field if present, otherwise null. Provides domain-specific guidance for explore/field selection.",
+          "type": [
+            "string",
+            "null",
+          ],
+        },
+        "userQuery": {
+          "description": "The latest user question or instruction the agent is responding to. Pass the full message — the subagent uses it to disambiguate explores and rank fields.",
+          "type": "string",
+        },
+      },
+      "required": [
+        "userQuery",
+        "agentInstruction",
+      ],
+      "type": "object",
+    },
+    "name": "discoverFields",
+    "outputSchema": null,
+  },
+  {
+    "description": "Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting.",
+      "properties": {
+        "patch": {
+          "description": "RFC6902 Patch to apply to the current dashboard or chart JSON.",
+        },
+        "slug": {
+          "description": "Slug of the dashboard or chart to edit.",
+          "minLength": 1,
+          "type": "string",
+        },
+        "type": {
+          "description": "Type of Lightdash content to edit.",
+          "enum": [
+            "dashboard",
+            "chart",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "slug",
+        "type",
+      ],
+      "type": "object",
+    },
+    "name": "editContent",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "Tool: "findContent"
+Purpose:
+Finds charts or dashboards by name or description within a project, returning detailed information about each.
+
+Usage tips:
+- IMPORTANT: Pass the user's full query or relevant portion directly (e.g., "revenue based on campaigns" instead of just "campaigns").
+- The search engine understands natural language and context — more descriptive queries yield better results.
+- You can provide multiple search queries to look for different topics simultaneously (e.g., ["monthly revenue", "user acquisition trends"]).
+- If results aren't relevant, retry with the full user query or more specific terms.
+- Dashboards with validation errors will be deprioritized.
+- Returns chart and dashboard URLs when available.
+- Dashboards show a preview of the first 5 charts and the total chart count. Use "getDashboardCharts" to see all charts for a specific dashboard.
+- It doesn't provide summaries for dashboards yet, so don't suggest this capability.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: "findContent"
+Purpose:
+Finds charts or dashboards by name or description within a project, returning detailed information about each.
+
+Usage tips:
+- IMPORTANT: Pass the user's full query or relevant portion directly (e.g., "revenue based on campaigns" instead of just "campaigns").
+- The search engine understands natural language and context — more descriptive queries yield better results.
+- You can provide multiple search queries to look for different topics simultaneously (e.g., ["monthly revenue", "user acquisition trends"]).
+- If results aren't relevant, retry with the full user query or more specific terms.
+- Dashboards with validation errors will be deprioritized.
+- Returns chart and dashboard URLs when available.
+- Dashboards show a preview of the first 5 charts and the total chart count. Use "getDashboardCharts" to see all charts for a specific dashboard.
+- It doesn't provide summaries for dashboards yet, so don't suggest this capability.",
+      "properties": {
+        "searchQueries": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "label": {
+                "description": "Full search query from the user (e.g., "revenue based on campaigns" not just "campaigns"). Include full context for better results.",
+                "type": "string",
+              },
+            },
+            "required": [
+              "label",
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "searchQueries",
+      ],
+      "type": "object",
+    },
+    "name": "findContent",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "Tool: findExplores
+
+Purpose:
+Returns an explore with all its fields, joined tables, AI hints and descriptions. When multiple explores match your search, also returns alternative explores and top 50 matching fields across ALL explores.
+IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
+
+Parameters:
+- searchQuery: Full user query for finding relevant explores
+
+Output:
+- Selected explore with all fields and metadata (including fields from joined tables)
+- Alternative explores (if multiple matches) with searchRank scores
+- Top matching fields with their explore names and searchRank scores
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: findExplores
+
+Purpose:
+Returns an explore with all its fields, joined tables, AI hints and descriptions. When multiple explores match your search, also returns alternative explores and top 50 matching fields across ALL explores.
+IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
+
+Parameters:
+- searchQuery: Full user query for finding relevant explores
+
+Output:
+- Selected explore with all fields and metadata (including fields from joined tables)
+- Alternative explores (if multiple matches) with searchRank scores
+- Top matching fields with their explore names and searchRank scores
+",
+      "properties": {
+        "searchQuery": {
+          "description": "The full user query or search terms to help find the most relevant explore. Use the complete user request for better search results.",
+          "type": "string",
+        },
+      },
+      "required": [
+        "searchQuery",
+      ],
+      "type": "object",
+    },
+    "name": "findExplores",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "ranking": {
+              "additionalProperties": false,
+              "properties": {
+                "exploreSearchResults": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "joinedTables": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                      "label": {
+                        "type": "string",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                      "searchRank": {
+                        "type": [
+                          "number",
+                          "null",
+                        ],
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "label",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "searchQuery": {
+                  "type": "string",
+                },
+                "topMatchingFields": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "chartUsage": {
+                        "type": [
+                          "number",
+                          "null",
+                        ],
+                      },
+                      "fieldType": {
+                        "type": "string",
+                      },
+                      "label": {
+                        "type": "string",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                      "searchRank": {
+                        "type": [
+                          "number",
+                          "null",
+                        ],
+                      },
+                      "tableName": {
+                        "type": "string",
+                      },
+                      "verifiedChartUsage": {
+                        "type": [
+                          "number",
+                          "null",
+                        ],
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "label",
+                      "tableName",
+                      "fieldType",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+              "required": [
+                "searchQuery",
+              ],
+              "type": "object",
+            },
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "Tool: "findFields"
+
+Purpose:
+Finds the most relevant Fields (Metrics & Dimensions) within Explores, returning detailed info about each.
+
+Usage tips:
+- Use "findExplores" first to discover available Explores and their field labels.
+- Use full field labels in search terms (e.g. "Total Revenue", "Order Date").
+- Pass all needed fields in one request.
+- Fields are sorted by relevance, with a maximum score of 1 and a minimum of 0, so the top results are the most relevant.
+- If results aren't relevant, retry with clearer or more specific terms.
+- Results are paginated — use the next page token to get more results if needed.
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: "findFields"
+
+Purpose:
+Finds the most relevant Fields (Metrics & Dimensions) within Explores, returning detailed info about each.
+
+Usage tips:
+- Use "findExplores" first to discover available Explores and their field labels.
+- Use full field labels in search terms (e.g. "Total Revenue", "Order Date").
+- Pass all needed fields in one request.
+- Fields are sorted by relevance, with a maximum score of 1 and a minimum of 0, so the top results are the most relevant.
+- If results aren't relevant, retry with clearer or more specific terms.
+- Results are paginated — use the next page token to get more results if needed.
+",
+      "properties": {
+        "fieldSearchQueries": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "label": {
+                "description": "Full field label",
+                "type": "string",
+              },
+            },
+            "required": [
+              "label",
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+        "page": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number",
+            },
+            {
+              "type": "null",
+            },
+          ],
+          "description": "Use this to paginate through the results. Starts at 1.",
+        },
+        "table": {
+          "description": "The table to search in.",
+          "type": "string",
+        },
+      },
+      "required": [
+        "table",
+        "fieldSearchQueries",
+        "page",
+      ],
+      "type": "object",
+    },
+    "name": "findFields",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "ranking": {
+              "additionalProperties": false,
+              "properties": {
+                "searchQueries": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                      },
+                      "pagination": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "page": {
+                            "type": "number",
+                          },
+                          "pageSize": {
+                            "type": "number",
+                          },
+                          "totalPageCount": {
+                            "type": "number",
+                          },
+                          "totalResults": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "page",
+                          "pageSize",
+                          "totalResults",
+                          "totalPageCount",
+                        ],
+                        "type": "object",
+                      },
+                      "results": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "chartUsage": {
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                            "fieldType": {
+                              "type": "string",
+                            },
+                            "label": {
+                              "type": "string",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                            "searchRank": {
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                            "tableName": {
+                              "type": "string",
+                            },
+                            "verifiedChartUsage": {
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "label",
+                            "tableName",
+                            "fieldType",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "required": [
+                      "label",
+                      "results",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+              "required": [
+                "searchQueries",
+              ],
+              "type": "object",
+            },
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "
+
+Use this tool to generate multiple visualizations for a dashboard based on a specific theme.
+
+Instead of making multiple parallel tool calls for individual visualizations, this tool takes an array of visualization configurations and generates them all at once, ensuring thematic consistency and better performance.
+
+Dashboard Design Philosophy:
+Create "summary" or "executive" level dashboards that provide high-level overviews of specific topics (e.g., Support Dashboard, Revenue Performance, Sales Operations). These dashboards should be designed to monitor trends and key metric performance at a glance.
+
+Recommended Dashboard Structure:
+1. **Summary Metrics at the Top**: Start with key performance indicators (KPIs) as tables showing overall summary metrics
+2. **Time-Series Analysis**: Include time-series charts (line or area charts) to show how metrics trend over time
+3. **Categorical Comparisons**: Use bar or horizontal bar charts to compare metrics across categories
+4. **Proportional Analysis**: Use pie charts to show part-to-whole relationships (e.g., market share, revenue by segment)
+5. **Correlation Analysis**: Use scatter plots to explore relationships between two metrics
+6. **Conversion Flows**: Use funnel charts to visualize sequential conversion processes (e.g., sales funnel, user onboarding)
+7. **Detailed Breakdowns**: Add tables with more detail and specific line items that have the biggest impact on metrics
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "
+
+Use this tool to generate multiple visualizations for a dashboard based on a specific theme.
+
+Instead of making multiple parallel tool calls for individual visualizations, this tool takes an array of visualization configurations and generates them all at once, ensuring thematic consistency and better performance.
+
+Dashboard Design Philosophy:
+Create "summary" or "executive" level dashboards that provide high-level overviews of specific topics (e.g., Support Dashboard, Revenue Performance, Sales Operations). These dashboards should be designed to monitor trends and key metric performance at a glance.
+
+Recommended Dashboard Structure:
+1. **Summary Metrics at the Top**: Start with key performance indicators (KPIs) as tables showing overall summary metrics
+2. **Time-Series Analysis**: Include time-series charts (line or area charts) to show how metrics trend over time
+3. **Categorical Comparisons**: Use bar or horizontal bar charts to compare metrics across categories
+4. **Proportional Analysis**: Use pie charts to show part-to-whole relationships (e.g., market share, revenue by segment)
+5. **Correlation Analysis**: Use scatter plots to explore relationships between two metrics
+6. **Conversion Flows**: Use funnel charts to visualize sequential conversion processes (e.g., sales funnel, user onboarding)
+7. **Detailed Breakdowns**: Add tables with more detail and specific line items that have the biggest impact on metrics
+",
+      "properties": {
+        "description": {
+          "description": "A descriptive summary or explanation for the dashboard.",
+          "type": "string",
+        },
+        "title": {
+          "description": "A descriptive title for the dashboard",
+          "type": "string",
+        },
+        "visualizations": {
+          "description": "Array of visualization configurations to generate for this dashboard. Each should contribute to the overall theme and leverage the available chart types (table, bar, horizontal, line, scatter, pie, funnel).",
+          "items": {
+            "additionalProperties": false,
+            "description": "Tool: runQuery
+
+Purpose:
+Execute a metric query and create a chart artifact. The results can be viewed as a table, bar, horizontal bar, line, scatter, pie, or funnel chart.
+You define the default visualization type to render but users can switch between visualization types after creation.
+
+Chart Type Selection Guide:
+- 'bar': Vertical bars for categorical comparisons (e.g., sales by product)
+- 'horizontal': Horizontal bars for long category names or ranking (e.g., top 10 customers)
+- 'line': Time series trends (e.g., revenue over months)
+- 'scatter': Correlation between two metrics (e.g., ad spend vs revenue)
+- 'pie': Part-to-whole proportions (e.g., market share by segment)
+- 'funnel': Sequential conversion flows (e.g., sales funnel stages)
+- 'table': Raw data display with all fields
+
+Configuration Tips:
+- Specify exploreName, dimensions (for grouping/x-axis), and metrics (for y-axis values)
+- First dimension is the x-axis; additional dimensions can be used for series breakdown via groupBy
+- At least one metric is required for all chart types except table
+- chartConfig.xAxisDimension: Select the primary dimension from queryConfig.dimensions (typically dimensions[0])
+- chartConfig.yAxisMetrics: Select the metrics to display from queryConfig.metrics or tableCalculations
+- chartConfig.groupBy: Use to split data into multiple series along a CATEGORICAL dimension (e.g., one line per region, one bar per product). Do NOT include the x-axis dimension. Do NOT use to split along a time dimension to simulate a period comparison — use a kind: "periodComparison" customMetric for that. Leave null for simple single-series charts.
+- For bar/horizontal charts: use xAxisType 'category' for strings or 'time' for dates/timestamps
+- For bar/horizontal charts: stackBars (when groupBy is provided) stacks bars instead of placing them side by side
+- For line charts: use lineType 'area' to fill the area under the line
+- For scatter charts: each point represents one row of data
+- For funnel charts: set funnelDataInput to 'row' (each row = stage) or 'column' (multiple funnels)
+- Users can switch between visualization types in the UI after creation
+- xAxisLabel and yAxisLabel provide helpful context for chart axes
+- filters can contain filters on fields from joined tables as well as the base table
+- For time-based comparisons (year-over-year, month-over-month, vs N periods ago), add a kind: "periodComparison" entry to customMetrics. Required ingredients: the time dimension in queryConfig.dimensions, the base metric in queryConfig.metrics, and the periodComparison custom metric pointing at both. Do NOT add a second time-dimension granularity (e.g. _year) and use groupBy — that produces a dimensional split, not a real period comparison.
+",
+            "properties": {
+              "chartConfig": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "defaultVizType": {
+                        "description": "The default visualization type to render",
+                        "enum": [
+                          "table",
+                          "bar",
+                          "horizontal",
+                          "line",
+                          "scatter",
+                          "pie",
+                          "funnel",
+                        ],
+                        "type": "string",
+                      },
+                      "funnelDataInput": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "row",
+                              "column",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "How to interpret funnel data. Use "row" when each row represents a funnel stage (most common). Use "column" when comparing multiple funnels side-by-side.",
+                      },
+                      "groupBy": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "Dimensions to split metrics into separate series (e.g., one line per region, one bar per status). IMPORTANT: Do NOT include the x-axis dimension in groupBy - only include dimensions you want to use for breaking down the data into multiple series. Example: dimensions=["order_date", "status"], groupBy=["status"] creates separate series for each status value. Leave null for simple single-series charts.",
+                      },
+                      "lineType": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "line",
+                              "area",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "default line. The type of line to display. If area then the area under the line will be filled in.",
+                      },
+                      "secondaryYAxisLabel": {
+                        "description": "A helpful label for the secondary y-axis",
+                        "type": [
+                          "string",
+                          "null",
+                        ],
+                      },
+                      "secondaryYAxisMetric": {
+                        "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
+                        "type": [
+                          "string",
+                          "null",
+                        ],
+                      },
+                      "stackBars": {
+                        "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.",
+                        "type": [
+                          "boolean",
+                          "null",
+                        ],
+                      },
+                      "xAxisDimension": {
+                        "description": "The dimension field ID to use for the x-axis. Must be included in queryConfig.dimensions",
+                        "type": [
+                          "string",
+                          "null",
+                        ],
+                      },
+                      "xAxisLabel": {
+                        "description": "A helpful label to explain the x-axis",
+                        "type": "string",
+                      },
+                      "xAxisType": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "category",
+                              "time",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "The x-axis type can be categorical for string value or time if the dimension is a date or timestamp. Applies to bar, horizontal, and scatter charts.",
+                      },
+                      "yAxisLabel": {
+                        "description": "A helpful label to explain the y-axis",
+                        "type": "string",
+                      },
+                      "yAxisMetrics": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "The metric field IDs to display on the y-axis. Must be included in queryConfig.metrics or come from tableCalculations",
+                      },
+                    },
+                    "required": [
+                      "defaultVizType",
+                      "xAxisDimension",
+                      "yAxisMetrics",
+                      "groupBy",
+                      "xAxisType",
+                      "stackBars",
+                      "lineType",
+                      "funnelDataInput",
+                      "xAxisLabel",
+                      "yAxisLabel",
+                      "secondaryYAxisMetric",
+                      "secondaryYAxisLabel",
+                    ],
+                    "type": "object",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+              },
+              "customMetrics": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "baseDimensionName": {
+                              "description": "Name of the base dimension/column this metric calculates from",
+                              "type": "string",
+                            },
+                            "description": {
+                              "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                              "type": "string",
+                            },
+                            "filters": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "filter": {
+                                        "anyOf": [
+                                          {
+                                            "anyOf": [
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "const": "boolean",
+                                                    "type": "string",
+                                                  },
+                                                  "fieldId": {
+                                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                    "type": "string",
+                                                  },
+                                                  "fieldType": {
+                                                    "enum": [
+                                                      "boolean",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "isNull",
+                                                      "notNull",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
+                                                  },
+                                                  "fieldId": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldId",
+                                                  },
+                                                  "fieldType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldType",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "equals",
+                                                      "notEquals",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "boolean",
+                                                    },
+                                                    "maxItems": 1,
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                  "values",
+                                                ],
+                                                "type": "object",
+                                              },
+                                            ],
+                                          },
+                                          {
+                                            "anyOf": [
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "const": "string",
+                                                    "type": "string",
+                                                  },
+                                                  "fieldId": {
+                                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                    "type": "string",
+                                                  },
+                                                  "fieldType": {
+                                                    "enum": [
+                                                      "string",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "isNull",
+                                                      "notNull",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
+                                                  },
+                                                  "fieldId": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldId",
+                                                  },
+                                                  "fieldType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldType",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "equals",
+                                                      "notEquals",
+                                                      "startsWith",
+                                                      "endsWith",
+                                                      "include",
+                                                      "doesNotInclude",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string",
+                                                    },
+                                                    "type": "array",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                  "values",
+                                                ],
+                                                "type": "object",
+                                              },
+                                            ],
+                                          },
+                                          {
+                                            "anyOf": [
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "const": "number",
+                                                    "type": "string",
+                                                  },
+                                                  "fieldId": {
+                                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                    "type": "string",
+                                                  },
+                                                  "fieldType": {
+                                                    "enum": [
+                                                      "number",
+                                                      "percentile",
+                                                      "median",
+                                                      "average",
+                                                      "count",
+                                                      "count_distinct",
+                                                      "sum",
+                                                      "sum_distinct",
+                                                      "average_distinct",
+                                                      "min",
+                                                      "max",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "isNull",
+                                                      "notNull",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                  },
+                                                  "fieldId": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                  },
+                                                  "fieldType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "equals",
+                                                      "notEquals",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "number",
+                                                    },
+                                                    "type": "array",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                  "values",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                  },
+                                                  "fieldId": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                  },
+                                                  "fieldType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "lessThan",
+                                                      "lessThanOrEqual",
+                                                      "greaterThan",
+                                                      "greaterThanOrEqual",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "number",
+                                                    },
+                                                    "maxItems": 1,
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                  "values",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                  },
+                                                  "fieldId": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                  },
+                                                  "fieldType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "inBetween",
+                                                      "notInBetween",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "number",
+                                                    },
+                                                    "maxItems": 2,
+                                                    "minItems": 2,
+                                                    "type": "array",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                  "values",
+                                                ],
+                                                "type": "object",
+                                              },
+                                            ],
+                                          },
+                                          {
+                                            "anyOf": [
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "const": "date",
+                                                    "type": "string",
+                                                  },
+                                                  "fieldId": {
+                                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                    "type": "string",
+                                                  },
+                                                  "fieldType": {
+                                                    "enum": [
+                                                      "date",
+                                                      "timestamp",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "isNull",
+                                                      "notNull",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                  },
+                                                  "fieldId": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                  },
+                                                  "fieldType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "equals",
+                                                      "notEquals",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "anyOf": [
+                                                        {
+                                                          "format": "date",
+                                                          "type": "string",
+                                                        },
+                                                        {
+                                                          "format": "date-time",
+                                                          "type": "string",
+                                                        },
+                                                      ],
+                                                    },
+                                                    "type": "array",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                  "values",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                  },
+                                                  "fieldId": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                  },
+                                                  "fieldType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "inThePast",
+                                                      "notInThePast",
+                                                      "inTheNext",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "settings": {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "completed": {
+                                                        "type": "boolean",
+                                                      },
+                                                      "unitOfTime": {
+                                                        "enum": [
+                                                          "days",
+                                                          "weeks",
+                                                          "months",
+                                                          "quarters",
+                                                          "years",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "completed",
+                                                      "unitOfTime",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "number",
+                                                    },
+                                                    "maxItems": 1,
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                  "values",
+                                                  "settings",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                  },
+                                                  "fieldId": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                  },
+                                                  "fieldType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "inTheCurrent",
+                                                      "notInTheCurrent",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "settings": {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "completed": {
+                                                        "const": false,
+                                                        "type": "boolean",
+                                                      },
+                                                      "unitOfTime": {
+                                                        "enum": [
+                                                          "days",
+                                                          "weeks",
+                                                          "months",
+                                                          "quarters",
+                                                          "years",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "completed",
+                                                      "unitOfTime",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "const": 1,
+                                                      "type": "number",
+                                                    },
+                                                    "maxItems": 1,
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                  "values",
+                                                  "settings",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                  },
+                                                  "fieldId": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                  },
+                                                  "fieldType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                  },
+                                                  "operator": {
+                                                    "enum": [
+                                                      "lessThan",
+                                                      "lessThanOrEqual",
+                                                      "greaterThan",
+                                                      "greaterThanOrEqual",
+                                                    ],
+                                                    "type": "string",
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                                    },
+                                                    "maxItems": 1,
+                                                    "minItems": 1,
+                                                    "type": "array",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                  "values",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fieldFilterType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                  },
+                                                  "fieldId": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                  },
+                                                  "fieldType": {
+                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                  },
+                                                  "operator": {
+                                                    "const": "inBetween",
+                                                    "type": "string",
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                                    },
+                                                    "maxItems": 2,
+                                                    "minItems": 2,
+                                                    "type": "array",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "fieldId",
+                                                  "fieldType",
+                                                  "fieldFilterType",
+                                                  "operator",
+                                                  "values",
+                                                ],
+                                                "type": "object",
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                      "table": {
+                                        "description": "Table name this filter field belongs to",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "filter",
+                                      "table",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "type": "array",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                              "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name.",
+                            },
+                            "kind": {
+                              "const": "aggregation",
+                              "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                              "type": "string",
+                            },
+                            "label": {
+                              "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                              "type": "string",
+                            },
+                            "name": {
+                              "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                              "type": "string",
+                            },
+                            "table": {
+                              "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                              "type": "string",
+                            },
+                            "type": {
+                              "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                              "enum": [
+                                "average",
+                                "count",
+                                "count_distinct",
+                                "max",
+                                "min",
+                                "sum",
+                                "percentile",
+                                "median",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "kind",
+                            "name",
+                            "label",
+                            "description",
+                            "baseDimensionName",
+                            "table",
+                            "type",
+                            "filters",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "baseMetricId": {
+                              "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                              "type": "string",
+                            },
+                            "granularity": {
+                              "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                              "enum": [
+                                "DAY",
+                                "WEEK",
+                                "MONTH",
+                                "QUARTER",
+                                "YEAR",
+                              ],
+                              "type": "string",
+                            },
+                            "kind": {
+                              "const": "periodComparison",
+                              "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                              "type": "string",
+                            },
+                            "periodOffset": {
+                              "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                              "minimum": 1,
+                              "type": "integer",
+                            },
+                            "timeDimensionId": {
+                              "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "kind",
+                            "baseMetricId",
+                            "timeDimensionId",
+                            "granularity",
+                            "periodOffset",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    "type": "array",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "Define new metric columns the explore doesn't already have. Two kinds:
+
+(1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
+    (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
+    Use when the requested metric doesn't exist in the explore.
+
+(2) kind: "periodComparison" — a column that is an EXISTING metric shifted
+    back in time. Use whenever the user asks for "year-over-year",
+    "month-over-month", "vs last quarter", "compare to previous period",
+    "N periods ago".
+
+For period comparisons, every successful chart has three things:
+- The time dimension in queryConfig.dimensions
+- The base metric in queryConfig.metrics
+- A customMetric of kind "periodComparison" pointing at that base metric and time dimension
+
+The server generates the comparison column automatically and appends it next to the base metric. Do NOT add the comparison column id to queryConfig.metrics yourself.
+
+DO NOT simulate a period comparison by adding a second time-dimension granularity (e.g. _year) and using groupBy. groupBy is for categorical splits (region, product). Time comparisons use a kind: "periodComparison" customMetric.
+
+For aggregation entries:
+1. Add the entry to customMetrics with kind: "aggregation"
+2. Reference it in queryConfig.metrics using the format "table_name" (e.g. "customers_avg_customer_age")
+3. Reference it the same way in sorts, filters, chartConfig.yAxisMetrics
+
+Example A — "Average customer age sorted descending"
+  customMetrics: [{ kind: "aggregation", name: "avg_customer_age", label: "Average Customer Age", description: "...", type: "AVERAGE", baseDimensionName: "age", table: "customers", filters: null }]
+  queryConfig.metrics: ["customers_avg_customer_age"]
+  sorts: [{ fieldId: "customers_avg_customer_age", descending: true }]
+
+Example B — "Revenue by month with year-over-year comparison"
+  queryConfig.dimensions: ["orders_order_date_month"]
+  queryConfig.metrics: ["orders_revenue"]
+  customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }]",
+              },
+              "description": {
+                "description": "A descriptive summary or explanation for the chart.",
+                "type": "string",
+              },
+              "filters": {
+                "anyOf": [
+                  {
+                    "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/filters",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+              },
+              "queryConfig": {
+                "additionalProperties": false,
+                "properties": {
+                  "dimensions": {
+                    "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
+                    "items": {
+                      "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  "exploreName": {
+                    "description": "The name of the explore containing the metrics and dimensions used for the chart.",
+                    "type": "string",
+                  },
+                  "filters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "dimensions": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0",
+                                },
+                                {
+                                  "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1",
+                                },
+                                {
+                                  "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
+                                },
+                                {
+                                  "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3",
+                                },
+                              ],
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                      "metrics": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/filters/properties/dimensions/anyOf/0/items",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                      "tableCalculations": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                      "type": {
+                        "description": "Type of filter group operation",
+                        "enum": [
+                          "and",
+                          "or",
+                        ],
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "type",
+                      "dimensions",
+                      "metrics",
+                      "tableCalculations",
+                    ],
+                    "type": "object",
+                  },
+                  "limit": {
+                    "description": "The total number of data points / rows allowed on the chart.",
+                    "type": [
+                      "number",
+                      "null",
+                    ],
+                  },
+                  "metrics": {
+                    "description": "The field ids of the metrics to be calculated. They will be grouped by the dimensions.",
+                    "items": {
+                      "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  "sorts": {
+                    "description": "Sort configuration for the query, it can use a combination of metrics and dimensions.",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "descending": {
+                          "description": "If true sorts in descending order, if false sorts in ascending order",
+                          "type": "boolean",
+                        },
+                        "fieldId": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "nullsFirst": {
+                          "description": "If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default",
+                          "type": [
+                            "boolean",
+                            "null",
+                          ],
+                        },
+                      },
+                      "required": [
+                        "fieldId",
+                        "descending",
+                        "nullsFirst",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                },
+                "required": [
+                  "exploreName",
+                  "dimensions",
+                  "metrics",
+                  "sorts",
+                  "limit",
+                ],
+                "type": "object",
+              },
+              "tableCalculations": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "displayName": {
+                              "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                              "type": "string",
+                            },
+                            "fieldId": {
+                              "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "name": {
+                              "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                              "type": "string",
+                            },
+                            "orderBy": {
+                              "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldId": {
+                                    "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                    "type": "string",
+                                  },
+                                  "order": {
+                                    "anyOf": [
+                                      {
+                                        "enum": [
+                                          "asc",
+                                          "desc",
+                                        ],
+                                        "type": "string",
+                                      },
+                                      {
+                                        "type": "null",
+                                      },
+                                    ],
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "order",
+                                ],
+                                "type": "object",
+                              },
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                            "partitionBy": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                    "type": "string",
+                                  },
+                                  "type": "array",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                              "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                            },
+                            "type": {
+                              "const": "percent_change_from_previous",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "displayName",
+                            "type",
+                            "fieldId",
+                            "orderBy",
+                            "partitionBy",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "displayName": {
+                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                            },
+                            "fieldId": {
+                              "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "name": {
+                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                            },
+                            "orderBy": {
+                              "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                              "items": {
+                                "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
+                              },
+                              "minItems": 1,
+                              "type": "array",
+                            },
+                            "partitionBy": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                                  },
+                                  "type": "array",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                              "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                            },
+                            "type": {
+                              "const": "percent_of_previous_value",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "displayName",
+                            "type",
+                            "fieldId",
+                            "orderBy",
+                            "partitionBy",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "displayName": {
+                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                            },
+                            "fieldId": {
+                              "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "name": {
+                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                            },
+                            "partitionBy": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                                  },
+                                  "type": "array",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                              "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                            },
+                            "type": {
+                              "const": "percent_of_column_total",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "displayName",
+                            "type",
+                            "fieldId",
+                            "partitionBy",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "displayName": {
+                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                            },
+                            "fieldId": {
+                              "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "name": {
+                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                            },
+                            "type": {
+                              "const": "rank_in_column",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "displayName",
+                            "type",
+                            "fieldId",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "displayName": {
+                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                            },
+                            "fieldId": {
+                              "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "name": {
+                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                            },
+                            "type": {
+                              "const": "running_total",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "displayName",
+                            "type",
+                            "fieldId",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "displayName": {
+                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                            },
+                            "fieldId": {
+                              "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": [
+                                "string",
+                                "null",
+                              ],
+                            },
+                            "frame": {
+                              "anyOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "end": {
+                                      "additionalProperties": false,
+                                      "description": "End boundary (required)",
+                                      "properties": {
+                                        "offset": {
+                                          "anyOf": [
+                                            {
+                                              "exclusiveMinimum": 0,
+                                              "type": "integer",
+                                            },
+                                            {
+                                              "type": "null",
+                                            },
+                                          ],
+                                          "description": "Number of rows for PRECEDING/FOLLOWING",
+                                        },
+                                        "type": {
+                                          "enum": [
+                                            "unbounded_preceding",
+                                            "preceding",
+                                            "current_row",
+                                            "following",
+                                            "unbounded_following",
+                                          ],
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                        "offset",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "frameType": {
+                                      "description": "Frame type:
+- rows: Physical row count
+- range: Logical value-based (includes peer rows with same ORDER BY value)",
+                                      "enum": [
+                                        "rows",
+                                        "range",
+                                      ],
+                                      "type": "string",
+                                    },
+                                    "start": {
+                                      "anyOf": [
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "offset": {
+                                              "anyOf": [
+                                                {
+                                                  "exclusiveMinimum": 0,
+                                                  "type": "integer",
+                                                },
+                                                {
+                                                  "type": "null",
+                                                },
+                                              ],
+                                              "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING")",
+                                            },
+                                            "type": {
+                                              "enum": [
+                                                "unbounded_preceding",
+                                                "preceding",
+                                                "current_row",
+                                                "following",
+                                                "unbounded_following",
+                                              ],
+                                              "type": "string",
+                                            },
+                                          },
+                                          "required": [
+                                            "type",
+                                            "offset",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "type": "null",
+                                        },
+                                      ],
+                                      "description": "Start boundary. Null for single-boundary syntax.",
+                                    },
+                                  },
+                                  "required": [
+                                    "frameType",
+                                    "start",
+                                    "end",
+                                  ],
+                                  "type": "object",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                              "description": "Defines which rows to include in calculation. Null uses database defaults.
+
+**Common patterns:**
+- Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
+- Running total: {frameType: "rows", start: {type: "unbounded_preceding"}, end: {type: "current_row"}}
+- Centered window: {frameType: "rows", start: {type: "preceding", offset: 1}, end: {type: "following", offset: 1}}
+
+**Default when null:**
+- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
+- Aggregates WITHOUT ORDER BY: Entire partition (all rows)
+- Ranking functions: Always use entire partition (frame clause has no effect)",
+                            },
+                            "name": {
+                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                            },
+                            "orderBy": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
+                                  },
+                                  "type": "array",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                              "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                            },
+                            "partitionBy": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                                  },
+                                  "type": "array",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                              "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                            },
+                            "type": {
+                              "const": "window_function",
+                              "type": "string",
+                            },
+                            "windowFunction": {
+                              "description": "Type of window function to apply.
+
+**Ranking functions** (fieldId optional, ignored if provided):
+- row_number: Sequential numbering (1, 2, 3...)
+- percent_rank: Relative rank as percentage (0.0-1.0)
+- cume_dist: Cumulative distribution as percentage (0.0-1.0)
+- rank: Positional rank (1, 2, 3...) with ties
+
+**Aggregate functions** (fieldId required):
+- sum: Sum values within frame
+- avg: Average values within frame
+- count: Count values within frame
+- min: Minimum value within frame
+- max: Maximum value within frame",
+                              "enum": [
+                                "row_number",
+                                "percent_rank",
+                                "cume_dist",
+                                "rank",
+                                "sum",
+                                "avg",
+                                "count",
+                                "min",
+                                "max",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "displayName",
+                            "type",
+                            "windowFunction",
+                            "fieldId",
+                            "orderBy",
+                            "partitionBy",
+                            "frame",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    "type": "array",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "
+Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
+
+**Available Types:**
+- Simple calculations: percent_change_from_previous, percent_of_previous_value, percent_of_column_total, rank_in_column, running_total
+- Advanced window_function: Supports row_number, percent_rank, sum, avg, count, min, max with optional partitioning, ordering, and frame clauses
+
+**Technical Requirements:**
+- Appear as additional columns in query results
+- Can be used in sorts and filters alongside dimensions/metrics
+- Multiple calculations can be combined in a single query
+- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
+",
+              },
+              "title": {
+                "description": "A descriptive title for the chart",
+                "type": "string",
+              },
+            },
+            "required": [
+              "title",
+              "description",
+              "customMetrics",
+              "tableCalculations",
+              "queryConfig",
+              "chartConfig",
+              "filters",
+            ],
+            "type": "object",
+          },
+          "maxItems": 15,
+          "minItems": 2,
+          "type": "array",
+        },
+      },
+      "required": [
+        "title",
+        "description",
+        "visualizations",
+      ],
+      "type": "object",
+    },
+    "name": "generateDashboard",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "Generate one or more UUIDs to use as stable identifiers when creating new objects.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Generate one or more UUIDs to use as stable identifiers when creating new objects.",
+      "properties": {
+        "count": {
+          "description": "Number of UUIDs to generate.",
+          "maximum": 20,
+          "minimum": 1,
+          "type": "number",
+        },
+      },
+      "required": [
+        "count",
+      ],
+      "type": "object",
+    },
+    "name": "generateUuids",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "Tool: "getDashboardCharts"
+Purpose:
+Retrieves the list of charts within a specific dashboard, with pagination support.
+
+Usage tips:
+- Use this tool after "findContent" to drill into a specific dashboard's charts.
+- Requires a dashboardUuid, which you can get from "findContent" results. Also pass the dashboardName for display purposes.
+- Results are paginated — use the page parameter to get more results if needed.
+- Each chart includes its name, description, type, and view count.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: "getDashboardCharts"
+Purpose:
+Retrieves the list of charts within a specific dashboard, with pagination support.
+
+Usage tips:
+- Use this tool after "findContent" to drill into a specific dashboard's charts.
+- Requires a dashboardUuid, which you can get from "findContent" results. Also pass the dashboardName for display purposes.
+- Results are paginated — use the page parameter to get more results if needed.
+- Each chart includes its name, description, type, and view count.",
+      "properties": {
+        "dashboardName": {
+          "description": "The name of the dashboard (for display purposes). Obtained from findContent results.",
+          "type": "string",
+        },
+        "dashboardUuid": {
+          "description": "The UUID of the dashboard to get charts for. Obtained from findContent results.",
+          "type": "string",
+        },
+        "page": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number",
+            },
+            {
+              "type": "null",
+            },
+          ],
+          "description": "Use this to paginate through the results. Starts at 1.",
+        },
+      },
+      "required": [
+        "dashboardUuid",
+        "page",
+      ],
+      "type": "object",
+    },
+    "name": "getDashboardCharts",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "Tool: get_knowledge_document_content
+
+Purpose:
+Read the full text content of a single knowledge document by its uuid. Use this after list_knowledge_documents has surfaced a document whose summary looks relevant to the current task.
+
+When to use:
+- A summary from list_knowledge_documents indicates the document contains information you need.
+- The user explicitly asks you to read a specific document.
+
+Do NOT use:
+- Before calling list_knowledge_documents — you need a uuid first.
+- Repeatedly for the same uuid in one turn — the content does not change between calls.
+
+Parameters:
+- documentUuid: The uuid of the document to read, taken from a previous list_knowledge_documents result.
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: get_knowledge_document_content
+
+Purpose:
+Read the full text content of a single knowledge document by its uuid. Use this after list_knowledge_documents has surfaced a document whose summary looks relevant to the current task.
+
+When to use:
+- A summary from list_knowledge_documents indicates the document contains information you need.
+- The user explicitly asks you to read a specific document.
+
+Do NOT use:
+- Before calling list_knowledge_documents — you need a uuid first.
+- Repeatedly for the same uuid in one turn — the content does not change between calls.
+
+Parameters:
+- documentUuid: The uuid of the document to read, taken from a previous list_knowledge_documents result.
+",
+      "properties": {
+        "documentUuid": {
+          "description": "Uuid of the document to read.",
+          "format": "uuid",
+          "type": "string",
+        },
+      },
+      "required": [
+        "documentUuid",
+      ],
+      "type": "object",
+    },
+    "name": "getKnowledgeDocumentContent",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "contentSizeBytes": {
+                  "type": "number",
+                },
+                "name": {
+                  "type": "string",
+                },
+                "status": {
+                  "const": "success",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+                "name",
+                "contentSizeBytes",
+              ],
+              "type": "object",
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "const": "error",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+              ],
+              "type": "object",
+            },
+          ],
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "
+Captures learnings from user corrections, clarifications, and guidance to improve future responses.
+
+**Supported Learning Categories:**
+- explore_selection: Which tables/explores to use for specific types of queries
+- field_selection: Which fields to use for specific metrics or dimensions
+- filter_logic: How to apply filters for calculations
+- calculation: How to perform specific calculations or aggregations
+- other: General preferences, formatting, or methodologies
+
+**Technical Requirements:**
+- Must provide original query context that led to the learning
+- Must capture what was incorrect and what the correct approach is
+- Must categorize the learning into one of the supported categories
+- Must provide a confidence score (0-1) indicating if this is a learnable pattern
+- Must generate a clear, actionable instruction to append to agent settings
+- Instructions should be specific and context-aware (not overly generic)
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "
+Captures learnings from user corrections, clarifications, and guidance to improve future responses.
+
+**Supported Learning Categories:**
+- explore_selection: Which tables/explores to use for specific types of queries
+- field_selection: Which fields to use for specific metrics or dimensions
+- filter_logic: How to apply filters for calculations
+- calculation: How to perform specific calculations or aggregations
+- other: General preferences, formatting, or methodologies
+
+**Technical Requirements:**
+- Must provide original query context that led to the learning
+- Must capture what was incorrect and what the correct approach is
+- Must categorize the learning into one of the supported categories
+- Must provide a confidence score (0-1) indicating if this is a learnable pattern
+- Must generate a clear, actionable instruction to append to agent settings
+- Instructions should be specific and context-aware (not overly generic)
+",
+      "properties": {
+        "category": {
+          "description": "Category of the learning",
+          "enum": [
+            "explore_selection",
+            "field_selection",
+            "filter_logic",
+            "calculation",
+            "other",
+          ],
+          "type": "string",
+        },
+        "confidence": {
+          "description": "Confidence score that this is a learnable learning or more context is needed",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number",
+        },
+        "correctResponse": {
+          "description": "What the user corrected or clarified",
+          "type": "string",
+        },
+        "incorrectResponse": {
+          "description": "What the AI incorrectly suggested or returned",
+          "type": "string",
+        },
+        "originalQuery": {
+          "description": "The original user query that led to incorrect results",
+          "type": "string",
+        },
+        "suggestedInstruction": {
+          "description": "The instruction to append to agent settings",
+          "type": "string",
+        },
+      },
+      "required": [
+        "originalQuery",
+        "incorrectResponse",
+        "correctResponse",
+        "category",
+        "confidence",
+        "suggestedInstruction",
+      ],
+      "type": "object",
+    },
+    "name": "improveContext",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "Tool: list_knowledge_documents
+
+Purpose:
+List the knowledge documents that have been curated for this AI agent by the organization. These are short, user-written reference notes (business rules, glossaries, definitions, policies, runbooks, domain background) intended to extend the agent's understanding of the project beyond what the semantic layer and warehouse schema describe.
+
+Each item in the result includes a short summary describing what the document is about. Use that summary to decide whether the full content is worth reading with get_knowledge_document_content.
+
+When to use:
+- At the start of a task, to discover what curated knowledge exists that might be relevant.
+- When the user references a concept that might be defined in business documentation (e.g. "what counts as an active user", "how do we classify a refund").
+- When you need background or policy context that the data warehouse alone cannot provide.
+
+Do NOT use:
+- For data queries — use runQuery / runSql / findFields instead.
+- For schema or table discovery — use findExplores / listWarehouseTables instead.
+
+Parameters:
+- (no parameters)
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: list_knowledge_documents
+
+Purpose:
+List the knowledge documents that have been curated for this AI agent by the organization. These are short, user-written reference notes (business rules, glossaries, definitions, policies, runbooks, domain background) intended to extend the agent's understanding of the project beyond what the semantic layer and warehouse schema describe.
+
+Each item in the result includes a short summary describing what the document is about. Use that summary to decide whether the full content is worth reading with get_knowledge_document_content.
+
+When to use:
+- At the start of a task, to discover what curated knowledge exists that might be relevant.
+- When the user references a concept that might be defined in business documentation (e.g. "what counts as an active user", "how do we classify a refund").
+- When you need background or policy context that the data warehouse alone cannot provide.
+
+Do NOT use:
+- For data queries — use runQuery / runSql / findFields instead.
+- For schema or table discovery — use findExplores / listWarehouseTables instead.
+
+Parameters:
+- (no parameters)
+",
+      "properties": {},
+      "type": "object",
+    },
+    "name": "listKnowledgeDocuments",
+    "outputSchema": null,
+  },
+  {
+    "description": "Tool: list_warehouse_tables
+
+Purpose:
+List physical tables available in the connected data warehouse. Use this BEFORE writing a runSql call when you need to discover the correct schema or table name for a table that isn't already exposed via an explore.
+
+Returns a list of fully-qualified tables (database, schema, table). Results come from a cached metadata catalog, so this is fast and does NOT require user approval.
+
+When to use:
+- You want to write raw SQL and need the qualified table name (database.schema.table) on the first try.
+- You're looking for a raw / staging / seed table that isn't surfaced by findExplores.
+- You're trying to confirm a schema name before writing SQL.
+
+Do NOT use:
+- For column/field discovery — use findFields on the relevant explore instead.
+- To run ad-hoc queries — use runSql.
+
+Parameters:
+- schema: Optional. Filter results to a specific schema name (e.g. "jaffle", "public", "raw").
+- search: Optional. Case-insensitive substring filter on table name (e.g. "work_order").
+- limit: Optional. Maximum number of tables to return. Defaults to 100.
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: list_warehouse_tables
+
+Purpose:
+List physical tables available in the connected data warehouse. Use this BEFORE writing a runSql call when you need to discover the correct schema or table name for a table that isn't already exposed via an explore.
+
+Returns a list of fully-qualified tables (database, schema, table). Results come from a cached metadata catalog, so this is fast and does NOT require user approval.
+
+When to use:
+- You want to write raw SQL and need the qualified table name (database.schema.table) on the first try.
+- You're looking for a raw / staging / seed table that isn't surfaced by findExplores.
+- You're trying to confirm a schema name before writing SQL.
+
+Do NOT use:
+- For column/field discovery — use findFields on the relevant explore instead.
+- To run ad-hoc queries — use runSql.
+
+Parameters:
+- schema: Optional. Filter results to a specific schema name (e.g. "jaffle", "public", "raw").
+- search: Optional. Case-insensitive substring filter on table name (e.g. "work_order").
+- limit: Optional. Maximum number of tables to return. Defaults to 100.
+",
+      "properties": {
+        "limit": {
+          "default": 100,
+          "description": "Maximum number of tables to return (default 100, max 500).",
+          "exclusiveMinimum": 0,
+          "maximum": 500,
+          "type": "integer",
+        },
+        "schema": {
+          "description": "Optional schema name to filter results.",
+          "type": "string",
+        },
+        "search": {
+          "description": "Optional case-insensitive substring filter on table name.",
+          "type": "string",
+        },
+      },
+      "type": "object",
+    },
+    "name": "listWarehouseTables",
+    "outputSchema": null,
+  },
+  {
+    "description": "Load a built-in skill by name, One of it's sub-resources. Always start by loading the skill itself and then load resources on demand",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Load a built-in skill by name, One of it's sub-resources. Always start by loading the skill itself and then load resources on demand",
+      "properties": {
+        "name": {
+          "description": "Exact name of the built-in skill to load.",
+          "minLength": 1,
+          "type": "string",
+        },
+        "resourceName": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string",
+            },
+            {
+              "type": "null",
+            },
+          ],
+          "description": "Optional sub-resource file name to load from the skill. You can find names of sub-resources by first loading the skill without this parameter.",
+        },
+      },
+      "required": [
+        "name",
+        "resourceName",
+      ],
+      "type": "object",
+    },
+    "name": "loadSkill",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "
+Creates a change proposal for tables, metrics, and dimensions. Changes are applied immediately but can be reviewed and rejected afterward.
+
+**Supported Operations:**
+- Update table descriptions and labels
+- Update metric/dimension descriptions and labels
+- Create new metrics
+
+**Technical Requirements:**
+- When updating descriptions or labels, must preserve as much original content as possible
+- Descriptions should maintain their original format (preserve complete value and formatting)
+- Must provide entity table name, rationale, and change details
+- Changes are tracked with proposer information and timestamp
+- For updates: use "replace" operation with complete updated value (not partial)
+- For adding new properties: use "add" operation (creates property if it does not exist)
+- For new metrics: use "create" operation with full metric definition
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "
+Creates a change proposal for tables, metrics, and dimensions. Changes are applied immediately but can be reviewed and rejected afterward.
+
+**Supported Operations:**
+- Update table descriptions and labels
+- Update metric/dimension descriptions and labels
+- Create new metrics
+
+**Technical Requirements:**
+- When updating descriptions or labels, must preserve as much original content as possible
+- Descriptions should maintain their original format (preserve complete value and formatting)
+- Must provide entity table name, rationale, and change details
+- Changes are tracked with proposer information and timestamp
+- For updates: use "replace" operation with complete updated value (not partial)
+- For adding new properties: use "add" operation (creates property if it does not exist)
+- For new metrics: use "create" operation with full metric definition
+",
+      "properties": {
+        "change": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "entityType": {
+                  "const": "table",
+                  "type": "string",
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "patch": {
+                          "additionalProperties": false,
+                          "description": "Patch to apply to the table. You can omit/set-to-null any fields you don't want to change.",
+                          "properties": {
+                            "description": {
+                              "anyOf": [
+                                {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "description": "Replace (overwrite) the value of the field.
+Updates the **entire** value of the field to reflect the necessary changes, replacing the current value entirely.
+Even if only the part is being changed, make sure to pass the entire value with changes included so that no part is lost.",
+                                      "properties": {
+                                        "op": {
+                                          "const": "replace",
+                                          "type": "string",
+                                        },
+                                        "value": {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "op",
+                                        "value",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "description": "Add a new value to the field. (Creates a new property if it does not exist)",
+                                      "properties": {
+                                        "op": {
+                                          "const": "add",
+                                          "type": "string",
+                                        },
+                                        "value": {
+                                          "$ref": "#/properties/change/anyOf/0/properties/value/anyOf/0/properties/patch/properties/description/anyOf/0/anyOf/0/properties/value",
+                                        },
+                                      },
+                                      "required": [
+                                        "op",
+                                        "value",
+                                      ],
+                                      "type": "object",
+                                    },
+                                  ],
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                            "label": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/properties/change/anyOf/0/properties/value/anyOf/0/properties/patch/properties/description/anyOf/0",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                          },
+                          "required": [
+                            "description",
+                            "label",
+                          ],
+                          "type": "object",
+                        },
+                        "type": {
+                          "const": "update",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "type",
+                        "patch",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+              "required": [
+                "entityType",
+                "value",
+              ],
+              "type": "object",
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "entityType": {
+                  "const": "dimension",
+                  "type": "string",
+                },
+                "fieldId": {
+                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "patch": {
+                          "additionalProperties": false,
+                          "description": "Patch to apply to the dimension. You can omit/set-to-null any fields you don't want to change.",
+                          "properties": {
+                            "description": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/properties/change/anyOf/0/properties/value/anyOf/0/properties/patch/properties/description/anyOf/0",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                            "label": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/properties/change/anyOf/0/properties/value/anyOf/0/properties/patch/properties/description/anyOf/0",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                          },
+                          "required": [
+                            "label",
+                            "description",
+                          ],
+                          "type": "object",
+                        },
+                        "type": {
+                          "const": "update",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "type",
+                        "patch",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+              "required": [
+                "entityType",
+                "fieldId",
+                "value",
+              ],
+              "type": "object",
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "entityType": {
+                  "const": "metric",
+                  "type": "string",
+                },
+                "fieldId": {
+                  "description": "if you are creating a new metric, this is the field id of the new metric not the dimension id "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "const": "create",
+                          "type": "string",
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "description": "Create a new metric",
+                              "properties": {
+                                "entityType": {
+                                  "const": "metric",
+                                  "type": "string",
+                                },
+                                "metric": {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "baseDimensionName": {
+                                          "description": "Name of the base dimension/column this metric calculates from",
+                                          "type": "string",
+                                        },
+                                        "description": {
+                                          "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                                          "type": "string",
+                                        },
+                                        "filters": {
+                                          "anyOf": [
+                                            {
+                                              "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "filter": {
+                                                    "anyOf": [
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "const": "boolean",
+                                                                "type": "string",
+                                                              },
+                                                              "fieldId": {
+                                                                "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                                "type": "string",
+                                                              },
+                                                              "fieldType": {
+                                                                "enum": [
+                                                                  "boolean",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "isNull",
+                                                                  "notNull",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
+                                                              },
+                                                              "fieldId": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldId",
+                                                              },
+                                                              "fieldType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldType",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "equals",
+                                                                  "notEquals",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "values": {
+                                                                "items": {
+                                                                  "type": "boolean",
+                                                                },
+                                                                "maxItems": 1,
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                              "values",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                        ],
+                                                      },
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "const": "string",
+                                                                "type": "string",
+                                                              },
+                                                              "fieldId": {
+                                                                "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                                "type": "string",
+                                                              },
+                                                              "fieldType": {
+                                                                "enum": [
+                                                                  "string",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "isNull",
+                                                                  "notNull",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
+                                                              },
+                                                              "fieldId": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldId",
+                                                              },
+                                                              "fieldType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldType",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "equals",
+                                                                  "notEquals",
+                                                                  "startsWith",
+                                                                  "endsWith",
+                                                                  "include",
+                                                                  "doesNotInclude",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "values": {
+                                                                "items": {
+                                                                  "type": "string",
+                                                                },
+                                                                "type": "array",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                              "values",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                        ],
+                                                      },
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "const": "number",
+                                                                "type": "string",
+                                                              },
+                                                              "fieldId": {
+                                                                "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                                "type": "string",
+                                                              },
+                                                              "fieldType": {
+                                                                "enum": [
+                                                                  "number",
+                                                                  "percentile",
+                                                                  "median",
+                                                                  "average",
+                                                                  "count",
+                                                                  "count_distinct",
+                                                                  "sum",
+                                                                  "sum_distinct",
+                                                                  "average_distinct",
+                                                                  "min",
+                                                                  "max",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "isNull",
+                                                                  "notNull",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                              },
+                                                              "fieldId": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                              },
+                                                              "fieldType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "equals",
+                                                                  "notEquals",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "values": {
+                                                                "items": {
+                                                                  "type": "number",
+                                                                },
+                                                                "type": "array",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                              "values",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                              },
+                                                              "fieldId": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                              },
+                                                              "fieldType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "lessThan",
+                                                                  "lessThanOrEqual",
+                                                                  "greaterThan",
+                                                                  "greaterThanOrEqual",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "values": {
+                                                                "items": {
+                                                                  "type": "number",
+                                                                },
+                                                                "maxItems": 1,
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                              "values",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                              },
+                                                              "fieldId": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                              },
+                                                              "fieldType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "inBetween",
+                                                                  "notInBetween",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "values": {
+                                                                "items": {
+                                                                  "type": "number",
+                                                                },
+                                                                "maxItems": 2,
+                                                                "minItems": 2,
+                                                                "type": "array",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                              "values",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                        ],
+                                                      },
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "const": "date",
+                                                                "type": "string",
+                                                              },
+                                                              "fieldId": {
+                                                                "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                                "type": "string",
+                                                              },
+                                                              "fieldType": {
+                                                                "enum": [
+                                                                  "date",
+                                                                  "timestamp",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "isNull",
+                                                                  "notNull",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                              },
+                                                              "fieldId": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                              },
+                                                              "fieldType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "equals",
+                                                                  "notEquals",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "values": {
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "format": "date",
+                                                                      "type": "string",
+                                                                    },
+                                                                    {
+                                                                      "format": "date-time",
+                                                                      "type": "string",
+                                                                    },
+                                                                  ],
+                                                                },
+                                                                "type": "array",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                              "values",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                              },
+                                                              "fieldId": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                              },
+                                                              "fieldType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "inThePast",
+                                                                  "notInThePast",
+                                                                  "inTheNext",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "settings": {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                  "completed": {
+                                                                    "type": "boolean",
+                                                                  },
+                                                                  "unitOfTime": {
+                                                                    "enum": [
+                                                                      "days",
+                                                                      "weeks",
+                                                                      "months",
+                                                                      "quarters",
+                                                                      "years",
+                                                                    ],
+                                                                    "type": "string",
+                                                                  },
+                                                                },
+                                                                "required": [
+                                                                  "completed",
+                                                                  "unitOfTime",
+                                                                ],
+                                                                "type": "object",
+                                                              },
+                                                              "values": {
+                                                                "items": {
+                                                                  "type": "number",
+                                                                },
+                                                                "maxItems": 1,
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                              "values",
+                                                              "settings",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                              },
+                                                              "fieldId": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                              },
+                                                              "fieldType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "inTheCurrent",
+                                                                  "notInTheCurrent",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "settings": {
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                  "completed": {
+                                                                    "const": false,
+                                                                    "type": "boolean",
+                                                                  },
+                                                                  "unitOfTime": {
+                                                                    "enum": [
+                                                                      "days",
+                                                                      "weeks",
+                                                                      "months",
+                                                                      "quarters",
+                                                                      "years",
+                                                                    ],
+                                                                    "type": "string",
+                                                                  },
+                                                                },
+                                                                "required": [
+                                                                  "completed",
+                                                                  "unitOfTime",
+                                                                ],
+                                                                "type": "object",
+                                                              },
+                                                              "values": {
+                                                                "items": {
+                                                                  "const": 1,
+                                                                  "type": "number",
+                                                                },
+                                                                "maxItems": 1,
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                              "values",
+                                                              "settings",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                              },
+                                                              "fieldId": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                              },
+                                                              "fieldType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                              },
+                                                              "operator": {
+                                                                "enum": [
+                                                                  "lessThan",
+                                                                  "lessThanOrEqual",
+                                                                  "greaterThan",
+                                                                  "greaterThanOrEqual",
+                                                                ],
+                                                                "type": "string",
+                                                              },
+                                                              "values": {
+                                                                "items": {
+                                                                  "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                                                },
+                                                                "maxItems": 1,
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                              "values",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                          {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                              "fieldFilterType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                              },
+                                                              "fieldId": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                              },
+                                                              "fieldType": {
+                                                                "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                              },
+                                                              "operator": {
+                                                                "const": "inBetween",
+                                                                "type": "string",
+                                                              },
+                                                              "values": {
+                                                                "items": {
+                                                                  "$ref": "#/properties/change/anyOf/2/properties/value/anyOf/0/properties/value/anyOf/0/properties/metric/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                                                },
+                                                                "maxItems": 2,
+                                                                "minItems": 2,
+                                                                "type": "array",
+                                                              },
+                                                            },
+                                                            "required": [
+                                                              "fieldId",
+                                                              "fieldType",
+                                                              "fieldFilterType",
+                                                              "operator",
+                                                              "values",
+                                                            ],
+                                                            "type": "object",
+                                                          },
+                                                        ],
+                                                      },
+                                                    ],
+                                                  },
+                                                  "table": {
+                                                    "description": "Table name this filter field belongs to",
+                                                    "type": "string",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "filter",
+                                                  "table",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              "type": "array",
+                                            },
+                                            {
+                                              "type": "null",
+                                            },
+                                          ],
+                                          "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name.",
+                                        },
+                                        "kind": {
+                                          "const": "aggregation",
+                                          "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                                          "type": "string",
+                                        },
+                                        "label": {
+                                          "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                                          "type": "string",
+                                        },
+                                        "name": {
+                                          "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                                          "type": "string",
+                                        },
+                                        "table": {
+                                          "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                                          "type": "string",
+                                        },
+                                        "type": {
+                                          "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                                          "enum": [
+                                            "average",
+                                            "count",
+                                            "count_distinct",
+                                            "max",
+                                            "min",
+                                            "sum",
+                                            "percentile",
+                                            "median",
+                                          ],
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "name",
+                                        "label",
+                                        "description",
+                                        "baseDimensionName",
+                                        "table",
+                                        "type",
+                                        "filters",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "baseMetricId": {
+                                          "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                                          "type": "string",
+                                        },
+                                        "granularity": {
+                                          "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                                          "enum": [
+                                            "DAY",
+                                            "WEEK",
+                                            "MONTH",
+                                            "QUARTER",
+                                            "YEAR",
+                                          ],
+                                          "type": "string",
+                                        },
+                                        "kind": {
+                                          "const": "periodComparison",
+                                          "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                                          "type": "string",
+                                        },
+                                        "periodOffset": {
+                                          "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                                          "minimum": 1,
+                                          "type": "integer",
+                                        },
+                                        "timeDimensionId": {
+                                          "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "baseMetricId",
+                                        "timeDimensionId",
+                                        "granularity",
+                                        "periodOffset",
+                                      ],
+                                      "type": "object",
+                                    },
+                                  ],
+                                },
+                              },
+                              "required": [
+                                "entityType",
+                                "metric",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                      },
+                      "required": [
+                        "type",
+                        "value",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "patch": {
+                          "additionalProperties": false,
+                          "description": "Patch to apply to the metric. You can omit/set-to-null any fields you don't want to change.",
+                          "properties": {
+                            "description": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/properties/change/anyOf/0/properties/value/anyOf/0/properties/patch/properties/description/anyOf/0",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                            "label": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/properties/change/anyOf/0/properties/value/anyOf/0/properties/patch/properties/description/anyOf/0",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                          },
+                          "required": [
+                            "label",
+                            "description",
+                          ],
+                          "type": "object",
+                        },
+                        "type": {
+                          "const": "update",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "type",
+                        "patch",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+              "required": [
+                "entityType",
+                "fieldId",
+                "value",
+              ],
+              "type": "object",
+            },
+          ],
+        },
+        "entityTableName": {
+          "description": "The name of the table/explore being modified",
+          "type": "string",
+        },
+        "rationale": {
+          "description": "Brief explanation of why this change is being proposed and what it improves",
+          "type": "string",
+        },
+      },
+      "required": [
+        "entityTableName",
+        "rationale",
+        "change",
+      ],
+      "type": "object",
+    },
+    "name": "proposeChange",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "changeUuid": {
+                  "type": "string",
+                },
+                "status": {
+                  "const": "success",
+                  "type": "string",
+                },
+                "userFeedback": {
+                  "default": "accepted",
+                  "enum": [
+                    "accepted",
+                    "rejected",
+                  ],
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+                "changeUuid",
+              ],
+              "type": "object",
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "const": "error",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+              ],
+              "type": "object",
+            },
+          ],
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "Read a dashboard or chart as JSON using its slug. Call this before editing.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Read a dashboard or chart as JSON using its slug. Call this before editing.",
+      "properties": {
+        "slug": {
+          "description": "Slug of the dashboard or chart to read.",
+          "minLength": 1,
+          "type": "string",
+        },
+        "type": {
+          "description": "Type of Lightdash content to read.",
+          "enum": [
+            "dashboard",
+            "chart",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "slug",
+        "type",
+      ],
+      "type": "object",
+    },
+    "name": "readContent",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "Tool: runQuery
+
+Purpose:
+Execute a metric query and create a chart artifact. The results can be viewed as a table, bar, horizontal bar, line, scatter, pie, or funnel chart.
+You define the default visualization type to render but users can switch between visualization types after creation.
+
+Chart Type Selection Guide:
+- 'bar': Vertical bars for categorical comparisons (e.g., sales by product)
+- 'horizontal': Horizontal bars for long category names or ranking (e.g., top 10 customers)
+- 'line': Time series trends (e.g., revenue over months)
+- 'scatter': Correlation between two metrics (e.g., ad spend vs revenue)
+- 'pie': Part-to-whole proportions (e.g., market share by segment)
+- 'funnel': Sequential conversion flows (e.g., sales funnel stages)
+- 'table': Raw data display with all fields
+
+Configuration Tips:
+- Specify exploreName, dimensions (for grouping/x-axis), and metrics (for y-axis values)
+- First dimension is the x-axis; additional dimensions can be used for series breakdown via groupBy
+- At least one metric is required for all chart types except table
+- chartConfig.xAxisDimension: Select the primary dimension from queryConfig.dimensions (typically dimensions[0])
+- chartConfig.yAxisMetrics: Select the metrics to display from queryConfig.metrics or tableCalculations
+- chartConfig.groupBy: Use to split data into multiple series along a CATEGORICAL dimension (e.g., one line per region, one bar per product). Do NOT include the x-axis dimension. Do NOT use to split along a time dimension to simulate a period comparison — use a kind: "periodComparison" customMetric for that. Leave null for simple single-series charts.
+- For bar/horizontal charts: use xAxisType 'category' for strings or 'time' for dates/timestamps
+- For bar/horizontal charts: stackBars (when groupBy is provided) stacks bars instead of placing them side by side
+- For line charts: use lineType 'area' to fill the area under the line
+- For scatter charts: each point represents one row of data
+- For funnel charts: set funnelDataInput to 'row' (each row = stage) or 'column' (multiple funnels)
+- Users can switch between visualization types in the UI after creation
+- xAxisLabel and yAxisLabel provide helpful context for chart axes
+- filters can contain filters on fields from joined tables as well as the base table
+- For time-based comparisons (year-over-year, month-over-month, vs N periods ago), add a kind: "periodComparison" entry to customMetrics. Required ingredients: the time dimension in queryConfig.dimensions, the base metric in queryConfig.metrics, and the periodComparison custom metric pointing at both. Do NOT add a second time-dimension granularity (e.g. _year) and use groupBy — that produces a dimensional split, not a real period comparison.
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: runQuery
+
+Purpose:
+Execute a metric query and create a chart artifact. The results can be viewed as a table, bar, horizontal bar, line, scatter, pie, or funnel chart.
+You define the default visualization type to render but users can switch between visualization types after creation.
+
+Chart Type Selection Guide:
+- 'bar': Vertical bars for categorical comparisons (e.g., sales by product)
+- 'horizontal': Horizontal bars for long category names or ranking (e.g., top 10 customers)
+- 'line': Time series trends (e.g., revenue over months)
+- 'scatter': Correlation between two metrics (e.g., ad spend vs revenue)
+- 'pie': Part-to-whole proportions (e.g., market share by segment)
+- 'funnel': Sequential conversion flows (e.g., sales funnel stages)
+- 'table': Raw data display with all fields
+
+Configuration Tips:
+- Specify exploreName, dimensions (for grouping/x-axis), and metrics (for y-axis values)
+- First dimension is the x-axis; additional dimensions can be used for series breakdown via groupBy
+- At least one metric is required for all chart types except table
+- chartConfig.xAxisDimension: Select the primary dimension from queryConfig.dimensions (typically dimensions[0])
+- chartConfig.yAxisMetrics: Select the metrics to display from queryConfig.metrics or tableCalculations
+- chartConfig.groupBy: Use to split data into multiple series along a CATEGORICAL dimension (e.g., one line per region, one bar per product). Do NOT include the x-axis dimension. Do NOT use to split along a time dimension to simulate a period comparison — use a kind: "periodComparison" customMetric for that. Leave null for simple single-series charts.
+- For bar/horizontal charts: use xAxisType 'category' for strings or 'time' for dates/timestamps
+- For bar/horizontal charts: stackBars (when groupBy is provided) stacks bars instead of placing them side by side
+- For line charts: use lineType 'area' to fill the area under the line
+- For scatter charts: each point represents one row of data
+- For funnel charts: set funnelDataInput to 'row' (each row = stage) or 'column' (multiple funnels)
+- Users can switch between visualization types in the UI after creation
+- xAxisLabel and yAxisLabel provide helpful context for chart axes
+- filters can contain filters on fields from joined tables as well as the base table
+- For time-based comparisons (year-over-year, month-over-month, vs N periods ago), add a kind: "periodComparison" entry to customMetrics. Required ingredients: the time dimension in queryConfig.dimensions, the base metric in queryConfig.metrics, and the periodComparison custom metric pointing at both. Do NOT add a second time-dimension granularity (e.g. _year) and use groupBy — that produces a dimensional split, not a real period comparison.
+",
+      "properties": {
+        "chartConfig": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "defaultVizType": {
+                  "description": "The default visualization type to render",
+                  "enum": [
+                    "table",
+                    "bar",
+                    "horizontal",
+                    "line",
+                    "scatter",
+                    "pie",
+                    "funnel",
+                  ],
+                  "type": "string",
+                },
+                "funnelDataInput": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "row",
+                        "column",
+                      ],
+                      "type": "string",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                  "description": "How to interpret funnel data. Use "row" when each row represents a funnel stage (most common). Use "column" when comparing multiple funnels side-by-side.",
+                },
+                "groupBy": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                  "description": "Dimensions to split metrics into separate series (e.g., one line per region, one bar per status). IMPORTANT: Do NOT include the x-axis dimension in groupBy - only include dimensions you want to use for breaking down the data into multiple series. Example: dimensions=["order_date", "status"], groupBy=["status"] creates separate series for each status value. Leave null for simple single-series charts.",
+                },
+                "lineType": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "line",
+                        "area",
+                      ],
+                      "type": "string",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                  "description": "default line. The type of line to display. If area then the area under the line will be filled in.",
+                },
+                "secondaryYAxisLabel": {
+                  "description": "A helpful label for the secondary y-axis",
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "secondaryYAxisMetric": {
+                  "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "stackBars": {
+                  "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.",
+                  "type": [
+                    "boolean",
+                    "null",
+                  ],
+                },
+                "xAxisDimension": {
+                  "description": "The dimension field ID to use for the x-axis. Must be included in queryConfig.dimensions",
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "xAxisLabel": {
+                  "description": "A helpful label to explain the x-axis",
+                  "type": "string",
+                },
+                "xAxisType": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "category",
+                        "time",
+                      ],
+                      "type": "string",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                  "description": "The x-axis type can be categorical for string value or time if the dimension is a date or timestamp. Applies to bar, horizontal, and scatter charts.",
+                },
+                "yAxisLabel": {
+                  "description": "A helpful label to explain the y-axis",
+                  "type": "string",
+                },
+                "yAxisMetrics": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                  "description": "The metric field IDs to display on the y-axis. Must be included in queryConfig.metrics or come from tableCalculations",
+                },
+              },
+              "required": [
+                "defaultVizType",
+                "xAxisDimension",
+                "yAxisMetrics",
+                "groupBy",
+                "xAxisType",
+                "stackBars",
+                "lineType",
+                "funnelDataInput",
+                "xAxisLabel",
+                "yAxisLabel",
+                "secondaryYAxisMetric",
+                "secondaryYAxisLabel",
+              ],
+              "type": "object",
+            },
+            {
+              "type": "null",
+            },
+          ],
+        },
+        "customMetrics": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "baseDimensionName": {
+                        "description": "Name of the base dimension/column this metric calculates from",
+                        "type": "string",
+                      },
+                      "description": {
+                        "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                        "type": "string",
+                      },
+                      "filters": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "filter": {
+                                  "anyOf": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "const": "boolean",
+                                              "type": "string",
+                                            },
+                                            "fieldId": {
+                                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                              "type": "string",
+                                            },
+                                            "fieldType": {
+                                              "enum": [
+                                                "boolean",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "isNull",
+                                                "notNull",
+                                              ],
+                                              "type": "string",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
+                                            },
+                                            "fieldId": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldId",
+                                            },
+                                            "fieldType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldType",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "equals",
+                                                "notEquals",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "boolean",
+                                              },
+                                              "maxItems": 1,
+                                              "minItems": 1,
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                            "values",
+                                          ],
+                                          "type": "object",
+                                        },
+                                      ],
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "const": "string",
+                                              "type": "string",
+                                            },
+                                            "fieldId": {
+                                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                              "type": "string",
+                                            },
+                                            "fieldType": {
+                                              "enum": [
+                                                "string",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "isNull",
+                                                "notNull",
+                                              ],
+                                              "type": "string",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
+                                            },
+                                            "fieldId": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldId",
+                                            },
+                                            "fieldType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldType",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "equals",
+                                                "notEquals",
+                                                "startsWith",
+                                                "endsWith",
+                                                "include",
+                                                "doesNotInclude",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string",
+                                              },
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                            "values",
+                                          ],
+                                          "type": "object",
+                                        },
+                                      ],
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "const": "number",
+                                              "type": "string",
+                                            },
+                                            "fieldId": {
+                                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                              "type": "string",
+                                            },
+                                            "fieldType": {
+                                              "enum": [
+                                                "number",
+                                                "percentile",
+                                                "median",
+                                                "average",
+                                                "count",
+                                                "count_distinct",
+                                                "sum",
+                                                "sum_distinct",
+                                                "average_distinct",
+                                                "min",
+                                                "max",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "isNull",
+                                                "notNull",
+                                              ],
+                                              "type": "string",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                            },
+                                            "fieldId": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                            },
+                                            "fieldType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "equals",
+                                                "notEquals",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "number",
+                                              },
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                            "values",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                            },
+                                            "fieldId": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                            },
+                                            "fieldType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "lessThan",
+                                                "lessThanOrEqual",
+                                                "greaterThan",
+                                                "greaterThanOrEqual",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "number",
+                                              },
+                                              "maxItems": 1,
+                                              "minItems": 1,
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                            "values",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                            },
+                                            "fieldId": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                            },
+                                            "fieldType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "inBetween",
+                                                "notInBetween",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "number",
+                                              },
+                                              "maxItems": 2,
+                                              "minItems": 2,
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                            "values",
+                                          ],
+                                          "type": "object",
+                                        },
+                                      ],
+                                    },
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "const": "date",
+                                              "type": "string",
+                                            },
+                                            "fieldId": {
+                                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                              "type": "string",
+                                            },
+                                            "fieldType": {
+                                              "enum": [
+                                                "date",
+                                                "timestamp",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "isNull",
+                                                "notNull",
+                                              ],
+                                              "type": "string",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                            },
+                                            "fieldId": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                            },
+                                            "fieldType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "equals",
+                                                "notEquals",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "format": "date",
+                                                    "type": "string",
+                                                  },
+                                                  {
+                                                    "format": "date-time",
+                                                    "type": "string",
+                                                  },
+                                                ],
+                                              },
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                            "values",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                            },
+                                            "fieldId": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                            },
+                                            "fieldType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "inThePast",
+                                                "notInThePast",
+                                                "inTheNext",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "settings": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "completed": {
+                                                  "type": "boolean",
+                                                },
+                                                "unitOfTime": {
+                                                  "enum": [
+                                                    "days",
+                                                    "weeks",
+                                                    "months",
+                                                    "quarters",
+                                                    "years",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "completed",
+                                                "unitOfTime",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "number",
+                                              },
+                                              "maxItems": 1,
+                                              "minItems": 1,
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                            "values",
+                                            "settings",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                            },
+                                            "fieldId": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                            },
+                                            "fieldType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "inTheCurrent",
+                                                "notInTheCurrent",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "settings": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "completed": {
+                                                  "const": false,
+                                                  "type": "boolean",
+                                                },
+                                                "unitOfTime": {
+                                                  "enum": [
+                                                    "days",
+                                                    "weeks",
+                                                    "months",
+                                                    "quarters",
+                                                    "years",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "completed",
+                                                "unitOfTime",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "const": 1,
+                                                "type": "number",
+                                              },
+                                              "maxItems": 1,
+                                              "minItems": 1,
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                            "values",
+                                            "settings",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                            },
+                                            "fieldId": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                            },
+                                            "fieldType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                            },
+                                            "operator": {
+                                              "enum": [
+                                                "lessThan",
+                                                "lessThanOrEqual",
+                                                "greaterThan",
+                                                "greaterThanOrEqual",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                              },
+                                              "maxItems": 1,
+                                              "minItems": 1,
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                            "values",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "fieldFilterType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                            },
+                                            "fieldId": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                            },
+                                            "fieldType": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                            },
+                                            "operator": {
+                                              "const": "inBetween",
+                                              "type": "string",
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                              },
+                                              "maxItems": 2,
+                                              "minItems": 2,
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "fieldId",
+                                            "fieldType",
+                                            "fieldFilterType",
+                                            "operator",
+                                            "values",
+                                          ],
+                                          "type": "object",
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                                "table": {
+                                  "description": "Table name this filter field belongs to",
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "filter",
+                                "table",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name.",
+                      },
+                      "kind": {
+                        "const": "aggregation",
+                        "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                        "type": "string",
+                      },
+                      "label": {
+                        "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                        "type": "string",
+                      },
+                      "name": {
+                        "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                        "type": "string",
+                      },
+                      "table": {
+                        "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                        "type": "string",
+                      },
+                      "type": {
+                        "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                        "enum": [
+                          "average",
+                          "count",
+                          "count_distinct",
+                          "max",
+                          "min",
+                          "sum",
+                          "percentile",
+                          "median",
+                        ],
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "kind",
+                      "name",
+                      "label",
+                      "description",
+                      "baseDimensionName",
+                      "table",
+                      "type",
+                      "filters",
+                    ],
+                    "type": "object",
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "baseMetricId": {
+                        "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                        "type": "string",
+                      },
+                      "granularity": {
+                        "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                        "enum": [
+                          "DAY",
+                          "WEEK",
+                          "MONTH",
+                          "QUARTER",
+                          "YEAR",
+                        ],
+                        "type": "string",
+                      },
+                      "kind": {
+                        "const": "periodComparison",
+                        "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                        "type": "string",
+                      },
+                      "periodOffset": {
+                        "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                        "minimum": 1,
+                        "type": "integer",
+                      },
+                      "timeDimensionId": {
+                        "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "kind",
+                      "baseMetricId",
+                      "timeDimensionId",
+                      "granularity",
+                      "periodOffset",
+                    ],
+                    "type": "object",
+                  },
+                ],
+              },
+              "type": "array",
+            },
+            {
+              "type": "null",
+            },
+          ],
+          "description": "Define new metric columns the explore doesn't already have. Two kinds:
+
+(1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
+    (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
+    Use when the requested metric doesn't exist in the explore.
+
+(2) kind: "periodComparison" — a column that is an EXISTING metric shifted
+    back in time. Use whenever the user asks for "year-over-year",
+    "month-over-month", "vs last quarter", "compare to previous period",
+    "N periods ago".
+
+For period comparisons, every successful chart has three things:
+- The time dimension in queryConfig.dimensions
+- The base metric in queryConfig.metrics
+- A customMetric of kind "periodComparison" pointing at that base metric and time dimension
+
+The server generates the comparison column automatically and appends it next to the base metric. Do NOT add the comparison column id to queryConfig.metrics yourself.
+
+DO NOT simulate a period comparison by adding a second time-dimension granularity (e.g. _year) and using groupBy. groupBy is for categorical splits (region, product). Time comparisons use a kind: "periodComparison" customMetric.
+
+For aggregation entries:
+1. Add the entry to customMetrics with kind: "aggregation"
+2. Reference it in queryConfig.metrics using the format "table_name" (e.g. "customers_avg_customer_age")
+3. Reference it the same way in sorts, filters, chartConfig.yAxisMetrics
+
+Example A — "Average customer age sorted descending"
+  customMetrics: [{ kind: "aggregation", name: "avg_customer_age", label: "Average Customer Age", description: "...", type: "AVERAGE", baseDimensionName: "age", table: "customers", filters: null }]
+  queryConfig.metrics: ["customers_avg_customer_age"]
+  sorts: [{ fieldId: "customers_avg_customer_age", descending: true }]
+
+Example B — "Revenue by month with year-over-year comparison"
+  queryConfig.dimensions: ["orders_order_date_month"]
+  queryConfig.metrics: ["orders_revenue"]
+  customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }]",
+        },
+        "description": {
+          "description": "A descriptive summary or explanation for the chart.",
+          "type": "string",
+        },
+        "filters": {
+          "anyOf": [
+            {
+              "$ref": "#/properties/queryConfig/properties/filters",
+            },
+            {
+              "type": "null",
+            },
+          ],
+        },
+        "queryConfig": {
+          "additionalProperties": false,
+          "properties": {
+            "dimensions": {
+              "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
+              "items": {
+                "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "exploreName": {
+              "description": "The name of the explore containing the metrics and dimensions used for the chart.",
+              "type": "string",
+            },
+            "filters": {
+              "additionalProperties": false,
+              "properties": {
+                "dimensions": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0",
+                          },
+                          {
+                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1",
+                          },
+                          {
+                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
+                          },
+                          {
+                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3",
+                          },
+                        ],
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                },
+                "metrics": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "$ref": "#/properties/queryConfig/properties/filters/properties/dimensions/anyOf/0/items",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                },
+                "tableCalculations": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                },
+                "type": {
+                  "description": "Type of filter group operation",
+                  "enum": [
+                    "and",
+                    "or",
+                  ],
+                  "type": "string",
+                },
+              },
+              "required": [
+                "type",
+                "dimensions",
+                "metrics",
+                "tableCalculations",
+              ],
+              "type": "object",
+            },
+            "limit": {
+              "description": "The total number of data points / rows allowed on the chart.",
+              "type": [
+                "number",
+                "null",
+              ],
+            },
+            "metrics": {
+              "description": "The field ids of the metrics to be calculated. They will be grouped by the dimensions.",
+              "items": {
+                "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "sorts": {
+              "description": "Sort configuration for the query, it can use a combination of metrics and dimensions.",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "descending": {
+                    "description": "If true sorts in descending order, if false sorts in ascending order",
+                    "type": "boolean",
+                  },
+                  "fieldId": {
+                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                    "type": "string",
+                  },
+                  "nullsFirst": {
+                    "description": "If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default",
+                    "type": [
+                      "boolean",
+                      "null",
+                    ],
+                  },
+                },
+                "required": [
+                  "fieldId",
+                  "descending",
+                  "nullsFirst",
+                ],
+                "type": "object",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "exploreName",
+            "dimensions",
+            "metrics",
+            "sorts",
+            "limit",
+          ],
+          "type": "object",
+        },
+        "tableCalculations": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "displayName": {
+                        "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                        "type": "string",
+                      },
+                      "fieldId": {
+                        "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "name": {
+                        "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                        "type": "string",
+                      },
+                      "orderBy": {
+                        "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldId": {
+                              "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "order": {
+                              "anyOf": [
+                                {
+                                  "enum": [
+                                    "asc",
+                                    "desc",
+                                  ],
+                                  "type": "string",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "order",
+                          ],
+                          "type": "object",
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                      },
+                      "partitionBy": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                      },
+                      "type": {
+                        "const": "percent_change_from_previous",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "displayName",
+                      "type",
+                      "fieldId",
+                      "orderBy",
+                      "partitionBy",
+                    ],
+                    "type": "object",
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "displayName": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                      },
+                      "fieldId": {
+                        "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "name": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                      },
+                      "orderBy": {
+                        "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                        "items": {
+                          "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                      },
+                      "partitionBy": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                      },
+                      "type": {
+                        "const": "percent_of_previous_value",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "displayName",
+                      "type",
+                      "fieldId",
+                      "orderBy",
+                      "partitionBy",
+                    ],
+                    "type": "object",
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "displayName": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                      },
+                      "fieldId": {
+                        "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "name": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                      },
+                      "partitionBy": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                      },
+                      "type": {
+                        "const": "percent_of_column_total",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "displayName",
+                      "type",
+                      "fieldId",
+                      "partitionBy",
+                    ],
+                    "type": "object",
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "displayName": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                      },
+                      "fieldId": {
+                        "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "name": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                      },
+                      "type": {
+                        "const": "rank_in_column",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "displayName",
+                      "type",
+                      "fieldId",
+                    ],
+                    "type": "object",
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "displayName": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                      },
+                      "fieldId": {
+                        "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "name": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                      },
+                      "type": {
+                        "const": "running_total",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "displayName",
+                      "type",
+                      "fieldId",
+                    ],
+                    "type": "object",
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "displayName": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                      },
+                      "fieldId": {
+                        "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": [
+                          "string",
+                          "null",
+                        ],
+                      },
+                      "frame": {
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "end": {
+                                "additionalProperties": false,
+                                "description": "End boundary (required)",
+                                "properties": {
+                                  "offset": {
+                                    "anyOf": [
+                                      {
+                                        "exclusiveMinimum": 0,
+                                        "type": "integer",
+                                      },
+                                      {
+                                        "type": "null",
+                                      },
+                                    ],
+                                    "description": "Number of rows for PRECEDING/FOLLOWING",
+                                  },
+                                  "type": {
+                                    "enum": [
+                                      "unbounded_preceding",
+                                      "preceding",
+                                      "current_row",
+                                      "following",
+                                      "unbounded_following",
+                                    ],
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "type",
+                                  "offset",
+                                ],
+                                "type": "object",
+                              },
+                              "frameType": {
+                                "description": "Frame type:
+- rows: Physical row count
+- range: Logical value-based (includes peer rows with same ORDER BY value)",
+                                "enum": [
+                                  "rows",
+                                  "range",
+                                ],
+                                "type": "string",
+                              },
+                              "start": {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "offset": {
+                                        "anyOf": [
+                                          {
+                                            "exclusiveMinimum": 0,
+                                            "type": "integer",
+                                          },
+                                          {
+                                            "type": "null",
+                                          },
+                                        ],
+                                        "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING")",
+                                      },
+                                      "type": {
+                                        "enum": [
+                                          "unbounded_preceding",
+                                          "preceding",
+                                          "current_row",
+                                          "following",
+                                          "unbounded_following",
+                                        ],
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                      "offset",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "type": "null",
+                                  },
+                                ],
+                                "description": "Start boundary. Null for single-boundary syntax.",
+                              },
+                            },
+                            "required": [
+                              "frameType",
+                              "start",
+                              "end",
+                            ],
+                            "type": "object",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "Defines which rows to include in calculation. Null uses database defaults.
+
+**Common patterns:**
+- Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
+- Running total: {frameType: "rows", start: {type: "unbounded_preceding"}, end: {type: "current_row"}}
+- Centered window: {frameType: "rows", start: {type: "preceding", offset: 1}, end: {type: "following", offset: 1}}
+
+**Default when null:**
+- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
+- Aggregates WITHOUT ORDER BY: Entire partition (all rows)
+- Ranking functions: Always use entire partition (frame clause has no effect)",
+                      },
+                      "name": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                      },
+                      "orderBy": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                      },
+                      "partitionBy": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                      },
+                      "type": {
+                        "const": "window_function",
+                        "type": "string",
+                      },
+                      "windowFunction": {
+                        "description": "Type of window function to apply.
+
+**Ranking functions** (fieldId optional, ignored if provided):
+- row_number: Sequential numbering (1, 2, 3...)
+- percent_rank: Relative rank as percentage (0.0-1.0)
+- cume_dist: Cumulative distribution as percentage (0.0-1.0)
+- rank: Positional rank (1, 2, 3...) with ties
+
+**Aggregate functions** (fieldId required):
+- sum: Sum values within frame
+- avg: Average values within frame
+- count: Count values within frame
+- min: Minimum value within frame
+- max: Maximum value within frame",
+                        "enum": [
+                          "row_number",
+                          "percent_rank",
+                          "cume_dist",
+                          "rank",
+                          "sum",
+                          "avg",
+                          "count",
+                          "min",
+                          "max",
+                        ],
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "displayName",
+                      "type",
+                      "windowFunction",
+                      "fieldId",
+                      "orderBy",
+                      "partitionBy",
+                      "frame",
+                    ],
+                    "type": "object",
+                  },
+                ],
+              },
+              "type": "array",
+            },
+            {
+              "type": "null",
+            },
+          ],
+          "description": "
+Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
+
+**Available Types:**
+- Simple calculations: percent_change_from_previous, percent_of_previous_value, percent_of_column_total, rank_in_column, running_total
+- Advanced window_function: Supports row_number, percent_rank, sum, avg, count, min, max with optional partitioning, ordering, and frame clauses
+
+**Technical Requirements:**
+- Appear as additional columns in query results
+- Can be used in sorts and filters alongside dimensions/metrics
+- Multiple calculations can be combined in a single query
+- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
+",
+        },
+        "title": {
+          "description": "A descriptive title for the chart",
+          "type": "string",
+        },
+      },
+      "required": [
+        "title",
+        "description",
+        "customMetrics",
+        "tableCalculations",
+        "queryConfig",
+        "chartConfig",
+        "filters",
+      ],
+      "type": "object",
+    },
+    "name": "runQuery",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "
+Run an existing saved chart by its UUID and return the rows it produces.
+
+When to use this tool:
+- The user has pinned a chart (you'll see it listed in the prompt context as
+  "Chart \\"...\\" (chartUuid: ...)") and you need to inspect its data to answer
+  their question.
+- You discovered a relevant chart via findContent / findCharts and want to read
+  its results without rebuilding the query from scratch.
+
+Prefer this over runQuery when a saved chart already exists for the data the
+user is asking about. The chart's saved metric query, filters, sorts, and
+custom metrics are applied automatically.
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "
+Run an existing saved chart by its UUID and return the rows it produces.
+
+When to use this tool:
+- The user has pinned a chart (you'll see it listed in the prompt context as
+  "Chart \\"...\\" (chartUuid: ...)") and you need to inspect its data to answer
+  their question.
+- You discovered a relevant chart via findContent / findCharts and want to read
+  its results without rebuilding the query from scratch.
+
+Prefer this over runQuery when a saved chart already exists for the data the
+user is asking about. The chart's saved metric query, filters, sorts, and
+custom metrics are applied automatically.
+",
+      "properties": {
+        "chartUuid": {
+          "description": "UUID of the saved chart to execute. Use the chartUuid from the prompt context or from a prior findContent / findCharts result.",
+          "type": "string",
+        },
+      },
+      "required": [
+        "chartUuid",
+      ],
+      "type": "object",
+    },
+    "name": "runSavedChart",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
+    "description": "Tool: run_sql
+
+Purpose:
+Execute an arbitrary SQL query against the project's data warehouse and return the results. Successful results can be linked from the final answer with [Open in SQL Runner](#sql-runner-link).
+
+Use this tool when the user wants to run a custom SQL query that doesn't fit the explore-based metric query model.
+This is useful for ad-hoc analysis, data exploration, or queries that join across tables not modeled in explores.
+
+The query is executed directly against the warehouse, so use the SQL dialect appropriate for the connected warehouse (e.g., PostgreSQL, BigQuery, Snowflake, etc.).
+
+Parameters:
+- sql: The SQL query to execute. Must be a valid SELECT statement.
+- limit: Maximum number of rows to return (default 500, max 500).
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: "<CSV string>" }] — header row + data rows, comma-separated. Provided for human/LLM display and as a fallback.
+- structuredContent: {
+    rows:     Array<Record<string, unknown>>,  // each row keyed by column name
+    columns:  string[],                        // column names in order
+    rowCount: number                           // total rows returned
+  }
+
+When writing code that consumes this tool (e.g. inside a live artifact), prefer structuredContent.rows over parsing the CSV. Example:
+
+  const result = await callMcpTool('run_sql', { sql, limit });
+  const rows    = result.structuredContent.rows;     // [{ status: 'completed', n: 94, total_amount: 2397 }, ...]
+  const columns = result.structuredContent.columns;  // ['status', 'n', 'total_amount']
+
+Notes:
+- Values in rows are JSON-serializable primitives: numbers, strings, booleans, ISO date strings, or null. They are NOT pre-stringified — there's no need for parseFloat / parseInt on numeric columns.
+- Empty results still return structuredContent with { rows: [], columns, rowCount: 0 } — distinct from a parse failure.
+- On error, the response has isError: true and content[0].text contains the error message; structuredContent is omitted.
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: run_sql
+
+Purpose:
+Execute an arbitrary SQL query against the project's data warehouse and return the results. Successful results can be linked from the final answer with [Open in SQL Runner](#sql-runner-link).
+
+Use this tool when the user wants to run a custom SQL query that doesn't fit the explore-based metric query model.
+This is useful for ad-hoc analysis, data exploration, or queries that join across tables not modeled in explores.
+
+The query is executed directly against the warehouse, so use the SQL dialect appropriate for the connected warehouse (e.g., PostgreSQL, BigQuery, Snowflake, etc.).
+
+Parameters:
+- sql: The SQL query to execute. Must be a valid SELECT statement.
+- limit: Maximum number of rows to return (default 500, max 500).
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: "<CSV string>" }] — header row + data rows, comma-separated. Provided for human/LLM display and as a fallback.
+- structuredContent: {
+    rows:     Array<Record<string, unknown>>,  // each row keyed by column name
+    columns:  string[],                        // column names in order
+    rowCount: number                           // total rows returned
+  }
+
+When writing code that consumes this tool (e.g. inside a live artifact), prefer structuredContent.rows over parsing the CSV. Example:
+
+  const result = await callMcpTool('run_sql', { sql, limit });
+  const rows    = result.structuredContent.rows;     // [{ status: 'completed', n: 94, total_amount: 2397 }, ...]
+  const columns = result.structuredContent.columns;  // ['status', 'n', 'total_amount']
+
+Notes:
+- Values in rows are JSON-serializable primitives: numbers, strings, booleans, ISO date strings, or null. They are NOT pre-stringified — there's no need for parseFloat / parseInt on numeric columns.
+- Empty results still return structuredContent with { rows: [], columns, rowCount: 0 } — distinct from a parse failure.
+- On error, the response has isError: true and content[0].text contains the error message; structuredContent is omitted.
+",
+      "properties": {
+        "limit": {
+          "default": 500,
+          "description": "Maximum number of rows to return. Defaults to 500, max 500.",
+          "exclusiveMinimum": 0,
+          "maximum": 500,
+          "type": "integer",
+        },
+        "sql": {
+          "description": "The SQL query to execute against the data warehouse.",
+          "type": "string",
+        },
+      },
+      "required": [
+        "sql",
+      ],
+      "type": "object",
+    },
+    "name": "runSql",
+    "outputSchema": null,
+  },
+  {
+    "description": "Tool: searchFieldValues
+
+Purpose:
+Search for unique values of a specific field in a table. Returns all unique values by default, or use the query parameter to narrow down results. This is useful for finding suggestions for field values when building filters or exploring data.
+
+Usage Tips:
+- Specify the table and field you want to search values for
+- Query parameter: use it to narrow down the search to matching values
+- Optionally add filters to further restrict the results
+- Results are returned as a list of unique field values (limited to 100)
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Tool: searchFieldValues
+
+Purpose:
+Search for unique values of a specific field in a table. Returns all unique values by default, or use the query parameter to narrow down results. This is useful for finding suggestions for field values when building filters or exploring data.
+
+Usage Tips:
+- Specify the table and field you want to search values for
+- Query parameter: use it to narrow down the search to matching values
+- Optionally add filters to further restrict the results
+- Results are returned as a list of unique field values (limited to 100)
+",
+      "properties": {
+        "fieldId": {
+          "description": "The ID of the field to search values for "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+          "type": "string",
+        },
+        "filters": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "dimensions": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "const": "boolean",
+                                    "type": "string",
+                                  },
+                                  "fieldId": {
+                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                    "type": "string",
+                                  },
+                                  "fieldType": {
+                                    "enum": [
+                                      "boolean",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "isNull",
+                                      "notNull",
+                                    ],
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/0/anyOf/0/properties/fieldFilterType",
+                                  },
+                                  "fieldId": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/0/anyOf/0/properties/fieldId",
+                                  },
+                                  "fieldType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/0/anyOf/0/properties/fieldType",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "equals",
+                                      "notEquals",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "type": "boolean",
+                                    },
+                                    "maxItems": 1,
+                                    "minItems": 1,
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                  "values",
+                                ],
+                                "type": "object",
+                              },
+                            ],
+                          },
+                          {
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "const": "string",
+                                    "type": "string",
+                                  },
+                                  "fieldId": {
+                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                    "type": "string",
+                                  },
+                                  "fieldType": {
+                                    "enum": [
+                                      "string",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "isNull",
+                                      "notNull",
+                                    ],
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/1/anyOf/0/properties/fieldFilterType",
+                                  },
+                                  "fieldId": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/1/anyOf/0/properties/fieldId",
+                                  },
+                                  "fieldType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/1/anyOf/0/properties/fieldType",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "equals",
+                                      "notEquals",
+                                      "startsWith",
+                                      "endsWith",
+                                      "include",
+                                      "doesNotInclude",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "type": "string",
+                                    },
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                  "values",
+                                ],
+                                "type": "object",
+                              },
+                            ],
+                          },
+                          {
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "const": "number",
+                                    "type": "string",
+                                  },
+                                  "fieldId": {
+                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                    "type": "string",
+                                  },
+                                  "fieldType": {
+                                    "enum": [
+                                      "number",
+                                      "percentile",
+                                      "median",
+                                      "average",
+                                      "count",
+                                      "count_distinct",
+                                      "sum",
+                                      "sum_distinct",
+                                      "average_distinct",
+                                      "min",
+                                      "max",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "isNull",
+                                      "notNull",
+                                    ],
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                  },
+                                  "fieldId": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldId",
+                                  },
+                                  "fieldType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldType",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "equals",
+                                      "notEquals",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "type": "number",
+                                    },
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                  "values",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                  },
+                                  "fieldId": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldId",
+                                  },
+                                  "fieldType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldType",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "lessThan",
+                                      "lessThanOrEqual",
+                                      "greaterThan",
+                                      "greaterThanOrEqual",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "type": "number",
+                                    },
+                                    "maxItems": 1,
+                                    "minItems": 1,
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                  "values",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                  },
+                                  "fieldId": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldId",
+                                  },
+                                  "fieldType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldType",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "inBetween",
+                                      "notInBetween",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "type": "number",
+                                    },
+                                    "maxItems": 2,
+                                    "minItems": 2,
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                  "values",
+                                ],
+                                "type": "object",
+                              },
+                            ],
+                          },
+                          {
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "const": "date",
+                                    "type": "string",
+                                  },
+                                  "fieldId": {
+                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                    "type": "string",
+                                  },
+                                  "fieldType": {
+                                    "enum": [
+                                      "date",
+                                      "timestamp",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "isNull",
+                                      "notNull",
+                                    ],
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                  },
+                                  "fieldId": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldId",
+                                  },
+                                  "fieldType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldType",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "equals",
+                                      "notEquals",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "anyOf": [
+                                        {
+                                          "format": "date",
+                                          "type": "string",
+                                        },
+                                        {
+                                          "format": "date-time",
+                                          "type": "string",
+                                        },
+                                      ],
+                                    },
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                  "values",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                  },
+                                  "fieldId": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldId",
+                                  },
+                                  "fieldType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldType",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "inThePast",
+                                      "notInThePast",
+                                      "inTheNext",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "settings": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "completed": {
+                                        "type": "boolean",
+                                      },
+                                      "unitOfTime": {
+                                        "enum": [
+                                          "days",
+                                          "weeks",
+                                          "months",
+                                          "quarters",
+                                          "years",
+                                        ],
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "completed",
+                                      "unitOfTime",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "type": "number",
+                                    },
+                                    "maxItems": 1,
+                                    "minItems": 1,
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                  "values",
+                                  "settings",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                  },
+                                  "fieldId": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldId",
+                                  },
+                                  "fieldType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldType",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "inTheCurrent",
+                                      "notInTheCurrent",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "settings": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "completed": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "unitOfTime": {
+                                        "enum": [
+                                          "days",
+                                          "weeks",
+                                          "months",
+                                          "quarters",
+                                          "years",
+                                        ],
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "completed",
+                                      "unitOfTime",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "const": 1,
+                                      "type": "number",
+                                    },
+                                    "maxItems": 1,
+                                    "minItems": 1,
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                  "values",
+                                  "settings",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                  },
+                                  "fieldId": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldId",
+                                  },
+                                  "fieldType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldType",
+                                  },
+                                  "operator": {
+                                    "enum": [
+                                      "lessThan",
+                                      "lessThanOrEqual",
+                                      "greaterThan",
+                                      "greaterThanOrEqual",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/1/properties/values/items",
+                                    },
+                                    "maxItems": 1,
+                                    "minItems": 1,
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                  "values",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldFilterType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                  },
+                                  "fieldId": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldId",
+                                  },
+                                  "fieldType": {
+                                    "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldType",
+                                  },
+                                  "operator": {
+                                    "const": "inBetween",
+                                    "type": "string",
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/1/properties/values/items",
+                                    },
+                                    "maxItems": 2,
+                                    "minItems": 2,
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldType",
+                                  "fieldFilterType",
+                                  "operator",
+                                  "values",
+                                ],
+                                "type": "object",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                },
+                "metrics": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                },
+                "tableCalculations": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                },
+                "type": {
+                  "description": "Type of filter group operation",
+                  "enum": [
+                    "and",
+                    "or",
+                  ],
+                  "type": "string",
+                },
+              },
+              "required": [
+                "type",
+                "dimensions",
+                "metrics",
+                "tableCalculations",
+              ],
+              "type": "object",
+            },
+            {
+              "type": "null",
+            },
+          ],
+          "description": "Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics.",
+        },
+        "query": {
+          "description": "Query string to filter field values",
+          "type": [
+            "string",
+            "null",
+          ],
+        },
+        "table": {
+          "description": "The table to search in.",
+          "type": "string",
+        },
+      },
+      "required": [
+        "table",
+        "fieldId",
+        "query",
+        "filters",
+      ],
+      "type": "object",
+    },
+    "name": "searchFieldValues",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+]
+`;

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -1,0 +1,171 @@
+import type { ZodTypeAny } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { getDiscoverFields } from '../agents/discoverFields/tool';
+import { getDescribeWarehouseTable } from './describeWarehouseTable';
+import { getEditContent } from './editContent';
+import { getFindContent } from './findContent';
+import { getFindExplores } from './findExplores';
+import { getFindFields } from './findFields';
+import { getGenerateDashboardV2 } from './generateDashboardV2';
+import { getGenerateUuids } from './generateUuids';
+import { getGetDashboardCharts } from './getDashboardCharts';
+import { getGetKnowledgeDocumentContent } from './getKnowledgeDocumentContent';
+import { getImproveContext } from './improveContext';
+import { getListKnowledgeDocuments } from './listKnowledgeDocuments';
+import { getListWarehouseTables } from './listWarehouseTables';
+import { getLoadSkill } from './loadSkill';
+import { getProposeChange } from './proposeChange';
+import { getReadContent } from './readContent';
+import { getRunQuery } from './runQuery';
+import { getRunSavedChart } from './runSavedChart';
+import { getRunSql } from './runSql';
+import { getSearchFieldValues } from './searchFieldValues';
+
+const schemaToJson = (schema: ZodTypeAny | undefined): unknown => {
+    if (!schema) {
+        return null;
+    }
+
+    return zodToJsonSchema(schema, {
+        target: 'jsonSchema7',
+    });
+};
+
+type SnapshotTool = {
+    description?: string;
+    inputSchema?: ZodTypeAny;
+    outputSchema?: ZodTypeAny;
+};
+
+const agentToolSnapshot = (name: string, toolDefinition: SnapshotTool) => ({
+    name,
+    description: toolDefinition.description,
+    inputSchema: schemaToJson(toolDefinition.inputSchema),
+    outputSchema: schemaToJson(toolDefinition.outputSchema),
+});
+
+const makeAgentTools = () => {
+    const noop = jest.fn();
+    const noopAsync = jest.fn().mockResolvedValue(undefined);
+
+    return {
+        describeWarehouseTable: getDescribeWarehouseTable({
+            describeWarehouseTable: noop,
+        }),
+        discoverFields: getDiscoverFields(
+            {
+                model: {} as never,
+                callOptions: {},
+                providerOptions: undefined,
+                availableExplores: [],
+                findExploresFieldSearchSize: 25,
+                findFieldsPageSize: 25,
+                promptUuid: 'prompt-uuid',
+                telemetry: {
+                    agentSettings: {
+                        uuid: 'agent-uuid',
+                        name: 'Agent',
+                        projectUuid: 'project-uuid',
+                    },
+                    threadUuid: 'thread-uuid',
+                    promptUuid: 'prompt-uuid',
+                    telemetryEnabled: false,
+                },
+            } as never,
+            {
+                findExplores: noop,
+                findFields: noop,
+                getExplore: noop,
+                storeToolCall: noopAsync,
+                storeToolResults: noopAsync,
+                updateProgress: noopAsync,
+            } as never,
+        ),
+        editContent: getEditContent({ editContent: noop }),
+        findContent: getFindContent({
+            findContent: noop,
+            siteUrl: 'https://lightdash.example',
+            trackCoverage: noop,
+        }),
+        findExplores: getFindExplores({
+            fieldSearchSize: 25,
+            findExplores: noop,
+            updateProgress: noopAsync,
+        }),
+        findFields: getFindFields({
+            findFields: noop,
+            getExplore: noop,
+            pageSize: 25,
+            updateProgress: noopAsync,
+        }),
+        generateDashboard: getGenerateDashboardV2({
+            createOrUpdateArtifact: noop,
+            getPrompt: noop,
+        }),
+        generateUuids: getGenerateUuids(),
+        getDashboardCharts: getGetDashboardCharts({
+            getDashboardCharts: noop,
+            pageSize: 25,
+            siteUrl: 'https://lightdash.example',
+        }),
+        getKnowledgeDocumentContent: getGetKnowledgeDocumentContent({
+            getKnowledgeDocumentContent: noop,
+        }),
+        improveContext: getImproveContext(),
+        listKnowledgeDocuments: getListKnowledgeDocuments({
+            listKnowledgeDocuments: noop,
+        }),
+        listWarehouseTables: getListWarehouseTables({
+            listWarehouseTables: noop,
+        }),
+        loadSkill: getLoadSkill({ loadSkill: noop }),
+        proposeChange: getProposeChange({
+            createChange: noop,
+            getExploreCompiler: noop,
+        }),
+        readContent: getReadContent({ readContent: noop }),
+        runQuery: getRunQuery({
+            createOrUpdateArtifact: noop,
+            enableDataAccess: true,
+            enableSelfImprovement: true,
+            getPrompt: noop,
+            maxLimit: 500,
+            runAsyncQuery: noop,
+            sendFile: noop,
+            updateProgress: noopAsync,
+        }),
+        runSavedChart: getRunSavedChart({
+            enableDataAccess: true,
+            getSavedChart: noop,
+            maxLimit: 500,
+            runAsyncQuery: noop,
+            updateProgress: noopAsync,
+        }),
+        runSql: getRunSql({
+            getPrompt: noop,
+            recordSqlApproval: noop,
+            runSqlJob: noop,
+            sendFile: noop,
+            siteUrl: 'https://lightdash.example',
+            maxQueryLimit: 500,
+            updateProgress: noopAsync,
+            updateSlackMessage: noop,
+            waitForSqlApproval: noop,
+        }),
+        searchFieldValues: getSearchFieldValues({
+            searchFieldValues: noop,
+        }),
+    };
+};
+
+describe('AI agent tool contracts', () => {
+    it('matches the current agent tool contract snapshot', () => {
+        const agentTools = makeAgentTools();
+
+        expect(
+            Object.entries(agentTools).map(([name, definition]) =>
+                agentToolSnapshot(name, definition as SnapshotTool),
+            ),
+        ).toMatchSnapshot();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,6 +634,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      zod-to-json-schema:
+        specifier: 3.25.1
+        version: 3.25.1(zod@3.25.55)
 
   packages/backend/src/ee/services/McpService/mcp-chart-app:
     dependencies:


### PR DESCRIPTION
## Summary
- add snapshot coverage for AI agent tool contracts and MCP tool/prompt contracts
- normalize Zod input/output schemas to JSON Schema for stable before/after comparisons
- add local AGENTS.md notes with SKILLS.md pointers for agent and MCP contract maintenance

## Testing
- corepack pnpm -F @lightdash/common build
- corepack pnpm -F backend test src/ee/services/ai/tools/toolContracts.snapshot.test.ts
- corepack pnpm -F backend linter src/ee/services/ai/tools/toolContracts.snapshot.test.ts