### PR TITLE
feat(ai-agents): add classifier review queue admin tab

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -1,8 +1,10 @@
 import {
     AiAgentAdminFilters,
     AiAgentAdminSort,
+    AiAgentReviewItemStatus,
     ApiAiAgentAdminConversationsResponse,
-    ApiAiAgentResponse,
+    ApiAiAgentReviewItemsResponse,
+    ApiAiAgentReviewSignalsResponse,
     ApiAiAgentSummaryResponse,
     ApiAiOrganizationSettingsResponse,
     ApiErrorPayload,
@@ -124,6 +126,50 @@ export class AiAgentAdminController extends BaseController {
         return {
             status: 'ok',
             results: await this.getAiAgentAdminService().listAgents(
+                toSessionUser(req.account),
+            ),
+        };
+    }
+
+    /**
+     * Get AI agent classifier review items for admin
+     * @summary List AI agent review items
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/review-items')
+    @OperationId('getAiAgentReviewItems')
+    async getReviewItems(
+        @Request() req: express.Request,
+        @Query() status?: AiAgentReviewItemStatus[],
+    ): Promise<ApiAiAgentReviewItemsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().listReviewItems(
+                toSessionUser(req.account),
+                status,
+            ),
+        };
+    }
+
+    /**
+     * Get AI agent classifier review signals for admin debugging
+     * @summary List AI agent review signals
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/review-signals')
+    @OperationId('getAiAgentReviewSignals')
+    async getReviewSignals(
+        @Request() req: express.Request,
+    ): Promise<ApiAiAgentReviewSignalsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().listReviewSignals(
                 toSessionUser(req.account),
             ),
         };

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -189,9 +189,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getAiWritebackService<AiWritebackService>(),
                     prometheusMetrics,
                 }),
-            aiAgentAdminService: ({ models, context }) =>
+            aiAgentAdminService: ({ models, repository, context }) =>
                 new AiAgentAdminService({
                     aiAgentModel: models.getAiAgentModel(),
+                    aiAgentReviewClassifierModel:
+                        models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
+                    featureFlagService: repository.getFeatureFlagService(),
                     lightdashConfig: context.lightdashConfig,
                 }),
             aiAgentDocumentService: ({ models, repository, context }) =>

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -584,6 +584,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 appGenerateService:
                     context.serviceRepository.getAppGenerateService(),
                 workerHealth: context.workerHealth,
+                aiAgentReviewClassifierService:
+                    context.serviceRepository.getAiAgentReviewClassifierService(),
             }),
         clientProviders: {
             schedulerClient: ({ context, models }) =>

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -1,5 +1,6 @@
 import {
     AiAgentEvalRunJobPayload,
+    AiAgentReviewClassifierJobPayload,
     AppGeneratePipelineJobPayload,
     EE_SCHEDULER_TASKS,
     EmbedArtifactVersionJobPayload,
@@ -32,6 +33,21 @@ export class CommercialSchedulerClient extends SchedulerClient {
             {
                 runAt: now, // now
                 maxAttempts: 1,
+            },
+        );
+        return { jobId };
+    }
+
+    async aiAgentReviewClassifier(payload: AiAgentReviewClassifierJobPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER,
+            payload,
+            {
+                runAt: now,
+                maxAttempts: 1,
+                jobKey: `ai-agent-review:${payload.eventType}:${payload.promptUuid}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -14,16 +14,19 @@ import {
     SchedulerWorkerArguments,
 } from '../../scheduler/SchedulerWorker';
 import { TypedEETaskList } from '../../scheduler/types';
+import { AiAgentReviewClassifierService } from '../services/AiAgentReviewClassifierService';
 import { AiAgentService } from '../services/AiAgentService/AiAgentService';
 import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
 import type { EmbedService } from '../services/EmbedService/EmbedService';
 import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgentService';
 
 const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 
 type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     aiAgentService: AiAgentService;
+    aiAgentReviewClassifierService: AiAgentReviewClassifierService;
     embedService: EmbedService;
     managedAgentService: ManagedAgentService;
     appGenerateService: AppGenerateService;
@@ -31,6 +34,8 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
     protected readonly aiAgentService: AiAgentService;
+
+    protected readonly aiAgentReviewClassifierService: AiAgentReviewClassifierService;
 
     protected readonly embedService: EmbedService;
 
@@ -41,6 +46,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
     constructor(args: CommercialSchedulerWorkerArguments) {
         super(args);
         this.aiAgentService = args.aiAgentService;
+        this.aiAgentReviewClassifierService =
+            args.aiAgentReviewClassifierService;
         this.embedService = args.embedService;
         this.managedAgentService = args.managedAgentService;
         this.appGenerateService = args.appGenerateService;
@@ -129,6 +136,46 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                                 agentUuid: payload.agentUuid,
                                 evalRunUuid: payload.evalRunUuid,
                                 evalRunResultUuid: payload.evalRunResultUuid,
+                            },
+                        });
+                    },
+                );
+            },
+            [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.aiAgentReviewClassifierService.runLiveEvent(
+                                {
+                                    ...payload,
+                                    requestedByUserUuid: payload.userUuid,
+                                },
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                error: getErrorMessage(e),
+                                projectUuid: payload.projectUuid,
+                                organizationUuid: payload.organizationUuid,
+                                agentUuid: payload.agentUuid,
+                                threadUuid: payload.threadUuid,
+                                promptUuid: payload.promptUuid,
+                                eventType: payload.eventType,
                             },
                         });
                     },

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -3,7 +3,11 @@ import {
     AiAgentAdminConversationsSummary,
     AiAgentAdminFilters,
     AiAgentAdminSort,
+    AiAgentReviewItemStatus,
+    AiAgentReviewItemSummary,
+    AiAgentReviewSignalSummary,
     AiAgentSummary,
+    FeatureFlags,
     ForbiddenError,
     KnexPaginateArgs,
     KnexPaginatedData,
@@ -12,10 +16,14 @@ import {
 import jwt from 'jsonwebtoken';
 import { type LightdashConfig } from '../../config/parseConfig';
 import { BaseService } from '../../services/BaseService';
+import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { AiAgentModel } from '../models/AiAgentModel';
+import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 
 type AiAgentAdminServiceDependencies = {
     aiAgentModel: AiAgentModel;
+    aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    featureFlagService: FeatureFlagService;
     lightdashConfig: LightdashConfig;
 };
 
@@ -24,9 +32,16 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly lightdashConfig: LightdashConfig;
 
+    private readonly aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+
+    private readonly featureFlagService: FeatureFlagService;
+
     constructor(dependencies: AiAgentAdminServiceDependencies) {
         super();
         this.aiAgentModel = dependencies.aiAgentModel;
+        this.aiAgentReviewClassifierModel =
+            dependencies.aiAgentReviewClassifierModel;
+        this.featureFlagService = dependencies.featureFlagService;
         this.lightdashConfig = dependencies.lightdashConfig;
     }
 
@@ -82,6 +97,66 @@ export class AiAgentAdminService extends BaseService {
         }
         this.checkOrganizationAdminAccess(user);
         return this.aiAgentModel.findAllAgents({
+            organizationUuid,
+        });
+    }
+
+    async listReviewItems(
+        user: SessionUser,
+        statuses?: AiAgentReviewItemStatus[],
+    ): Promise<AiAgentReviewItemSummary[]> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const featureFlag = await this.featureFlagService.get({
+            featureFlagId: FeatureFlags.AiAgentReviewClassifier,
+            user: {
+                userUuid: user.userUuid,
+                organizationUuid,
+                organizationName: user.organizationName ?? '',
+            },
+        });
+
+        if (!featureFlag.enabled) {
+            throw new ForbiddenError(
+                'AI agent review classifier is not enabled',
+            );
+        }
+
+        return this.aiAgentReviewClassifierModel.listReviewItems({
+            organizationUuid,
+            statuses,
+        });
+    }
+
+    async listReviewSignals(
+        user: SessionUser,
+    ): Promise<AiAgentReviewSignalSummary[]> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const featureFlag = await this.featureFlagService.get({
+            featureFlagId: FeatureFlags.AiAgentReviewClassifier,
+            user: {
+                userUuid: user.userUuid,
+                organizationUuid,
+                organizationName: user.organizationName ?? '',
+            },
+        });
+
+        if (!featureFlag.enabled) {
+            throw new ForbiddenError(
+                'AI agent review classifier is not enabled',
+            );
+        }
+
+        return this.aiAgentReviewClassifierModel.listReviewSignals({
             organizationUuid,
         });
     }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8,6 +8,7 @@ import {
     AiAgentEvaluationRun,
     AiAgentEvaluationSummary,
     AiAgentNotFoundError,
+    AiAgentReviewClassifierEventType,
     AiAgentSummary,
     AiAgentThread,
     AiAgentThreadSummary,
@@ -551,6 +552,53 @@ export class AiAgentService extends BaseService {
             aiAgentModel: this.aiAgentModel,
             lightdashConfig: this.lightdashConfig,
         });
+    }
+
+    private enqueueReviewClassifierEvent(args: {
+        eventType: AiAgentReviewClassifierEventType;
+        organizationUuid: string | null | undefined;
+        projectUuid: string | null | undefined;
+        agentUuid: string | null | undefined;
+        threadUuid: string | null | undefined;
+        promptUuid: string;
+        userUuid?: string | null;
+    }) {
+        const { organizationUuid, projectUuid, agentUuid, threadUuid } = args;
+        if (!organizationUuid || !projectUuid || !agentUuid || !threadUuid) {
+            return;
+        }
+
+        const userUuid = args.userUuid ?? 'system';
+
+        void this.featureFlagService
+            .get({
+                featureFlagId: FeatureFlags.AiAgentReviewClassifier,
+                user: {
+                    userUuid,
+                    organizationUuid,
+                    organizationName: '',
+                },
+            })
+            .then((flag) => {
+                if (!flag.enabled) {
+                    return undefined;
+                }
+                return this.schedulerClient.aiAgentReviewClassifier({
+                    eventType: args.eventType,
+                    organizationUuid,
+                    projectUuid,
+                    agentUuid,
+                    threadUuid,
+                    promptUuid: args.promptUuid,
+                    userUuid,
+                });
+            })
+            .catch((error) => {
+                Logger.error(
+                    'Failed to enqueue AI agent review classifier job',
+                    error,
+                );
+            });
     }
 
     private getIsVerifiedArtifactsEnabled(): boolean {
@@ -3394,6 +3442,16 @@ export class AiAgentService extends BaseService {
             humanScore,
             humanFeedback,
         });
+
+        this.enqueueReviewClassifierEvent({
+            eventType: 'feedback_changed',
+            organizationUuid,
+            projectUuid: message.projectUuid,
+            agentUuid: message.agentUuid,
+            threadUuid: message.threadUuid,
+            promptUuid: threadMessage.uuid,
+            userUuid: user.userUuid,
+        });
     }
 
     async updateMessageSavedQuery(
@@ -5465,7 +5523,36 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             updateProgress: (progress: string) => updateProgress(progress),
             updatePrompt: (
                 update: UpdateSlackResponse | UpdateWebAppResponse,
-            ) => this.aiAgentModel.updateModelResponse(update),
+            ) => {
+                const updatePromise =
+                    this.aiAgentModel.updateModelResponse(update);
+
+                if (
+                    update.errorMessage !== undefined ||
+                    update.tokenUsage !== undefined
+                ) {
+                    void updatePromise
+                        .then(() => {
+                            this.enqueueReviewClassifierEvent({
+                                eventType: 'response_saved',
+                                organizationUuid: user.organizationUuid,
+                                projectUuid: prompt.projectUuid,
+                                agentUuid: agentSettings.uuid,
+                                threadUuid: prompt.threadUuid,
+                                promptUuid: update.promptUuid,
+                                userUuid: user.userUuid,
+                            });
+                        })
+                        .catch((error) => {
+                            Logger.error(
+                                'Failed to enqueue AI agent review classifier after response save',
+                                error,
+                            );
+                        });
+                }
+
+                return updatePromise;
+            },
             trackEvent: (
                 event:
                     | AiAgentResponseStreamed
@@ -5575,6 +5662,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             promptUuid,
             humanScore,
             humanFeedback,
+        });
+
+        const promptContext =
+            await this.aiAgentModel.findPromptContext(promptUuid);
+
+        this.enqueueReviewClassifierEvent({
+            eventType: 'feedback_changed',
+            organizationUuid: promptContext?.organizationUuid,
+            projectUuid: promptContext?.projectUuid,
+            agentUuid: promptContext?.agentUuid,
+            threadUuid: promptContext?.threadUuid,
+            promptUuid,
+            userUuid: userId,
         });
     }
 
@@ -6557,6 +6657,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     promptUuid,
                     humanScore: -1,
                     humanFeedback: feedbackValue,
+                });
+
+                const promptContext =
+                    await this.aiAgentModel.findPromptContext(promptUuid);
+
+                this.enqueueReviewClassifierEvent({
+                    eventType: 'feedback_changed',
+                    organizationUuid: promptContext?.organizationUuid,
+                    projectUuid: promptContext?.projectUuid,
+                    agentUuid: promptContext?.agentUuid,
+                    threadUuid: promptContext?.threadUuid,
+                    promptUuid,
+                    userUuid: body.user.id,
                 });
             }
         });

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -11753,11 +11753,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -11815,11 +11815,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12630,11 +12630,30 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiPromptTokenUsage: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                totalTokens: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentMessageAssistant: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                tokenUsage: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiPromptTokenUsage' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 modelConfig: {
                     dataType: 'union',
                     subSchemas: [
@@ -17867,6 +17886,833 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentRootCause: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['semantic_layer'] },
+                { dataType: 'enum', enums: ['project_context'] },
+                { dataType: 'enum', enums: ['agent_configuration'] },
+                { dataType: 'enum', enums: ['data_gap'] },
+                { dataType: 'enum', enums: ['product_capability'] },
+                { dataType: 'enum', enums: ['runtime_reliability'] },
+                { dataType: 'enum', enums: ['feedback_quality'] },
+                { dataType: 'enum', enums: ['not_a_failure'] },
+                { dataType: 'enum', enums: ['ambiguous'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['open'] },
+                { dataType: 'enum', enums: ['in_progress'] },
+                { dataType: 'enum', enums: ['resolved'] },
+                { dataType: 'enum', enums: ['dismissed'] },
+                { dataType: 'enum', enums: ['duplicate'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemDismissedReason: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['not_actionable'] },
+                { dataType: 'enum', enums: ['expected_behavior'] },
+                { dataType: 'enum', enums: ['duplicate'] },
+                { dataType: 'enum', enums: ['low_confidence'] },
+                { dataType: 'enum', enums: ['other'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemOwnerType: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['semantic_layer_owner'] },
+                { dataType: 'enum', enums: ['agent_admin'] },
+                { dataType: 'enum', enums: ['product'] },
+                { dataType: 'enum', enums: ['support'] },
+                { dataType: 'enum', enums: ['unknown'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                linkedPrUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                linkedIssueUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                statusUpdatedByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                statusUpdatedAt: { dataType: 'datetime', required: true },
+                findingCount: { dataType: 'double', required: true },
+                lastSeenAt: { dataType: 'datetime', required: true },
+                firstSeenAt: { dataType: 'datetime', required: true },
+                assignedToUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                ownerType: {
+                    ref: 'AiAgentReviewItemOwnerType',
+                    required: true,
+                },
+                dismissedReason: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiAgentReviewItemDismissedReason' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { ref: 'AiAgentReviewItemStatus', required: true },
+                primaryRootCause: { ref: 'AiAgentRootCause', required: true },
+                description: { dataType: 'string', required: true },
+                title: { dataType: 'string', required: true },
+                agentUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                projectUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                organizationUuid: { dataType: 'string', required: true },
+                fingerprint: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentFixTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['semantic_yaml_patch'] },
+                { dataType: 'enum', enums: ['project_context_rule'] },
+                { dataType: 'enum', enums: ['agent_configuration_change'] },
+                { dataType: 'enum', enums: ['dbt_modeling_ticket'] },
+                { dataType: 'enum', enums: ['semantic_layer_ticket'] },
+                { dataType: 'enum', enums: ['product_capability_ticket'] },
+                { dataType: 'enum', enums: ['runtime_reliability_ticket'] },
+                { dataType: 'enum', enums: ['feedback_needed'] },
+                { dataType: 'enum', enums: ['no_action'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentSemanticTargetRef: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        yamlPath: { dataType: 'string' },
+                        modelName: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['model'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        yamlPath: { dataType: 'string' },
+                        exploreName: { dataType: 'string', required: true },
+                        modelName: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['explore'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        yamlPath: { dataType: 'string' },
+                        exploreName: { dataType: 'string' },
+                        joinName: { dataType: 'string', required: true },
+                        modelName: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['join'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        yamlPath: { dataType: 'string' },
+                        dimensionName: { dataType: 'string', required: true },
+                        modelName: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['dimension'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        yamlPath: { dataType: 'string' },
+                        dimensionName: { dataType: 'string' },
+                        metricName: { dataType: 'string', required: true },
+                        modelName: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['metric'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        yamlPath: { dataType: 'string' },
+                        dimensionName: { dataType: 'string', required: true },
+                        parentDimensionName: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                        modelName: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['additional_dimension'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        yamlPath: { dataType: 'string' },
+                        fieldName: { dataType: 'string', required: true },
+                        exploreName: { dataType: 'string', required: true },
+                        modelName: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['required_filter'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        yamlPath: { dataType: 'string' },
+                        targetName: { dataType: 'string', required: true },
+                        targetType: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'enum', enums: ['model'] },
+                                { dataType: 'enum', enums: ['dimension'] },
+                                { dataType: 'enum', enums: ['metric'] },
+                            ],
+                            required: true,
+                        },
+                        modelName: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['ai_hint'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentConfigurationSetting: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['instructions'] },
+                { dataType: 'enum', enums: ['knowledge_documents'] },
+                { dataType: 'enum', enums: ['data_access'] },
+                { dataType: 'enum', enums: ['self_improvement'] },
+                { dataType: 'enum', enums: ['sql_mode'] },
+                { dataType: 'enum', enums: ['mcp_servers'] },
+                { dataType: 'enum', enums: ['explore_tags'] },
+                { dataType: 'enum', enums: ['space_access'] },
+                { dataType: 'enum', enums: ['user_or_group_access'] },
+                { dataType: 'enum', enums: ['unknown'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentTargetRef: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'AiAgentSemanticTargetRef' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        agentUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['agent'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        setting: {
+                            ref: 'AiAgentConfigurationSetting',
+                            required: true,
+                        },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['agent_config'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        capabilityKey: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['product_capability'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        key: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['runtime'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentEvidenceExcerpt: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                redacted: { dataType: 'boolean', required: true },
+                text: { dataType: 'string', required: true },
+                source: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['user_prompt'] },
+                        { dataType: 'enum', enums: ['assistant_answer'] },
+                        { dataType: 'enum', enums: ['next_user_prompt'] },
+                        { dataType: 'enum', enums: ['conversation_context'] },
+                        { dataType: 'enum', enums: ['tool_call'] },
+                        { dataType: 'enum', enums: ['tool_result'] },
+                        { dataType: 'enum', enums: ['agent_config'] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentRecommendationAction: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['update_semantic_yaml'] },
+                { dataType: 'enum', enums: ['update_agent_instructions'] },
+                { dataType: 'enum', enums: ['add_knowledge_document'] },
+                { dataType: 'enum', enums: ['enable_data_access'] },
+                { dataType: 'enum', enums: ['enable_sql_mode'] },
+                { dataType: 'enum', enums: ['enable_self_improvement'] },
+                { dataType: 'enum', enums: ['configure_mcp_server'] },
+                { dataType: 'enum', enums: ['adjust_explore_tags'] },
+                { dataType: 'enum', enums: ['update_access'] },
+                { dataType: 'enum', enums: ['route_to_product_work'] },
+                { dataType: 'enum', enums: ['request_more_evidence'] },
+                { dataType: 'enum', enums: ['no_action'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentRecommendation: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                targetRefs: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiAgentTargetRef' },
+                    required: true,
+                },
+                rationale: { dataType: 'string', required: true },
+                title: { dataType: 'string', required: true },
+                actionType: {
+                    ref: 'AiAgentRecommendationAction',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'AiAgentReviewItem' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        latestFinding: {
+                            dataType: 'union',
+                            subSchemas: [
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        createdAt: {
+                                            dataType: 'datetime',
+                                            required: true,
+                                        },
+                                        recommendation: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    ref: 'AiAgentRecommendation',
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: [null],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                        evidenceExcerpts: {
+                                            dataType: 'array',
+                                            array: {
+                                                dataType: 'refAlias',
+                                                ref: 'AiAgentEvidenceExcerpt',
+                                            },
+                                            required: true,
+                                        },
+                                        targetRefs: {
+                                            dataType: 'array',
+                                            array: {
+                                                dataType: 'refAlias',
+                                                ref: 'AiAgentTargetRef',
+                                            },
+                                            required: true,
+                                        },
+                                        fixTargets: {
+                                            dataType: 'array',
+                                            array: {
+                                                dataType: 'refAlias',
+                                                ref: 'AiAgentFixTarget',
+                                            },
+                                            required: true,
+                                        },
+                                        subcategories: {
+                                            dataType: 'array',
+                                            array: { dataType: 'string' },
+                                            required: true,
+                                        },
+                                        agentUuid: {
+                                            dataType: 'string',
+                                            required: true,
+                                        },
+                                        projectUuid: {
+                                            dataType: 'string',
+                                            required: true,
+                                        },
+                                        threadUuid: {
+                                            dataType: 'string',
+                                            required: true,
+                                        },
+                                        promptUuid: {
+                                            dataType: 'string',
+                                            required: true,
+                                        },
+                                        uuid: {
+                                            dataType: 'string',
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiAgentReviewItemSummary-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentReviewItemSummary',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentReviewItemsResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiAgentReviewItemSummary-Array_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentTurnSignal: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['normal_refinement'] },
+                { dataType: 'enum', enums: ['implicit_correction'] },
+                { dataType: 'enum', enums: ['explicit_dispute'] },
+                { dataType: 'enum', enums: ['retry_after_failure'] },
+                { dataType: 'enum', enums: ['output_shape_correction'] },
+                { dataType: 'enum', enums: ['new_question'] },
+                { dataType: 'enum', enums: ['acceptance_or_continuation'] },
+                { dataType: 'enum', enums: ['product_capability_request'] },
+                { dataType: 'enum', enums: ['human_intervention'] },
+                { dataType: 'enum', enums: ['ambiguous'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentImplicitSignalSource: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['next_user_correction'] },
+                { dataType: 'enum', enums: ['next_user_dispute'] },
+                { dataType: 'enum', enums: ['next_user_retry'] },
+                { dataType: 'enum', enums: ['output_shape_correction'] },
+                { dataType: 'enum', enums: ['tool_error'] },
+                { dataType: 'enum', enums: ['assistant_no_answer'] },
+                { dataType: 'enum', enums: ['product_capability_request'] },
+                { dataType: 'enum', enums: ['human_intervention'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewClassifierConfidence: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['low'] },
+                { dataType: 'enum', enums: ['medium'] },
+                { dataType: 'enum', enums: ['high'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewClassifierEventType: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['response_saved'] },
+                { dataType: 'enum', enums: ['feedback_changed'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewClassifierRunScope: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dryRun: { dataType: 'boolean' },
+                        agentUuid: { dataType: 'string' },
+                        projectUuid: { dataType: 'string' },
+                        endedAt: { dataType: 'string', required: true },
+                        startedAt: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['backfill'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        agentUuid: { dataType: 'string', required: true },
+                        projectUuid: { dataType: 'string', required: true },
+                        threadUuid: { dataType: 'string', required: true },
+                        promptUuid: { dataType: 'string', required: true },
+                        eventType: {
+                            ref: 'AiAgentReviewClassifierEventType',
+                            required: true,
+                        },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['live_event'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        filters: {
+                            ref: 'Record_string.unknown_',
+                            required: true,
+                        },
+                        requestedByUserUuid: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['manual'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewSignalSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                finding: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                recommendation: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { ref: 'AiAgentRecommendation' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                evidenceExcerpts: {
+                                    dataType: 'array',
+                                    array: {
+                                        dataType: 'refAlias',
+                                        ref: 'AiAgentEvidenceExcerpt',
+                                    },
+                                    required: true,
+                                },
+                                fixTargets: {
+                                    dataType: 'array',
+                                    array: {
+                                        dataType: 'refAlias',
+                                        ref: 'AiAgentFixTarget',
+                                    },
+                                    required: true,
+                                },
+                                subcategories: {
+                                    dataType: 'array',
+                                    array: { dataType: 'string' },
+                                    required: true,
+                                },
+                                primaryRootCause: {
+                                    ref: 'AiAgentRootCause',
+                                    required: true,
+                                },
+                                reviewItemUuid: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                uuid: { dataType: 'string', required: true },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                errorMessage: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                responsePreview: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                prompt: { dataType: 'string', required: true },
+                runScope: {
+                    ref: 'AiAgentReviewClassifierRunScope',
+                    required: true,
+                },
+                createdAt: { dataType: 'datetime', required: true },
+                promotionReason: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                promotedToFinding: { dataType: 'boolean', required: true },
+                confidence: {
+                    ref: 'AiAgentReviewClassifierConfidence',
+                    required: true,
+                },
+                implicitSignalSources: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentImplicitSignalSource',
+                    },
+                    required: true,
+                },
+                signal: { ref: 'AiAgentTurnSignal', required: true },
+                agentUuid: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                threadUuid: { dataType: 'string', required: true },
+                promptUuid: { dataType: 'string', required: true },
+                runUuid: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiAgentReviewSignalSummary-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentReviewSignalSummary',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentReviewSignalsResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiAgentReviewSignalSummary-Array_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiOrganizationSettings: {
         dataType: 'refAlias',
         type: {
@@ -22086,6 +22932,7 @@ const models: TsoaRoute.Models = {
             subSchemas: [
                 { dataType: 'enum', enums: ['slackAiPrompt'] },
                 { dataType: 'enum', enums: ['aiAgentEvalResult'] },
+                { dataType: 'enum', enums: ['aiAgentReviewClassifier'] },
                 { dataType: 'enum', enums: ['embedArtifactVersion'] },
                 { dataType: 'enum', enums: ['generateArtifactQuestion'] },
                 { dataType: 'enum', enums: ['appGeneratePipeline'] },
@@ -24809,7 +25656,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24819,7 +25666,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24829,7 +25676,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -24842,7 +25689,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -25497,7 +26344,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -25507,7 +26354,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -25517,7 +26364,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -25530,7 +26377,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -45720,6 +46567,122 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getAllAgents',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getReviewItems: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        status: {
+            in: 'query',
+            name: 'status',
+            dataType: 'array',
+            array: { dataType: 'refAlias', ref: 'AiAgentReviewItemStatus' },
+        },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/review-items',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getReviewItems,
+        ),
+
+        async function AiAgentAdminController_getReviewItems(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getReviewItems,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getReviewItems',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getReviewSignals: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/review-signals',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getReviewSignals,
+        ),
+
+        async function AiAgentAdminController_getReviewSignals(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getReviewSignals,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getReviewSignals',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13321,8 +13321,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13380,8 +13380,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13787,8 +13787,26 @@
             "AiAgentMessageAssistantArtifact": {
                 "$ref": "#/components/schemas/Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_"
             },
+            "AiPromptTokenUsage": {
+                "properties": {
+                    "totalTokens": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["totalTokens"],
+                "type": "object"
+            },
             "AiAgentMessageAssistant": {
                 "properties": {
+                    "tokenUsage": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiPromptTokenUsage"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "modelConfig": {
                         "properties": {
                             "reasoning": {
@@ -13878,6 +13896,7 @@
                     }
                 },
                 "required": [
+                    "tokenUsage",
                     "modelConfig",
                     "referencedArtifacts",
                     "artifacts",
@@ -18822,6 +18841,873 @@
                 "type": "string",
                 "enum": ["createdAt", "title"]
             },
+            "AiAgentRootCause": {
+                "type": "string",
+                "enum": [
+                    "semantic_layer",
+                    "project_context",
+                    "agent_configuration",
+                    "data_gap",
+                    "product_capability",
+                    "runtime_reliability",
+                    "feedback_quality",
+                    "not_a_failure",
+                    "ambiguous"
+                ]
+            },
+            "AiAgentReviewItemStatus": {
+                "type": "string",
+                "enum": [
+                    "open",
+                    "in_progress",
+                    "resolved",
+                    "dismissed",
+                    "duplicate"
+                ]
+            },
+            "AiAgentReviewItemDismissedReason": {
+                "type": "string",
+                "enum": [
+                    "not_actionable",
+                    "expected_behavior",
+                    "duplicate",
+                    "low_confidence",
+                    "other"
+                ]
+            },
+            "AiAgentReviewItemOwnerType": {
+                "type": "string",
+                "enum": [
+                    "semantic_layer_owner",
+                    "agent_admin",
+                    "product",
+                    "support",
+                    "unknown"
+                ]
+            },
+            "AiAgentReviewItem": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "linkedPrUrl": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "linkedIssueUrl": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "statusUpdatedByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "statusUpdatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "findingCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "lastSeenAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "firstSeenAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "assignedToUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "ownerType": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemOwnerType"
+                    },
+                    "dismissedReason": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiAgentReviewItemDismissedReason"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemStatus"
+                    },
+                    "primaryRootCause": {
+                        "$ref": "#/components/schemas/AiAgentRootCause"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "agentUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "projectUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "fingerprint": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "createdAt",
+                    "linkedPrUrl",
+                    "linkedIssueUrl",
+                    "statusUpdatedByUserUuid",
+                    "statusUpdatedAt",
+                    "findingCount",
+                    "lastSeenAt",
+                    "firstSeenAt",
+                    "assignedToUserUuid",
+                    "ownerType",
+                    "dismissedReason",
+                    "status",
+                    "primaryRootCause",
+                    "description",
+                    "title",
+                    "agentUuid",
+                    "projectUuid",
+                    "organizationUuid",
+                    "fingerprint",
+                    "uuid"
+                ],
+                "type": "object"
+            },
+            "AiAgentFixTarget": {
+                "type": "string",
+                "enum": [
+                    "semantic_yaml_patch",
+                    "project_context_rule",
+                    "agent_configuration_change",
+                    "dbt_modeling_ticket",
+                    "semantic_layer_ticket",
+                    "product_capability_ticket",
+                    "runtime_reliability_ticket",
+                    "feedback_needed",
+                    "no_action"
+                ]
+            },
+            "AiAgentSemanticTargetRef": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "yamlPath": {
+                                "type": "string"
+                            },
+                            "modelName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["model"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["modelName", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "yamlPath": {
+                                "type": "string"
+                            },
+                            "exploreName": {
+                                "type": "string"
+                            },
+                            "modelName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["explore"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["exploreName", "modelName", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "yamlPath": {
+                                "type": "string"
+                            },
+                            "exploreName": {
+                                "type": "string"
+                            },
+                            "joinName": {
+                                "type": "string"
+                            },
+                            "modelName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["join"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["joinName", "modelName", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "yamlPath": {
+                                "type": "string"
+                            },
+                            "dimensionName": {
+                                "type": "string"
+                            },
+                            "modelName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["dimension"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["dimensionName", "modelName", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "yamlPath": {
+                                "type": "string"
+                            },
+                            "dimensionName": {
+                                "type": "string"
+                            },
+                            "metricName": {
+                                "type": "string"
+                            },
+                            "modelName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["metric"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["metricName", "modelName", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "yamlPath": {
+                                "type": "string"
+                            },
+                            "dimensionName": {
+                                "type": "string"
+                            },
+                            "parentDimensionName": {
+                                "type": "string"
+                            },
+                            "modelName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["additional_dimension"],
+                                "nullable": false
+                            }
+                        },
+                        "required": [
+                            "dimensionName",
+                            "parentDimensionName",
+                            "modelName",
+                            "type"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "yamlPath": {
+                                "type": "string"
+                            },
+                            "fieldName": {
+                                "type": "string"
+                            },
+                            "exploreName": {
+                                "type": "string"
+                            },
+                            "modelName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["required_filter"],
+                                "nullable": false
+                            }
+                        },
+                        "required": [
+                            "fieldName",
+                            "exploreName",
+                            "modelName",
+                            "type"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "yamlPath": {
+                                "type": "string"
+                            },
+                            "targetName": {
+                                "type": "string"
+                            },
+                            "targetType": {
+                                "type": "string",
+                                "enum": ["model", "dimension", "metric"]
+                            },
+                            "modelName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["ai_hint"],
+                                "nullable": false
+                            }
+                        },
+                        "required": [
+                            "targetName",
+                            "targetType",
+                            "modelName",
+                            "type"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AiAgentConfigurationSetting": {
+                "type": "string",
+                "enum": [
+                    "instructions",
+                    "knowledge_documents",
+                    "data_access",
+                    "self_improvement",
+                    "sql_mode",
+                    "mcp_servers",
+                    "explore_tags",
+                    "space_access",
+                    "user_or_group_access",
+                    "unknown"
+                ]
+            },
+            "AiAgentTargetRef": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/AiAgentSemanticTargetRef"
+                    },
+                    {
+                        "properties": {
+                            "agentUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["agent"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["agentUuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "setting": {
+                                "$ref": "#/components/schemas/AiAgentConfigurationSetting"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["agent_config"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["setting", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "capabilityKey": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["product_capability"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["capabilityKey", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["runtime"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["key", "type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AiAgentEvidenceExcerpt": {
+                "properties": {
+                    "redacted": {
+                        "type": "boolean"
+                    },
+                    "text": {
+                        "type": "string"
+                    },
+                    "source": {
+                        "type": "string",
+                        "enum": [
+                            "user_prompt",
+                            "assistant_answer",
+                            "next_user_prompt",
+                            "conversation_context",
+                            "tool_call",
+                            "tool_result",
+                            "agent_config"
+                        ]
+                    }
+                },
+                "required": ["redacted", "text", "source"],
+                "type": "object"
+            },
+            "AiAgentRecommendationAction": {
+                "type": "string",
+                "enum": [
+                    "update_semantic_yaml",
+                    "update_agent_instructions",
+                    "add_knowledge_document",
+                    "enable_data_access",
+                    "enable_sql_mode",
+                    "enable_self_improvement",
+                    "configure_mcp_server",
+                    "adjust_explore_tags",
+                    "update_access",
+                    "route_to_product_work",
+                    "request_more_evidence",
+                    "no_action"
+                ]
+            },
+            "AiAgentRecommendation": {
+                "properties": {
+                    "targetRefs": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentTargetRef"
+                        },
+                        "type": "array"
+                    },
+                    "rationale": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "actionType": {
+                        "$ref": "#/components/schemas/AiAgentRecommendationAction"
+                    }
+                },
+                "required": ["targetRefs", "rationale", "title", "actionType"],
+                "type": "object"
+            },
+            "AiAgentReviewItemSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AiAgentReviewItem"
+                    },
+                    {
+                        "properties": {
+                            "latestFinding": {
+                                "properties": {
+                                    "createdAt": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "recommendation": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/AiAgentRecommendation"
+                                            }
+                                        ],
+                                        "nullable": true
+                                    },
+                                    "evidenceExcerpts": {
+                                        "items": {
+                                            "$ref": "#/components/schemas/AiAgentEvidenceExcerpt"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "targetRefs": {
+                                        "items": {
+                                            "$ref": "#/components/schemas/AiAgentTargetRef"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "fixTargets": {
+                                        "items": {
+                                            "$ref": "#/components/schemas/AiAgentFixTarget"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "subcategories": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "agentUuid": {
+                                        "type": "string"
+                                    },
+                                    "projectUuid": {
+                                        "type": "string"
+                                    },
+                                    "threadUuid": {
+                                        "type": "string"
+                                    },
+                                    "promptUuid": {
+                                        "type": "string"
+                                    },
+                                    "uuid": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "createdAt",
+                                    "recommendation",
+                                    "evidenceExcerpts",
+                                    "targetRefs",
+                                    "fixTargets",
+                                    "subcategories",
+                                    "agentUuid",
+                                    "projectUuid",
+                                    "threadUuid",
+                                    "promptUuid",
+                                    "uuid"
+                                ],
+                                "type": "object",
+                                "nullable": true
+                            }
+                        },
+                        "required": ["latestFinding"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiSuccess_AiAgentReviewItemSummary-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentReviewItemSummary"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentReviewItemsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewItemSummary-Array_"
+            },
+            "AiAgentTurnSignal": {
+                "type": "string",
+                "enum": [
+                    "normal_refinement",
+                    "implicit_correction",
+                    "explicit_dispute",
+                    "retry_after_failure",
+                    "output_shape_correction",
+                    "new_question",
+                    "acceptance_or_continuation",
+                    "product_capability_request",
+                    "human_intervention",
+                    "ambiguous"
+                ]
+            },
+            "AiAgentImplicitSignalSource": {
+                "type": "string",
+                "enum": [
+                    "next_user_correction",
+                    "next_user_dispute",
+                    "next_user_retry",
+                    "output_shape_correction",
+                    "tool_error",
+                    "assistant_no_answer",
+                    "product_capability_request",
+                    "human_intervention"
+                ]
+            },
+            "AiAgentReviewClassifierConfidence": {
+                "type": "string",
+                "enum": ["low", "medium", "high"]
+            },
+            "AiAgentReviewClassifierEventType": {
+                "type": "string",
+                "enum": ["response_saved", "feedback_changed"]
+            },
+            "AiAgentReviewClassifierRunScope": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "dryRun": {
+                                "type": "boolean"
+                            },
+                            "agentUuid": {
+                                "type": "string"
+                            },
+                            "projectUuid": {
+                                "type": "string"
+                            },
+                            "endedAt": {
+                                "type": "string"
+                            },
+                            "startedAt": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["backfill"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["endedAt", "startedAt", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "agentUuid": {
+                                "type": "string"
+                            },
+                            "projectUuid": {
+                                "type": "string"
+                            },
+                            "threadUuid": {
+                                "type": "string"
+                            },
+                            "promptUuid": {
+                                "type": "string"
+                            },
+                            "eventType": {
+                                "$ref": "#/components/schemas/AiAgentReviewClassifierEventType"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["live_event"],
+                                "nullable": false
+                            }
+                        },
+                        "required": [
+                            "agentUuid",
+                            "projectUuid",
+                            "threadUuid",
+                            "promptUuid",
+                            "eventType",
+                            "type"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "filters": {
+                                "$ref": "#/components/schemas/Record_string.unknown_"
+                            },
+                            "requestedByUserUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["manual"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["filters", "requestedByUserUuid", "type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AiAgentReviewSignalSummary": {
+                "properties": {
+                    "finding": {
+                        "properties": {
+                            "recommendation": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/AiAgentRecommendation"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "evidenceExcerpts": {
+                                "items": {
+                                    "$ref": "#/components/schemas/AiAgentEvidenceExcerpt"
+                                },
+                                "type": "array"
+                            },
+                            "fixTargets": {
+                                "items": {
+                                    "$ref": "#/components/schemas/AiAgentFixTarget"
+                                },
+                                "type": "array"
+                            },
+                            "subcategories": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "primaryRootCause": {
+                                "$ref": "#/components/schemas/AiAgentRootCause"
+                            },
+                            "reviewItemUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "recommendation",
+                            "evidenceExcerpts",
+                            "fixTargets",
+                            "subcategories",
+                            "primaryRootCause",
+                            "reviewItemUuid",
+                            "uuid"
+                        ],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "errorMessage": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "responsePreview": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "prompt": {
+                        "type": "string"
+                    },
+                    "runScope": {
+                        "$ref": "#/components/schemas/AiAgentReviewClassifierRunScope"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "promotionReason": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "promotedToFinding": {
+                        "type": "boolean"
+                    },
+                    "confidence": {
+                        "$ref": "#/components/schemas/AiAgentReviewClassifierConfidence"
+                    },
+                    "implicitSignalSources": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentImplicitSignalSource"
+                        },
+                        "type": "array"
+                    },
+                    "signal": {
+                        "$ref": "#/components/schemas/AiAgentTurnSignal"
+                    },
+                    "agentUuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "threadUuid": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
+                        "type": "string"
+                    },
+                    "runUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "finding",
+                    "errorMessage",
+                    "responsePreview",
+                    "prompt",
+                    "runScope",
+                    "createdAt",
+                    "promotionReason",
+                    "promotedToFinding",
+                    "confidence",
+                    "implicitSignalSources",
+                    "signal",
+                    "agentUuid",
+                    "projectUuid",
+                    "threadUuid",
+                    "promptUuid",
+                    "runUuid",
+                    "uuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiAgentReviewSignalSummary-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentReviewSignalSummary"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentReviewSignalsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewSignalSummary-Array_"
+            },
             "AiOrganizationSettings": {
                 "properties": {
                     "aiAgentsVisible": {
@@ -23124,6 +24010,7 @@
                 "enum": [
                     "slackAiPrompt",
                     "aiAgentEvalResult",
+                    "aiAgentReviewClassifier",
                     "embedArtifactVersion",
                     "generateArtifactQuestion",
                     "appGeneratePipeline",
@@ -26044,22 +26931,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -26619,22 +27506,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -35383,7 +36270,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3028.1",
+        "version": "0.3031.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -41516,6 +42403,80 @@
                 },
                 "description": "Get all AI agents for admin",
                 "summary": "List AI agents",
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/aiAgents/admin/review-items": {
+            "get": {
+                "operationId": "getAiAgentReviewItems",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get AI agent classifier review items for admin",
+                "summary": "List AI agent review items",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/AiAgentReviewItemStatus"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/aiAgents/admin/review-signals": {
+            "get": {
+                "operationId": "getAiAgentReviewSignals",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewSignalsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get AI agent classifier review signals for admin debugging",
+                "summary": "List AI agent review signals",
                 "security": [],
                 "parameters": []
             }

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -156,6 +156,15 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
 
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'agent.uuid': payload.agentUuid,
+        'thread.uuid': payload.threadUuid,
+        'prompt.uuid': payload.promptUuid,
+        'ai_agent_review.event_type': payload.eventType,
+    }),
+
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -1,6 +1,7 @@
 import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
+    type AiAgentReviewClassifierJobPayload,
     type ChartReference,
     type DataAppClaudeModel,
     type DataAppTemplate,
@@ -60,6 +61,7 @@ export type AppGeneratePipelineJobPayload = TraceTaskBase & {
 export const EE_SCHEDULER_TASKS = {
     SLACK_AI_PROMPT: 'slackAiPrompt',
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
+    AI_AGENT_REVIEW_CLASSIFIER: 'aiAgentReviewClassifier',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
@@ -143,6 +145,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: ManagedAgentHeartbeatPayload;
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
@@ -152,6 +155,7 @@ export interface TaskPayloadMap {
 export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
+    [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -82,6 +82,10 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
                 path: 'agents',
                 element: <AiAgentsAdminPage />,
             },
+            {
+                path: 'reviews',
+                element: <AiAgentsAdminPage />,
+            },
         ],
     },
     {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.module.css
@@ -1,0 +1,65 @@
+.categoryToken {
+    display: inline-flex;
+    align-items: center;
+    min-height: 22px;
+    padding: 3px 8px;
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-dark-4));
+    border-radius: 5px;
+    background: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-dark-6)
+    );
+    line-height: 1;
+}
+
+.categoryTokenText {
+    color: light-dark(
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-dark-0)
+    );
+}
+
+.categoryTokenSecondary {
+    background: transparent;
+    border-color: light-dark(
+        var(--mantine-color-ldGray-3),
+        var(--mantine-color-dark-5)
+    );
+}
+
+.categoryTokenSecondaryText {
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-dark-2)
+    );
+}
+
+.expandableText {
+    cursor: zoom-in;
+}
+
+.expandableText:hover {
+    color: light-dark(
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-dark-1)
+    );
+}
+
+.confidenceIcon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-dark-2)
+    );
+}
+
+.headerHelpIcon {
+    display: inline-flex;
+    align-items: center;
+    cursor: help;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -1,0 +1,1142 @@
+import {
+    type AiAgentRecommendationAction,
+    type AiAgentReviewItemStatus,
+    type AiAgentReviewItemSummary,
+    type AiAgentReviewSignalSummary,
+    type AiAgentRootCause,
+    type AiAgentTargetRef,
+    type AiAgentTurnSignal,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Divider,
+    Group,
+    Paper,
+    SegmentedControl,
+    Stack,
+    Text,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine-8/core';
+import {
+    IconBox,
+    IconCircleCheck,
+    IconCircleDashed,
+    IconClock,
+    IconHelpCircle,
+    IconInfoCircle,
+    IconListCheck,
+    IconMessages,
+    IconRobotFace,
+    IconTag,
+    IconTriangle,
+} from '@tabler/icons-react';
+import { useDeferredValue, useMemo, useState } from 'react';
+import { LightdashUserAvatar } from '../../../../../components/Avatar';
+import {
+    ContentTable,
+    useContentTable,
+    type MRT_ColumnDef,
+} from '../../../../../components/common/ContentTable';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useProjects } from '../../../../../hooks/useProjects';
+import {
+    useAiAgentAdminAgents,
+    useAiAgentAdminReviewItems,
+    useAiAgentAdminReviewSignals,
+} from '../../hooks/useAiAgentAdmin';
+import styles from './AiAgentAdminReviewItemsTable.module.css';
+import { SearchFilter } from './SearchFilter';
+
+const ALL_REVIEW_ITEM_STATUSES: AiAgentReviewItemStatus[] = [
+    'open',
+    'in_progress',
+    'resolved',
+    'dismissed',
+    'duplicate',
+];
+
+const rootCauseLabels: Record<AiAgentRootCause, string> = {
+    semantic_layer: 'Semantic layer',
+    project_context: 'Project context',
+    agent_configuration: 'Agent config',
+    data_gap: 'Data gap',
+    product_capability: 'Product',
+    runtime_reliability: 'Runtime',
+    feedback_quality: 'Feedback',
+    not_a_failure: 'Not failure',
+    ambiguous: 'Ambiguous',
+};
+
+const signalLabels: Record<AiAgentTurnSignal, string> = {
+    normal_refinement: 'Normal refinement',
+    implicit_correction: 'Implicit correction',
+    explicit_dispute: 'Explicit dispute',
+    retry_after_failure: 'Retry after failure',
+    output_shape_correction: 'Output correction',
+    new_question: 'New question',
+    acceptance_or_continuation: 'Accepted',
+    product_capability_request: 'Capability request',
+    human_intervention: 'Human intervention',
+    ambiguous: 'Ambiguous',
+};
+
+const actionLabels: Record<AiAgentRecommendationAction, string> = {
+    update_semantic_yaml: 'Update semantic layer',
+    update_agent_instructions: 'Update instructions',
+    add_knowledge_document: 'Add knowledge doc',
+    enable_data_access: 'Enable data access',
+    enable_sql_mode: 'Enable SQL mode',
+    enable_self_improvement: 'Enable self-improvement',
+    configure_mcp_server: 'Configure MCP',
+    adjust_explore_tags: 'Adjust explore tags',
+    update_access: 'Update access',
+    route_to_product_work: 'Route to product',
+    request_more_evidence: 'Needs more evidence',
+    no_action: 'No action',
+};
+
+const formatLastSeenDate = (date: Date): string => {
+    const parsedDate = new Date(date);
+    const now = new Date();
+    const isCurrentYear = parsedDate.getFullYear() === now.getFullYear();
+
+    return parsedDate.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        ...(!isCurrentYear && { year: 'numeric' }),
+    });
+};
+
+type ReviewSurface = 'findings' | 'signals';
+
+export type AiAgentAdminReviewItemPreviewTarget = {
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    reviewItemUuid?: string | null;
+};
+
+type AiAgentAdminReviewItemsTableProps = {
+    selectedReviewItemUuid?: string | null;
+    onReviewItemSelect?: (target: AiAgentAdminReviewItemPreviewTarget) => void;
+};
+
+const getTargetLabel = (targetRefs: AiAgentTargetRef[]): string | null => {
+    const targetRef = targetRefs[0];
+    if (!targetRef) return null;
+
+    switch (targetRef.type) {
+        case 'dimension':
+            return `${targetRef.modelName}.${targetRef.dimensionName}`;
+        case 'metric':
+            return `${targetRef.modelName}.${targetRef.metricName}`;
+        case 'model':
+            return targetRef.modelName;
+        case 'explore':
+            return `${targetRef.modelName}.${targetRef.exploreName}`;
+        case 'join':
+            return `${targetRef.modelName}.${targetRef.joinName}`;
+        case 'agent_config':
+            return targetRef.setting.replaceAll('_', ' ');
+        case 'product_capability':
+            return targetRef.capabilityKey;
+        case 'runtime':
+            return targetRef.key;
+        default:
+            return null;
+    }
+};
+
+const isTriageReviewItem = (reviewItem: AiAgentReviewItemSummary): boolean =>
+    reviewItem.primaryRootCause === 'ambiguous' ||
+    reviewItem.latestFinding?.fixTargets.includes('feedback_needed') === true;
+
+const getIssueTitle = (reviewItem: AiAgentReviewItemSummary): string => {
+    if (isTriageReviewItem(reviewItem)) {
+        return 'Triage correction signal';
+    }
+
+    const targetLabel = getTargetLabel(
+        reviewItem.latestFinding?.targetRefs ?? [],
+    );
+    if (targetLabel && reviewItem.primaryRootCause === 'semantic_layer') {
+        return `Review ${targetLabel}`;
+    }
+
+    return reviewItem.latestFinding?.recommendation?.title ?? reviewItem.title;
+};
+
+const getWhatHappened = (reviewItem: AiAgentReviewItemSummary): string => {
+    const evidence = reviewItem.latestFinding?.evidenceExcerpts ?? [];
+    const correction =
+        evidence.find((excerpt) => excerpt.source === 'next_user_prompt')
+            ?.text ??
+        evidence.find((excerpt) => excerpt.source === 'user_prompt')?.text;
+    const assistantAnswer = evidence.find(
+        (excerpt) => excerpt.source === 'assistant_answer',
+    )?.text;
+
+    if (correction && assistantAnswer) {
+        return `User correction: ${correction}`;
+    }
+
+    return correction ?? reviewItem.description;
+};
+
+const getWhyText = (reviewItem: AiAgentReviewItemSummary): string => {
+    if (isTriageReviewItem(reviewItem)) {
+        return 'Could be a real failure or a normal change in user intent.';
+    }
+
+    return (
+        reviewItem.latestFinding?.recommendation?.rationale ??
+        `Review agent judged this as ${rootCauseLabels[reviewItem.primaryRootCause].toLowerCase()}.`
+    );
+};
+
+const getActionLabel = (reviewItem: AiAgentReviewItemSummary): string => {
+    const recommendation = reviewItem.latestFinding?.recommendation;
+    if (recommendation) {
+        return actionLabels[recommendation.actionType];
+    }
+
+    const fixTarget = reviewItem.latestFinding?.fixTargets[0];
+    if (fixTarget) {
+        return fixTarget.replaceAll('_', ' ');
+    }
+
+    return 'Review';
+};
+
+const getSuggestedNextStep = (reviewItem: AiAgentReviewItemSummary): string => {
+    const action = getActionLabel(reviewItem);
+
+    if (isTriageReviewItem(reviewItem)) {
+        return 'Review the backing thread before deciding whether this is actionable.';
+    }
+
+    if (action === 'No action') {
+        return 'No action suggested.';
+    }
+
+    return action;
+};
+
+const getSignalResultLabel = (signal: AiAgentReviewSignalSummary): string => {
+    if (signal.finding) {
+        return rootCauseLabels[signal.finding.primaryRootCause];
+    }
+
+    return signal.promotedToFinding ? 'Finding pending' : 'Signal only';
+};
+
+const getSignalWhyText = (signal: AiAgentReviewSignalSummary): string =>
+    signal.promotionReason ??
+    signal.finding?.recommendation?.rationale ??
+    'The judge reviewed this turn but did not promote it into a review item.';
+
+const getSignalActionText = (signal: AiAgentReviewSignalSummary): string => {
+    if (signal.finding?.recommendation) {
+        return actionLabels[signal.finding.recommendation.actionType];
+    }
+
+    if (signal.promotedToFinding) {
+        return 'Review finding';
+    }
+
+    return 'No admin action';
+};
+
+const getConfidenceIcon = (
+    confidence: AiAgentReviewSignalSummary['confidence'],
+) => {
+    switch (confidence) {
+        case 'high':
+            return IconCircleCheck;
+        case 'medium':
+            return IconCircleDashed;
+        case 'low':
+        default:
+            return IconTriangle;
+    }
+};
+
+const CategoryToken = ({
+    children,
+    secondary = false,
+}: {
+    children: string;
+    secondary?: boolean;
+}) => (
+    <Box
+        className={`${styles.categoryToken} ${
+            secondary ? styles.categoryTokenSecondary : ''
+        }`}
+    >
+        <Text
+            fz="xs"
+            fw={secondary ? 450 : 500}
+            className={
+                secondary
+                    ? styles.categoryTokenSecondaryText
+                    : styles.categoryTokenText
+            }
+        >
+            {children}
+        </Text>
+    </Box>
+);
+
+const ExpandableText = ({
+    children,
+    lineClamp = 2,
+    color = 'ldGray.6',
+    size = 'xs',
+    weight,
+}: {
+    children: string;
+    lineClamp?: number;
+    color?: string;
+    size?: string;
+    weight?: number;
+}) => {
+    const [expanded, setExpanded] = useState(false);
+    const canExpand = children.length > lineClamp * 72;
+
+    return (
+        <Text
+            fz={size}
+            c={color}
+            fw={weight}
+            lineClamp={expanded ? undefined : lineClamp}
+            className={canExpand ? styles.expandableText : undefined}
+            onClick={(event) => {
+                if (!canExpand) return;
+                event.stopPropagation();
+                setExpanded((isExpanded) => !isExpanded);
+            }}
+            title={canExpand ? 'Click to expand' : undefined}
+        >
+            {children}
+        </Text>
+    );
+};
+
+const ReviewConceptHelp = () => (
+    <Tooltip
+        label="Turn: one user prompt and assistant response. Signal: the judge's per-turn assessment. Finding: a promoted signal that needs admin review."
+        withArrow
+        multiline
+        maw={320}
+    >
+        <Box className={styles.headerHelpIcon}>
+            <MantineIcon icon={IconHelpCircle} color="ldGray.5" size="sm" />
+        </Box>
+    </Tooltip>
+);
+
+const AiAgentAdminReviewItemsTable = ({
+    onReviewItemSelect,
+    selectedReviewItemUuid,
+}: AiAgentAdminReviewItemsTableProps) => {
+    const theme = useMantineTheme();
+    const [search, setSearch] = useState<string | undefined>(undefined);
+    const [reviewSurface, setReviewSurface] =
+        useState<ReviewSurface>('findings');
+    const deferredSearch = useDeferredValue(search);
+
+    const { data: reviewItems = [], isLoading } = useAiAgentAdminReviewItems({
+        statuses: ALL_REVIEW_ITEM_STATUSES,
+    });
+    const { data: reviewSignals = [], isLoading: isSignalsLoading } =
+        useAiAgentAdminReviewSignals({
+            enabled: reviewSurface === 'signals',
+        });
+    const { data: agents } = useAiAgentAdminAgents();
+    const { data: projects } = useProjects();
+
+    const agentsMap = useMemo(() => {
+        if (!agents) return new Map();
+        return new Map(agents.map((agent) => [agent.uuid, agent]));
+    }, [agents]);
+
+    const projectsMap = useMemo(() => {
+        if (!projects) return new Map();
+        return new Map(
+            projects.map((project) => [project.projectUuid, project]),
+        );
+    }, [projects]);
+
+    const filteredReviewItems = useMemo(() => {
+        if (!deferredSearch) return reviewItems;
+
+        const searchLower = deferredSearch.toLowerCase();
+        return reviewItems.filter((reviewItem) => {
+            const agentUuid =
+                reviewItem.latestFinding?.agentUuid ?? reviewItem.agentUuid;
+            const projectUuid =
+                reviewItem.latestFinding?.projectUuid ?? reviewItem.projectUuid;
+            const agent = agentUuid ? agentsMap.get(agentUuid) : undefined;
+            const project = projectUuid
+                ? projectsMap.get(projectUuid)
+                : undefined;
+
+            return [
+                getIssueTitle(reviewItem),
+                getWhatHappened(reviewItem),
+                getWhyText(reviewItem),
+                getSuggestedNextStep(reviewItem),
+                getActionLabel(reviewItem),
+                rootCauseLabels[reviewItem.primaryRootCause],
+                agent?.name,
+                project?.name,
+                reviewItem.latestFinding?.recommendation?.title,
+            ]
+                .filter(Boolean)
+                .some((value) => value?.toLowerCase().includes(searchLower));
+        });
+    }, [agentsMap, deferredSearch, projectsMap, reviewItems]);
+
+    const filteredReviewSignals = useMemo(() => {
+        if (!deferredSearch) return reviewSignals;
+
+        const searchLower = deferredSearch.toLowerCase();
+        return reviewSignals.filter((signal) => {
+            const agent = agentsMap.get(signal.agentUuid);
+            const project = projectsMap.get(signal.projectUuid);
+            return [
+                signal.prompt,
+                signal.responsePreview,
+                signal.errorMessage,
+                signalLabels[signal.signal],
+                getSignalResultLabel(signal),
+                getSignalWhyText(signal),
+                getSignalActionText(signal),
+                agent?.name,
+                project?.name,
+            ]
+                .filter(Boolean)
+                .some((value) => value?.toLowerCase().includes(searchLower));
+        });
+    }, [agentsMap, deferredSearch, projectsMap, reviewSignals]);
+
+    const columns: MRT_ColumnDef<AiAgentReviewItemSummary>[] = useMemo(
+        () => [
+            {
+                accessorKey: 'title',
+                header: 'Issue',
+                enableSorting: false,
+                size: 330,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconListCheck} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const reviewItem = row.original;
+                    return (
+                        <Stack gap="two">
+                            <Text fw={600} fz="sm" c="ldGray.9" lineClamp={1}>
+                                {getIssueTitle(reviewItem)}
+                            </Text>
+                            <ExpandableText lineClamp={2}>
+                                {getWhatHappened(reviewItem)}
+                            </ExpandableText>
+                        </Stack>
+                    );
+                },
+            },
+            {
+                accessorKey: 'primaryRootCause',
+                header: 'Review note',
+                enableSorting: false,
+                size: 430,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconInfoCircle} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const reviewItem = row.original;
+                    const subcategory =
+                        reviewItem.latestFinding?.subcategories[0];
+                    return (
+                        <Stack gap="xs">
+                            <Group gap="two">
+                                <CategoryToken>
+                                    {
+                                        rootCauseLabels[
+                                            reviewItem.primaryRootCause
+                                        ]
+                                    }
+                                </CategoryToken>
+                                {subcategory && (
+                                    <CategoryToken secondary>
+                                        {subcategory.replaceAll('_', ' ')}
+                                    </CategoryToken>
+                                )}
+                            </Group>
+                            <ExpandableText lineClamp={2}>
+                                {getWhyText(reviewItem)}
+                            </ExpandableText>
+                            <Text fz="xs" c="ldGray.7" fw={500}>
+                                Suggested next step:{' '}
+                                {getSuggestedNextStep(reviewItem)}
+                            </Text>
+                        </Stack>
+                    );
+                },
+            },
+            {
+                accessorKey: 'agentUuid',
+                header: 'Agent',
+                enableSorting: false,
+                size: 220,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconRobotFace} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const reviewItem = row.original;
+                    const agentUuid =
+                        reviewItem.latestFinding?.agentUuid ??
+                        reviewItem.agentUuid;
+                    const projectUuid =
+                        reviewItem.latestFinding?.projectUuid ??
+                        reviewItem.projectUuid;
+                    const agent = agentUuid
+                        ? agentsMap.get(agentUuid)
+                        : undefined;
+                    const project = projectUuid
+                        ? projectsMap.get(projectUuid)
+                        : undefined;
+
+                    return (
+                        <Stack gap="two">
+                            {agent ? (
+                                <Paper px="xs" w="fit-content" maw="100%">
+                                    <Group gap="two" wrap="nowrap">
+                                        <LightdashUserAvatar
+                                            size={16}
+                                            name={agent.name}
+                                            src={agent.imageUrl}
+                                        />
+                                        <Text
+                                            fz="sm"
+                                            fw={600}
+                                            c="ldGray.9"
+                                            truncate
+                                        >
+                                            {agent.name}
+                                        </Text>
+                                    </Group>
+                                </Paper>
+                            ) : (
+                                <Group gap="two" wrap="nowrap">
+                                    <MantineIcon
+                                        icon={IconBox}
+                                        color="ldGray.6"
+                                        size="sm"
+                                    />
+                                    <Text fz="sm" c="ldGray.9" lineClamp={1}>
+                                        {project?.name ?? 'Organization'}
+                                    </Text>
+                                </Group>
+                            )}
+                            {agent && project && (
+                                <Text fz="xs" c="ldGray.6" lineClamp={1}>
+                                    Project: {project.name}
+                                </Text>
+                            )}
+                        </Stack>
+                    );
+                },
+            },
+            {
+                accessorKey: 'lastSeenAt',
+                header: 'Last seen',
+                enableSorting: true,
+                size: 140,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconClock} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Stack gap={0}>
+                        <Text fz="xs" c="ldGray.7" fw={500}>
+                            {formatLastSeenDate(row.original.lastSeenAt)}
+                        </Text>
+                        <Text fz="xs" c="ldGray.6">
+                            {row.original.findingCount}{' '}
+                            {row.original.findingCount === 1
+                                ? 'finding'
+                                : 'findings'}
+                        </Text>
+                    </Stack>
+                ),
+            },
+            {
+                id: 'threadPreview',
+                header: '',
+                enableSorting: false,
+                size: 56,
+                Cell: ({ row }) => {
+                    const reviewItem = row.original;
+                    const latestFinding = reviewItem.latestFinding;
+
+                    if (!latestFinding) return null;
+
+                    return (
+                        <Tooltip label="Open AI thread preview" withArrow>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                aria-label="Open AI thread preview"
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    onReviewItemSelect?.({
+                                        projectUuid: latestFinding.projectUuid,
+                                        agentUuid: latestFinding.agentUuid,
+                                        threadUuid: latestFinding.threadUuid,
+                                        reviewItemUuid: reviewItem.uuid,
+                                    });
+                                }}
+                            >
+                                <MantineIcon icon={IconMessages} />
+                            </ActionIcon>
+                        </Tooltip>
+                    );
+                },
+            },
+        ],
+        [agentsMap, onReviewItemSelect, projectsMap],
+    );
+
+    const signalColumns: MRT_ColumnDef<AiAgentReviewSignalSummary>[] = useMemo(
+        () => [
+            {
+                accessorKey: 'promotedToFinding',
+                header: 'Result',
+                enableSorting: false,
+                size: 110,
+                Header: ({ column }) => (
+                    <Group gap="two" wrap="nowrap">
+                        <MantineIcon icon={IconTag} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const signal = row.original;
+                    const ConfidenceIcon = getConfidenceIcon(signal.confidence);
+                    return (
+                        <Stack gap="two">
+                            <Group gap="xs" wrap="nowrap">
+                                <CategoryToken>
+                                    {getSignalResultLabel(signal)}
+                                </CategoryToken>
+                                <Tooltip
+                                    label={`${signal.confidence} confidence`}
+                                    withArrow
+                                >
+                                    <Box className={styles.confidenceIcon}>
+                                        <MantineIcon
+                                            icon={ConfidenceIcon}
+                                            color="ldGray.6"
+                                            size="sm"
+                                        />
+                                    </Box>
+                                </Tooltip>
+                            </Group>
+                            <Text fz="xs" c="ldGray.6">
+                                {signal.finding
+                                    ? 'Promoted by judge'
+                                    : 'Not promoted'}
+                            </Text>
+                        </Stack>
+                    );
+                },
+            },
+            {
+                accessorKey: 'signal',
+                header: 'Signal',
+                enableSorting: false,
+                size: 260,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconInfoCircle} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const signal = row.original;
+                    const subcategory = signal.finding?.subcategories[0];
+
+                    return (
+                        <Stack gap="xs">
+                            <Group gap="two">
+                                <CategoryToken>
+                                    {signalLabels[signal.signal]}
+                                </CategoryToken>
+                                {subcategory && (
+                                    <CategoryToken secondary>
+                                        {subcategory.replaceAll('_', ' ')}
+                                    </CategoryToken>
+                                )}
+                            </Group>
+                            <ExpandableText lineClamp={2}>
+                                {getSignalWhyText(signal)}
+                            </ExpandableText>
+                            <Text fz="xs" c="ldGray.7" fw={500}>
+                                Suggested next step:{' '}
+                                {getSignalActionText(signal)}
+                            </Text>
+                        </Stack>
+                    );
+                },
+            },
+            {
+                accessorKey: 'prompt',
+                header: 'Turn',
+                enableSorting: false,
+                size: 380,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconListCheck} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const signal = row.original;
+                    return (
+                        <Stack gap="two">
+                            <Text fw={600} fz="sm" c="ldGray.9" lineClamp={1}>
+                                {signal.prompt}
+                            </Text>
+                            <ExpandableText lineClamp={2}>
+                                {signal.errorMessage ??
+                                    signal.responsePreview ??
+                                    'No response captured'}
+                            </ExpandableText>
+                        </Stack>
+                    );
+                },
+            },
+            {
+                accessorKey: 'agentUuid',
+                header: 'Agent',
+                enableSorting: false,
+                size: 220,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconRobotFace} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const signal = row.original;
+                    const agent = agentsMap.get(signal.agentUuid);
+                    const project = projectsMap.get(signal.projectUuid);
+
+                    return (
+                        <Stack gap="two">
+                            {agent ? (
+                                <Paper px="xs" w="fit-content" maw="100%">
+                                    <Group gap="two" wrap="nowrap">
+                                        <LightdashUserAvatar
+                                            size={16}
+                                            name={agent.name}
+                                            src={agent.imageUrl}
+                                        />
+                                        <Text
+                                            fz="sm"
+                                            fw={600}
+                                            c="ldGray.9"
+                                            truncate
+                                        >
+                                            {agent.name}
+                                        </Text>
+                                    </Group>
+                                </Paper>
+                            ) : (
+                                <Group gap="two" wrap="nowrap">
+                                    <MantineIcon
+                                        icon={IconBox}
+                                        color="ldGray.6"
+                                        size="sm"
+                                    />
+                                    <Text fz="sm" c="ldGray.9" lineClamp={1}>
+                                        {project?.name ?? 'Unknown agent'}
+                                    </Text>
+                                </Group>
+                            )}
+                            {project && (
+                                <Text fz="xs" c="ldGray.6" lineClamp={1}>
+                                    Project: {project.name}
+                                </Text>
+                            )}
+                        </Stack>
+                    );
+                },
+            },
+            {
+                accessorKey: 'createdAt',
+                header: 'Reviewed',
+                enableSorting: true,
+                size: 130,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconClock} color="ldGray.6" />
+                        {column.columnDef.header}
+                        <Tooltip
+                            label="Signal means the judge reviewed the turn. Finding means the judge promoted the signal for admin review."
+                            withArrow
+                            multiline
+                            maw={260}
+                        >
+                            <Box className={styles.headerHelpIcon}>
+                                <MantineIcon
+                                    icon={IconHelpCircle}
+                                    color="ldGray.5"
+                                    size="sm"
+                                />
+                            </Box>
+                        </Tooltip>
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Stack gap={0}>
+                        <Text fz="xs" c="ldGray.7" fw={500}>
+                            {formatLastSeenDate(row.original.createdAt)}
+                        </Text>
+                        <Text fz="xs" c="ldGray.6">
+                            {row.original.finding ? 'finding' : 'signal'}
+                        </Text>
+                    </Stack>
+                ),
+            },
+            {
+                id: 'threadPreview',
+                header: '',
+                enableSorting: false,
+                size: 56,
+                Cell: ({ row }) => {
+                    const signal = row.original;
+
+                    return (
+                        <Tooltip label="Open AI thread preview" withArrow>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                aria-label="Open AI thread preview"
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    onReviewItemSelect?.({
+                                        projectUuid: signal.projectUuid,
+                                        agentUuid: signal.agentUuid,
+                                        threadUuid: signal.threadUuid,
+                                        reviewItemUuid:
+                                            signal.finding?.reviewItemUuid,
+                                    });
+                                }}
+                            >
+                                <MantineIcon icon={IconMessages} />
+                            </ActionIcon>
+                        </Tooltip>
+                    );
+                },
+            },
+        ],
+        [agentsMap, onReviewItemSelect, projectsMap],
+    );
+
+    const table = useContentTable({
+        columns,
+        data: filteredReviewItems,
+        enableColumnResizing: false,
+        enableRowNumbers: false,
+        enablePagination: false,
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableGlobalFilterModes: false,
+        enableSorting: true,
+        enableTopToolbar: true,
+        enableBottomToolbar: false,
+        mantinePaperProps: {
+            shadow: undefined,
+            style: {
+                border: `1px solid ${theme.colors.ldGray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableContainerProps: {
+            style: {
+                maxHeight: 'calc(100dvh - 350px)',
+            },
+        },
+        mantineTableHeadRowProps: {
+            style: {
+                boxShadow: 'none',
+            },
+        },
+        mantineTableBodyCellProps: {
+            h: 86,
+            style: {
+                padding: `${theme.spacing.md} ${theme.spacing.xl}`,
+                borderRight: 'none',
+                borderLeft: 'none',
+                borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
+                borderTop: 'none',
+            },
+        },
+        mantineTableBodyRowProps: ({ row, table: mantineTable }) => {
+            if (mantineTable.getState().showSkeletons) {
+                return {};
+            }
+
+            const reviewItem = row.original;
+            const isSelected = selectedReviewItemUuid === reviewItem.uuid;
+
+            return {
+                style: {
+                    backgroundColor: isSelected
+                        ? theme.colors.ldGray[1]
+                        : undefined,
+                },
+            };
+        },
+        renderTopToolbar: () => (
+            <Box>
+                <Group
+                    p={`${theme.spacing.lg} ${theme.spacing.xl}`}
+                    justify="space-between"
+                >
+                    <Group gap="xs">
+                        <SearchFilter
+                            search={search}
+                            setSearch={setSearch}
+                            placeholder="Search reviews"
+                        />
+
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{
+                                alignSelf: 'center',
+                            }}
+                        />
+                        <SegmentedControl
+                            size="xs"
+                            radius="md"
+                            value={reviewSurface}
+                            onChange={(value) =>
+                                setReviewSurface(value as ReviewSurface)
+                            }
+                            data={[
+                                { value: 'findings', label: 'Findings' },
+                                { value: 'signals', label: 'Signals' },
+                            ]}
+                        />
+                        <ReviewConceptHelp />
+                    </Group>
+
+                    <Box
+                        bg="ldGray.1"
+                        c="ldGray.9"
+                        style={{
+                            borderRadius: 6,
+                            padding: `${theme.spacing.sm} ${theme.spacing.xs}`,
+                            height: 32,
+                            display: 'flex',
+                            alignItems: 'center',
+                        }}
+                    >
+                        <Text fz="sm" fw={500}>
+                            {isLoading
+                                ? 'Loading...'
+                                : `${filteredReviewItems.length} ${
+                                      filteredReviewItems.length === 1
+                                          ? 'item'
+                                          : 'items'
+                                  }`}
+                        </Text>
+                    </Box>
+                </Group>
+                <Divider color="ldGray.2" />
+            </Box>
+        ),
+        state: {
+            showProgressBars: false,
+            showSkeletons: isLoading,
+            density: 'md',
+        },
+        mantineLoadingOverlayProps: {
+            loaderProps: {
+                color: 'violet',
+            },
+        },
+    });
+
+    const signalTable = useContentTable({
+        columns: signalColumns,
+        data: filteredReviewSignals,
+        enableColumnResizing: false,
+        enableRowNumbers: false,
+        enablePagination: false,
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableGlobalFilterModes: false,
+        enableSorting: true,
+        enableTopToolbar: true,
+        enableBottomToolbar: false,
+        mantinePaperProps: {
+            shadow: undefined,
+            style: {
+                border: `1px solid ${theme.colors.ldGray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableContainerProps: {
+            style: {
+                maxHeight: 'calc(100dvh - 350px)',
+            },
+        },
+        mantineTableHeadRowProps: {
+            style: {
+                boxShadow: 'none',
+            },
+        },
+        mantineTableBodyCellProps: {
+            h: 92,
+            style: {
+                padding: `${theme.spacing.md} ${theme.spacing.xl}`,
+                borderRight: 'none',
+                borderLeft: 'none',
+                borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
+                borderTop: 'none',
+            },
+        },
+        mantineTableBodyRowProps: ({ row, table: mantineTable }) => {
+            if (mantineTable.getState().showSkeletons) {
+                return {};
+            }
+
+            const signal = row.original;
+            return {
+                style: {
+                    backgroundColor:
+                        selectedReviewItemUuid &&
+                        selectedReviewItemUuid ===
+                            signal.finding?.reviewItemUuid
+                            ? theme.colors.ldGray[1]
+                            : undefined,
+                },
+            };
+        },
+        renderTopToolbar: () => (
+            <Box>
+                <Group
+                    p={`${theme.spacing.lg} ${theme.spacing.xl}`}
+                    justify="space-between"
+                >
+                    <Group gap="xs">
+                        <SearchFilter
+                            search={search}
+                            setSearch={setSearch}
+                            placeholder="Search reviews"
+                        />
+
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{
+                                alignSelf: 'center',
+                            }}
+                        />
+                        <SegmentedControl
+                            size="xs"
+                            radius="md"
+                            value={reviewSurface}
+                            onChange={(value) =>
+                                setReviewSurface(value as ReviewSurface)
+                            }
+                            data={[
+                                { value: 'findings', label: 'Findings' },
+                                { value: 'signals', label: 'Signals' },
+                            ]}
+                        />
+                        <ReviewConceptHelp />
+                    </Group>
+
+                    <Box
+                        bg="ldGray.1"
+                        c="ldGray.9"
+                        style={{
+                            borderRadius: 6,
+                            padding: `${theme.spacing.sm} ${theme.spacing.xs}`,
+                            height: 32,
+                            display: 'flex',
+                            alignItems: 'center',
+                        }}
+                    >
+                        <Text fz="sm" fw={500}>
+                            {isSignalsLoading
+                                ? 'Loading...'
+                                : `${filteredReviewSignals.length} ${
+                                      filteredReviewSignals.length === 1
+                                          ? 'signal'
+                                          : 'signals'
+                                  }`}
+                        </Text>
+                    </Box>
+                </Group>
+                <Divider color="ldGray.2" />
+            </Box>
+        ),
+        state: {
+            showProgressBars: false,
+            showSkeletons: isSignalsLoading,
+            density: 'md',
+        },
+        mantineLoadingOverlayProps: {
+            loaderProps: {
+                color: 'violet',
+            },
+        },
+    });
+
+    return (
+        <Box>
+            {reviewSurface === 'findings' ? (
+                <ContentTable table={table} />
+            ) : (
+                <ContentTable table={signalTable} />
+            )}
+        </Box>
+    );
+};
+
+export default AiAgentAdminReviewItemsTable;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
@@ -1,4 +1,7 @@
-import { type AiAgentAdminThreadSummary } from '@lightdash/common';
+import {
+    FeatureFlags,
+    type AiAgentAdminThreadSummary,
+} from '@lightdash/common';
 import {
     Alert,
     Box,
@@ -15,12 +18,13 @@ import {
     IconChartDots,
     IconGripVertical,
     IconInfoCircle,
+    IconListCheck,
     IconLock,
     IconMessageCircle,
     IconMessageCircleShare,
     IconRobotFace,
 } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useLocation, useNavigate } from 'react-router';
 import LinkButton from '../../../../../components/common/LinkButton';
@@ -30,9 +34,13 @@ import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
 import useHealth from '../../../../../hooks/health/useHealth';
 import { useActiveProjectUuid } from '../../../../../hooks/useActiveProject';
+import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import { useAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings';
 import AiAgentAdminAgentsTable from './AiAgentAdminAgentsTable';
+import AiAgentAdminReviewItemsTable, {
+    type AiAgentAdminReviewItemPreviewTarget,
+} from './AiAgentAdminReviewItemsTable';
 import AiAgentAdminThreadsTable from './AiAgentAdminThreadsTable';
 import { AiAgentsAdminEnableFeatureToggle } from './AiAgentsAdminEnableFeatureToggle';
 import styles from './AiAgentsAdminLayout.module.css';
@@ -47,12 +55,21 @@ export const AiAgentsAdminLayout = () => {
     const navigate = useNavigate();
     const { activeProjectUuid } = useActiveProjectUuid();
     const { data: settings } = useAiOrganizationSettings();
-    const activeTab = location.pathname.endsWith('/agents')
-        ? 'agents'
-        : 'threads';
+    const { data: reviewClassifierFlag, isFetched: hasFetchedReviewFlag } =
+        useServerFeatureFlag(FeatureFlags.AiAgentReviewClassifier);
+    const isReviewTabEnabled = reviewClassifierFlag?.enabled === true;
+    const isReviewTabPath = location.pathname.endsWith('/reviews');
+    const activeTab =
+        isReviewTabPath && isReviewTabEnabled
+            ? 'reviews'
+            : location.pathname.endsWith('/agents')
+              ? 'agents'
+              : 'threads';
 
     const [selectedThread, setSelectedThread] =
         useState<AiAgentAdminThreadSummary | null>(null);
+    const [selectedReviewItem, setSelectedReviewItem] =
+        useState<AiAgentAdminReviewItemPreviewTarget | null>(null);
     const [isSidebarOpen, setIsSidebarOpen] = useState(false);
     const [isAnalyticsEmbedOpen, { toggle: toggleAnalyticsEmbed }] =
         useDisclosure(false);
@@ -64,6 +81,18 @@ export const AiAgentsAdminLayout = () => {
 
     const handleThreadSelect = (thread: AiAgentAdminThreadSummary): void => {
         setSelectedThread(thread);
+        setSelectedReviewItem(null);
+        setIsSidebarOpen(true);
+        if (isAnalyticsEmbedOpen) {
+            toggleAnalyticsEmbed();
+        }
+    };
+
+    const handleReviewItemSelect = (
+        reviewItem: AiAgentAdminReviewItemPreviewTarget,
+    ): void => {
+        setSelectedReviewItem(reviewItem);
+        setSelectedThread(null);
         setIsSidebarOpen(true);
         if (isAnalyticsEmbedOpen) {
             toggleAnalyticsEmbed();
@@ -73,10 +102,66 @@ export const AiAgentsAdminLayout = () => {
     const handleCloseSidebar = () => {
         setIsSidebarOpen(false);
         setSelectedThread(null);
+        setSelectedReviewItem(null);
     };
 
     const isAnalyticsEmbedEnabled =
         health?.ai.analyticsProjectUuid && health?.ai.analyticsDashboardUuid;
+
+    useEffect(() => {
+        if (isReviewTabPath && hasFetchedReviewFlag && !isReviewTabEnabled) {
+            void navigate('/ai-agents/admin/threads', { replace: true });
+        }
+    }, [hasFetchedReviewFlag, isReviewTabEnabled, isReviewTabPath, navigate]);
+
+    const tabDescription = useMemo(() => {
+        switch (activeTab) {
+            case 'agents':
+                return 'View and manage AI Agents';
+            case 'reviews':
+                return 'Review AI Agent findings';
+            case 'threads':
+            default:
+                return 'View and manage AI Agents threads';
+        }
+    }, [activeTab]);
+
+    const tabs = useMemo(
+        () => [
+            {
+                value: 'threads',
+                label: (
+                    <Group gap="xs" wrap="nowrap">
+                        <MantineIcon icon={IconMessageCircle} />
+                        <Text fz="sm">Threads</Text>
+                    </Group>
+                ),
+            },
+            {
+                value: 'agents',
+                label: (
+                    <Group gap="xs" wrap="nowrap">
+                        <MantineIcon icon={IconRobotFace} />
+                        <Text fz="sm">Agents</Text>
+                    </Group>
+                ),
+            },
+            ...(isReviewTabEnabled
+                ? [
+                      {
+                          value: 'reviews',
+                          label: (
+                              <Group gap="xs" wrap="nowrap">
+                                  <MantineIcon icon={IconListCheck} />
+                                  <Text fz="sm">Reviews</Text>
+                              </Group>
+                          ),
+                      },
+                  ]
+                : []),
+        ],
+        [isReviewTabEnabled],
+    );
 
     if (!canManageOrganization) {
         return (
@@ -126,9 +211,7 @@ export const AiAgentsAdminLayout = () => {
                                     )}
                             </Group>
                             <Text c="ldGray.6" size="sm" fw={400}>
-                                {activeTab === 'threads'
-                                    ? 'View and manage AI Agents threads'
-                                    : 'View and manage AI Agents'}
+                                {tabDescription}
                             </Text>
                         </Box>
                         <AiAgentsAdminEnableFeatureToggle
@@ -159,33 +242,12 @@ export const AiAgentsAdminLayout = () => {
                             radius="md"
                             value={activeTab}
                             onChange={(value) => {
-                                if (value === 'agents') {
+                                if (value !== 'threads') {
                                     handleCloseSidebar();
                                 }
                                 void navigate(`/ai-agents/admin/${value}`);
                             }}
-                            data={[
-                                {
-                                    value: 'threads',
-                                    label: (
-                                        <Group gap="xs" wrap="nowrap">
-                                            <MantineIcon
-                                                icon={IconMessageCircle}
-                                            />
-                                            <Text fz="sm">Threads</Text>
-                                        </Group>
-                                    ),
-                                },
-                                {
-                                    value: 'agents',
-                                    label: (
-                                        <Group gap="xs" wrap="nowrap">
-                                            <MantineIcon icon={IconRobotFace} />
-                                            <Text fz="sm">Agents</Text>
-                                        </Group>
-                                    ),
-                                },
-                            ]}
+                            data={tabs}
                         />
                         {activeTab === 'threads' && (
                             <LinkButton
@@ -209,55 +271,85 @@ export const AiAgentsAdminLayout = () => {
                         )}
                     </Group>
 
-                    {activeTab === 'threads' ? (
+                    {activeTab === 'threads' && (
                         <AiAgentAdminThreadsTable
                             onThreadSelect={handleThreadSelect}
                             selectedThread={selectedThread}
                             setSelectedThread={setSelectedThread}
                         />
-                    ) : (
-                        <AiAgentAdminAgentsTable />
+                    )}
+                    {activeTab === 'agents' && <AiAgentAdminAgentsTable />}
+                    {activeTab === 'reviews' && (
+                        <AiAgentAdminReviewItemsTable
+                            selectedReviewItemUuid={
+                                selectedReviewItem?.reviewItemUuid
+                            }
+                            onReviewItemSelect={handleReviewItemSelect}
+                        />
                     )}
                 </Panel>
 
-                {isSidebarOpen && activeTab === 'threads' && (
-                    <>
-                        <PanelResizeHandle
-                            className={styles.resizeHandle}
-                            style={{
-                                width: 2,
-                                backgroundColor: theme.colors.ldGray[3],
-                                cursor: 'col-resize',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                            }}
-                        >
-                            <MantineIcon
-                                color="gray"
-                                icon={IconGripVertical}
-                                size="sm"
-                            />
-                        </PanelResizeHandle>
-                        <Panel
-                            id="thread-preview"
-                            defaultSize={30}
-                            minSize={25}
-                            maxSize={50}
-                        >
-                            {!!selectedThread && (
-                                <ThreadPreviewSidebar
-                                    projectUuid={selectedThread.project.uuid}
-                                    agentUuid={selectedThread.agent.uuid}
-                                    threadUuid={selectedThread.uuid}
-                                    isOpen={isSidebarOpen}
-                                    onClose={handleCloseSidebar}
-                                    showAddToEvalsButton
+                {isSidebarOpen &&
+                    (activeTab === 'threads' || activeTab === 'reviews') && (
+                        <>
+                            <PanelResizeHandle
+                                className={styles.resizeHandle}
+                                style={{
+                                    width: 2,
+                                    backgroundColor: theme.colors.ldGray[3],
+                                    cursor: 'col-resize',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                }}
+                            >
+                                <MantineIcon
+                                    color="gray"
+                                    icon={IconGripVertical}
+                                    size="sm"
                                 />
-                            )}
-                        </Panel>
-                    </>
-                )}
+                            </PanelResizeHandle>
+                            <Panel
+                                id="thread-preview"
+                                defaultSize={30}
+                                minSize={25}
+                                maxSize={50}
+                            >
+                                {activeTab === 'threads' &&
+                                    !!selectedThread && (
+                                        <ThreadPreviewSidebar
+                                            projectUuid={
+                                                selectedThread.project.uuid
+                                            }
+                                            agentUuid={
+                                                selectedThread.agent.uuid
+                                            }
+                                            threadUuid={selectedThread.uuid}
+                                            isOpen={isSidebarOpen}
+                                            onClose={handleCloseSidebar}
+                                            showAddToEvalsButton
+                                        />
+                                    )}
+                                {activeTab === 'reviews' &&
+                                    !!selectedReviewItem && (
+                                        <ThreadPreviewSidebar
+                                            projectUuid={
+                                                selectedReviewItem.projectUuid
+                                            }
+                                            agentUuid={
+                                                selectedReviewItem.agentUuid
+                                            }
+                                            threadUuid={
+                                                selectedReviewItem.threadUuid
+                                            }
+                                            isOpen={isSidebarOpen}
+                                            onClose={handleCloseSidebar}
+                                            showAddToEvalsButton
+                                        />
+                                    )}
+                            </Panel>
+                        </>
+                    )}
             </PanelGroup>
             <MantineModal
                 opened={isAnalyticsEmbedOpen}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -2,9 +2,12 @@ import {
     type AiAgentAdminFilters,
     type AiAgentAdminSort,
     type ApiAiAgentAdminConversationsResponse,
+    type ApiAiAgentReviewItemsResponse,
+    type ApiAiAgentReviewSignalsResponse,
     type ApiAiAgentSummaryResponse,
     type ApiAiAgentVerifiedArtifactsResponse,
     type ApiError,
+    type AiAgentReviewItemStatus,
 } from '@lightdash/common';
 import {
     useInfiniteQuery,
@@ -101,6 +104,53 @@ export const useAiAgentAdminAgents = (options?: { enabled?: boolean }) => {
     return useQuery<ApiAiAgentSummaryResponse['results'], ApiError>({
         queryKey: ['ai-agent-admin-list'],
         queryFn: getAiAgentAdminAgents,
+        keepPreviousData: true,
+        enabled: options?.enabled ?? true,
+    });
+};
+
+const getAiAgentAdminReviewItems = async (args: {
+    statuses?: AiAgentReviewItemStatus[];
+}) => {
+    const params = createQueryString({
+        status: args.statuses,
+    });
+
+    return lightdashApi<ApiAiAgentReviewItemsResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items${params ? `?${params}` : ''}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useAiAgentAdminReviewItems = (
+    args: { statuses?: AiAgentReviewItemStatus[] },
+    options?: { enabled?: boolean },
+) => {
+    return useQuery<ApiAiAgentReviewItemsResponse['results'], ApiError>({
+        queryKey: ['ai-agent-admin-review-items', args],
+        queryFn: () => getAiAgentAdminReviewItems(args),
+        keepPreviousData: true,
+        enabled: options?.enabled ?? true,
+    });
+};
+
+const getAiAgentAdminReviewSignals = async () => {
+    return lightdashApi<ApiAiAgentReviewSignalsResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-signals`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useAiAgentAdminReviewSignals = (options?: {
+    enabled?: boolean;
+}) => {
+    return useQuery<ApiAiAgentReviewSignalsResponse['results'], ApiError>({
+        queryKey: ['ai-agent-admin-review-signals'],
+        queryFn: getAiAgentAdminReviewSignals,
         keepPreviousData: true,
         enabled: options?.enabled ?? true,
     });


### PR DESCRIPTION
## Summary
- add a feature-flagged Reviews tab to the AI Agents admin panel
- expose a read-only admin endpoint for classifier review items with latest evidence/recommendation
- keep the queue focused on deduped review items, with Open and All views for local analytics testing

## Linear
Refs PROD-7922
Refs PROD-7920

## Testing
- pnpm -F @lightdash/common typecheck
- pnpm -F backend typecheck
- pnpm -F frontend typecheck
- pnpm -F backend test -- AiAgentReviewClassifierModel.test.ts --runInBand
- pnpm -F @lightdash/common linter src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
- pnpm -F backend linter src/ee/controllers/AiAgentAdminController.ts src/ee/services/AiAgentAdminService.ts src/ee/models/AiAgentReviewClassifierModel.ts src/ee/models/AiAgentReviewClassifierModel.test.ts src/ee/index.ts
- pnpm -F frontend linter src/ee/CommercialRoutes.tsx src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
- pnpm run common-build && pnpm -F backend generate-api && pnpm -F backend formatter --write ./src/generated
- pnpm -F backend migrate