### PR TITLE
feat(ee): fall back to a system agent for Slack when no agents are configured

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -20,6 +20,13 @@ export type DbAiAgent = {
      * Column kept on the table (DB default `false`); drop in a follow-up migration.
      */
     enable_reasoning?: boolean;
+    /**
+     * Built-in fallback agent used when an organization has no configured
+     * agents. Hidden from normal agent listings (so it never counts as "an
+     * agent configured") but usable as a Slack fallback. At most one per
+     * (organization, project).
+     */
+    is_system: boolean;
     version: number;
     created_at: Date;
     updated_at: Date;

--- a/packages/backend/src/ee/database/migrations/20260527150000_add_ai_agent_is_system.ts
+++ b/packages/backend/src/ee/database/migrations/20260527150000_add_ai_agent_is_system.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+const AI_AGENT_TABLE = 'ai_agent';
+const ONE_SYSTEM_PER_PROJECT_INDEX = 'ai_agent_one_system_agent_per_project';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AI_AGENT_TABLE, (table) => {
+        // System agents are the built-in fallback used when an org has no
+        // configured agents. They are hidden from normal agent listings so they
+        // never count as "an agent configured".
+        table.boolean('is_system').notNullable().defaultTo(false);
+    });
+
+    // At most one system agent per (organization, project).
+    await knex.raw(`
+        CREATE UNIQUE INDEX ${ONE_SYSTEM_PER_PROJECT_INDEX}
+        ON ${AI_AGENT_TABLE} (organization_uuid, project_uuid)
+        WHERE is_system
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP INDEX IF EXISTS ${ONE_SYSTEM_PER_PROJECT_INDEX}`);
+    await knex.schema.alterTable(AI_AGENT_TABLE, (table) => {
+        table.dropColumn('is_system');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -516,6 +516,9 @@ export class AiAgentModel {
                 `),
             } satisfies Record<keyof AiAgentSummary, unknown>)
             .where(`${AiAgentTableName}.organization_uuid`, organizationUuid)
+            // System agents are an internal fallback — never surface them in
+            // normal listings, or they'd count as "an agent configured".
+            .where(`${AiAgentTableName}.is_system`, false)
             .groupBy(`${AiAgentTableName}.ai_agent_uuid`);
 
         if (filter?.projectType) {
@@ -1650,6 +1653,7 @@ export class AiAgentModel {
             | 'mcpServerUuids'
         > & {
             organizationUuid: string;
+            isSystem?: boolean;
         },
     ): Promise<AiAgent> {
         return this.database.transaction(async (trx) => {
@@ -1671,6 +1675,7 @@ export class AiAgentModel {
                     enable_data_access: args.enableDataAccess,
                     enable_self_improvement: args.enableSelfImprovement,
                     version: args.version,
+                    is_system: args.isSystem ?? false,
                 })
                 .returning('*');
 
@@ -1771,6 +1776,71 @@ export class AiAgentModel {
                 version: agent.version,
             };
         });
+    }
+
+    /**
+     * Returns the org's system (built-in fallback) agent for a project,
+     * creating it on first use. There is at most one per (org, project),
+     * enforced by a partial unique index — so a concurrent create losing the
+     * race is caught and re-read rather than erroring.
+     */
+    async getOrCreateSystemAgent({
+        organizationUuid,
+        projectUuid,
+        name,
+        instruction,
+    }: {
+        organizationUuid: string;
+        projectUuid: string;
+        name: string;
+        instruction: string;
+    }): Promise<AiAgent> {
+        const findExisting = () =>
+            this.database(AiAgentTableName)
+                .where('organization_uuid', organizationUuid)
+                .where('project_uuid', projectUuid)
+                .where('is_system', true)
+                .first();
+
+        const existing = await findExisting();
+        if (existing) {
+            return this.getAgent({
+                organizationUuid,
+                agentUuid: existing.ai_agent_uuid,
+            });
+        }
+
+        try {
+            return await this.createAgent({
+                name,
+                description: 'Built-in Lightdash assistant',
+                projectUuid,
+                organizationUuid,
+                tags: null,
+                integrations: [],
+                instruction,
+                groupAccess: [],
+                userAccess: [],
+                spaceAccess: [],
+                enableDataAccess: true,
+                enableSelfImprovement: false,
+                version: 1,
+                mcpServerUuids: [],
+                isSystem: true,
+            });
+        } catch (error) {
+            // Lost the create race against a concurrent mention — re-read.
+            if (isUniqueConstraintViolation(error)) {
+                const row = await findExisting();
+                if (row) {
+                    return this.getAgent({
+                        organizationUuid,
+                        agentUuid: row.ai_agent_uuid,
+                    });
+                }
+            }
+            throw error;
+        }
     }
 
     async updateAgent(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -319,6 +319,18 @@ const CLARIFYING_QUESTION_RE =
 const REFUSAL_RE =
     /(doesn't have)|(does not have)|(couldn't (find|locate))|(could not (find|locate))|(no .{0,40}(field|data|column|metric|dimension))|(not available)|(doesn't seem to)|(does not seem to)|(unable to)|(i can't)|(i cannot)|(this dataset)/i;
 
+/**
+ * The built-in "system" agent used as a fallback when an organization has no
+ * configured agents (gated behind the AiWriteback feature flag). It answers
+ * data questions with the normal query/find tools, and — because the run path
+ * attaches the `proposeWriteback` tool whenever AiWriteback is enabled — it
+ * routes dbt/semantic-layer change requests to the AI writeback flow.
+ */
+const SYSTEM_AGENT_NAME = 'Lightdash Assistant';
+const SYSTEM_AGENT_INSTRUCTION = `You are Lightdash's built-in assistant. Help the user explore their data by using your query and find tools to answer questions about metrics, dimensions, charts, and dashboards.
+
+If the user asks you to change the dbt project or semantic layer — for example renaming or adding a metric or dimension, editing a model's YAML, or otherwise modifying definitions — use the proposeWriteback tool, passing along the user's request. It opens a pull request against the project's dbt repository. Do not attempt to make such changes any other way.`;
+
 function detectClarifyingQuestion(text: string): boolean {
     return CLARIFYING_QUESTION_RE.test(text);
 }
@@ -6587,6 +6599,79 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
      *
      * @returns The selected agent and a flag indicating whether to skip forwarding the query, or undefined if selection is pending (UI shown) or no agents available
      */
+    /**
+     * Resolve the built-in system agent to use when no agents are configured.
+     * Gated behind the AiWriteback feature flag.
+     *
+     * Returns:
+     *  - an `AiAgentWithContext` to use as the fallback agent;
+     *  - `'handled'` when it has already replied to the user (e.g. asking which
+     *    project to use) and the caller should stop;
+     *  - `undefined` when the fallback does not apply (flag off) and the caller
+     *    should keep its existing behaviour.
+     */
+    private async resolveSystemAgentForSlack({
+        organizationUuid,
+        userUuid,
+        projectUuids,
+        say,
+        threadTs,
+    }: {
+        organizationUuid: string;
+        userUuid: string;
+        // Optional restriction (e.g. the multi-agent channel's project filter).
+        // When omitted, all of the organization's projects are candidates.
+        projectUuids: string[] | null | undefined;
+        say: Function;
+        threadTs: string | undefined;
+    }): Promise<AiAgentWithContext | 'handled' | undefined> {
+        const user = await this.userModel.findSessionUserAndOrgByUuid(
+            userUuid,
+            organizationUuid,
+        );
+
+        const { enabled } = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.AiWriteback,
+        });
+        if (!enabled) {
+            return undefined;
+        }
+
+        // Candidate projects: the org's projects, optionally restricted to the
+        // channel's configured project filter (dropping any stale/deleted ones).
+        const orgProjects =
+            await this.projectModel.getAllByOrganizationUuid(organizationUuid);
+        let candidateProjectUuids = orgProjects.map((p) => p.projectUuid);
+        if (projectUuids && projectUuids.length > 0) {
+            const allowed = new Set(projectUuids);
+            candidateProjectUuids = candidateProjectUuids.filter((uuid) =>
+                allowed.has(uuid),
+            );
+        }
+
+        if (candidateProjectUuids.length !== 1) {
+            await say({
+                text:
+                    candidateProjectUuids.length === 0
+                        ? "⚠️ I couldn't find a project to work with. Ask an admin to set one up in Lightdash."
+                        : "⚠️ This organization has multiple projects, so I'm not sure which one to use. Configure an AI agent for this channel (or restrict the channel to a single project) and I'll use that.",
+                thread_ts: threadTs,
+            });
+            return 'handled';
+        }
+
+        const agent = await this.aiAgentModel.getOrCreateSystemAgent({
+            organizationUuid,
+            projectUuid: candidateProjectUuids[0],
+            name: SYSTEM_AGENT_NAME,
+            instruction: SYSTEM_AGENT_INSTRUCTION,
+        });
+
+        const context = await this.getAgentSummaryContext(user, agent);
+        return { ...agent, context };
+    }
+
     private async selectAgentForSlack({
         availableAgents,
         messageText,
@@ -6596,6 +6681,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         botUserId,
         client,
         isMultiAgentChannel,
+        organizationUuid,
+        userUuid,
+        multiAgentProjectUuids,
     }: {
         availableAgents: AiAgentWithContext[];
         messageText: string;
@@ -6605,6 +6693,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         botUserId: string | undefined;
         client: WebClient;
         isMultiAgentChannel: boolean;
+        organizationUuid: string;
+        userUuid: string;
+        multiAgentProjectUuids: string[] | null | undefined;
     }): Promise<
         | { agent: AiAgentWithContext; shouldSkipForwardingQuery: boolean }
         | undefined
@@ -6621,6 +6712,22 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             '⚠️ No AI agents are available. Please contact your administrator to configure agents.';
 
         if (availableAgents.length === 0) {
+            // No configured agents — fall back to the built-in system agent
+            // (gated behind AiWriteback). If the flag is off, keep the
+            // original "no agents" message.
+            const fallback = await this.resolveSystemAgentForSlack({
+                organizationUuid,
+                userUuid,
+                projectUuids: multiAgentProjectUuids,
+                say,
+                threadTs,
+            });
+            if (fallback === 'handled') {
+                return undefined;
+            }
+            if (fallback) {
+                return { agent: fallback, shouldSkipForwardingQuery: false };
+            }
             await say({
                 text: noAgentsMessage,
                 thread_ts: threadTs,
@@ -6945,6 +7052,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 botUserId: context.botUserId,
                 client,
                 isMultiAgentChannel,
+                organizationUuid,
+                userUuid,
+                multiAgentProjectUuids: slackSettings.aiMultiAgentProjectUuids,
             });
 
             if (!selectionResult) {
@@ -7817,6 +7927,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     botUserId: context.botUserId,
                     client,
                     isMultiAgentChannel,
+                    organizationUuid,
+                    userUuid,
+                    multiAgentProjectUuids:
+                        slackSettings.aiMultiAgentProjectUuids,
                 });
 
                 if (!selectionResult) {
@@ -7881,6 +7995,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         botUserId: context.botUserId,
                         client,
                         isMultiAgentChannel,
+                        organizationUuid,
+                        userUuid,
+                        multiAgentProjectUuids:
+                            slackSettings.aiMultiAgentProjectUuids,
                     });
 
                     if (!selectionResult) {
@@ -7903,10 +8021,35 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
             if (!isMultiAgentChannel) {
                 // Regular channel: Use existing agent routing by channel ID
-                agentConfig = await this.aiAgentModel.getAgentBySlackChannelId({
-                    organizationUuid,
-                    slackChannelId: event.channel,
-                });
+                try {
+                    agentConfig =
+                        await this.aiAgentModel.getAgentBySlackChannelId({
+                            organizationUuid,
+                            slackChannelId: event.channel,
+                        });
+                } catch (e) {
+                    // No agent mapped to this channel — fall back to the
+                    // built-in system agent (gated behind AiWriteback). If the
+                    // flag is off, rethrow so the existing "no agent
+                    // configured" message is shown.
+                    if (!(e instanceof AiAgentNotFoundError)) {
+                        throw e;
+                    }
+                    const fallback = await this.resolveSystemAgentForSlack({
+                        organizationUuid,
+                        userUuid,
+                        projectUuids: undefined,
+                        say,
+                        threadTs: event.thread_ts,
+                    });
+                    if (fallback === 'handled') {
+                        return;
+                    }
+                    if (!fallback) {
+                        throw e;
+                    }
+                    agentConfig = fallback;
+                }
             }
 
             // At this point, we should have a selected agent


### PR DESCRIPTION
## What & why

When an organization has **no configured AI agents**, a Slack `@mention` previously dead-ended with *"No AI agents are available. Please contact your administrator to configure agents."* (and a regular channel with no mapped agent showed *"no AI agent configured for this channel"*).

Behind the **`AiWriteback` feature flag**, this adds a built-in **"system" agent** fallback so the bot still responds. It answers data questions with the normal query/find tools and — because the agent run path attaches the `proposeWriteback` tool whenever `AiWriteback` is enabled (#23514) — routes dbt/semantic-layer change requests (rename a metric, edit YAML, add a dimension) to the AI writeback flow. No separate intent classifier: the LLM picks the tool.

With the flag **off**, behaviour is unchanged.

## How

- **Migration** `add_ai_agent_is_system`: adds `is_system` to `ai_agent` plus a partial unique index (`WHERE is_system`) — at most one system agent per `(organization, project)`.
- **`AiAgentModel`**:
  - `createAgent` accepts/persists `isSystem`.
  - `findAllAgents` **excludes** system agents — so creating one never flips the org out of the "no agents configured" state, and they don't appear in the UI or multi-agent selection.
  - `getOrCreateSystemAgent` — lazily creates the per-(org, project) system agent, race-safe via the unique index.
- **`AiAgentService`**:
  - `resolveSystemAgentForSlack` — flag check → resolve the target project (**exactly one** candidate → use it; 0 or >1 → reply asking the user to pick/configure) → get-or-create the system agent.
  - Wired into **both** no-agent paths in `handleAppMention`: the multi-agent empty-agents branch (`selectAgentForSlack`) and the regular-channel `AiAgentNotFoundError` branch.
  - System agents pass `verifyAgentAccess` (no access lists ⇒ open access).

No controller/API surface changes (Slack-event-driven), so no `generate-api` needed.

## Test plan

- `pnpm -F backend typecheck` ✅
- `pnpm -F backend lint` ✅
- `pnpm -F backend test:dev:nowatch` ✅ (39 suites, 611 passing)
- Manual: EE instance, org with 0 agents + 1 project + `AiWriteback` enabled → `@mention` in Slack → the system agent ("Lightdash Assistant") responds; asking it to change a dbt model triggers `proposeWriteback` (opens a PR against a GitHub-connected project; returns a clear error for non-GitHub projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)