### PR TITLE
feat(ai-agents): run review classifier from live events

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -584,6 +584,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 appGenerateService:
                     context.serviceRepository.getAppGenerateService(),
                 workerHealth: context.workerHealth,
+                aiAgentReviewClassifierService:
+                    context.serviceRepository.getAiAgentReviewClassifierService(),
             }),
         clientProviders: {
             schedulerClient: ({ context, models }) =>

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -1,5 +1,6 @@
 import {
     AiAgentEvalRunJobPayload,
+    AiAgentReviewClassifierJobPayload,
     AppGeneratePipelineJobPayload,
     EE_SCHEDULER_TASKS,
     EmbedArtifactVersionJobPayload,
@@ -32,6 +33,21 @@ export class CommercialSchedulerClient extends SchedulerClient {
             {
                 runAt: now, // now
                 maxAttempts: 1,
+            },
+        );
+        return { jobId };
+    }
+
+    async aiAgentReviewClassifier(payload: AiAgentReviewClassifierJobPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER,
+            payload,
+            {
+                runAt: now,
+                maxAttempts: 1,
+                jobKey: `ai-agent-review:${payload.eventType}:${payload.promptUuid}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -14,16 +14,19 @@ import {
     SchedulerWorkerArguments,
 } from '../../scheduler/SchedulerWorker';
 import { TypedEETaskList } from '../../scheduler/types';
+import { AiAgentReviewClassifierService } from '../services/AiAgentReviewClassifierService';
 import { AiAgentService } from '../services/AiAgentService/AiAgentService';
 import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
 import type { EmbedService } from '../services/EmbedService/EmbedService';
 import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgentService';
 
 const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 
 type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     aiAgentService: AiAgentService;
+    aiAgentReviewClassifierService: AiAgentReviewClassifierService;
     embedService: EmbedService;
     managedAgentService: ManagedAgentService;
     appGenerateService: AppGenerateService;
@@ -31,6 +34,8 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
     protected readonly aiAgentService: AiAgentService;
+
+    protected readonly aiAgentReviewClassifierService: AiAgentReviewClassifierService;
 
     protected readonly embedService: EmbedService;
 
@@ -41,6 +46,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
     constructor(args: CommercialSchedulerWorkerArguments) {
         super(args);
         this.aiAgentService = args.aiAgentService;
+        this.aiAgentReviewClassifierService =
+            args.aiAgentReviewClassifierService;
         this.embedService = args.embedService;
         this.managedAgentService = args.managedAgentService;
         this.appGenerateService = args.appGenerateService;
@@ -129,6 +136,46 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                                 agentUuid: payload.agentUuid,
                                 evalRunUuid: payload.evalRunUuid,
                                 evalRunResultUuid: payload.evalRunResultUuid,
+                            },
+                        });
+                    },
+                );
+            },
+            [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.aiAgentReviewClassifierService.runLiveEvent(
+                                {
+                                    ...payload,
+                                    requestedByUserUuid: payload.userUuid,
+                                },
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                error: getErrorMessage(e),
+                                projectUuid: payload.projectUuid,
+                                organizationUuid: payload.organizationUuid,
+                                agentUuid: payload.agentUuid,
+                                threadUuid: payload.threadUuid,
+                                promptUuid: payload.promptUuid,
+                                eventType: payload.eventType,
                             },
                         });
                     },

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8,6 +8,7 @@ import {
     AiAgentEvaluationRun,
     AiAgentEvaluationSummary,
     AiAgentNotFoundError,
+    AiAgentReviewClassifierEventType,
     AiAgentSummary,
     AiAgentThread,
     AiAgentThreadSummary,
@@ -551,6 +552,53 @@ export class AiAgentService extends BaseService {
             aiAgentModel: this.aiAgentModel,
             lightdashConfig: this.lightdashConfig,
         });
+    }
+
+    private enqueueReviewClassifierEvent(args: {
+        eventType: AiAgentReviewClassifierEventType;
+        organizationUuid: string | null | undefined;
+        projectUuid: string | null | undefined;
+        agentUuid: string | null | undefined;
+        threadUuid: string | null | undefined;
+        promptUuid: string;
+        userUuid?: string | null;
+    }) {
+        const { organizationUuid, projectUuid, agentUuid, threadUuid } = args;
+        if (!organizationUuid || !projectUuid || !agentUuid || !threadUuid) {
+            return;
+        }
+
+        const userUuid = args.userUuid ?? 'system';
+
+        void this.featureFlagService
+            .get({
+                featureFlagId: FeatureFlags.AiAgentReviewClassifier,
+                user: {
+                    userUuid,
+                    organizationUuid,
+                    organizationName: '',
+                },
+            })
+            .then((flag) => {
+                if (!flag.enabled) {
+                    return undefined;
+                }
+                return this.schedulerClient.aiAgentReviewClassifier({
+                    eventType: args.eventType,
+                    organizationUuid,
+                    projectUuid,
+                    agentUuid,
+                    threadUuid,
+                    promptUuid: args.promptUuid,
+                    userUuid,
+                });
+            })
+            .catch((error) => {
+                Logger.error(
+                    'Failed to enqueue AI agent review classifier job',
+                    error,
+                );
+            });
     }
 
     private getIsVerifiedArtifactsEnabled(): boolean {
@@ -3394,6 +3442,16 @@ export class AiAgentService extends BaseService {
             humanScore,
             humanFeedback,
         });
+
+        this.enqueueReviewClassifierEvent({
+            eventType: 'feedback_changed',
+            organizationUuid,
+            projectUuid: message.projectUuid,
+            agentUuid: message.agentUuid,
+            threadUuid: message.threadUuid,
+            promptUuid: threadMessage.uuid,
+            userUuid: user.userUuid,
+        });
     }
 
     async updateMessageSavedQuery(
@@ -5465,7 +5523,36 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             updateProgress: (progress: string) => updateProgress(progress),
             updatePrompt: (
                 update: UpdateSlackResponse | UpdateWebAppResponse,
-            ) => this.aiAgentModel.updateModelResponse(update),
+            ) => {
+                const updatePromise =
+                    this.aiAgentModel.updateModelResponse(update);
+
+                if (
+                    update.errorMessage !== undefined ||
+                    update.tokenUsage !== undefined
+                ) {
+                    void updatePromise
+                        .then(() => {
+                            this.enqueueReviewClassifierEvent({
+                                eventType: 'response_saved',
+                                organizationUuid: user.organizationUuid,
+                                projectUuid: prompt.projectUuid,
+                                agentUuid: agentSettings.uuid,
+                                threadUuid: prompt.threadUuid,
+                                promptUuid: update.promptUuid,
+                                userUuid: user.userUuid,
+                            });
+                        })
+                        .catch((error) => {
+                            Logger.error(
+                                'Failed to enqueue AI agent review classifier after response save',
+                                error,
+                            );
+                        });
+                }
+
+                return updatePromise;
+            },
             trackEvent: (
                 event:
                     | AiAgentResponseStreamed
@@ -5575,6 +5662,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             promptUuid,
             humanScore,
             humanFeedback,
+        });
+
+        const promptContext =
+            await this.aiAgentModel.findPromptContext(promptUuid);
+
+        this.enqueueReviewClassifierEvent({
+            eventType: 'feedback_changed',
+            organizationUuid: promptContext?.organizationUuid,
+            projectUuid: promptContext?.projectUuid,
+            agentUuid: promptContext?.agentUuid,
+            threadUuid: promptContext?.threadUuid,
+            promptUuid,
+            userUuid: userId,
         });
     }
 
@@ -6557,6 +6657,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     promptUuid,
                     humanScore: -1,
                     humanFeedback: feedbackValue,
+                });
+
+                const promptContext =
+                    await this.aiAgentModel.findPromptContext(promptUuid);
+
+                this.enqueueReviewClassifierEvent({
+                    eventType: 'feedback_changed',
+                    organizationUuid: promptContext?.organizationUuid,
+                    projectUuid: promptContext?.projectUuid,
+                    agentUuid: promptContext?.agentUuid,
+                    threadUuid: promptContext?.threadUuid,
+                    promptUuid,
+                    userUuid: body.user.id,
                 });
             }
         });

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -156,6 +156,15 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
 
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'agent.uuid': payload.agentUuid,
+        'thread.uuid': payload.threadUuid,
+        'prompt.uuid': payload.promptUuid,
+        'ai_agent_review.event_type': payload.eventType,
+    }),
+
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -1,6 +1,7 @@
 import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
+    type AiAgentReviewClassifierJobPayload,
     type ChartReference,
     type DataAppClaudeModel,
     type DataAppTemplate,
@@ -60,6 +61,7 @@ export type AppGeneratePipelineJobPayload = TraceTaskBase & {
 export const EE_SCHEDULER_TASKS = {
     SLACK_AI_PROMPT: 'slackAiPrompt',
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
+    AI_AGENT_REVIEW_CLASSIFIER: 'aiAgentReviewClassifier',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
@@ -143,6 +145,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: ManagedAgentHeartbeatPayload;
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
@@ -152,6 +155,7 @@ export interface TaskPayloadMap {
 export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
+    [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;


### PR DESCRIPTION
## Summary

Wires the classifier into live AI agent events through the scheduler worker.

This includes:
- scheduler task and worker execution for review classifier jobs
- response-saved enqueue hook for completed/error AI turns
- feedback-changed enqueue hooks for app and Slack feedback
- worker tracing tags for review jobs
- live-event run scope and target-turn review hints

Refs PROD-7920
Refs PROD-7921

## Validation

Run on the stack:
- `pnpm -F @lightdash/common test -- aiAgentReviewClassifierTypes.test.ts --runInBand`
- `pnpm -F @lightdash/common typecheck`
- `pnpm -F backend test -- AiAgentReviewClassifierService.test.ts AiAgentReviewClassifierModel.test.ts --runInBand`
- `pnpm -F backend typecheck`
