### PR TITLE
feat(ai-agents): classify review candidates

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -17,6 +17,7 @@ import OpenAi from './clients/OpenAi';
 import { CommercialSlackClient } from './clients/Slack/SlackClient';
 import { AiAgentDocumentModel } from './models/AiAgentDocumentModel';
 import { AiAgentModel } from './models/AiAgentModel';
+import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
 import { AiWritebackThreadModel } from './models/AiWritebackThreadModel';
 import { CommercialFeatureFlagModel } from './models/CommercialFeatureFlagModel';
@@ -32,6 +33,7 @@ import { CommercialSchedulerWorker } from './scheduler/SchedulerWorker';
 import { AiAgentContentValidation } from './services/ai/utils/AiAgentContentValidation';
 import { AiAgentAdminService } from './services/AiAgentAdminService';
 import { AiAgentDocumentService } from './services/AiAgentDocumentService';
+import { AiAgentReviewClassifierService } from './services/AiAgentReviewClassifierService';
 import { AiAgentService } from './services/AiAgentService/AiAgentService';
 import { AiOrganizationSettingsService } from './services/AiOrganizationSettingsService';
 import { AiService } from './services/AiService/AiService';
@@ -201,6 +203,15 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getFeatureFlagModel() as CommercialFeatureFlagModel,
                     aiAgentService:
                         repository.getAiAgentService<AiAgentService>(),
+                    lightdashConfig: context.lightdashConfig,
+                }),
+            aiAgentReviewClassifierService: ({ models, repository, context }) =>
+                new AiAgentReviewClassifierService({
+                    aiAgentReviewClassifierModel:
+                        models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
+                    aiAgentModel: models.getAiAgentModel<AiAgentModel>(),
+                    catalogModel: models.getCatalogModel(),
+                    featureFlagService: repository.getFeatureFlagService(),
                     lightdashConfig: context.lightdashConfig,
                 }),
             aiOrganizationSettingsService: ({ models, context }) =>
@@ -502,6 +513,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AiAgentDocumentModel({ database }),
             aiWritebackThreadModel: ({ database }) =>
                 new AiWritebackThreadModel({ database }),
