### PR TITLE
feat(ai-agents): add review classifier contract

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -360,6 +360,12 @@ import {
     AiAgentDocumentTableName,
 } from '../ee/database/entities/aiAgentDocument';
 import {
+    AiAgentReviewClassifierRunTable,
+    AiAgentReviewClassifierRunTableName,
+    AiAgentTurnSignalTable,
+    AiAgentTurnSignalTableName,
+} from '../ee/database/entities/aiAgentReviewClassifier';
+import {
     AiAgentUserPreferencesTable,
     AiAgentUserPreferencesTableName,
 } from '../ee/database/entities/aiAgentUserPreferences';
@@ -507,6 +513,8 @@ declare module 'knex/types/tables' {
         [AiAgentTableName]: AiAgentTable;
         [AiAgentDocumentTableName]: AiAgentDocumentTable;
         [AiAgentDocumentAccessTableName]: AiAgentDocumentAccessTable;
+        [AiAgentReviewClassifierRunTableName]: AiAgentReviewClassifierRunTable;
+        [AiAgentTurnSignalTableName]: AiAgentTurnSignalTable;
         [AiAgentGroupAccessTableName]: AiAgentGroupAccessTable;
         [AiAgentIntegrationTableName]: AiAgentIntegrationTable;
         [AiAgentSlackIntegrationTableName]: AiAgentSlackIntegrationTable;

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -1,0 +1,161 @@
+import type {
+    AiAgentConfigSnapshot,
+    AiAgentEvidenceExcerpt,
+    AiAgentFixTarget,
+    AiAgentImplicitSignalSource,
+    AiAgentInteractionSource,
+    AiAgentModelMetadata,
+    AiAgentRecommendation,
+    AiAgentReviewClassifierConfidence,
+    AiAgentReviewClassifierRunScope,
+    AiAgentReviewClassifierRunStatus,
+    AiAgentReviewItemOwnerType,
+    AiAgentRootCause,
+    AiAgentRuntimeContextSnapshot,
+    AiAgentTargetRef,
+    AiAgentTurnSignal,
+    AiAgentTurnSignalSourceRef,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const AiAgentReviewClassifierRunTableName = 'ai_agent_review_run';
+
+export type DbAiAgentReviewClassifierRun = {
+    ai_agent_review_run_uuid: string;
+    organization_uuid: string;
+    status: AiAgentReviewClassifierRunStatus;
+    review_agent_version: string;
+    judge_prompt_hash: string;
+    agent_config_snapshot_hash: string | null;
+    agent_config_snapshot: AiAgentConfigSnapshot | null;
+    agent_config_snapshot_agent_updated_at: Date | null;
+    run_scope: AiAgentReviewClassifierRunScope;
+    total_turns: number;
+    processed_turns: number;
+    signal_count: number;
+    finding_count: number;
+    review_item_count: number;
+    error_message: string | null;
+    completed_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiAgentReviewClassifierRunTable = Knex.CompositeTableType<
+    DbAiAgentReviewClassifierRun,
+    Pick<
+        DbAiAgentReviewClassifierRun,
+        | 'organization_uuid'
+        | 'review_agent_version'
+        | 'judge_prompt_hash'
+        | 'run_scope'
+    > &
+        Partial<
+            Pick<
+                DbAiAgentReviewClassifierRun,
+                | 'agent_config_snapshot_hash'
+                | 'agent_config_snapshot'
+                | 'agent_config_snapshot_agent_updated_at'
+                | 'status'
+                | 'total_turns'
+                | 'processed_turns'
+                | 'signal_count'
+                | 'finding_count'
+                | 'review_item_count'
+                | 'error_message'
+                | 'completed_at'
+            >
+        >,
+    Partial<
+        Pick<
+            DbAiAgentReviewClassifierRun,
+            | 'status'
+            | 'total_turns'
+            | 'processed_turns'
+            | 'signal_count'
+            | 'finding_count'
+            | 'review_item_count'
+            | 'error_message'
+            | 'completed_at'
+        >
+    > & {
+        updated_at?: Date | Knex.Raw;
+    }
+>;
+
+export const AiAgentTurnSignalTableName = 'ai_agent_review_turn_signal';
+
+export type DbAiAgentTurnSignal = {
+    ai_agent_review_turn_signal_uuid: string;
+    ai_agent_review_run_uuid: string;
+    ai_prompt_uuid: string;
+    ai_thread_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    agent_uuid: string;
+    interaction_source: AiAgentInteractionSource;
+    source_ref: AiAgentTurnSignalSourceRef;
+    signal: AiAgentTurnSignal;
+    implicit_signal_sources: AiAgentImplicitSignalSource[];
+    confidence: AiAgentReviewClassifierConfidence;
+    promoted_to_finding: boolean;
+    promotion_reason: string | null;
+    tool_evidence_refs: string[];
+    fingerprint: string | null;
+    primary_root_cause: AiAgentRootCause | null;
+    secondary_root_causes: AiAgentRootCause[] | null;
+    subcategories: string[] | null;
+    fix_targets: AiAgentFixTarget[] | null;
+    target_refs: AiAgentTargetRef[] | null;
+    evidence_excerpts: AiAgentEvidenceExcerpt[] | null;
+    recommendation: AiAgentRecommendation | null;
+    owner_type: AiAgentReviewItemOwnerType | null;
+    review_item_title: string | null;
+    review_item_description: string | null;
+    runtime_context_snapshot: AiAgentRuntimeContextSnapshot;
+    model_metadata: AiAgentModelMetadata;
+    created_at: Date;
+};
+
+export type AiAgentTurnSignalTable = Knex.CompositeTableType<
+    DbAiAgentTurnSignal,
+    Omit<
+        DbAiAgentTurnSignal,
+        | 'ai_agent_review_turn_signal_uuid'
+        | 'created_at'
+        | 'promoted_to_finding'
+        | 'promotion_reason'
+        | 'fingerprint'
+        | 'primary_root_cause'
+        | 'secondary_root_causes'
+        | 'subcategories'
+        | 'fix_targets'
+        | 'target_refs'
+        | 'evidence_excerpts'
+        | 'recommendation'
+        | 'owner_type'
+        | 'review_item_title'
+        | 'review_item_description'
+    > &
+        Partial<
+            Pick<
+                DbAiAgentTurnSignal,
+                | 'promoted_to_finding'
+                | 'promotion_reason'
+                | 'fingerprint'
+                | 'primary_root_cause'
+                | 'secondary_root_causes'
+                | 'subcategories'
+                | 'fix_targets'
+                | 'target_refs'
+                | 'evidence_excerpts'
+                | 'recommendation'
+                | 'owner_type'
+                | 'review_item_title'
+                | 'review_item_description'
+            >
+        >,
+    Partial<
+        Pick<DbAiAgentTurnSignal, 'promoted_to_finding' | 'promotion_reason'>
+    >
+>;

--- a/packages/backend/src/ee/database/migrations/20260528091000_add_ai_agent_review_classifier_tables.ts
+++ b/packages/backend/src/ee/database/migrations/20260528091000_add_ai_agent_review_classifier_tables.ts
@@ -1,0 +1,166 @@
+import { Knex } from 'knex';
+
+const runTable = 'ai_agent_review_run';
+const turnSignalTable = 'ai_agent_review_turn_signal';
+
+const organizationsTable = 'organizations';
+const projectsTable = 'projects';
+const aiAgentTable = 'ai_agent';
+const aiThreadTable = 'ai_thread';
+const aiPromptTable = 'ai_prompt';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(runTable, (table) => {
+        table
+            .uuid('ai_agent_review_run_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable(organizationsTable)
+            .onDelete('CASCADE');
+        table
+            .enum('status', ['queued', 'running', 'completed', 'failed'])
+            .notNullable()
+            .defaultTo('queued');
+        table.text('review_agent_version').notNullable();
+        table.text('judge_prompt_hash').notNullable();
+        table.text('agent_config_snapshot_hash');
+        table.jsonb('agent_config_snapshot');
+        table.timestamp('agent_config_snapshot_agent_updated_at', {
+            useTz: false,
+        });
+        table.jsonb('run_scope').notNullable();
+        table.integer('total_turns').notNullable().defaultTo(0);
+        table.integer('processed_turns').notNullable().defaultTo(0);
+        table.integer('signal_count').notNullable().defaultTo(0);
+        table.integer('finding_count').notNullable().defaultTo(0);
+        table.integer('review_item_count').notNullable().defaultTo(0);
+        table.text('error_message');
+        table.timestamp('completed_at', { useTz: false });
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['organization_uuid', 'created_at']);
+        table.index(['status']);
+    });
+
+    await knex.schema.createTable(turnSignalTable, (table) => {
+        table
+            .uuid('ai_agent_review_turn_signal_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_agent_review_run_uuid')
+            .notNullable()
+            .references('ai_agent_review_run_uuid')
+            .inTable(runTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('ai_prompt_uuid')
+            .notNullable()
+            .references('ai_prompt_uuid')
+            .inTable(aiPromptTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('ai_thread_uuid')
+            .notNullable()
+            .references('ai_thread_uuid')
+            .inTable(aiThreadTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable(organizationsTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable(projectsTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('agent_uuid')
+            .notNullable()
+            .references('ai_agent_uuid')
+            .inTable(aiAgentTable)
+            .onDelete('CASCADE');
+        table.enum('interaction_source', ['app', 'slack']).notNullable();
+        table.jsonb('source_ref').notNullable();
+        table
+            .enum('signal', [
+                'normal_refinement',
+                'implicit_correction',
+                'explicit_dispute',
+                'retry_after_failure',
+                'output_shape_correction',
+                'new_question',
+                'acceptance_or_continuation',
+                'product_capability_request',
+                'human_intervention',
+                'ambiguous',
+            ])
+            .notNullable();
+        table.jsonb('implicit_signal_sources').notNullable();
+        table.enum('confidence', ['low', 'medium', 'high']).notNullable();
+        table.boolean('promoted_to_finding').notNullable().defaultTo(false);
+        table.text('promotion_reason');
+        table.jsonb('tool_evidence_refs').notNullable();
+        table.text('fingerprint');
+        table.enum('primary_root_cause', [
+            'semantic_layer',
+            'project_context',
+            'agent_configuration',
+            'data_gap',
+            'product_capability',
+            'runtime_reliability',
+            'feedback_quality',
+            'not_a_failure',
+            'ambiguous',
+        ]);
+        table.jsonb('secondary_root_causes');
+        table.jsonb('subcategories');
+        table.jsonb('fix_targets');
+        table.jsonb('target_refs');
+        table.jsonb('evidence_excerpts');
+        table.jsonb('recommendation');
+        table.enum('owner_type', [
+            'semantic_layer_owner',
+            'agent_admin',
+            'product',
+            'support',
+            'unknown',
+        ]);
+        table.text('review_item_title');
+        table.text('review_item_description');
+        table.jsonb('runtime_context_snapshot').notNullable();
+        table.jsonb('model_metadata').notNullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['ai_agent_review_run_uuid']);
+        table.index(['ai_prompt_uuid']);
+        table.index(['organization_uuid', 'created_at']);
+        table.index(['project_uuid']);
+        table.index(['agent_uuid']);
+        table.index(['signal']);
+        table.index(['fingerprint']);
+        table.index(['primary_root_cause']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(turnSignalTable);
+    await knex.schema.dropTableIfExists(runTable);
+}

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -1,0 +1,136 @@
+import {
+    getAiAgentConfigSnapshotHash,
+    getAiAgentReviewItemFingerprint,
+    getAiAgentReviewItemFingerprintScope,
+    type AiAgentConfigSnapshot,
+    type AiAgentReviewItemFingerprintInput,
+} from './aiAgentReviewClassifierTypes';
+
+const baseInput: AiAgentReviewItemFingerprintInput = {
+    organizationUuid: 'org-1',
+    projectUuid: 'project-1',
+    agentUuid: 'agent-1',
+    primaryRootCause: 'semantic_layer',
+    subcategories: ['wrong_field_or_domain_term', 'missing_default_filter'],
+    fixTargets: ['semantic_yaml_patch'],
+    targetRefs: [
+        {
+            type: 'metric',
+            modelName: 'orders',
+            metricName: 'total_order_amount',
+            yamlPath: 'lightdash/models/orders.yml',
+        },
+    ],
+    agentConfigurationSettings: [],
+    capabilityKey: null,
+};
+
+describe('getAiAgentReviewItemFingerprint', () => {
+    it('is stable when unordered inputs are reordered', () => {
+        const reordered: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            subcategories: [
+                'missing_default_filter',
+                'wrong_field_or_domain_term',
+            ],
+            targetRefs: [...baseInput.targetRefs].reverse(),
+        };
+
+        expect(getAiAgentReviewItemFingerprint(reordered)).toEqual(
+            getAiAgentReviewItemFingerprint(baseInput),
+        );
+    });
+
+    it('changes when the actionable semantic target changes', () => {
+        const differentTarget: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            targetRefs: [
+                {
+                    type: 'metric',
+                    modelName: 'orders',
+                    metricName: 'completed_order_count',
+                    yamlPath: 'lightdash/models/orders.yml',
+                },
+            ],
+        };
+
+        expect(getAiAgentReviewItemFingerprint(differentTarget)).not.toEqual(
+            getAiAgentReviewItemFingerprint(baseInput),
+        );
+    });
+
+    it('scopes agent configuration findings to agent, not project', () => {
+        const agentConfigInput: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            primaryRootCause: 'agent_configuration',
+            projectUuid: 'project-a',
+            targetRefs: [{ type: 'agent_config', setting: 'data_access' }],
+            agentConfigurationSettings: ['data_access'],
+        };
+
+        expect(
+            getAiAgentReviewItemFingerprint({
+                ...agentConfigInput,
+                projectUuid: 'project-b',
+            }),
+        ).toEqual(getAiAgentReviewItemFingerprint(agentConfigInput));
+    });
+
+    it('requires project scope for semantic layer findings', () => {
+        expect(() =>
+            getAiAgentReviewItemFingerprintScope({
+                organizationUuid: 'org-1',
+                projectUuid: null,
+                agentUuid: 'agent-1',
+                primaryRootCause: 'semantic_layer',
+            }),
+        ).toThrow('projectUuid is required for semantic_layer fingerprints');
+    });
+});
+
+describe('getAiAgentConfigSnapshotHash', () => {
+    const baseSnapshot: AiAgentConfigSnapshot = {
+        capturedAt: '2026-05-26T10:00:00.000Z',
+        agentUpdatedAt: '2026-05-26T09:00:00.000Z',
+        settings: ['instructions', 'knowledge_documents'],
+        availableCapabilities: ['semantic_query', 'chart_generation'],
+        instructionHash: 'instruction-hash',
+        instructionSummary: 'Use finance definitions.',
+        knowledgeDocuments: [
+            {
+                uuid: 'doc-1',
+                name: 'Revenue definitions',
+                updatedAt: '2026-05-25T10:00:00.000Z',
+                summary: {
+                    description: 'Revenue definitions',
+                    definedTerms: ['revenue', 'arr'],
+                    relatedExploreNames: ['orders'],
+                    useWhen: 'Revenue questions',
+                    relevance: 'high',
+                    warning: null,
+                },
+            },
+        ],
+    };
+
+    it('is stable when unordered snapshot arrays are reordered', () => {
+        expect(
+            getAiAgentConfigSnapshotHash({
+                ...baseSnapshot,
+                settings: [...baseSnapshot.settings].reverse(),
+                availableCapabilities: [
+                    ...baseSnapshot.availableCapabilities,
+                ].reverse(),
+            }),
+        ).toEqual(getAiAgentConfigSnapshotHash(baseSnapshot));
+    });
+
+    it('changes when instruction content hash changes', () => {
+        expect(
+            getAiAgentConfigSnapshotHash({
+                ...baseSnapshot,
+                instructionHash: 'different-instruction-hash',
+            }),
+        ).not.toEqual(getAiAgentConfigSnapshotHash(baseSnapshot));
+    });
+});

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -1,0 +1,779 @@
+import { z } from 'zod';
+import type { ApiSuccess } from '../../types/api/success';
+import type { MetricQuery } from '../../types/metricQuery';
+import type { QueryHistoryStatus } from '../../types/queryHistory';
+import type { AiAgentDocumentStructuredSummary } from './documentTypes';
+import type { AiAgentReviewClassifierEventType } from './requestTypes';
+
+export type AiAgentReviewClassifierSubject = {
+    type: 'turn_review';
+    assistantPromptUuid: string;
+    threadUuid: string;
+    agentUuid: string;
+    projectUuid: string;
+    organizationUuid: string;
+};
+
+export type AiAgentInteractionSource = 'app' | 'slack';
+
+export type AiAgentTurnSignalSourceRef =
+    | {
+          source: 'app';
+          threadUuid: string;
+          promptUuid: string;
+          appUrl: string | null;
+      }
+    | {
+          source: 'slack';
+          channelId: string;
+          threadTs: string | null;
+          messageTs: string;
+          slackPermalink: string | null;
+      };
+
+export type AiAgentTurnSignal =
+    | 'normal_refinement'
+    | 'implicit_correction'
+    | 'explicit_dispute'
+    | 'retry_after_failure'
+    | 'output_shape_correction'
+    | 'new_question'
+    | 'acceptance_or_continuation'
+    | 'product_capability_request'
+    | 'human_intervention'
+    | 'ambiguous';
+
+export type AiAgentImplicitSignalSource =
+    | 'next_user_correction'
+    | 'next_user_dispute'
+    | 'next_user_retry'
+    | 'output_shape_correction'
+    | 'tool_error'
+    | 'assistant_no_answer'
+    | 'product_capability_request'
+    | 'human_intervention';
+
+export type AiAgentReviewClassifierConfidence = 'low' | 'medium' | 'high';
+
+export type AiAgentRootCause =
+    | 'semantic_layer'
+    | 'project_context'
+    | 'agent_configuration'
+    | 'data_gap'
+    | 'product_capability'
+    | 'runtime_reliability'
+    | 'feedback_quality'
+    | 'not_a_failure'
+    | 'ambiguous';
+
+export type AiAgentFixTarget =
+    | 'semantic_yaml_patch'
+    | 'project_context_rule'
+    | 'agent_configuration_change'
+    | 'dbt_modeling_ticket'
+    | 'semantic_layer_ticket'
+    | 'product_capability_ticket'
+    | 'runtime_reliability_ticket'
+    | 'feedback_needed'
+    | 'no_action';
+
+export type AiAgentConfigurationSetting =
+    | 'instructions'
+    | 'knowledge_documents'
+    | 'data_access'
+    | 'self_improvement'
+    | 'sql_mode'
+    | 'mcp_servers'
+    | 'explore_tags'
+    | 'space_access'
+    | 'user_or_group_access'
+    | 'unknown';
+
+export type AiAgentAvailableCapability =
+    | 'semantic_query'
+    | 'chart_generation'
+    | 'dashboard_generation'
+    | 'data_value_search'
+    | 'chart_data_access'
+    | 'sql_runner'
+    | 'context_improvement'
+    | 'semantic_change_proposals'
+    | 'mcp_tools';
+
+export type AiAgentKnowledgeDocumentSnapshot = {
+    uuid: string;
+    name: string;
+    updatedAt: string;
+    summary: AiAgentDocumentStructuredSummary;
+};
+
+export type AiAgentConfigSnapshot = {
+    capturedAt: string;
+    agentUpdatedAt: string | null;
+    settings: AiAgentConfigurationSetting[];
+    availableCapabilities: AiAgentAvailableCapability[];
+    instructionHash: string | null;
+    instructionSummary: string | null;
+    knowledgeDocuments: AiAgentKnowledgeDocumentSnapshot[];
+};
+
+const normalizeForHash = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+        return value
+            .map(normalizeForHash)
+            .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+    }
+
+    if (value && typeof value === 'object') {
+        return Object.keys(value)
+            .sort()
+            .reduce<Record<string, unknown>>((acc, key) => {
+                const normalized = normalizeForHash(
+                    (value as Record<string, unknown>)[key],
+                );
+                if (normalized !== undefined) {
+                    acc[key] = normalized;
+                }
+                return acc;
+            }, {});
+    }
+
+    return value;
+};
+
+const hashStringToBase36 = (
+    input: string,
+    modulus: number,
+    base: number,
+): string => {
+    let hash = 0;
+    for (let i = 0; i < input.length; i += 1) {
+        hash = (hash * base + input.charCodeAt(i)) % modulus;
+    }
+
+    return hash.toString(36).padStart(8, '0');
+};
+
+const hashCanonicalJson = (input: string): string =>
+    [
+        hashStringToBase36(input, 2_147_483_647, 31),
+        hashStringToBase36(input, 2_147_483_629, 37),
+    ].join('');
+
+export const getAiAgentConfigSnapshotHash = (
+    snapshot: AiAgentConfigSnapshot,
+): string => {
+    const canonicalJson = JSON.stringify(normalizeForHash(snapshot));
+    return `ai_agent_review_config_snapshot:${hashCanonicalJson(canonicalJson)}`;
+};
+
+export type AiAgentRuntimeContextSnapshot = {
+    userUuid: string | null;
+    canRunSql: boolean;
+    canManageAgent: boolean;
+};
+
+export type AiAgentModelMetadata = {
+    provider: string | null;
+    model: string | null;
+};
+
+export type AiAgentEvidenceWindow = {
+    userPromptUuid: string;
+    explicitFeedbackUuid: string | null;
+    nextUserPromptUuid: string | null;
+    previousPromptUuids: string[];
+};
+
+export type AiAgentSemanticTargetRef =
+    | { type: 'model'; modelName: string; yamlPath?: string }
+    | {
+          type: 'explore';
+          modelName: string;
+          exploreName: string;
+          yamlPath?: string;
+      }
+    | {
+          type: 'join';
+          modelName: string;
+          joinName: string;
+          exploreName?: string;
+          yamlPath?: string;
+      }
+    | {
+          type: 'dimension';
+          modelName: string;
+          dimensionName: string;
+          yamlPath?: string;
+      }
+    | {
+          type: 'metric';
+          modelName: string;
+          metricName: string;
+          dimensionName?: string;
+          yamlPath?: string;
+      }
+    | {
+          type: 'additional_dimension';
+          modelName: string;
+          parentDimensionName: string;
+          dimensionName: string;
+          yamlPath?: string;
+      }
+    | {
+          type: 'required_filter';
+          modelName: string;
+          exploreName: string;
+          fieldName: string;
+          yamlPath?: string;
+      }
+    | {
+          type: 'ai_hint';
+          modelName: string;
+          targetType: 'model' | 'dimension' | 'metric';
+          targetName: string;
+          yamlPath?: string;
+      };
+
+export type AiAgentTargetRef =
+    | AiAgentSemanticTargetRef
+    | { type: 'agent'; agentUuid: string }
+    | { type: 'agent_config'; setting: AiAgentConfigurationSetting }
+    | { type: 'product_capability'; capabilityKey: string }
+    | { type: 'runtime'; key: string };
+
+export type AiAgentEvidenceExcerpt = {
+    source:
+        | 'user_prompt'
+        | 'assistant_answer'
+        | 'next_user_prompt'
+        | 'conversation_context'
+        | 'tool_call'
+        | 'tool_result'
+        | 'agent_config';
+    text: string;
+    redacted: boolean;
+};
+
+export type AiAgentRecommendationAction =
+    | 'update_semantic_yaml'
+    | 'update_agent_instructions'
+    | 'add_knowledge_document'
+    | 'enable_data_access'
+    | 'enable_sql_mode'
+    | 'enable_self_improvement'
+    | 'configure_mcp_server'
+    | 'adjust_explore_tags'
+    | 'update_access'
+    | 'route_to_product_work'
+    | 'request_more_evidence'
+    | 'no_action';
+
+export type AiAgentRecommendation = {
+    actionType: AiAgentRecommendationAction;
+    title: string;
+    rationale: string;
+    targetRefs: AiAgentTargetRef[];
+};
+
+export type AiAgentReviewClassifierTurnSignal = {
+    subject: AiAgentReviewClassifierSubject;
+    interactionSource: AiAgentInteractionSource;
+    sourceRef: AiAgentTurnSignalSourceRef;
+    signal: AiAgentTurnSignal;
+    implicitSignalSources: AiAgentImplicitSignalSource[];
+    confidence: AiAgentReviewClassifierConfidence;
+    promotedToFinding: boolean;
+    promotionReason: string | null;
+    toolEvidenceRefs: string[];
+    runtimeContextSnapshot: AiAgentRuntimeContextSnapshot;
+    modelMetadata: AiAgentModelMetadata;
+};
+
+export type AiAgentFindingReviewStatus =
+    | 'unreviewed'
+    | 'accepted'
+    | 'rejected'
+    | 'needs_more_evidence';
+
+export type AiAgentReviewItemStatus =
+    | 'open'
+    | 'in_progress'
+    | 'resolved'
+    | 'dismissed'
+    | 'duplicate';
+
+export type AiAgentReviewItemDismissedReason =
+    | 'not_actionable'
+    | 'expected_behavior'
+    | 'duplicate'
+    | 'low_confidence'
+    | 'other';
+
+export type AiAgentReviewItemOwnerType =
+    | 'semantic_layer_owner'
+    | 'agent_admin'
+    | 'product'
+    | 'support'
+    | 'unknown';
+
+const aiAgentConfigurationSettingSchema = z.enum([
+    'instructions',
+    'knowledge_documents',
+    'data_access',
+    'self_improvement',
+    'sql_mode',
+    'mcp_servers',
+    'explore_tags',
+    'space_access',
+    'user_or_group_access',
+    'unknown',
+]);
+
+const aiAgentJudgeTargetRefSchema = z.object({
+    type: z.enum([
+        'model',
+        'explore',
+        'join',
+        'dimension',
+        'metric',
+        'additional_dimension',
+        'required_filter',
+        'ai_hint',
+        'agent',
+        'agent_config',
+        'product_capability',
+        'runtime',
+    ]),
+    label: z.string(),
+    modelName: z.string().nullable(),
+    fieldName: z.string().nullable(),
+    setting: aiAgentConfigurationSettingSchema.nullable(),
+    key: z.string().nullable(),
+});
+
+export const aiAgentReviewClassifierJudgeOutputSchema = z.object({
+    signal: z.enum([
+        'normal_refinement',
+        'implicit_correction',
+        'explicit_dispute',
+        'retry_after_failure',
+        'output_shape_correction',
+        'new_question',
+        'acceptance_or_continuation',
+        'product_capability_request',
+        'human_intervention',
+        'ambiguous',
+    ]),
+    implicitSignalSources: z.array(
+        z.enum([
+            'next_user_correction',
+            'next_user_dispute',
+            'next_user_retry',
+            'output_shape_correction',
+            'tool_error',
+            'assistant_no_answer',
+            'product_capability_request',
+            'human_intervention',
+        ]),
+    ),
+    confidence: z.enum(['low', 'medium', 'high']),
+    promotedToFinding: z.boolean(),
+    promotionReason: z.string().nullable(),
+    primaryRootCause: z.enum([
+        'semantic_layer',
+        'project_context',
+        'agent_configuration',
+        'data_gap',
+        'product_capability',
+        'runtime_reliability',
+        'feedback_quality',
+        'not_a_failure',
+        'ambiguous',
+    ]),
+    secondaryRootCauses: z.array(
+        z.enum([
+            'semantic_layer',
+            'project_context',
+            'agent_configuration',
+            'data_gap',
+            'product_capability',
+            'runtime_reliability',
+            'feedback_quality',
+            'not_a_failure',
+            'ambiguous',
+        ]),
+    ),
+    subcategories: z.array(z.string()),
+    fixTargets: z.array(
+        z.enum([
+            'semantic_yaml_patch',
+            'project_context_rule',
+            'agent_configuration_change',
+            'dbt_modeling_ticket',
+            'semantic_layer_ticket',
+            'product_capability_ticket',
+            'runtime_reliability_ticket',
+            'feedback_needed',
+            'no_action',
+        ]),
+    ),
+    targetRefs: z.array(aiAgentJudgeTargetRefSchema),
+    agentConfigurationSettings: z.array(aiAgentConfigurationSettingSchema),
+    ownerType: z.enum([
+        'semantic_layer_owner',
+        'agent_admin',
+        'product',
+        'support',
+        'unknown',
+    ]),
+    evidenceExcerpts: z.array(
+        z.object({
+            source: z.enum([
+                'user_prompt',
+                'assistant_answer',
+                'next_user_prompt',
+                'conversation_context',
+                'tool_call',
+                'tool_result',
+                'agent_config',
+            ]),
+            text: z.string(),
+            redacted: z.boolean(),
+        }),
+    ),
+    recommendation: z
+        .object({
+            actionType: z.enum([
+                'update_semantic_yaml',
+                'update_agent_instructions',
+                'add_knowledge_document',
+                'enable_data_access',
+                'enable_sql_mode',
+                'enable_self_improvement',
+                'configure_mcp_server',
+                'adjust_explore_tags',
+                'update_access',
+                'route_to_product_work',
+                'request_more_evidence',
+                'no_action',
+            ]),
+            title: z.string(),
+            rationale: z.string(),
+            targetRefs: z.array(aiAgentJudgeTargetRefSchema),
+        })
+        .nullable(),
+    reviewItem: z.object({
+        title: z.string(),
+        description: z.string(),
+    }),
+});
+
+export type AiAgentReviewClassifierJudgeOutput = z.infer<
+    typeof aiAgentReviewClassifierJudgeOutputSchema
+>;
+
+export type AiAgentReviewItem = {
+    uuid: string;
+    fingerprint: string;
+    organizationUuid: string;
+    projectUuid: string | null;
+    agentUuid: string | null;
+    title: string;
+    description: string;
+    primaryRootCause: AiAgentRootCause;
+    status: AiAgentReviewItemStatus;
+    dismissedReason: AiAgentReviewItemDismissedReason | null;
+    ownerType: AiAgentReviewItemOwnerType;
+    assignedToUserUuid: string | null;
+    firstSeenAt: Date;
+    lastSeenAt: Date;
+    findingCount: number;
+    statusUpdatedAt: Date;
+    statusUpdatedByUserUuid: string | null;
+    linkedIssueUrl: string | null;
+    linkedPrUrl: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type AiAgentReviewItemSummary = AiAgentReviewItem & {
+    latestFinding: {
+        uuid: string;
+        promptUuid: string;
+        threadUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+        subcategories: string[];
+        fixTargets: AiAgentFixTarget[];
+        targetRefs: AiAgentTargetRef[];
+        evidenceExcerpts: AiAgentEvidenceExcerpt[];
+        recommendation: AiAgentRecommendation | null;
+        createdAt: Date;
+    } | null;
+};
+
+export type ApiAiAgentReviewItemsResponse = ApiSuccess<
+    AiAgentReviewItemSummary[]
+>;
+
+export type AiAgentReviewSignalSummary = {
+    uuid: string;
+    runUuid: string;
+    promptUuid: string;
+    threadUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+    signal: AiAgentTurnSignal;
+    implicitSignalSources: AiAgentImplicitSignalSource[];
+    confidence: AiAgentReviewClassifierConfidence;
+    promotedToFinding: boolean;
+    promotionReason: string | null;
+    createdAt: Date;
+    runScope: AiAgentReviewClassifierRunScope;
+    prompt: string;
+    responsePreview: string | null;
+    errorMessage: string | null;
+    finding: {
+        uuid: string;
+        reviewItemUuid: string | null;
+        primaryRootCause: AiAgentRootCause;
+        subcategories: string[];
+        fixTargets: AiAgentFixTarget[];
+        evidenceExcerpts: AiAgentEvidenceExcerpt[];
+        recommendation: AiAgentRecommendation | null;
+    } | null;
+};
+
+export type ApiAiAgentReviewSignalsResponse = ApiSuccess<
+    AiAgentReviewSignalSummary[]
+>;
+
+export type AiAgentReviewClassifierRunStatus =
+    | 'queued'
+    | 'running'
+    | 'completed'
+    | 'failed';
+
+export type AiAgentReviewClassifierRunScope =
+    | {
+          type: 'backfill';
+          startedAt: string;
+          endedAt: string;
+          projectUuid?: string;
+          agentUuid?: string;
+          dryRun?: boolean;
+      }
+    | {
+          type: 'live_event';
+          eventType: AiAgentReviewClassifierEventType;
+          promptUuid: string;
+          threadUuid: string;
+          projectUuid: string;
+          agentUuid: string;
+      }
+    | {
+          type: 'manual';
+          requestedByUserUuid: string;
+          filters: Record<string, unknown>;
+      };
+
+export type AiAgentReviewClassifierRun = {
+    uuid: string;
+    organizationUuid: string;
+    status: AiAgentReviewClassifierRunStatus;
+    reviewAgentVersion: string;
+    judgePromptHash: string;
+    agentConfigSnapshotHash: string | null;
+    agentConfigSnapshot: AiAgentConfigSnapshot | null;
+    agentConfigSnapshotAgentUpdatedAt: Date | null;
+    runScope: AiAgentReviewClassifierRunScope;
+    totalTurns: number;
+    processedTurns: number;
+    signalCount: number;
+    findingCount: number;
+    reviewItemCount: number;
+    errorMessage: string | null;
+    completedAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type AiAgentReviewClassifierTurnSnapshot = {
+    promptUuid: string;
+    userPrompt: string;
+    assistantResponse: string | null;
+    errorMessage: string | null;
+    createdAt: Date;
+    respondedAt: Date | null;
+};
+
+export type AiAgentReviewClassifierContextTurn =
+    AiAgentReviewClassifierTurnSnapshot & {
+        relation: 'previous' | 'next' | 'referenced';
+    };
+
+export type AiAgentReviewClassifierTurnCandidate = {
+    subject: AiAgentReviewClassifierSubject;
+    interactionSource: AiAgentInteractionSource;
+    sourceRef: AiAgentTurnSignalSourceRef;
+    targetTurn: AiAgentReviewClassifierTurnSnapshot;
+    contextTurns: AiAgentReviewClassifierContextTurn[];
+    reviewHints?: {
+        useTargetPromptAsCorrectionEvidence?: boolean;
+    };
+    userPrompt: string;
+    assistantResponse: string | null;
+    errorMessage: string | null;
+    humanScore: number | null;
+    humanFeedback: string | null;
+    createdAt: Date;
+    respondedAt: Date | null;
+    nextUserPromptUuid: string | null;
+    nextUserPrompt: string | null;
+    modelMetadata: AiAgentModelMetadata;
+    tokenUsageTotal: number | null;
+    queryHistory: AiAgentReviewClassifierQueryHistorySummary[];
+    supportingEvidence: AiAgentReviewClassifierSupportingEvidence[];
+};
+
+export type AiAgentReviewClassifierQueryHistorySummary = {
+    queryUuid: string;
+    status: QueryHistoryStatus;
+    error: string | null;
+    createdAt: Date;
+    totalRowCount: number | null;
+    warehouseExecutionTimeMs: number | null;
+    metricQuery: Pick<
+        MetricQuery,
+        'exploreName' | 'dimensions' | 'metrics' | 'filters' | 'sorts'
+    >;
+};
+
+export type AiAgentReviewClassifierSupportingEvidence = {
+    source: 'tool_trace';
+    toolCallId: string;
+    toolName: string;
+    parentToolCallId: string | null;
+    createdAt: Date;
+    relevanceScore: number;
+    toolArgsPreview: string | null;
+    resultPreview: string | null;
+};
+
+export type AiAgentReviewClassifierSignalFinding = {
+    primaryRootCause: AiAgentRootCause;
+    secondaryRootCauses: AiAgentRootCause[];
+    subcategories: string[];
+    fixTargets: AiAgentFixTarget[];
+    targetRefs: AiAgentTargetRef[];
+    evidenceExcerpts: AiAgentEvidenceExcerpt[];
+    recommendation: AiAgentRecommendation | null;
+    reviewItem: {
+        fingerprint: string;
+        title: string;
+        description: string;
+        ownerType: AiAgentReviewItemOwnerType;
+    };
+};
+
+export type AiAgentReviewItemFingerprintInput = {
+    organizationUuid: string;
+    projectUuid: string | null;
+    agentUuid: string | null;
+    primaryRootCause: AiAgentRootCause;
+    subcategories: string[];
+    fixTargets: AiAgentFixTarget[];
+    targetRefs: AiAgentTargetRef[];
+    agentConfigurationSettings: AiAgentConfigurationSetting[];
+    capabilityKey: string | null;
+};
+
+type AiAgentReviewItemFingerprintScope =
+    | {
+          type: 'organization';
+          organizationUuid: string;
+      }
+    | {
+          type: 'project';
+          organizationUuid: string;
+          projectUuid: string;
+      }
+    | {
+          type: 'agent';
+          organizationUuid: string;
+          agentUuid: string;
+      };
+
+const requireScopeValue = (
+    value: string | null,
+    field: 'projectUuid' | 'agentUuid',
+    rootCause: AiAgentRootCause,
+): string => {
+    if (!value) {
+        throw new Error(`${field} is required for ${rootCause} fingerprints`);
+    }
+    return value;
+};
+
+export const getAiAgentReviewItemFingerprintScope = (
+    input: Pick<
+        AiAgentReviewItemFingerprintInput,
+        'organizationUuid' | 'projectUuid' | 'agentUuid' | 'primaryRootCause'
+    >,
+): AiAgentReviewItemFingerprintScope => {
+    switch (input.primaryRootCause) {
+        case 'semantic_layer':
+        case 'project_context':
+        case 'data_gap':
+            return {
+                type: 'project',
+                organizationUuid: input.organizationUuid,
+                projectUuid: requireScopeValue(
+                    input.projectUuid,
+                    'projectUuid',
+                    input.primaryRootCause,
+                ),
+            };
+        case 'agent_configuration':
+            return {
+                type: 'agent',
+                organizationUuid: input.organizationUuid,
+                agentUuid: requireScopeValue(
+                    input.agentUuid,
+                    'agentUuid',
+                    input.primaryRootCause,
+                ),
+            };
+        default:
+            return input.projectUuid
+                ? {
+                      type: 'project',
+                      organizationUuid: input.organizationUuid,
+                      projectUuid: input.projectUuid,
+                  }
+                : {
+                      type: 'organization',
+                      organizationUuid: input.organizationUuid,
+                  };
+    }
+};
+
+export const getAiAgentReviewItemFingerprint = (
+    input: AiAgentReviewItemFingerprintInput,
+): string => {
+    const scope = getAiAgentReviewItemFingerprintScope(input);
+    const canonicalJson = JSON.stringify(
+        normalizeForHash({
+            scope,
+            primaryRootCause: input.primaryRootCause,
+            subcategories: input.subcategories,
+            fixTargets: input.fixTargets,
+            targetRefs: input.targetRefs,
+            agentConfigurationSettings: input.agentConfigurationSettings,
+            capabilityKey: input.capabilityKey,
+        }),
+    );
+
+    return `ai_agent_review_item:${hashCanonicalJson(canonicalJson)}`;
+};

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -29,6 +29,7 @@ export * from './aiEvalAssessment';
 export * from './chartConfig/slack';
 export * from './chartConfig/web';
 export * from './constants';
+export * from './aiAgentReviewClassifierTypes';
 export * from './documentTypes';
 export * from './filterExploreByTags';
 export * from './followUpTools';

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -168,6 +168,19 @@ export type AiAgentEvalRunJobPayload = TraceTaskBase & {
     threadUuid: string;
 };
 
+export type AiAgentReviewClassifierEventType =
+    | 'response_saved'
+    | 'feedback_changed';
+
+export type AiAgentReviewClassifierJobPayload = TraceTaskBase & {
+    eventType: AiAgentReviewClassifierEventType;
+    organizationUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+};
+
 export type EmbedArtifactVersionJobPayload = TraceTaskBase & {
     artifactVersionUuid: string;
     title: string | null;

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -203,6 +203,11 @@ export enum FeatureFlags {
     AiContextCompaction = 'ai-context-compaction',
 
     /**
+     * Enable AI agent review classifier experiments.
+     */
+    AiAgentReviewClassifier = 'ai-agent-review-classifier',
+
+    /**
      * Show a persistent trial warning banner for an organization on shared
      * instances. This does not block product access.
      */


### PR DESCRIPTION
## Summary

Adds the classifier output contract and persistence layer for the Context Studio classifier experiment.

This includes:
- review classifier taxonomy, target/evidence/recommendation types, and stable fingerprints
- feature flag for the experiment
- persistence tables for classifier runs, config snapshots, signals, findings, review items, and artifacts
- backend table typings and common contract tests

Refs PROD-7917
Refs PROD-7919

## Validation

Run on the stack:
- `pnpm -F @lightdash/common test -- aiAgentReviewClassifierTypes.test.ts --runInBand`
- `pnpm -F @lightdash/common typecheck`
- `pnpm -F backend test -- AiAgentReviewClassifierService.test.ts AiAgentReviewClassifierModel.test.ts --runInBand`
- `pnpm -F backend typecheck`