+            aiAgentReviewClassifierModel: ({ database }) =>
+                new AiAgentReviewClassifierModel({ database }),
             aiOrganizationSettingsModel: ({ database }) =>
                 new AiOrganizationSettingsModel({ database }),
             embedModel: ({ database }) => new EmbedModel({ database }),

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -1,0 +1,409 @@
+import knex, { Knex } from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import {
+    AiAgentReviewClassifierRunTableName,
+    AiAgentTurnSignalTableName,
+} from '../database/entities/aiAgentReviewClassifier';
+import { AiAgentReviewClassifierModel } from './AiAgentReviewClassifierModel';
+
+const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000002';
+const AGENT_UUID = '00000000-0000-0000-0000-000000000003';
+const RUN_UUID = '00000000-0000-0000-0000-000000000006';
+const THREAD_UUID = '00000000-0000-0000-0000-000000000007';
+const PROMPT_UUID = '00000000-0000-0000-0000-000000000008';
+const TURN_SIGNAL_UUID = '00000000-0000-0000-0000-000000000009';
+const SEEN_AT = new Date('2026-05-26T10:00:00.000Z');
+const FINGERPRINT = 'ai_agent_review_item:fingerprint';
+
+const snapshot = {
+    capturedAt: '2026-05-26T10:00:00.000Z',
+    agentUpdatedAt: '2026-05-26T09:00:00.000Z',
+    settings: ['instructions' as const],
+    availableCapabilities: ['semantic_query' as const],
+    instructionHash: 'hash',
+    instructionSummary: 'Use finance definitions.',
+    knowledgeDocuments: [],
+};
+
+const makeRunRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    ai_agent_review_run_uuid: RUN_UUID,
+    organization_uuid: ORGANIZATION_UUID,
+    status: 'queued',
+    review_agent_version: 'v1',
+    judge_prompt_hash: 'prompt-hash',
+    agent_config_snapshot_hash: null,
+    agent_config_snapshot: null,
+    agent_config_snapshot_agent_updated_at: null,
+    run_scope: {
+        type: 'backfill',
+        startedAt: '2026-05-26T00:00:00.000Z',
+        endedAt: '2026-05-27T00:00:00.000Z',
+    },
+    total_turns: 0,
+    processed_turns: 0,
+    signal_count: 0,
+    finding_count: 0,
+    review_item_count: 0,
+    error_message: null,
+    completed_at: null,
+    created_at: SEEN_AT,
+    updated_at: SEEN_AT,
+    ...overrides,
+});
+
+const makeTurnSignalRow = (
+    overrides: Partial<Record<string, unknown>> = {},
+) => ({
+    ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID,
+    ai_agent_review_run_uuid: RUN_UUID,
+    ai_prompt_uuid: PROMPT_UUID,
+    ai_thread_uuid: THREAD_UUID,
+    organization_uuid: ORGANIZATION_UUID,
+    project_uuid: PROJECT_UUID,
+    agent_uuid: AGENT_UUID,
+    interaction_source: 'app',
+    source_ref: {
+        source: 'app',
+        threadUuid: THREAD_UUID,
+        promptUuid: PROMPT_UUID,
+        appUrl: null,
+    },
+    signal: 'implicit_correction',
+    implicit_signal_sources: ['next_user_correction'],
+    confidence: 'high',
+    promoted_to_finding: true,
+    promotion_reason: 'User corrected the answer.',
+    tool_evidence_refs: [],
+    fingerprint: FINGERPRINT,
+    primary_root_cause: 'semantic_layer',
+    secondary_root_causes: ['project_context'],
+    subcategories: ['wrong_metric'],
+    fix_targets: ['semantic_yaml_patch'],
+    target_refs: [
+        {
+            type: 'metric',
+            modelName: 'orders',
+            metricName: 'total_completed_order_amount',
+        },
+    ],
+    evidence_excerpts: [
+        {
+            source: 'next_user_prompt',
+            text: 'No, use revenue not order count.',
+            redacted: false,
+        },
+    ],
+    recommendation: {
+        actionType: 'update_semantic_yaml',
+        title: 'Add revenue metric guidance',
+        rationale: 'The user corrected the metric choice.',
+        targetRefs: [],
+    },
+    owner_type: 'semantic_layer_owner',
+    review_item_title: 'Review revenue metric',
+    review_item_description: 'The agent selected order count for revenue.',
+    runtime_context_snapshot: {
+        userUuid: null,
+        canRunSql: false,
+        canManageAgent: false,
+    },
+    model_metadata: {
+        provider: 'openai',
+        model: 'gpt-5',
+    },
+    created_at: SEEN_AT,
+    ...overrides,
+});
+
+const turnSignal = {
+    subject: {
+        type: 'turn_review' as const,
+        assistantPromptUuid: PROMPT_UUID,
+        threadUuid: THREAD_UUID,
+        agentUuid: AGENT_UUID,
+        projectUuid: PROJECT_UUID,
+        organizationUuid: ORGANIZATION_UUID,
+    },
+    interactionSource: 'app' as const,
+    sourceRef: {
+        source: 'app' as const,
+        threadUuid: THREAD_UUID,
+        promptUuid: PROMPT_UUID,
+        appUrl: null,
+    },
+    signal: 'implicit_correction' as const,
+    implicitSignalSources: ['next_user_correction' as const],
+    confidence: 'medium' as const,
+    promotedToFinding: true,
+    promotionReason: 'User corrected the requested grouping.',
+    toolEvidenceRefs: [],
+    runtimeContextSnapshot: {
+        userUuid: null,
+        canRunSql: false,
+        canManageAgent: false,
+    },
+    modelMetadata: {
+        provider: 'openai',
+        model: 'gpt-5',
+    },
+};
+
+describe('AiAgentReviewClassifierModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new AiAgentReviewClassifierModel({
+        database: database as unknown as Knex,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    describe('createRun', () => {
+        it('creates a review agent run with run-level config snapshot', async () => {
+            tracker.on
+                .insert(AiAgentReviewClassifierRunTableName)
+                .responseOnce([
+                    makeRunRow({
+                        agent_config_snapshot_hash: 'snapshot-hash',
+                        agent_config_snapshot: snapshot,
+                        agent_config_snapshot_agent_updated_at: SEEN_AT,
+                    }),
+                ]);
+
+            const result = await model.createRun({
+                organizationUuid: ORGANIZATION_UUID,
+                reviewAgentVersion: 'v1',
+                judgePromptHash: 'prompt-hash',
+                runScope: {
+                    type: 'backfill',
+                    startedAt: '2026-05-26T00:00:00.000Z',
+                    endedAt: '2026-05-27T00:00:00.000Z',
+                },
+                agentConfigSnapshotHash: 'snapshot-hash',
+                agentConfigSnapshot: snapshot,
+                agentConfigSnapshotAgentUpdatedAt: SEEN_AT,
+            });
+
+            expect(result.uuid).toBe(RUN_UUID);
+            expect(result.agentConfigSnapshotHash).toBe('snapshot-hash');
+            expect(result.agentConfigSnapshot).toEqual(snapshot);
+        });
+    });
+
+    describe('updateRun', () => {
+        it('updates run progress and completion fields', async () => {
+            tracker.on
+                .update(AiAgentReviewClassifierRunTableName)
+                .responseOnce([
+                    makeRunRow({
+                        status: 'completed',
+                        total_turns: 4,
+                        processed_turns: 4,
+                        signal_count: 2,
+                        finding_count: 1,
+                        review_item_count: 1,
+                        completed_at: SEEN_AT,
+                    }),
+                ]);
+
+            const result = await model.updateRun({
+                runUuid: RUN_UUID,
+                status: 'completed',
+                totalTurns: 4,
+                processedTurns: 4,
+                signalCount: 2,
+                findingCount: 1,
+                reviewItemCount: 1,
+                completedAt: SEEN_AT,
+            });
+
+            expect(result.status).toBe('completed');
+            expect(result.processedTurns).toBe(4);
+            expect(result.completedAt).toEqual(SEEN_AT);
+        });
+    });
+
+    describe('mapTurnReviewCandidate', () => {
+        it('maps app turns into review agent candidate input', () => {
+            const result = AiAgentReviewClassifierModel.mapTurnReviewCandidate({
+                ai_prompt_uuid: PROMPT_UUID,
+                ai_thread_uuid: THREAD_UUID,
+                organization_uuid: ORGANIZATION_UUID,
+                project_uuid: PROJECT_UUID,
+                agent_uuid: AGENT_UUID,
+                created_from: 'web_app',
+                prompt: 'Show airport volume by country',
+                response: 'Country is not available.',
+                error_message: null,
+                human_score: null,
+                human_feedback: null,
+                prompt_created_at: SEEN_AT,
+                responded_at: SEEN_AT,
+                model_config: {
+                    modelName: 'gpt-5',
+                    modelProvider: 'openai',
+                },
+                token_usage: { totalTokens: 123 },
+                next_user_prompt_uuid: null,
+                next_user_prompt: null,
+                previous_turn_context: [
+                    {
+                        relation: 'previous',
+                        promptUuid: '00000000-0000-0000-0000-000000000012',
+                        userPrompt: 'Show total airport volume',
+                        assistantResponse:
+                            'Airport volume is calculated from scheduled flights.',
+                        errorMessage: null,
+                        createdAt: SEEN_AT.toISOString(),
+                        respondedAt: SEEN_AT.toISOString(),
+                    },
+                ],
+                slack_channel_id: null,
+                slack_thread_ts: null,
+                prompt_slack_ts: null,
+                query_history_summaries: [],
+                supporting_evidence_summaries: [],
+            });
+
+            expect(result.subject.assistantPromptUuid).toBe(PROMPT_UUID);
+            expect(result.interactionSource).toBe('app');
+            expect(result.tokenUsageTotal).toBe(123);
+        });
+    });
+
+    describe('listReviewItems', () => {
+        it('groups actionable signals into review item projections', async () => {
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
+                makeTurnSignalRow(),
+                makeTurnSignalRow({
+                    ai_agent_review_turn_signal_uuid:
+                        '00000000-0000-0000-0000-000000000011',
+                    created_at: new Date('2026-05-26T09:00:00.000Z'),
+                }),
+            ]);
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual(
+                expect.objectContaining({
+                    uuid: FINGERPRINT,
+                    fingerprint: FINGERPRINT,
+                    title: 'Review revenue metric',
+                    status: 'open',
+                    findingCount: 2,
+                }),
+            );
+            expect(result[0].latestFinding).toEqual(
+                expect.objectContaining({
+                    uuid: TURN_SIGNAL_UUID,
+                    promptUuid: PROMPT_UUID,
+                    targetRefs: [
+                        {
+                            type: 'metric',
+                            modelName: 'orders',
+                            metricName: 'total_completed_order_amount',
+                        },
+                    ],
+                }),
+            );
+        });
+    });
+
+    describe('listReviewSignals', () => {
+        it('returns recent classifier signals with inline finding context', async () => {
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
+                {
+                    ...makeTurnSignalRow(),
+                    signal_created_at: SEEN_AT,
+                    run_scope: {
+                        type: 'live_event',
+                        eventType: 'response_saved',
+                        promptUuid: PROMPT_UUID,
+                        threadUuid: THREAD_UUID,
+                        projectUuid: PROJECT_UUID,
+                        agentUuid: AGENT_UUID,
+                    },
+                    prompt: 'Show revenue',
+                    response: 'Revenue is order count.',
+                    error_message: null,
+                },
+            ]);
+
+            const result = await model.listReviewSignals({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual(
+                expect.objectContaining({
+                    uuid: TURN_SIGNAL_UUID,
+                    runUuid: RUN_UUID,
+                    promptUuid: PROMPT_UUID,
+                    signal: 'implicit_correction',
+                    promotedToFinding: true,
+                    prompt: 'Show revenue',
+                    responsePreview: 'Revenue is order count.',
+                    finding: expect.objectContaining({
+                        uuid: TURN_SIGNAL_UUID,
+                        reviewItemUuid: FINGERPRINT,
+                        primaryRootCause: 'semantic_layer',
+                    }),
+                }),
+            );
+        });
+    });
+
+    describe('createTurnSignal', () => {
+        it('persists a classified signal with inline finding fields', async () => {
+            tracker.on.insert(AiAgentTurnSignalTableName).responseOnce([
+                {
+                    ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID,
+                },
+            ]);
+
+            const result = await model.createTurnSignal({
+                runUuid: RUN_UUID,
+                turnSignal,
+                finding: {
+                    primaryRootCause: 'semantic_layer',
+                    secondaryRootCauses: ['project_context'],
+                    subcategories: ['missing_dimension'],
+                    fixTargets: ['semantic_yaml_patch'],
+                    targetRefs: [
+                        {
+                            type: 'dimension',
+                            modelName: 'airports',
+                            dimensionName: 'country',
+                        },
+                    ],
+                    evidenceExcerpts: [
+                        {
+                            source: 'next_user_prompt',
+                            text: 'Country is not available here.',
+                            redacted: false,
+                        },
+                    ],
+                    recommendation: null,
+                    reviewItem: {
+                        fingerprint: FINGERPRINT,
+                        title: 'Review airports.country',
+                        description: 'Country needs semantic clarification.',
+                        ownerType: 'semantic_layer_owner',
+                    },
+                },
+            });
+
+            expect(result).toBe(TURN_SIGNAL_UUID);
+            expect(tracker.history.insert).toHaveLength(1);
+        });
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1,0 +1,972 @@
+import { QueryExecutionContext } from '@lightdash/common';
+import type {
+    AiAgentConfigSnapshot,
+    AiAgentEvidenceExcerpt,
+    AiAgentFixTarget,
+    AiAgentImplicitSignalSource,
+    AiAgentRecommendation,
+    AiAgentReviewClassifierConfidence,
+    AiAgentReviewClassifierContextTurn,
+    AiAgentReviewClassifierQueryHistorySummary,
+    AiAgentReviewClassifierRun,
+    AiAgentReviewClassifierRunScope,
+    AiAgentReviewClassifierRunStatus,
+    AiAgentReviewClassifierSignalFinding,
+    AiAgentReviewClassifierSupportingEvidence,
+    AiAgentReviewClassifierTurnCandidate,
+    AiAgentReviewClassifierTurnSignal,
+    AiAgentReviewItemStatus,
+    AiAgentReviewItemSummary,
+    AiAgentReviewSignalSummary,
+    AiAgentRootCause,
+    AiAgentTargetRef,
+    AiAgentTurnSignal,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { QueryHistoryTableName } from '../../database/entities/queryHistory';
+import {
+    AiAgentToolCallTableName,
+    AiAgentToolResultTableName,
+    AiPromptTableName,
+    AiSlackPromptTableName,
+    AiSlackThreadTableName,
+    AiThreadTableName,
+} from '../database/entities/ai';
+import {
+    AiAgentReviewClassifierRunTableName,
+    AiAgentTurnSignalTableName,
+    type AiAgentReviewClassifierRunTable,
+    type AiAgentTurnSignalTable,
+    type DbAiAgentReviewClassifierRun,
+    type DbAiAgentTurnSignal,
+} from '../database/entities/aiAgentReviewClassifier';
+
+type Dependencies = {
+    database: Knex;
+};
+
+type CreateRunArgs = {
+    organizationUuid: string;
+    reviewAgentVersion: string;
+    judgePromptHash: string;
+    runScope: AiAgentReviewClassifierRunScope;
+    agentConfigSnapshotHash?: string | null;
+    agentConfigSnapshot?: AiAgentConfigSnapshot | null;
+    agentConfigSnapshotAgentUpdatedAt?: Date | null;
+    status?: AiAgentReviewClassifierRunStatus;
+    totalTurns?: number;
+};
+
+type UpdateRunArgs = {
+    runUuid: string;
+    status?: AiAgentReviewClassifierRunStatus;
+    totalTurns?: number;
+    processedTurns?: number;
+    signalCount?: number;
+    findingCount?: number;
+    reviewItemCount?: number;
+    errorMessage?: string | null;
+    completedAt?: Date | null;
+};
+
+type ListTurnReviewCandidatesArgs = {
+    organizationUuid: string;
+    projectUuid?: string;
+    agentUuid?: string;
+    threadUuid?: string;
+    promptUuid?: string;
+    startedAt?: Date;
+    endedAt?: Date;
+    limit?: number;
+};
+
+type ListReviewItemsArgs = {
+    organizationUuid: string;
+    projectUuid?: string;
+    agentUuid?: string;
+    statuses?: AiAgentReviewItemStatus[];
+    limit?: number;
+};
+
+type ListReviewSignalsArgs = {
+    organizationUuid: string;
+    projectUuid?: string;
+    agentUuid?: string;
+    limit?: number;
+};
+
+type BaseCandidateRow = {
+    ai_prompt_uuid: string;
+    ai_thread_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    agent_uuid: string;
+    created_from: 'web_app' | 'slack';
+    prompt: string;
+    response: string | null;
+    error_message: string | null;
+    human_score: number | null;
+    human_feedback: string | null;
+    prompt_created_at: Date;
+    responded_at: Date | null;
+    model_config: { modelName: string; modelProvider: string } | null;
+    token_usage: { totalTokens?: number } | null;
+    slack_channel_id: string | null;
+    slack_thread_ts: string | null;
+    prompt_slack_ts: string | null;
+};
+
+type TurnReviewCandidateRow = BaseCandidateRow & {
+    next_user_prompt_uuid: string | null;
+    next_user_prompt: string | null;
+    previous_turn_context:
+        | (Omit<
+              AiAgentReviewClassifierContextTurn,
+              'createdAt' | 'respondedAt'
+          > & {
+              createdAt: string;
+              respondedAt: string | null;
+          })[]
+        | null;
+    query_history_summaries:
+        | (Omit<AiAgentReviewClassifierQueryHistorySummary, 'createdAt'> & {
+              createdAt: string;
+          })[]
+        | null;
+    supporting_evidence_summaries:
+        | (Omit<AiAgentReviewClassifierSupportingEvidence, 'createdAt'> & {
+              createdAt: string;
+          })[]
+        | null;
+};
+
+type ToolCallEvidenceRow = {
+    tool_call_id: string;
+    tool_name: string;
+    parent_tool_call_id: string | null;
+    created_at: Date;
+    tool_args: unknown;
+    result: string | null;
+};
+
+const TOOL_NAME_PRIORITY = new Map<string, number>([
+    ['findFields', 80],
+    ['find_fields', 80],
+    ['findExplores', 70],
+    ['find_explores', 70],
+    ['runQuery', 65],
+    ['run_metric_query', 65],
+    ['runSql', 60],
+    ['run_sql', 60],
+    ['searchFieldValues', 55],
+    ['search_field_values', 55],
+    ['discoverFields', 50],
+]);
+
+const TOOL_RESULT_ERROR_PATTERN =
+    /no match|no relevant|not found|empty|error|failed/i;
+
+const tokenize = (text: string): Set<string> =>
+    new Set(
+        text
+            .toLowerCase()
+            .split(/[^a-z0-9]+/i)
+            .filter((token) => token.length > 2),
+    );
+
+const rankToolCallEvidence = ({
+    rows,
+    userPrompt,
+    humanFeedback,
+    errorMessage,
+}: {
+    rows: ToolCallEvidenceRow[];
+    userPrompt: string;
+    humanFeedback: string | null;
+    errorMessage: string | null;
+}): (ToolCallEvidenceRow & { relevance_score: number })[] => {
+    const queryText = [userPrompt, humanFeedback, errorMessage]
+        .filter((value): value is string => Boolean(value))
+        .join(' ')
+        .slice(0, 1000);
+    const queryTokens = tokenize(queryText);
+
+    return rows
+        .map((row) => {
+            const argsText =
+                typeof row.tool_args === 'string'
+                    ? row.tool_args
+                    : JSON.stringify(row.tool_args ?? '');
+            const resultText = row.result ?? '';
+            const haystackTokens = tokenize(
+                `${row.tool_name} ${argsText} ${resultText}`,
+            );
+            const overlapCount = Array.from(queryTokens).reduce(
+                (count, token) => count + (haystackTokens.has(token) ? 1 : 0),
+                0,
+            );
+            const overlapBonus =
+                queryTokens.size > 0
+                    ? (100 * overlapCount) / queryTokens.size
+                    : 0;
+
+            const nameScore = TOOL_NAME_PRIORITY.get(row.tool_name) ?? 10;
+            const parentBonus = row.parent_tool_call_id ? 15 : 0;
+            const errorBonus = TOOL_RESULT_ERROR_PATTERN.test(resultText)
+                ? 25
+                : 0;
+
+            return {
+                ...row,
+                relevance_score:
+                    nameScore + parentBonus + errorBonus + overlapBonus,
+            };
+        })
+        .sort(
+            (a, b) =>
+                b.relevance_score - a.relevance_score ||
+                a.created_at.getTime() - b.created_at.getTime(),
+        );
+};
+
+const previewToolArgs = (toolArgs: unknown): string | null => {
+    const serialized =
+        typeof toolArgs === 'string' ? toolArgs : JSON.stringify(toolArgs);
+    if (!serialized) return null;
+    const truncated = serialized.slice(0, 800);
+    return truncated.length > 0 ? truncated : null;
+};
+
+const previewResult = (result: string | null): string | null => {
+    if (!result) return null;
+    const truncated = result.slice(0, 1200);
+    return truncated.length > 0 ? truncated : null;
+};
+
+type ReviewSignalSummaryRow = {
+    ai_agent_review_turn_signal_uuid: string;
+    ai_agent_review_run_uuid: string;
+    ai_prompt_uuid: string;
+    ai_thread_uuid: string;
+    project_uuid: string;
+    agent_uuid: string;
+    signal: AiAgentTurnSignal;
+    implicit_signal_sources: AiAgentImplicitSignalSource[];
+    confidence: AiAgentReviewClassifierConfidence;
+    promoted_to_finding: boolean;
+    promotion_reason: string | null;
+    signal_created_at: Date;
+    run_scope: AiAgentReviewClassifierRunScope;
+    prompt: string;
+    response: string | null;
+    error_message: string | null;
+    fingerprint: string | null;
+    primary_root_cause: AiAgentRootCause | null;
+    subcategories: string[] | null;
+    fix_targets: AiAgentFixTarget[] | null;
+    target_refs: AiAgentTargetRef[] | null;
+    evidence_excerpts: AiAgentEvidenceExcerpt[] | null;
+    recommendation: AiAgentRecommendation | null;
+};
+
+type CreateTurnSignalArgs = {
+    runUuid: string;
+    turnSignal: AiAgentReviewClassifierTurnSignal;
+    finding?: AiAgentReviewClassifierSignalFinding | null;
+};
+
+export class AiAgentReviewClassifierModel {
+    private readonly database: Knex;
+
+    constructor({ database }: Dependencies) {
+        this.database = database;
+    }
+
+    private jsonb(value: unknown): Knex.Raw {
+        return this.database.raw('?::jsonb', [JSON.stringify(value)]);
+    }
+
+    static mapRun(
+        row: DbAiAgentReviewClassifierRun,
+    ): AiAgentReviewClassifierRun {
+        return {
+            uuid: row.ai_agent_review_run_uuid,
+            organizationUuid: row.organization_uuid,
+            status: row.status,
+            reviewAgentVersion: row.review_agent_version,
+            judgePromptHash: row.judge_prompt_hash,
+            agentConfigSnapshotHash: row.agent_config_snapshot_hash,
+            agentConfigSnapshot: row.agent_config_snapshot,
+            agentConfigSnapshotAgentUpdatedAt:
+                row.agent_config_snapshot_agent_updated_at,
+            runScope: row.run_scope,
+            totalTurns: row.total_turns,
+            processedTurns: row.processed_turns,
+            signalCount: row.signal_count,
+            findingCount: row.finding_count,
+            reviewItemCount: row.review_item_count,
+            errorMessage: row.error_message,
+            completedAt: row.completed_at,
+            createdAt: row.created_at,
+            updatedAt: row.updated_at,
+        };
+    }
+
+    static mapReviewSignalSummary(
+        row: ReviewSignalSummaryRow,
+    ): AiAgentReviewSignalSummary {
+        return {
+            uuid: row.ai_agent_review_turn_signal_uuid,
+            runUuid: row.ai_agent_review_run_uuid,
+            promptUuid: row.ai_prompt_uuid,
+            threadUuid: row.ai_thread_uuid,
+            projectUuid: row.project_uuid,
+            agentUuid: row.agent_uuid,
+            signal: row.signal,
+            implicitSignalSources: row.implicit_signal_sources,
+            confidence: row.confidence,
+            promotedToFinding: row.promoted_to_finding,
+            promotionReason: row.promotion_reason,
+            createdAt: row.signal_created_at,
+            runScope: row.run_scope,
+            prompt: row.prompt,
+            responsePreview: row.response ? row.response.slice(0, 800) : null,
+            errorMessage: row.error_message,
+            finding: row.promoted_to_finding
+                ? {
+                      uuid: row.ai_agent_review_turn_signal_uuid,
+                      reviewItemUuid: row.fingerprint,
+                      primaryRootCause: row.primary_root_cause ?? 'ambiguous',
+                      subcategories: row.subcategories ?? [],
+                      fixTargets: row.fix_targets ?? [],
+                      evidenceExcerpts: row.evidence_excerpts ?? [],
+                      recommendation: row.recommendation,
+                  }
+                : null,
+        };
+    }
+
+    static mapTurnReviewCandidate(
+        row: TurnReviewCandidateRow,
+    ): AiAgentReviewClassifierTurnCandidate {
+        const interactionSource =
+            row.created_from === 'slack' ? 'slack' : 'app';
+        return {
+            subject: {
+                type: 'turn_review',
+                assistantPromptUuid: row.ai_prompt_uuid,
+                threadUuid: row.ai_thread_uuid,
+                agentUuid: row.agent_uuid,
+                projectUuid: row.project_uuid,
+                organizationUuid: row.organization_uuid,
+            },
+            interactionSource,
+            sourceRef:
+                interactionSource === 'slack'
+                    ? {
+                          source: 'slack',
+                          channelId: row.slack_channel_id ?? '',
+                          threadTs: row.slack_thread_ts,
+                          messageTs: row.prompt_slack_ts ?? row.ai_prompt_uuid,
+                          slackPermalink: null,
+                      }
+                    : {
+                          source: 'app',
+                          threadUuid: row.ai_thread_uuid,
+                          promptUuid: row.ai_prompt_uuid,
+                          appUrl: null,
+                      },
+            targetTurn: {
+                promptUuid: row.ai_prompt_uuid,
+                userPrompt: row.prompt,
+                assistantResponse: row.response,
+                errorMessage: row.error_message,
+                createdAt: row.prompt_created_at,
+                respondedAt: row.responded_at,
+            },
+            contextTurns: (row.previous_turn_context ?? []).map(
+                (contextTurn) => ({
+                    ...contextTurn,
+                    createdAt: new Date(contextTurn.createdAt),
+                    respondedAt: contextTurn.respondedAt
+                        ? new Date(contextTurn.respondedAt)
+                        : null,
+                }),
+            ),
+            userPrompt: row.prompt,
+            assistantResponse: row.response,
+            errorMessage: row.error_message,
+            humanScore: row.human_score,
+            humanFeedback: row.human_feedback,
+            createdAt: row.prompt_created_at,
+            respondedAt: row.responded_at,
+            nextUserPromptUuid: row.next_user_prompt_uuid,
+            nextUserPrompt: row.next_user_prompt,
+            modelMetadata: {
+                provider: row.model_config?.modelProvider ?? null,
+                model: row.model_config?.modelName ?? null,
+            },
+            tokenUsageTotal:
+                typeof row.token_usage?.totalTokens === 'number'
+                    ? row.token_usage.totalTokens
+                    : null,
+            queryHistory: (row.query_history_summaries ?? []).map(
+                (queryHistory) => ({
+                    ...queryHistory,
+                    createdAt: new Date(queryHistory.createdAt),
+                    metricQuery: {
+                        exploreName: queryHistory.metricQuery.exploreName,
+                        dimensions: queryHistory.metricQuery.dimensions ?? [],
+                        metrics: queryHistory.metricQuery.metrics ?? [],
+                        filters: queryHistory.metricQuery.filters,
+                        sorts: queryHistory.metricQuery.sorts ?? [],
+                    },
+                }),
+            ),
+            supportingEvidence: (row.supporting_evidence_summaries ?? []).map(
+                (evidence) => ({
+                    ...evidence,
+                    createdAt: new Date(evidence.createdAt),
+                }),
+            ),
+        };
+    }
+
+    async createRun(args: CreateRunArgs): Promise<AiAgentReviewClassifierRun> {
+        const [row] = await this.database<AiAgentReviewClassifierRunTable>(
+            AiAgentReviewClassifierRunTableName,
+        )
+            .insert({
+                organization_uuid: args.organizationUuid,
+                review_agent_version: args.reviewAgentVersion,
+                judge_prompt_hash: args.judgePromptHash,
+                run_scope: this.jsonb(args.runScope) as never,
+                agent_config_snapshot_hash: args.agentConfigSnapshotHash,
+                agent_config_snapshot: args.agentConfigSnapshot
+                    ? (this.jsonb(args.agentConfigSnapshot) as never)
+                    : null,
+                agent_config_snapshot_agent_updated_at:
+                    args.agentConfigSnapshotAgentUpdatedAt,
+                status: args.status,
+                total_turns: args.totalTurns,
+            })
+            .returning('*');
+
+        return AiAgentReviewClassifierModel.mapRun(row);
+    }
+
+    async updateRun(args: UpdateRunArgs): Promise<AiAgentReviewClassifierRun> {
+        const update: Omit<
+            Partial<DbAiAgentReviewClassifierRun>,
+            'updated_at'
+        > & {
+            updated_at: Knex.Raw;
+        } = {
+            updated_at: this.database.fn.now(),
+        };
+
+        if (args.status !== undefined) update.status = args.status;
+        if (args.totalTurns !== undefined) update.total_turns = args.totalTurns;
+        if (args.processedTurns !== undefined) {
+            update.processed_turns = args.processedTurns;
+        }
+        if (args.signalCount !== undefined) {
+            update.signal_count = args.signalCount;
+        }
+        if (args.findingCount !== undefined) {
+            update.finding_count = args.findingCount;
+        }
+        if (args.reviewItemCount !== undefined) {
+            update.review_item_count = args.reviewItemCount;
+        }
+        if (args.errorMessage !== undefined) {
+            update.error_message = args.errorMessage;
+        }
+        if (args.completedAt !== undefined) {
+            update.completed_at = args.completedAt;
+        }
+
+        const [row] = await this.database<AiAgentReviewClassifierRunTable>(
+            AiAgentReviewClassifierRunTableName,
+        )
+            .where('ai_agent_review_run_uuid', args.runUuid)
+            .update(update)
+            .returning('*');
+
+        return AiAgentReviewClassifierModel.mapRun(row);
+    }
+
+    async listTurnReviewCandidates(
+        args: ListTurnReviewCandidatesArgs,
+    ): Promise<AiAgentReviewClassifierTurnCandidate[]> {
+        const baseRows = await this.fetchBaseCandidateRows(args);
+
+        const enriched = await Promise.all(
+            baseRows.map(async (base) => {
+                const [
+                    nextPrompt,
+                    previousTurnContext,
+                    queryHistorySummaries,
+                    supportingEvidenceSummaries,
+                ] = await Promise.all([
+                    this.fetchNextPrompt(
+                        base.ai_thread_uuid,
+                        base.prompt_created_at,
+                    ),
+                    this.fetchPreviousTurnContext(
+                        base.ai_thread_uuid,
+                        base.prompt_created_at,
+                    ),
+                    this.fetchQueryHistorySummaries(
+                        base.organization_uuid,
+                        base.project_uuid,
+                        base.prompt_created_at,
+                        base.responded_at,
+                    ),
+                    this.fetchSupportingEvidence(
+                        base.ai_prompt_uuid,
+                        base.prompt,
+                        base.human_feedback,
+                        base.error_message,
+                    ),
+                ]);
+
+                const row: TurnReviewCandidateRow = {
+                    ...base,
+                    next_user_prompt_uuid: nextPrompt?.ai_prompt_uuid ?? null,
+                    next_user_prompt: nextPrompt?.prompt ?? null,
+                    previous_turn_context: previousTurnContext,
+                    query_history_summaries: queryHistorySummaries,
+                    supporting_evidence_summaries: supportingEvidenceSummaries,
+                };
+
+                return AiAgentReviewClassifierModel.mapTurnReviewCandidate(row);
+            }),
+        );
+
+        return enriched;
+    }
+
+    private async fetchBaseCandidateRows(
+        args: ListTurnReviewCandidatesArgs,
+    ): Promise<BaseCandidateRow[]> {
+        const query = this.database(`${AiPromptTableName} as prompt`)
+            .join(
+                `${AiThreadTableName} as thread`,
+                'thread.ai_thread_uuid',
+                'prompt.ai_thread_uuid',
+            )
+            .leftJoin(
+                `${AiSlackPromptTableName} as slack_prompt`,
+                'slack_prompt.ai_prompt_uuid',
+                'prompt.ai_prompt_uuid',
+            )
+            .leftJoin(
+                `${AiSlackThreadTableName} as slack_thread`,
+                'slack_thread.ai_thread_uuid',
+                'thread.ai_thread_uuid',
+            )
+            .select<BaseCandidateRow[]>({
+                ai_prompt_uuid: 'prompt.ai_prompt_uuid',
+                ai_thread_uuid: 'prompt.ai_thread_uuid',
+                organization_uuid: 'thread.organization_uuid',
+                project_uuid: 'thread.project_uuid',
+                agent_uuid: 'thread.agent_uuid',
+                created_from: 'thread.created_from',
+                prompt: 'prompt.prompt',
+                response: 'prompt.response',
+                error_message: 'prompt.error_message',
+                human_score: 'prompt.human_score',
+                human_feedback: 'prompt.human_feedback',
+                prompt_created_at: 'prompt.created_at',
+                responded_at: 'prompt.responded_at',
+                model_config: 'prompt.model_config',
+                token_usage: 'prompt.token_usage',
+                slack_channel_id: 'slack_thread.slack_channel_id',
+                slack_thread_ts: 'slack_thread.slack_thread_ts',
+                prompt_slack_ts: 'slack_prompt.prompt_slack_ts',
+            })
+            .where('thread.organization_uuid', args.organizationUuid)
+            .whereNotNull('thread.agent_uuid')
+            .whereIn('thread.created_from', ['web_app', 'slack'])
+            .where((builder) => {
+                void builder
+                    .whereNotNull('prompt.response')
+                    .orWhereNotNull('prompt.error_message');
+            })
+            .orderBy('prompt.created_at', 'desc')
+            .limit(Math.min(args.limit ?? 500, 5000));
+
+        if (args.projectUuid) {
+            void query.where('thread.project_uuid', args.projectUuid);
+        }
+        if (args.agentUuid) {
+            void query.where('thread.agent_uuid', args.agentUuid);
+        }
+        if (args.threadUuid) {
+            void query.where('thread.ai_thread_uuid', args.threadUuid);
+        }
+        if (args.promptUuid) {
+            void query.where('prompt.ai_prompt_uuid', args.promptUuid);
+        }
+        if (args.startedAt) {
+            void query.where('prompt.created_at', '>=', args.startedAt);
+        }
+        if (args.endedAt) {
+            void query.where('prompt.created_at', '<', args.endedAt);
+        }
+
+        return query;
+    }
+
+    private async fetchNextPrompt(
+        threadUuid: string,
+        after: Date,
+    ): Promise<{ ai_prompt_uuid: string; prompt: string } | null> {
+        const row = await this.database(AiPromptTableName)
+            .select('ai_prompt_uuid', 'prompt')
+            .where('ai_thread_uuid', threadUuid)
+            .where('created_at', '>', after)
+            .orderBy('created_at', 'asc')
+            .first();
+        return row ?? null;
+    }
+
+    private async fetchPreviousTurnContext(
+        threadUuid: string,
+        before: Date,
+    ): Promise<TurnReviewCandidateRow['previous_turn_context']> {
+        const rows = await this.database(AiPromptTableName)
+            .select(
+                'ai_prompt_uuid',
+                'prompt',
+                'response',
+                'error_message',
+                'created_at',
+                'responded_at',
+            )
+            .where('ai_thread_uuid', threadUuid)
+            .where('created_at', '<', before)
+            .where((builder) => {
+                void builder
+                    .whereNotNull('response')
+                    .orWhereNotNull('error_message');
+            })
+            .orderBy('created_at', 'desc')
+            .limit(3);
+
+        return rows
+            .slice()
+            .reverse()
+            .map((row) => ({
+                relation: 'previous' as const,
+                promptUuid: row.ai_prompt_uuid,
+                userPrompt: row.prompt,
+                assistantResponse: row.response,
+                errorMessage: row.error_message,
+                createdAt: row.created_at.toISOString(),
+                respondedAt: row.responded_at
+                    ? row.responded_at.toISOString()
+                    : null,
+            }));
+    }
+
+    private async fetchQueryHistorySummaries(
+        organizationUuid: string,
+        projectUuid: string,
+        promptCreatedAt: Date,
+        respondedAt: Date | null,
+    ): Promise<TurnReviewCandidateRow['query_history_summaries']> {
+        const windowEnd = new Date(
+            (respondedAt?.getTime() ??
+                promptCreatedAt.getTime() + 10 * 60 * 1000) +
+                2 * 60 * 1000,
+        );
+
+        const rows = await this.database(QueryHistoryTableName)
+            .select(
+                'query_uuid',
+                'status',
+                'error',
+                'created_at',
+                'total_row_count',
+                'warehouse_execution_time_ms',
+                'metric_query',
+            )
+            .where('organization_uuid', organizationUuid)
+            .where('project_uuid', projectUuid)
+            .where('context', QueryExecutionContext.AI)
+            .where('created_at', '>=', promptCreatedAt)
+            .where('created_at', '<=', windowEnd)
+            .orderBy('created_at', 'asc');
+
+        return rows.map((row) => ({
+            queryUuid: row.query_uuid,
+            status: row.status,
+            error: row.error,
+            createdAt: row.created_at.toISOString(),
+            totalRowCount: row.total_row_count,
+            warehouseExecutionTimeMs: row.warehouse_execution_time_ms,
+            metricQuery: {
+                exploreName: row.metric_query?.exploreName ?? '',
+                dimensions: row.metric_query?.dimensions ?? [],
+                metrics: row.metric_query?.metrics ?? [],
+                filters: row.metric_query?.filters ?? {},
+                sorts: row.metric_query?.sorts ?? [],
+            },
+        }));
+    }
+
+    private async fetchSupportingEvidence(
+        promptUuid: string,
+        userPrompt: string,
+        humanFeedback: string | null,
+        errorMessage: string | null,
+    ): Promise<TurnReviewCandidateRow['supporting_evidence_summaries']> {
+        const rows: ToolCallEvidenceRow[] = await this.database(
+            `${AiAgentToolCallTableName} as tool_call`,
+        )
+            .leftJoin(
+                `${AiAgentToolResultTableName} as tool_result`,
+                function joinToolResult() {
+                    this.on(
+                        'tool_result.ai_prompt_uuid',
+                        '=',
+                        'tool_call.ai_prompt_uuid',
+                    ).andOn(
+                        'tool_result.tool_call_id',
+                        '=',
+                        'tool_call.tool_call_id',
+                    );
+                },
+            )
+            .select<ToolCallEvidenceRow[]>({
+                tool_call_id: 'tool_call.tool_call_id',
+                tool_name: 'tool_call.tool_name',
+                parent_tool_call_id: 'tool_call.parent_tool_call_id',
+                created_at: 'tool_call.created_at',
+                tool_args: 'tool_call.tool_args',
+                result: 'tool_result.result',
+            })
+            .where('tool_call.ai_prompt_uuid', promptUuid)
+            .where((builder) => {
+                void builder
+                    .whereIn(
+                        'tool_call.tool_name',
+                        Array.from(TOOL_NAME_PRIORITY.keys()),
+                    )
+                    .orWhereNotNull('tool_call.parent_tool_call_id');
+            });
+
+        const ranked = rankToolCallEvidence({
+            rows,
+            userPrompt,
+            humanFeedback,
+            errorMessage,
+        });
+
+        return ranked.slice(0, 5).map((entry) => ({
+            source: 'tool_trace' as const,
+            toolCallId: entry.tool_call_id,
+            toolName: entry.tool_name,
+            parentToolCallId: entry.parent_tool_call_id,
+            createdAt: entry.created_at.toISOString(),
+            relevanceScore: entry.relevance_score,
+            toolArgsPreview: previewToolArgs(entry.tool_args),
+            resultPreview: previewResult(entry.result),
+        }));
+    }
+
+    async listReviewItems(
+        args: ListReviewItemsArgs,
+    ): Promise<AiAgentReviewItemSummary[]> {
+        if (args.statuses && !args.statuses.includes('open')) {
+            return [];
+        }
+
+        const rows: DbAiAgentTurnSignal[] =
+            await this.database<AiAgentTurnSignalTable>(
+                AiAgentTurnSignalTableName,
+            )
+                .where('organization_uuid', args.organizationUuid)
+                .where('promoted_to_finding', true)
+                .whereNotNull('fingerprint')
+                .modify((query) => {
+                    if (args.projectUuid) {
+                        void query.where('project_uuid', args.projectUuid);
+                    }
+                    if (args.agentUuid) {
+                        void query.where('agent_uuid', args.agentUuid);
+                    }
+                })
+                .orderBy('created_at', 'desc')
+                .limit(Math.min((args.limit ?? 100) * 10, 1000));
+
+        const byFingerprint = new Map<string, DbAiAgentTurnSignal[]>();
+        rows.forEach((row) => {
+            if (!row.fingerprint) return;
+            const group = byFingerprint.get(row.fingerprint) ?? [];
+            group.push(row);
+            byFingerprint.set(row.fingerprint, group);
+        });
+
+        return Array.from(byFingerprint.entries())
+            .map(([fingerprint, group]) => {
+                const latest = group[0];
+                const createdAts = group.map((row) => row.created_at.getTime());
+                const firstSeenAt = new Date(Math.min(...createdAts));
+                const lastSeenAt = new Date(Math.max(...createdAts));
+                return {
+                    uuid: fingerprint,
+                    fingerprint,
+                    organizationUuid: latest.organization_uuid,
+                    projectUuid: latest.project_uuid,
+                    agentUuid: latest.agent_uuid,
+                    title: latest.review_item_title ?? 'Review AI agent issue',
+                    description: latest.review_item_description ?? '',
+                    primaryRootCause: latest.primary_root_cause ?? 'ambiguous',
+                    status: 'open' as const,
+                    dismissedReason: null,
+                    ownerType: latest.owner_type ?? 'unknown',
+                    assignedToUserUuid: null,
+                    firstSeenAt,
+                    lastSeenAt,
+                    findingCount: group.length,
+                    statusUpdatedAt: lastSeenAt,
+                    statusUpdatedByUserUuid: null,
+                    linkedIssueUrl: null,
+                    linkedPrUrl: null,
+                    createdAt: firstSeenAt,
+                    updatedAt: lastSeenAt,
+                    latestFinding: {
+                        uuid: latest.ai_agent_review_turn_signal_uuid,
+                        promptUuid: latest.ai_prompt_uuid,
+                        threadUuid: latest.ai_thread_uuid,
+                        projectUuid: latest.project_uuid,
+                        agentUuid: latest.agent_uuid,
+                        subcategories: latest.subcategories ?? [],
+                        fixTargets: latest.fix_targets ?? [],
+                        targetRefs: latest.target_refs ?? [],
+                        evidenceExcerpts: latest.evidence_excerpts ?? [],
+                        recommendation: latest.recommendation,
+                        createdAt: latest.created_at,
+                    },
+                };
+            })
+            .slice(0, Math.min(args.limit ?? 100, 500));
+    }
+
+    async listReviewSignals(
+        args: ListReviewSignalsArgs,
+    ): Promise<AiAgentReviewSignalSummary[]> {
+        const rows = await this.database(
+            `${AiAgentTurnSignalTableName} as signal`,
+        )
+            .join(
+                `${AiAgentReviewClassifierRunTableName} as run`,
+                'run.ai_agent_review_run_uuid',
+                'signal.ai_agent_review_run_uuid',
+            )
+            .join(
+                `${AiPromptTableName} as prompt`,
+                'prompt.ai_prompt_uuid',
+                'signal.ai_prompt_uuid',
+            )
+            .select<ReviewSignalSummaryRow[]>({
+                ai_agent_review_turn_signal_uuid:
+                    'signal.ai_agent_review_turn_signal_uuid',
+                ai_agent_review_run_uuid: 'signal.ai_agent_review_run_uuid',
+                ai_prompt_uuid: 'signal.ai_prompt_uuid',
+                ai_thread_uuid: 'signal.ai_thread_uuid',
+                project_uuid: 'signal.project_uuid',
+                agent_uuid: 'signal.agent_uuid',
+                signal: 'signal.signal',
+                implicit_signal_sources: 'signal.implicit_signal_sources',
+                confidence: 'signal.confidence',
+                promoted_to_finding: 'signal.promoted_to_finding',
+                promotion_reason: 'signal.promotion_reason',
+                signal_created_at: 'signal.created_at',
+                run_scope: 'run.run_scope',
+                prompt: 'prompt.prompt',
+                response: 'prompt.response',
+                error_message: 'prompt.error_message',
+                fingerprint: 'signal.fingerprint',
+                primary_root_cause: 'signal.primary_root_cause',
+                subcategories: 'signal.subcategories',
+                fix_targets: 'signal.fix_targets',
+                target_refs: 'signal.target_refs',
+                evidence_excerpts: 'signal.evidence_excerpts',
+                recommendation: 'signal.recommendation',
+            })
+            .where('signal.organization_uuid', args.organizationUuid)
+            .modify((query) => {
+                if (args.projectUuid) {
+                    void query.where('signal.project_uuid', args.projectUuid);
+                }
+                if (args.agentUuid) {
+                    void query.where('signal.agent_uuid', args.agentUuid);
+                }
+            })
+            .orderBy('signal.created_at', 'desc')
+            .limit(Math.min(args.limit ?? 100, 500));
+
+        return rows.map(AiAgentReviewClassifierModel.mapReviewSignalSummary);
+    }
+
+    async createTurnSignal(args: CreateTurnSignalArgs): Promise<string> {
+        const { finding, turnSignal } = args;
+        const [row] = await this.database<AiAgentTurnSignalTable>(
+            AiAgentTurnSignalTableName,
+        )
+            .insert({
+                ai_agent_review_run_uuid: args.runUuid,
+                ai_prompt_uuid: turnSignal.subject.assistantPromptUuid,
+                ai_thread_uuid: turnSignal.subject.threadUuid,
+                organization_uuid: turnSignal.subject.organizationUuid,
+                project_uuid: turnSignal.subject.projectUuid,
+                agent_uuid: turnSignal.subject.agentUuid,
+                interaction_source: turnSignal.interactionSource,
+                source_ref: this.jsonb(turnSignal.sourceRef) as never,
+                signal: turnSignal.signal,
+                implicit_signal_sources: this.jsonb(
+                    turnSignal.implicitSignalSources,
+                ) as never,
+                confidence: turnSignal.confidence,
+                promoted_to_finding: turnSignal.promotedToFinding,
+                promotion_reason: turnSignal.promotionReason,
+                tool_evidence_refs: this.jsonb(
+                    turnSignal.toolEvidenceRefs,
+                ) as never,
+                fingerprint: finding?.reviewItem.fingerprint,
+                primary_root_cause: finding?.primaryRootCause,
+                secondary_root_causes: finding
+                    ? (this.jsonb(finding.secondaryRootCauses) as never)
+                    : null,
+                subcategories: finding
+                    ? (this.jsonb(finding.subcategories) as never)
+                    : null,
+                fix_targets: finding
+                    ? (this.jsonb(finding.fixTargets) as never)
+                    : null,
+                target_refs: finding
+                    ? (this.jsonb(finding.targetRefs) as never)
+                    : null,
+                evidence_excerpts: finding
+                    ? (this.jsonb(finding.evidenceExcerpts) as never)
+                    : null,
+                recommendation: finding
+                    ? (this.jsonb(finding.recommendation) as never)
+                    : null,
+                owner_type: finding?.reviewItem.ownerType,
+                review_item_title: finding?.reviewItem.title,
+                review_item_description: finding?.reviewItem.description,
+                runtime_context_snapshot: this.jsonb(
+                    turnSignal.runtimeContextSnapshot,
+                ) as never,
+                model_metadata: this.jsonb(turnSignal.modelMetadata) as never,
+            })
+            .returning('ai_agent_review_turn_signal_uuid');
+
+        return row.ai_agent_review_turn_signal_uuid;
+    }
+}

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -1,0 +1,499 @@
+import {
+    FeatureFlags,
+    ForbiddenError,
+    type AiAgentReviewClassifierJudgeOutput,
+    type AiAgentReviewClassifierTurnCandidate,
+} from '@lightdash/common';
+import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
+import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
+import { AiAgentReviewClassifierService } from './AiAgentReviewClassifierService';
+
+const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000002';
+const AGENT_UUID = '00000000-0000-0000-0000-000000000003';
+const RUN_UUID = '00000000-0000-0000-0000-000000000004';
+const THREAD_UUID = '00000000-0000-0000-0000-000000000005';
+const PROMPT_UUID = '00000000-0000-0000-0000-000000000006';
+const SIGNAL_UUID = '00000000-0000-0000-0000-000000000007';
+const NOW = new Date('2026-05-26T10:00:00.000Z');
+
+const makeCandidate = (
+    overrides: Partial<AiAgentReviewClassifierTurnCandidate> = {},
+): AiAgentReviewClassifierTurnCandidate => ({
+    subject: {
+        type: 'turn_review',
+        assistantPromptUuid: PROMPT_UUID,
+        threadUuid: THREAD_UUID,
+        agentUuid: AGENT_UUID,
+        projectUuid: PROJECT_UUID,
+        organizationUuid: ORGANIZATION_UUID,
+    },
+    interactionSource: 'app',
+    sourceRef: {
+        source: 'app',
+        threadUuid: THREAD_UUID,
+        promptUuid: PROMPT_UUID,
+        appUrl: null,
+    },
+    targetTurn: {
+        promptUuid: PROMPT_UUID,
+        userPrompt: 'Show airport volume by country',
+        assistantResponse: 'Country is not available.',
+        errorMessage: null,
+        createdAt: NOW,
+        respondedAt: NOW,
+    },
+    contextTurns: [],
+    userPrompt: 'Show airport volume by country',
+    assistantResponse: 'Country is not available.',
+    errorMessage: null,
+    humanScore: null,
+    humanFeedback: null,
+    createdAt: NOW,
+    respondedAt: NOW,
+    nextUserPromptUuid: null,
+    nextUserPrompt: null,
+    modelMetadata: {
+        provider: 'openai',
+        model: 'gpt-5',
+    },
+    tokenUsageTotal: 123,
+    queryHistory: [],
+    supportingEvidence: [],
+    ...overrides,
+});
+
+const makeRun = (overrides: Record<string, unknown> = {}) => ({
+    uuid: RUN_UUID,
+    organizationUuid: ORGANIZATION_UUID,
+    status: 'running' as const,
+    reviewAgentVersion: 'llm-judge-v1',
+    judgePromptHash: 'ai-agent-review-judge-v1',
+    agentConfigSnapshotHash: null,
+    agentConfigSnapshot: null,
+    agentConfigSnapshotAgentUpdatedAt: null,
+    runScope: {
+        type: 'backfill' as const,
+        startedAt: '2026-05-26T00:00:00.000Z',
+        endedAt: '2026-05-27T00:00:00.000Z',
+    },
+    totalTurns: 1,
+    processedTurns: 0,
+    signalCount: 0,
+    findingCount: 0,
+    reviewItemCount: 0,
+    errorMessage: null,
+    completedAt: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+});
+
+const makeJudgeOutput = (
+    overrides: Partial<AiAgentReviewClassifierJudgeOutput> = {},
+): AiAgentReviewClassifierJudgeOutput => ({
+    signal: 'acceptance_or_continuation',
+    implicitSignalSources: [],
+    confidence: 'low',
+    promotedToFinding: false,
+    promotionReason: null,
+    primaryRootCause: 'not_a_failure',
+    secondaryRootCauses: [],
+    subcategories: [],
+    fixTargets: ['no_action'],
+    targetRefs: [],
+    agentConfigurationSettings: [],
+    ownerType: 'unknown',
+    evidenceExcerpts: [
+        {
+            source: 'user_prompt',
+            text: 'Show airport volume by country',
+            redacted: false,
+        },
+    ],
+    recommendation: null,
+    reviewItem: {
+        title: 'No review needed',
+        description: 'Judge found no actionable issue.',
+    },
+    ...overrides,
+});
+
+const makeSemanticJudgeOutput = (): AiAgentReviewClassifierJudgeOutput =>
+    makeJudgeOutput({
+        signal: 'implicit_correction',
+        implicitSignalSources: ['next_user_correction'],
+        confidence: 'high',
+        promotedToFinding: true,
+        promotionReason: 'LLM judge found a semantic-layer correction.',
+        primaryRootCause: 'semantic_layer',
+        secondaryRootCauses: ['data_gap'],
+        subcategories: ['missing_dimension'],
+        fixTargets: ['semantic_yaml_patch'],
+        targetRefs: [
+            {
+                type: 'dimension',
+                label: 'airports.country',
+                modelName: 'airports',
+                fieldName: 'country',
+                setting: null,
+                key: null,
+            },
+        ],
+        ownerType: 'semantic_layer_owner',
+        evidenceExcerpts: [
+            {
+                source: 'next_user_prompt',
+                text: 'No, country is not available here, so use airport name.',
+                redacted: false,
+            },
+        ],
+        recommendation: {
+            actionType: 'update_semantic_yaml',
+            title: 'Review semantic layer definition',
+            rationale:
+                'The correction points to a model, field, metric, or join context issue.',
+            targetRefs: [
+                {
+                    type: 'dimension',
+                    label: 'airports.country',
+                    modelName: 'airports',
+                    fieldName: 'country',
+                    setting: null,
+                    key: null,
+                },
+            ],
+        },
+        reviewItem: {
+            title: 'Review airports.country',
+            description: 'LLM judge grouped a semantic-layer correction.',
+        },
+    });
+
+const makeProductJudgeOutput = (): AiAgentReviewClassifierJudgeOutput =>
+    makeJudgeOutput({
+        signal: 'product_capability_request',
+        implicitSignalSources: ['product_capability_request'],
+        confidence: 'medium',
+        promotedToFinding: true,
+        promotionReason: 'LLM judge found a product capability request.',
+        primaryRootCause: 'product_capability',
+        secondaryRootCauses: [],
+        subcategories: ['capability_request'],
+        fixTargets: ['product_capability_ticket'],
+        targetRefs: [
+            {
+                type: 'product_capability',
+                label: 'AI agent capability request',
+                modelName: null,
+                fieldName: null,
+                setting: null,
+                key: 'ai_agent_capability_request',
+            },
+        ],
+        ownerType: 'product',
+        evidenceExcerpts: [
+            {
+                source: 'next_user_prompt',
+                text: 'I wish the product should support exporting this analysis to slides.',
+                redacted: false,
+            },
+        ],
+        recommendation: {
+            actionType: 'route_to_product_work',
+            title: 'Review product capability request',
+            rationale:
+                'This may require product work rather than semantic-layer or agent-admin changes.',
+            targetRefs: [
+                {
+                    type: 'product_capability',
+                    label: 'AI agent capability request',
+                    modelName: null,
+                    fieldName: null,
+                    setting: null,
+                    key: 'ai_agent_capability_request',
+                },
+            ],
+        },
+        reviewItem: {
+            title: 'Review AI agent product limitation',
+            description: 'LLM judge found a product capability limitation.',
+        },
+    });
+
+describe('AiAgentReviewClassifierService', () => {
+    const featureFlagService = {
+        get: jest.fn(),
+    } as unknown as jest.Mocked<FeatureFlagService>;
+
+    const model = {
+        listTurnReviewCandidates: jest.fn(),
+        createRun: jest.fn(),
+        updateRun: jest.fn(),
+        createTurnSignal: jest.fn(),
+    } as unknown as jest.Mocked<AiAgentReviewClassifierModel>;
+    const aiAgentModel = {
+        getAgent: jest.fn(),
+    };
+    const catalogModel = {
+        getCatalogItemsSummary: jest.fn(),
+    };
+    const judgeTurn = jest.fn();
+
+    const service = new AiAgentReviewClassifierService({
+        aiAgentReviewClassifierModel: model,
+        aiAgentModel: aiAgentModel as never,
+        catalogModel: catalogModel as never,
+        featureFlagService,
+        lightdashConfig: {} as never,
+        judgeTurn,
+    });
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        featureFlagService.get.mockResolvedValue({
+            id: FeatureFlags.AiAgentReviewClassifier,
+            enabled: true,
+        });
+        model.createRun.mockResolvedValue(makeRun());
+        model.updateRun.mockResolvedValue(makeRun({ status: 'completed' }));
+        model.createTurnSignal.mockResolvedValue(SIGNAL_UUID);
+        aiAgentModel.getAgent.mockResolvedValue({
+            uuid: AGENT_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            name: 'Jaffle Shop',
+            description: null,
+            tags: [],
+            integrations: [],
+            updatedAt: NOW,
+            createdAt: NOW,
+            instruction: 'Use semantic metrics before raw fields.',
+            imageUrl: null,
+            enableDataAccess: true,
+            enableSelfImprovement: false,
+            version: 'v1',
+            groupAccess: [],
+            userAccess: [],
+            spaceAccess: [],
+        });
+        catalogModel.getCatalogItemsSummary.mockResolvedValue([
+            {
+                catalogSearchUuid: 'catalog-1',
+                cachedExploreUuid: 'explore-1',
+                projectUuid: PROJECT_UUID,
+                name: 'payments_total_revenue',
+                label: 'Total revenue',
+                description: 'Total payment amount.',
+                type: 'field',
+                tableName: 'payments',
+                fieldType: 'metric',
+            },
+        ]);
+        judgeTurn.mockResolvedValue(makeJudgeOutput());
+    });
+
+    it('throws when the feature flag is disabled', async () => {
+        featureFlagService.get.mockResolvedValueOnce({
+            id: FeatureFlags.AiAgentReviewClassifier,
+            enabled: false,
+        });
+
+        await expect(
+            service.run({
+                organizationUuid: ORGANIZATION_UUID,
+                startedAt: NOW,
+                endedAt: NOW,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+
+        expect(model.createRun).not.toHaveBeenCalled();
+    });
+
+    it('persists one signal per candidate and completes the run', async () => {
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate(),
+            makeCandidate({
+                subject: {
+                    ...makeCandidate().subject,
+                    assistantPromptUuid: '00000000-0000-0000-0000-000000000010',
+                },
+            }),
+        ]);
+
+        const result = await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+        });
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                runUuid: RUN_UUID,
+                processedTurns: 2,
+                signalCount: 2,
+                findingCount: 0,
+                reviewItemCount: 0,
+            }),
+        );
+        expect(model.createTurnSignal).toHaveBeenCalledTimes(2);
+        expect(model.updateRun).toHaveBeenCalledWith(
+            expect.objectContaining({
+                runUuid: RUN_UUID,
+                status: 'completed',
+                processedTurns: 2,
+                signalCount: 2,
+            }),
+        );
+    });
+
+    it('stores actionable findings inline on persisted signals', async () => {
+        judgeTurn.mockResolvedValueOnce(makeSemanticJudgeOutput());
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate({
+                nextUserPrompt:
+                    'No, country is not available here, so use airport name.',
+            }),
+        ]);
+
+        const result = await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+            persistFindings: true,
+            promoteFindingsToReviewItems: true,
+        });
+
+        expect(result.findingCount).toBe(1);
+        expect(result.reviewItemCount).toBe(1);
+        expect(model.createTurnSignal).toHaveBeenCalledWith(
+            expect.objectContaining({
+                runUuid: RUN_UUID,
+                finding: expect.objectContaining({
+                    primaryRootCause: 'semantic_layer',
+                    secondaryRootCauses: ['data_gap'],
+                    reviewItem: expect.objectContaining({
+                        fingerprint: expect.stringContaining(
+                            'ai_agent_review_item:',
+                        ),
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it('dry-runs without persisting signals or findings by default', async () => {
+        judgeTurn.mockResolvedValueOnce(makeSemanticJudgeOutput());
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate({
+                nextUserPrompt:
+                    'No, country is not available here, so use airport name.',
+            }),
+        ]);
+
+        const result = await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+            dryRun: true,
+            persistFindings: true,
+            promoteFindingsToReviewItems: true,
+        });
+
+        expect(result.findingCount).toBe(1);
+        expect(result.reviewItemCount).toBe(0);
+        expect(result.report.dryRun).toBe(true);
+        expect(result.report.findingsByRootCause.semantic_layer).toBe(1);
+        expect(model.createTurnSignal).not.toHaveBeenCalled();
+    });
+
+    it('runs a live response-saved event as one target-turn worker job', async () => {
+        judgeTurn.mockResolvedValueOnce(makeSemanticJudgeOutput());
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate({
+                userPrompt:
+                    'No, country is not available here, so use airport name.',
+                contextTurns: [
+                    {
+                        relation: 'previous',
+                        promptUuid: '00000000-0000-0000-0000-000000000012',
+                        userPrompt: 'Show airport volume by country',
+                        assistantResponse:
+                            'Airport country is scheduled origin country.',
+                        errorMessage: null,
+                        createdAt: NOW,
+                        respondedAt: NOW,
+                    },
+                ],
+            }),
+        ]);
+
+        const result = await service.runLiveEvent({
+            eventType: 'response_saved',
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            threadUuid: THREAD_UUID,
+            promptUuid: PROMPT_UUID,
+        });
+
+        expect(result?.processedTurns).toBe(1);
+        expect(model.listTurnReviewCandidates).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            threadUuid: THREAD_UUID,
+            promptUuid: PROMPT_UUID,
+            limit: 1,
+        });
+        expect(model.createRun).toHaveBeenCalledWith(
+            expect.objectContaining({
+                organizationUuid: ORGANIZATION_UUID,
+                runScope: expect.objectContaining({
+                    type: 'live_event',
+                    eventType: 'response_saved',
+                    promptUuid: PROMPT_UUID,
+                    threadUuid: THREAD_UUID,
+                }),
+                totalTurns: 1,
+            }),
+        );
+        expect(model.createTurnSignal).toHaveBeenCalledWith(
+            expect.objectContaining({
+                finding: expect.objectContaining({
+                    primaryRootCause: 'semantic_layer',
+                }),
+            }),
+        );
+    });
+
+    it('stores product capability findings as grouped review projections', async () => {
+        judgeTurn.mockResolvedValueOnce(makeProductJudgeOutput());
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate({
+                nextUserPrompt:
+                    'I wish the product should support exporting this analysis to slides.',
+            }),
+        ]);
+
+        const result = await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+            persistFindings: true,
+            promoteFindingsToReviewItems: true,
+        });
+
+        expect(result.findingCount).toBe(1);
+        expect(result.reviewItemCount).toBe(1);
+        expect(model.createTurnSignal).toHaveBeenCalledWith(
+            expect.objectContaining({
+                finding: expect.objectContaining({
+                    primaryRootCause: 'product_capability',
+                }),
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -1,0 +1,1226 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import {
+    aiAgentReviewClassifierJudgeOutputSchema,
+    CatalogType,
+    FeatureFlags,
+    ForbiddenError,
+    getAiAgentConfigSnapshotHash,
+    getAiAgentReviewItemFingerprint,
+    type AiAgentAvailableCapability,
+    type AiAgentConfigSnapshot,
+    type AiAgentConfigurationSetting,
+    type AiAgentEvidenceExcerpt,
+    type AiAgentReviewClassifierEventType,
+    type AiAgentReviewClassifierJudgeOutput,
+    type AiAgentReviewClassifierRunScope,
+    type AiAgentReviewClassifierSignalFinding,
+    type AiAgentReviewClassifierTurnCandidate,
+    type AiAgentReviewClassifierTurnSignal,
+    type AiAgentRootCause,
+    type AiAgentTargetRef,
+    type AiAgentTurnSignal,
+    type CatalogItemSummary,
+    type QueryHistoryStatus,
+} from '@lightdash/common';
+import { generateObject } from 'ai';
+import { createHash } from 'crypto';
+import { LightdashConfig } from '../../config/parseConfig';
+import Logger from '../../logging/logger';
+import { type CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { BaseService } from '../../services/BaseService';
+import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
+import { type AiAgentModel } from '../models/AiAgentModel';
+import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
+import { defaultAgentOptions } from './ai/agents/agentV2';
+import { getModel } from './ai/models';
+
+const REVIEW_AGENT_VERSION = 'llm-judge-v1';
+const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v1';
+
+type AiAgentReviewClassifierJudge = (
+    candidate: AiAgentReviewClassifierTurnCandidate,
+    evidencePacket: AiAgentReviewJudgeEvidencePacket,
+) => Promise<AiAgentReviewClassifierJudgeOutput>;
+
+type AiAgentReviewClassifierJudgeTargetRef =
+    AiAgentReviewClassifierJudgeOutput['targetRefs'][number];
+
+type AiAgentReviewClassifierServiceDependencies = {
+    aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    aiAgentModel: AiAgentModel;
+    catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
+    featureFlagService: FeatureFlagService;
+    lightdashConfig: LightdashConfig;
+    judgeTurn?: AiAgentReviewClassifierJudge;
+};
+
+type AiAgentReviewCatalogEvidenceItem = {
+    name: string;
+    label: string | null;
+    type: string;
+    tableName: string | null;
+    fieldType: string | null;
+    description: string | null;
+};
+
+type AiAgentReviewJudgeEvidencePacket = {
+    subject: AiAgentReviewClassifierTurnCandidate['subject'];
+    interactionSource: AiAgentReviewClassifierTurnCandidate['interactionSource'];
+    targetTurn: AiAgentReviewClassifierTurnCandidate['targetTurn'];
+    reviewHints: AiAgentReviewClassifierTurnCandidate['reviewHints'];
+    humanFeedback: {
+        score: number | null;
+        comment: string | null;
+    };
+    agentConfig: {
+        snapshotHash: string | null;
+        settings: AiAgentConfigurationSetting[];
+        availableCapabilities: AiAgentAvailableCapability[];
+        dataAccessEnabled: boolean | null;
+        selfImprovementEnabled: boolean | null;
+        instructionSummary: string | null;
+        knowledgeDocumentCount: number;
+    };
+    semanticContext: {
+        queriedExploreNames: string[];
+        queriedFieldNames: string[];
+        catalogMatches: AiAgentReviewCatalogEvidenceItem[];
+    };
+    nextUserPrompt: {
+        promptUuid: string | null;
+        text: string;
+    } | null;
+    previousTurns: AiAgentReviewClassifierTurnCandidate['contextTurns'];
+    queryHistory: {
+        queryUuid: string;
+        status: QueryHistoryStatus;
+        error: string | null;
+        metricQuery: AiAgentReviewClassifierTurnCandidate['queryHistory'][number]['metricQuery'];
+        totalRowCount: number | null;
+        warehouseExecutionTimeMs: number | null;
+    }[];
+    supportingEvidence: (AiAgentReviewClassifierTurnCandidate['supportingEvidence'][number] & {
+        summary: string;
+    })[];
+    suggestedEvidenceExcerpts: AiAgentEvidenceExcerpt[];
+};
+
+type AiAgentReviewAgentConfigEvidence =
+    AiAgentReviewJudgeEvidencePacket['agentConfig'] & {
+        snapshot: AiAgentConfigSnapshot | null;
+        agentUpdatedAt: Date | null;
+    };
+
+type RunArgs = {
+    organizationUuid: string;
+    organizationName?: string;
+    requestedByUserUuid?: string;
+    projectUuid?: string;
+    agentUuid?: string;
+    startedAt: Date;
+    endedAt: Date;
+    limit?: number;
+    dryRun?: boolean;
+    persistSignals?: boolean;
+    persistFindings?: boolean;
+    promoteFindingsToReviewItems?: boolean;
+};
+
+type RunLiveEventArgs = {
+    eventType: AiAgentReviewClassifierEventType;
+    organizationUuid: string;
+    organizationName?: string;
+    requestedByUserUuid?: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+};
+
+type ProcessCandidatesArgs = {
+    organizationUuid: string;
+    organizationName?: string;
+    requestedByUserUuid?: string;
+    candidates: AiAgentReviewClassifierTurnCandidate[];
+    runScope: AiAgentReviewClassifierRunScope;
+    dryRun?: boolean;
+    persistSignals?: boolean;
+    persistFindings?: boolean;
+    promoteFindingsToReviewItems?: boolean;
+    failWhenDisabled?: boolean;
+};
+
+export type AiAgentReviewClassifierRunResult = {
+    runUuid: string;
+    processedTurns: number;
+    signalCount: number;
+    findingCount: number;
+    reviewItemCount: number;
+    report: AiAgentReviewClassifierExperimentReport;
+};
+
+export type AiAgentReviewClassifierExperimentReport = {
+    dryRun: boolean;
+    totalCandidates: number;
+    signalsByType: Partial<Record<AiAgentTurnSignal, number>>;
+    findingsByRootCause: Partial<Record<AiAgentRootCause, number>>;
+    examples: AiAgentReviewClassifierExperimentExample[];
+};
+
+export type AiAgentReviewClassifierExperimentExample = {
+    promptUuid: string;
+    signal: AiAgentTurnSignal;
+    rootCause: AiAgentRootCause | null;
+    evidence: string[];
+    queryStatuses: QueryHistoryStatus[];
+    supportingEvidence: string[];
+};
+
+export type AiAgentReviewClassifierClassifiedFinding =
+    AiAgentReviewClassifierSignalFinding;
+
+export type AiAgentReviewClassifierClassifiedTurn = {
+    signal: AiAgentReviewClassifierTurnSignal;
+    finding: AiAgentReviewClassifierClassifiedFinding | null;
+};
+
+export type AiAgentReviewClassifierReviewedTurn = {
+    candidate: AiAgentReviewClassifierTurnCandidate;
+    classifiedTurn: AiAgentReviewClassifierClassifiedTurn;
+};
+
+export class AiAgentReviewClassifierService extends BaseService {
+    private readonly aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+
+    private readonly aiAgentModel: AiAgentModel;
+
+    private readonly catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
+
+    private readonly featureFlagService: FeatureFlagService;
+
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly judgeTurn: AiAgentReviewClassifierJudge;
+
+    constructor(dependencies: AiAgentReviewClassifierServiceDependencies) {
+        super();
+        this.aiAgentReviewClassifierModel =
+            dependencies.aiAgentReviewClassifierModel;
+        this.aiAgentModel = dependencies.aiAgentModel;
+        this.catalogModel = dependencies.catalogModel;
+        this.featureFlagService = dependencies.featureFlagService;
+        this.lightdashConfig = dependencies.lightdashConfig;
+        this.judgeTurn =
+            dependencies.judgeTurn ??
+            ((candidate, evidencePacket) =>
+                this.judgeTurnWithLlm(candidate, evidencePacket));
+    }
+
+    private debugLog(context: string, payload: Record<string, unknown>): void {
+        if (this.lightdashConfig.ai?.copilot?.debugLoggingEnabled === true) {
+            Logger.debug(
+                `[AiAgentReview][${context}] ${JSON.stringify(payload)}`,
+            );
+        }
+    }
+
+    async run(args: RunArgs): Promise<AiAgentReviewClassifierRunResult> {
+        const candidates =
+            await this.aiAgentReviewClassifierModel.listTurnReviewCandidates({
+                organizationUuid: args.organizationUuid,
+                projectUuid: args.projectUuid,
+                agentUuid: args.agentUuid,
+                startedAt: args.startedAt,
+                endedAt: args.endedAt,
+                limit: args.limit,
+            });
+
+        this.debugLog('BackfillCandidatesLoaded', {
+            organizationUuid: args.organizationUuid,
+            projectUuid: args.projectUuid,
+            agentUuid: args.agentUuid,
+            startedAt: args.startedAt.toISOString(),
+            endedAt: args.endedAt.toISOString(),
+            candidateCount: candidates?.length ?? 0,
+            dryRun: !!args.dryRun,
+        });
+
+        const result = await this.processCandidates({
+            organizationUuid: args.organizationUuid,
+            organizationName: args.organizationName,
+            requestedByUserUuid: args.requestedByUserUuid,
+            candidates,
+            runScope: {
+                type: 'backfill',
+                startedAt: args.startedAt.toISOString(),
+                endedAt: args.endedAt.toISOString(),
+                projectUuid: args.projectUuid,
+                agentUuid: args.agentUuid,
+                dryRun: !!args.dryRun,
+            },
+            dryRun: args.dryRun,
+            persistSignals: args.persistSignals,
+            persistFindings: args.persistFindings,
+            promoteFindingsToReviewItems: args.promoteFindingsToReviewItems,
+            failWhenDisabled: true,
+        });
+        if (!result) {
+            throw new ForbiddenError('AI agent review agent is not enabled');
+        }
+        return result;
+    }
+
+    async runLiveEvent(
+        args: RunLiveEventArgs,
+    ): Promise<AiAgentReviewClassifierRunResult | null> {
+        const candidates =
+            await this.aiAgentReviewClassifierModel.listTurnReviewCandidates({
+                organizationUuid: args.organizationUuid,
+                projectUuid: args.projectUuid,
+                agentUuid: args.agentUuid,
+                threadUuid: args.threadUuid,
+                promptUuid: args.promptUuid,
+                limit: 1,
+            });
+
+        this.debugLog('LiveEventCandidatesLoaded', {
+            eventType: args.eventType,
+            organizationUuid: args.organizationUuid,
+            projectUuid: args.projectUuid,
+            agentUuid: args.agentUuid,
+            threadUuid: args.threadUuid,
+            promptUuid: args.promptUuid,
+            candidateCount: candidates?.length ?? 0,
+        });
+
+        return this.processCandidates({
+            organizationUuid: args.organizationUuid,
+            organizationName: args.organizationName,
+            requestedByUserUuid: args.requestedByUserUuid,
+            candidates: candidates.map((candidate) => ({
+                ...candidate,
+                reviewHints: {
+                    ...candidate.reviewHints,
+                    useTargetPromptAsCorrectionEvidence:
+                        args.eventType === 'response_saved',
+                },
+            })),
+            runScope: {
+                type: 'live_event',
+                eventType: args.eventType,
+                promptUuid: args.promptUuid,
+                threadUuid: args.threadUuid,
+                projectUuid: args.projectUuid,
+                agentUuid: args.agentUuid,
+            },
+            persistSignals: true,
+            persistFindings: true,
+            promoteFindingsToReviewItems: true,
+            failWhenDisabled: false,
+        });
+    }
+
+    private async processCandidates(
+        args: ProcessCandidatesArgs,
+    ): Promise<AiAgentReviewClassifierRunResult | null> {
+        const enabled = await this.isEnabled(args);
+        if (!enabled) {
+            this.debugLog('SkippedDisabled', {
+                organizationUuid: args.organizationUuid,
+                runScope: args.runScope,
+            });
+            if (args.failWhenDisabled) {
+                throw new ForbiddenError(
+                    'AI agent review agent is not enabled',
+                );
+            }
+            return null;
+        }
+
+        const runAgentConfig = args.candidates[0]
+            ? await this.captureAgentConfigSnapshot(args.candidates[0])
+            : AiAgentReviewClassifierService.emptyAgentConfigEvidence();
+
+        const run = await this.aiAgentReviewClassifierModel.createRun({
+            organizationUuid: args.organizationUuid,
+            reviewAgentVersion: REVIEW_AGENT_VERSION,
+            judgePromptHash: JUDGE_PROMPT_HASH,
+            status: 'running',
+            totalTurns: args.candidates.length,
+            runScope: args.runScope,
+            agentConfigSnapshotHash: runAgentConfig.snapshotHash,
+            agentConfigSnapshot: runAgentConfig.snapshot,
+            agentConfigSnapshotAgentUpdatedAt: runAgentConfig.agentUpdatedAt,
+        });
+
+        this.debugLog('RunStarted', {
+            runUuid: run.uuid,
+            organizationUuid: args.organizationUuid,
+            runScope: args.runScope,
+            agentConfigSnapshotHash: runAgentConfig.snapshotHash,
+            candidateCount: args.candidates.length,
+            persistSignals: args.persistSignals ?? !args.dryRun,
+            persistFindings: !args.dryRun && !!args.persistFindings,
+            promoteFindingsToReviewItems:
+                !args.dryRun &&
+                !!args.persistFindings &&
+                !!args.promoteFindingsToReviewItems,
+        });
+
+        let processedTurns = 0;
+        let signalCount = 0;
+        let findingCount = 0;
+        let reviewItemCount = 0;
+        const reviewItemFingerprints = new Set<string>();
+        const shouldPersistSignals = args.persistSignals ?? !args.dryRun;
+        const shouldPersistFindings = !args.dryRun && !!args.persistFindings;
+        const shouldPromoteFindingsToReviewItems =
+            shouldPersistFindings && !!args.promoteFindingsToReviewItems;
+
+        try {
+            const reviewedTurns = await Promise.all(
+                args.candidates.map(async (candidate) => ({
+                    candidate,
+                    classifiedTurn: await this.classifyTurnWithJudge(
+                        candidate,
+                        runAgentConfig,
+                    ),
+                })),
+            );
+
+            const report = AiAgentReviewClassifierService.buildReport({
+                dryRun: !!args.dryRun,
+                reviewedTurns,
+            });
+            const reviewedFindingCount = reviewedTurns.filter(
+                ({ classifiedTurn }) => !!classifiedTurn.finding,
+            ).length;
+
+            /* eslint-disable no-await-in-loop */
+            // eslint-disable-next-line no-restricted-syntax
+            for (const { classifiedTurn } of reviewedTurns) {
+                if (shouldPersistSignals) {
+                    await this.aiAgentReviewClassifierModel.createTurnSignal({
+                        runUuid: run.uuid,
+                        turnSignal: classifiedTurn.signal,
+                        finding: shouldPersistFindings
+                            ? classifiedTurn.finding
+                            : null,
+                    });
+                }
+                signalCount += 1;
+
+                if (shouldPersistFindings && classifiedTurn.finding) {
+                    findingCount += 1;
+                    if (shouldPromoteFindingsToReviewItems) {
+                        reviewItemFingerprints.add(
+                            classifiedTurn.finding.reviewItem.fingerprint,
+                        );
+                        reviewItemCount = reviewItemFingerprints.size;
+                    }
+                }
+
+                processedTurns += 1;
+            }
+            /* eslint-enable no-await-in-loop */
+
+            await this.aiAgentReviewClassifierModel.updateRun({
+                runUuid: run.uuid,
+                status: 'completed',
+                processedTurns,
+                signalCount,
+                findingCount: reviewedFindingCount,
+                reviewItemCount,
+                completedAt: new Date(),
+            });
+
+            this.debugLog('RunCompleted', {
+                runUuid: run.uuid,
+                processedTurns,
+                signalCount,
+                findingCount: reviewedFindingCount,
+                reviewItemCount,
+            });
+
+            return {
+                runUuid: run.uuid,
+                processedTurns,
+                signalCount,
+                findingCount: reviewedFindingCount,
+                reviewItemCount,
+                report,
+            };
+        } catch (error) {
+            this.debugLog('RunFailed', {
+                runUuid: run.uuid,
+                processedTurns,
+                signalCount,
+                findingCount,
+                reviewItemCount,
+                errorMessage:
+                    error instanceof Error ? error.message : String(error),
+            });
+            await this.aiAgentReviewClassifierModel.updateRun({
+                runUuid: run.uuid,
+                status: 'failed',
+                processedTurns,
+                signalCount,
+                findingCount,
+                reviewItemCount,
+                errorMessage:
+                    error instanceof Error ? error.message : String(error),
+                completedAt: new Date(),
+            });
+            throw error;
+        }
+    }
+
+    private async classifyTurnWithJudge(
+        candidate: AiAgentReviewClassifierTurnCandidate,
+        agentConfig: AiAgentReviewAgentConfigEvidence,
+    ): Promise<AiAgentReviewClassifierClassifiedTurn> {
+        const reviewEvidence = await this.buildReviewEvidence(
+            candidate,
+            agentConfig,
+        );
+        const judgeOutput = await this.judgeTurn(
+            candidate,
+            reviewEvidence.evidencePacket,
+        );
+        const signal: AiAgentReviewClassifierTurnSignal = {
+            subject: candidate.subject,
+            interactionSource: candidate.interactionSource,
+            sourceRef: candidate.sourceRef,
+            signal: judgeOutput.signal,
+            implicitSignalSources: judgeOutput.implicitSignalSources,
+            confidence: judgeOutput.confidence,
+            promotedToFinding: judgeOutput.promotedToFinding,
+            promotionReason: judgeOutput.promotionReason,
+            toolEvidenceRefs: candidate.supportingEvidence
+                .map((evidence) => evidence.toolCallId)
+                .slice(0, 5),
+            runtimeContextSnapshot: {
+                userUuid: null,
+                canRunSql: false,
+                canManageAgent: false,
+            },
+            modelMetadata: candidate.modelMetadata,
+        };
+
+        Logger.info('AI agent review agent judged turn', {
+            runPromptUuid: candidate.subject.assistantPromptUuid,
+            threadUuid: candidate.subject.threadUuid,
+            projectUuid: candidate.subject.projectUuid,
+            agentUuid: candidate.subject.agentUuid,
+            signal: judgeOutput.signal,
+            primaryRootCause: judgeOutput.primaryRootCause,
+            promotedToFinding: judgeOutput.promotedToFinding,
+            confidence: judgeOutput.confidence,
+        });
+        this.debugLog('TurnJudged', {
+            promptUuid: candidate.subject.assistantPromptUuid,
+            threadUuid: candidate.subject.threadUuid,
+            agentConfigSnapshotHash: reviewEvidence.agentConfig.snapshotHash,
+            catalogMatchCount:
+                reviewEvidence.evidencePacket.semanticContext.catalogMatches
+                    .length,
+            signal: judgeOutput.signal,
+            implicitSignalSources: judgeOutput.implicitSignalSources,
+            promotedToFinding: judgeOutput.promotedToFinding,
+            promotionReason: judgeOutput.promotionReason,
+            confidence: judgeOutput.confidence,
+            primaryRootCause: judgeOutput.primaryRootCause,
+            secondaryRootCauses: judgeOutput.secondaryRootCauses,
+            subcategories: judgeOutput.subcategories,
+            fixTargets: judgeOutput.fixTargets,
+            targetRefs: judgeOutput.targetRefs,
+            recommendationAction: judgeOutput.recommendation?.actionType,
+            reviewItemTitle: judgeOutput.reviewItem.title,
+        });
+
+        if (!judgeOutput.promotedToFinding) {
+            return { signal, finding: null };
+        }
+
+        const targetRefs =
+            AiAgentReviewClassifierService.normalizeJudgeTargetRefs({
+                judgeTargetRefs: judgeOutput.targetRefs,
+                agentUuid: candidate.subject.agentUuid,
+            });
+        const recommendation = judgeOutput.recommendation
+            ? {
+                  ...judgeOutput.recommendation,
+                  targetRefs:
+                      AiAgentReviewClassifierService.normalizeJudgeTargetRefs({
+                          judgeTargetRefs:
+                              judgeOutput.recommendation.targetRefs.length > 0
+                                  ? judgeOutput.recommendation.targetRefs
+                                  : judgeOutput.targetRefs,
+                          agentUuid: candidate.subject.agentUuid,
+                      }),
+              }
+            : null;
+
+        const fingerprint = getAiAgentReviewItemFingerprint({
+            organizationUuid: candidate.subject.organizationUuid,
+            projectUuid: candidate.subject.projectUuid,
+            agentUuid: candidate.subject.agentUuid,
+            primaryRootCause: judgeOutput.primaryRootCause,
+            subcategories: judgeOutput.subcategories,
+            fixTargets: judgeOutput.fixTargets,
+            targetRefs,
+            agentConfigurationSettings: judgeOutput.agentConfigurationSettings,
+            capabilityKey:
+                targetRefs.find(
+                    (
+                        targetRef,
+                    ): targetRef is Extract<
+                        AiAgentTargetRef,
+                        { type: 'product_capability' }
+                    > => targetRef.type === 'product_capability',
+                )?.capabilityKey ?? null,
+        });
+
+        return {
+            signal,
+            finding: {
+                primaryRootCause: judgeOutput.primaryRootCause,
+                secondaryRootCauses: judgeOutput.secondaryRootCauses,
+                subcategories: judgeOutput.subcategories,
+                fixTargets: judgeOutput.fixTargets,
+                targetRefs,
+                evidenceExcerpts: judgeOutput.evidenceExcerpts,
+                recommendation,
+                reviewItem: {
+                    fingerprint,
+                    title: judgeOutput.reviewItem.title,
+                    description: judgeOutput.reviewItem.description,
+                    ownerType: judgeOutput.ownerType,
+                },
+            },
+        };
+    }
+
+    private static normalizeJudgeTargetRefs({
+        judgeTargetRefs,
+        agentUuid,
+    }: {
+        judgeTargetRefs: AiAgentReviewClassifierJudgeTargetRef[];
+        agentUuid: string;
+    }): AiAgentTargetRef[] {
+        return judgeTargetRefs.map((targetRef) => {
+            const modelName = targetRef.modelName ?? targetRef.label;
+            const fieldName = targetRef.fieldName ?? targetRef.label;
+            const key = targetRef.key ?? targetRef.label;
+
+            switch (targetRef.type) {
+                case 'model':
+                    return { type: 'model', modelName };
+                case 'explore':
+                    return {
+                        type: 'explore',
+                        modelName,
+                        exploreName: fieldName,
+                    };
+                case 'join':
+                    return { type: 'join', modelName, joinName: fieldName };
+                case 'dimension':
+                    return {
+                        type: 'dimension',
+                        modelName,
+                        dimensionName: fieldName,
+                    };
+                case 'metric':
+                    return { type: 'metric', modelName, metricName: fieldName };
+                case 'additional_dimension':
+                    return {
+                        type: 'additional_dimension',
+                        modelName,
+                        parentDimensionName: modelName,
+                        dimensionName: fieldName,
+                    };
+                case 'required_filter':
+                    return {
+                        type: 'required_filter',
+                        modelName,
+                        exploreName: modelName,
+                        fieldName,
+                    };
+                case 'ai_hint':
+                    return {
+                        type: 'ai_hint',
+                        modelName,
+                        targetType: 'model',
+                        targetName: fieldName,
+                    };
+                case 'agent':
+                    return { type: 'agent', agentUuid };
+                case 'agent_config':
+                    return {
+                        type: 'agent_config',
+                        setting: targetRef.setting ?? 'unknown',
+                    };
+                case 'product_capability':
+                    return { type: 'product_capability', capabilityKey: key };
+                case 'runtime':
+                    return { type: 'runtime', key };
+                default:
+                    return { type: 'agent', agentUuid };
+            }
+        });
+    }
+
+    private async buildReviewEvidence(
+        candidate: AiAgentReviewClassifierTurnCandidate,
+        agentConfig: AiAgentReviewAgentConfigEvidence,
+    ): Promise<{
+        evidencePacket: AiAgentReviewJudgeEvidencePacket;
+        agentConfig: AiAgentReviewAgentConfigEvidence;
+    }> {
+        const semanticContext = await this.buildSemanticContext(candidate);
+
+        return {
+            agentConfig,
+            evidencePacket:
+                AiAgentReviewClassifierService.buildJudgeEvidencePacket({
+                    candidate,
+                    agentConfig,
+                    semanticContext,
+                }),
+        };
+    }
+
+    private async captureAgentConfigSnapshot(
+        candidate: AiAgentReviewClassifierTurnCandidate,
+    ): Promise<AiAgentReviewAgentConfigEvidence> {
+        try {
+            const agent = await this.aiAgentModel.getAgent({
+                organizationUuid: candidate.subject.organizationUuid,
+                projectUuid: candidate.subject.projectUuid,
+                agentUuid: candidate.subject.agentUuid,
+            });
+
+            const instruction = agent.instruction ?? null;
+            const settings = [
+                instruction ? 'instructions' : null,
+                'data_access',
+                agent.enableSelfImprovement ? 'self_improvement' : null,
+                agent.spaceAccess.length > 0 ? 'space_access' : null,
+                agent.groupAccess.length > 0 || agent.userAccess.length > 0
+                    ? 'user_or_group_access'
+                    : null,
+            ].filter(
+                (setting): setting is AiAgentConfigurationSetting => !!setting,
+            );
+            const availableCapabilities: AiAgentAvailableCapability[] = [
+                'semantic_query',
+                'chart_generation',
+                'data_value_search',
+                ...(agent.enableDataAccess
+                    ? (['chart_data_access'] as const)
+                    : []),
+                ...(agent.enableSelfImprovement
+                    ? (['context_improvement'] as const)
+                    : []),
+            ];
+
+            const snapshot: AiAgentConfigSnapshot = {
+                capturedAt: new Date().toISOString(),
+                agentUpdatedAt: agent.updatedAt
+                    ? new Date(agent.updatedAt).toISOString()
+                    : null,
+                settings,
+                availableCapabilities,
+                instructionHash: instruction ? hashText(instruction) : null,
+                instructionSummary: instruction
+                    ? truncate(instruction, 500)
+                    : null,
+                knowledgeDocuments: [],
+            };
+            const snapshotHash = getAiAgentConfigSnapshotHash(snapshot);
+
+            return {
+                snapshot,
+                snapshotHash,
+                agentUpdatedAt: agent.updatedAt
+                    ? new Date(agent.updatedAt)
+                    : null,
+                settings: snapshot.settings,
+                availableCapabilities: snapshot.availableCapabilities,
+                dataAccessEnabled: agent.enableDataAccess,
+                selfImprovementEnabled: agent.enableSelfImprovement,
+                instructionSummary: snapshot.instructionSummary,
+                knowledgeDocumentCount: snapshot.knowledgeDocuments.length,
+            };
+        } catch (error) {
+            this.debugLog('AgentConfigSnapshotFailed', {
+                promptUuid: candidate.subject.assistantPromptUuid,
+                agentUuid: candidate.subject.agentUuid,
+                errorMessage:
+                    error instanceof Error ? error.message : String(error),
+            });
+
+            return AiAgentReviewClassifierService.emptyAgentConfigEvidence();
+        }
+    }
+
+    private static emptyAgentConfigEvidence(): AiAgentReviewAgentConfigEvidence {
+        return {
+            snapshot: null,
+            snapshotHash: null,
+            agentUpdatedAt: null,
+            settings: [],
+            availableCapabilities: [],
+            dataAccessEnabled: null,
+            selfImprovementEnabled: null,
+            instructionSummary: null,
+            knowledgeDocumentCount: 0,
+        };
+    }
+
+    private async buildSemanticContext(
+        candidate: AiAgentReviewClassifierTurnCandidate,
+    ): Promise<AiAgentReviewJudgeEvidencePacket['semanticContext']> {
+        const queriedExploreNames = [
+            ...new Set(
+                candidate.queryHistory
+                    .map((queryHistory) => queryHistory.metricQuery.exploreName)
+                    .filter((exploreName): exploreName is string =>
+                        Boolean(exploreName),
+                    ),
+            ),
+        ];
+        const queriedFieldNames = [
+            ...new Set(
+                candidate.queryHistory.flatMap((queryHistory) => [
+                    ...(queryHistory.metricQuery.metrics ?? []),
+                    ...(queryHistory.metricQuery.dimensions ?? []),
+                ]),
+            ),
+        ];
+
+        try {
+            const catalogItems = await this.catalogModel.getCatalogItemsSummary(
+                candidate.subject.projectUuid,
+            );
+
+            return {
+                queriedExploreNames,
+                queriedFieldNames,
+                catalogMatches:
+                    AiAgentReviewClassifierService.getRelevantCatalogMatches({
+                        catalogItems,
+                        candidate,
+                        queriedExploreNames,
+                        queriedFieldNames,
+                    }),
+            };
+        } catch (error) {
+            this.debugLog('CatalogEvidenceFailed', {
+                promptUuid: candidate.subject.assistantPromptUuid,
+                projectUuid: candidate.subject.projectUuid,
+                errorMessage:
+                    error instanceof Error ? error.message : String(error),
+            });
+
+            return {
+                queriedExploreNames,
+                queriedFieldNames,
+                catalogMatches: [],
+            };
+        }
+    }
+
+    private async judgeTurnWithLlm(
+        candidate: AiAgentReviewClassifierTurnCandidate,
+        evidencePacket: AiAgentReviewJudgeEvidencePacket,
+    ): Promise<AiAgentReviewClassifierJudgeOutput> {
+        const model = getModel(this.lightdashConfig.ai.copilot, {
+            useFastModel: true,
+        });
+
+        this.debugLog('JudgeRequest', {
+            promptUuid: candidate.subject.assistantPromptUuid,
+            threadUuid: candidate.subject.threadUuid,
+            modelProvider: candidate.modelMetadata.provider,
+            modelName: candidate.modelMetadata.model,
+            previousTurnCount: evidencePacket.previousTurns.length,
+            queryHistoryCount: evidencePacket.queryHistory.length,
+            catalogMatchCount:
+                evidencePacket.semanticContext.catalogMatches.length,
+            agentConfigSnapshotHash: evidencePacket.agentConfig.snapshotHash,
+            supportingEvidenceCount: evidencePacket.supportingEvidence.length,
+            hasNextUserPrompt: !!evidencePacket.nextUserPrompt,
+            hasHumanFeedback:
+                evidencePacket.humanFeedback.score !== null ||
+                !!evidencePacket.humanFeedback.comment,
+            evidenceExcerptCount:
+                evidencePacket.suggestedEvidenceExcerpts.length,
+        });
+
+        const result = await generateObject({
+            model: model.model,
+            ...defaultAgentOptions,
+            ...model.callOptions,
+            providerOptions: model.providerOptions,
+            schema: aiAgentReviewClassifierJudgeOutputSchema,
+            messages: [
+                {
+                    role: 'system',
+                    content: `You are an LLM-as-judge review agent for Lightdash AI analyst turns.
+
+Classify whether the assistant turn contains an actionable issue. Use only the supplied evidence packet. Do not invent project fields or facts.
+
+Definitions:
+- semantic_layer: dbt/Lightdash YAML model, dimension, metric, join, filter, or AI hint should change.
+- project_context: available explores, project context, or knowledge about which explore to use is missing/wrong.
+- agent_configuration: Lightdash agent settings should change, e.g. instructions, knowledge docs, data access, SQL mode, MCP, access.
+- data_gap: underlying warehouse/dbt data is missing or insufficient.
+- product_capability: Lightdash product capability limitation or feature request.
+- runtime_reliability: query/tool/runtime failed or timed out.
+- feedback_quality: explicit feedback is too ambiguous to classify without admin review.
+- not_a_failure: normal refinement, new request, acceptance, formatting-only change, or harmless follow-up.
+- ambiguous: likely issue, but insufficient evidence to choose one root cause.
+
+Return promotedToFinding=false for normal refinement, acceptance/continuation, unrelated new questions, or formatting-only changes.
+Successful queries can still be findings when the user asked broad business language and the semantic/catalog context does not clearly support the selected field, explore, or metric. Promote those as semantic_layer or project_context when a model definition, AI hint, or project context rule would prevent future ambiguity.
+Use agentConfig to catch Lightdash-layer fixes: missing instructions, disabled data access, missing knowledge docs, access restrictions, or capability settings. Promote those as agent_configuration when the answer quality depends on agent setup.
+When promotedToFinding=true, provide concise evidence excerpts copied or summarized from the packet and a practical recommendation.
+Use one primaryRootCause. Secondary causes are optional.
+For targetRefs, return compact refs:
+- type: one of the allowed target types.
+- label: short human-readable target.
+- modelName: dbt/Lightdash model when known, otherwise null.
+- fieldName: dimension/metric/join/explore/filter name when known, otherwise null.
+- setting: agent config setting for agent_config targets, otherwise null.
+- key: runtime/product capability key when useful, otherwise null.
+reviewItem.title should be concise and admin-facing.
+reviewItem.description should summarize why this grouping exists.`,
+                },
+                {
+                    role: 'user',
+                    content: JSON.stringify(evidencePacket, null, 2),
+                },
+            ],
+        });
+
+        return result.object as AiAgentReviewClassifierJudgeOutput;
+    }
+
+    private async isEnabled(args: {
+        requestedByUserUuid?: string;
+        organizationUuid: string;
+        organizationName?: string;
+    }): Promise<boolean> {
+        const featureFlag = await this.featureFlagService.get({
+            featureFlagId: FeatureFlags.AiAgentReviewClassifier,
+            user: {
+                userUuid: args.requestedByUserUuid ?? 'system',
+                organizationUuid: args.organizationUuid,
+                organizationName: args.organizationName ?? '',
+            },
+        });
+
+        return featureFlag.enabled;
+    }
+
+    private static buildEvidenceExcerpts(
+        candidate: AiAgentReviewClassifierTurnCandidate,
+    ): AiAgentEvidenceExcerpt[] {
+        return [
+            {
+                source: 'user_prompt',
+                text: truncate(candidate.userPrompt),
+                redacted: false,
+            },
+            candidate.assistantResponse
+                ? {
+                      source: 'assistant_answer' as const,
+                      text: truncate(candidate.assistantResponse),
+                      redacted: false,
+                  }
+                : null,
+            ...candidate.contextTurns.slice(-3).map(
+                (contextTurn): AiAgentEvidenceExcerpt => ({
+                    source: 'conversation_context',
+                    text: truncate(
+                        AiAgentReviewClassifierService.buildContextTurnText(
+                            contextTurn,
+                        ),
+                    ),
+                    redacted: false,
+                }),
+            ),
+            candidate.nextUserPrompt
+                ? {
+                      source: 'next_user_prompt' as const,
+                      text: truncate(candidate.nextUserPrompt),
+                      redacted: false,
+                  }
+                : null,
+            candidate.errorMessage
+                ? {
+                      source: 'tool_result' as const,
+                      text: truncate(candidate.errorMessage),
+                      redacted: false,
+                  }
+                : null,
+            candidate.queryHistory.find((queryHistory) => queryHistory.error)
+                ?.error
+                ? {
+                      source: 'tool_result' as const,
+                      text: truncate(
+                          candidate.queryHistory.find(
+                              (queryHistory) => queryHistory.error,
+                          )?.error ?? '',
+                      ),
+                      redacted: false,
+                  }
+                : null,
+            ...candidate.supportingEvidence.slice(0, 3).map(
+                (evidence): AiAgentEvidenceExcerpt => ({
+                    source: 'tool_call',
+                    text: truncate(
+                        AiAgentReviewClassifierService.buildSupportingEvidenceText(
+                            evidence,
+                        ),
+                    ),
+                    redacted: false,
+                }),
+            ),
+        ].filter((excerpt): excerpt is AiAgentEvidenceExcerpt => !!excerpt);
+    }
+
+    private static buildJudgeEvidencePacket({
+        candidate,
+        agentConfig,
+        semanticContext,
+    }: {
+        candidate: AiAgentReviewClassifierTurnCandidate;
+        agentConfig: AiAgentReviewJudgeEvidencePacket['agentConfig'];
+        semanticContext: AiAgentReviewJudgeEvidencePacket['semanticContext'];
+    }): AiAgentReviewJudgeEvidencePacket {
+        return {
+            subject: candidate.subject,
+            interactionSource: candidate.interactionSource,
+            targetTurn: candidate.targetTurn,
+            reviewHints: candidate.reviewHints,
+            humanFeedback: {
+                score: candidate.humanScore,
+                comment: candidate.humanFeedback,
+            },
+            agentConfig,
+            semanticContext,
+            nextUserPrompt: candidate.nextUserPrompt
+                ? {
+                      promptUuid: candidate.nextUserPromptUuid,
+                      text: candidate.nextUserPrompt,
+                  }
+                : null,
+            previousTurns: candidate.contextTurns.slice(-3),
+            queryHistory: candidate.queryHistory.map((queryHistory) => ({
+                queryUuid: queryHistory.queryUuid,
+                status: queryHistory.status,
+                error: queryHistory.error,
+                metricQuery: queryHistory.metricQuery,
+                totalRowCount: queryHistory.totalRowCount,
+                warehouseExecutionTimeMs: queryHistory.warehouseExecutionTimeMs,
+            })),
+            supportingEvidence: candidate.supportingEvidence.map(
+                (evidence) => ({
+                    ...evidence,
+                    summary:
+                        AiAgentReviewClassifierService.buildSupportingEvidenceText(
+                            evidence,
+                        ),
+                }),
+            ),
+            suggestedEvidenceExcerpts:
+                AiAgentReviewClassifierService.buildEvidenceExcerpts(candidate),
+        };
+    }
+
+    private static buildContextTurnText(
+        contextTurn: AiAgentReviewClassifierTurnCandidate['contextTurns'][number],
+    ): string {
+        const response =
+            contextTurn.assistantResponse ??
+            contextTurn.errorMessage ??
+            'No assistant response captured.';
+
+        return `${contextTurn.relation} turn (${contextTurn.promptUuid}): prompt=${truncate(contextTurn.userPrompt, 320)} response=${truncate(response, 480)}`;
+    }
+
+    private static buildSupportingEvidenceText(
+        evidence: AiAgentReviewClassifierTurnCandidate['supportingEvidence'][number],
+    ): string {
+        const subagentPrefix = evidence.parentToolCallId
+            ? 'Subagent tool trace'
+            : 'Tool trace';
+        const args = evidence.toolArgsPreview
+            ? ` args=${truncate(evidence.toolArgsPreview, 320)}`
+            : '';
+        const result = evidence.resultPreview
+            ? ` result=${truncate(evidence.resultPreview, 480)}`
+            : '';
+
+        return `${subagentPrefix}: ${evidence.toolName} (${evidence.toolCallId}).${args}${result}`;
+    }
+
+    private static getRelevantCatalogMatches({
+        catalogItems,
+        candidate,
+        queriedExploreNames,
+        queriedFieldNames,
+    }: {
+        catalogItems: CatalogItemSummary[];
+        candidate: AiAgentReviewClassifierTurnCandidate;
+        queriedExploreNames: string[];
+        queriedFieldNames: string[];
+    }): AiAgentReviewCatalogEvidenceItem[] {
+        const promptTerms = AiAgentReviewClassifierService.extractSearchTerms(
+            [
+                candidate.userPrompt,
+                candidate.nextUserPrompt,
+                candidate.humanFeedback,
+                ...candidate.contextTurns.map((turn) => turn.userPrompt),
+            ]
+                .filter((value): value is string => !!value)
+                .join(' '),
+        );
+        const queriedFields = new Set(
+            queriedFieldNames.map((fieldName) => fieldName.toLowerCase()),
+        );
+        const queriedExplores = new Set(
+            queriedExploreNames.map((exploreName) => exploreName.toLowerCase()),
+        );
+
+        return catalogItems
+            .map((item) => {
+                const searchableText = [
+                    item.name,
+                    item.label,
+                    item.description,
+                    item.tableName,
+                ]
+                    .filter((value): value is string => !!value)
+                    .join(' ')
+                    .toLowerCase();
+                const exactFieldMatch = queriedFields.has(
+                    item.name.toLowerCase(),
+                );
+                const exactExploreMatch =
+                    item.type === CatalogType.Table &&
+                    queriedExplores.has(item.name.toLowerCase());
+                const promptTermScore = promptTerms.filter((term) =>
+                    searchableText.includes(term),
+                ).length;
+
+                return {
+                    item,
+                    score:
+                        (exactFieldMatch ? 100 : 0) +
+                        (exactExploreMatch ? 80 : 0) +
+                        promptTermScore,
+                };
+            })
+            .filter(({ score }) => score > 0)
+            .sort((a, b) => b.score - a.score)
+            .slice(0, 20)
+            .map(({ item }) => ({
+                name: item.name,
+                label: item.label ?? null,
+                type: item.type,
+                tableName: item.tableName ?? null,
+                fieldType: item.fieldType ?? null,
+                description: item.description ?? null,
+            }));
+    }
+
+    private static extractSearchTerms(input: string): string[] {
+        const stopWords = new Set([
+            'the',
+            'and',
+            'for',
+            'with',
+            'from',
+            'what',
+            'show',
+            'give',
+            'tell',
+            'our',
+            'this',
+            'that',
+            'use',
+            'not',
+        ]);
+
+        return [
+            ...new Set(
+                input
+                    .toLowerCase()
+                    .split(/[^a-z0-9_]+/)
+                    .filter((term) => term.length >= 3 && !stopWords.has(term)),
+            ),
+        ].slice(0, 25);
+    }
+
+    private static buildReport({
+        dryRun,
+        reviewedTurns,
+    }: {
+        dryRun: boolean;
+        reviewedTurns: AiAgentReviewClassifierReviewedTurn[];
+    }): AiAgentReviewClassifierExperimentReport {
+        const signalsByType: Partial<Record<AiAgentTurnSignal, number>> = {};
+        const findingsByRootCause: Partial<Record<AiAgentRootCause, number>> =
+            {};
+        reviewedTurns.forEach(({ classifiedTurn }) => {
+            signalsByType[classifiedTurn.signal.signal] =
+                (signalsByType[classifiedTurn.signal.signal] ?? 0) + 1;
+
+            if (classifiedTurn.finding) {
+                findingsByRootCause[classifiedTurn.finding.primaryRootCause] =
+                    (findingsByRootCause[
+                        classifiedTurn.finding.primaryRootCause
+                    ] ?? 0) + 1;
+            }
+        });
+
+        const examples = reviewedTurns
+            .filter(
+                ({ classifiedTurn }) =>
+                    classifiedTurn.signal.promotedToFinding ||
+                    classifiedTurn.finding,
+            )
+            .slice(0, 10)
+            .map(({ candidate, classifiedTurn }) => ({
+                promptUuid: candidate.subject.assistantPromptUuid,
+                signal: classifiedTurn.signal.signal,
+                rootCause: classifiedTurn.finding?.primaryRootCause ?? null,
+                evidence: classifiedTurn.finding?.evidenceExcerpts.map(
+                    (evidence) => evidence.text,
+                ) ?? [candidate.userPrompt],
+                queryStatuses: candidate.queryHistory.map(
+                    (queryHistory) => queryHistory.status,
+                ),
+                supportingEvidence: candidate.supportingEvidence.map(
+                    AiAgentReviewClassifierService.buildSupportingEvidenceText,
+                ),
+            }));
+
+        return {
+            dryRun,
+            totalCandidates: reviewedTurns.length,
+            signalsByType,
+            findingsByRootCause,
+            examples,
+        };
+    }
+}
+
+const truncate = (input: string, maxLength = 1200): string =>
+    input.length > maxLength ? `${input.slice(0, maxLength)}...` : input;
+
+const hashText = (input: string): string =>
+    createHash('sha256').update(input).digest('hex');

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -139,6 +139,7 @@ export type ModelManifest = {
     aiAgentModel: unknown;
     aiAgentDocumentModel: unknown;
     aiWritebackThreadModel: unknown;
+    aiAgentReviewClassifierModel: unknown;
     managedAgentModel: unknown;
     aiOrganizationSettingsModel: unknown;
     embedModel: unknown;
@@ -736,6 +737,10 @@ export class ModelRepository
 
     public getAiWritebackThreadModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiWritebackThreadModel');
+    }
+
+    public getAiAgentReviewClassifierModel<ModelImplT>(): ModelImplT {
+        return this.getModel('aiAgentReviewClassifierModel');
     }
 
     public getAiOrganizationSettingsModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -138,6 +138,7 @@ interface ServiceManifest {
     aiAgentService: unknown;
     aiAgentAdminService: unknown;
     aiAgentDocumentService: unknown;
+    aiAgentReviewClassifierService: unknown;
     aiOrganizationSettingsService: unknown;
     scimService: unknown;
     supportService: unknown;
@@ -1268,6 +1269,12 @@ export class ServiceRepository
         AiAgentDocumentServiceImplT,
     >(): AiAgentDocumentServiceImplT {
         return this.getService('aiAgentDocumentService');
+    }
+
+    public getAiAgentReviewClassifierService<
+        AiAgentReviewClassifierServiceImplT,
+    >(): AiAgentReviewClassifierServiceImplT {
+        return this.getService('aiAgentReviewClassifierService');
     }
 
     public getRolesService(): RolesService {


### PR DESCRIPTION
## Summary

Builds the review classifier model and service on top of the output contract.

This includes:
- candidate collection from completed AI turns
- previous-turn context, query history, and ranked tool-call evidence
- first-pass signal classification, query failure routing, and final review pass
- persistence of signals, findings, review items, and recommendation metadata
- focused model/service tests

Refs PROD-7921
Refs PROD-7923
Refs PROD-7924

## Validation

Run on the stack:
- `pnpm -F @lightdash/common test -- aiAgentReviewClassifierTypes.test.ts --runInBand`
- `pnpm -F @lightdash/common typecheck`
- `pnpm -F backend test -- AiAgentReviewClassifierService.test.ts AiAgentReviewClassifierModel.test.ts --runInBand`
- `pnpm -F backend typecheck`
