### PR TITLE
feat(ai-writeback): add ai_writeback_thread table + PR update helper

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -334,6 +334,8 @@ import {
     AiThreadTableName,
     AiWebAppPromptTable,
     AiWebAppPromptTableName,
+    AiWritebackThreadTable,
+    AiWritebackThreadTableName,
 } from '../ee/database/entities/ai';
 import {
     AiAgentGroupAccessTable,
@@ -504,6 +506,7 @@ declare module 'knex/types/tables' {
         [AiArtifactVersionsTableName]: AiArtifactVersionsTable;
         [AiSlackPromptTableName]: AiSlackPromptTable;
         [AiWebAppPromptTableName]: AiWebAppPromptTable;
+        [AiWritebackThreadTableName]: AiWritebackThreadTable;
         [AiAgentTableName]: AiAgentTable;
         [AiAgentDocumentTableName]: AiAgentDocumentTable;
         [AiAgentDocumentAccessTableName]: AiAgentDocumentAccessTable;

--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -368,6 +368,41 @@ export const createPullRequest = async ({
     }
 };
 
+export const updatePullRequest = async ({
+    owner,
+    repo,
+    pullNumber,
+    title,
+    body,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    pullNumber: number;
+    title: string;
+    body: string;
+    installationId?: string;
+    token?: string;
+}) => {
+    const { octokit, headers } = getOctokit(installationId, token);
+
+    try {
+        const response = await octokit.rest.pulls.update({
+            owner,
+            repo,
+            pull_number: pullNumber,
+            title,
+            body,
+            headers,
+        });
+
+        return response.data;
+    } catch (e) {
+        throw new UnexpectedGitError(getErrorMessage(e));
+    }
+};
+
 export const checkFileDoesNotExist = async ({
     owner,
     repo,

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -64,6 +64,22 @@ export type AiWebAppThreadTable = Knex.CompositeTableType<
     never
 >;
 
+export const AiWritebackThreadTableName = 'ai_writeback_thread';
+
+export type DbAiWritebackThread = {
+    ai_writeback_thread_uuid: string;
+    ai_thread_uuid: string;
+    sandbox_id: string;
+    pr_url: string;
+    created_at: Date;
+};
+
+export type AiWritebackThreadTable = Knex.CompositeTableType<
+    DbAiWritebackThread,
+    Pick<DbAiWritebackThread, 'ai_thread_uuid' | 'sandbox_id' | 'pr_url'>,
+    Pick<DbAiWritebackThread, 'sandbox_id'>
+>;
+
 export const AiPromptTableName = 'ai_prompt';
 
 export type DbAiPrompt = {

--- a/packages/backend/src/ee/database/migrations/20260527120000_add_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260527120000_add_ai_writeback_thread.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+const AiWritebackThreadTableName = 'ai_writeback_thread';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AiWritebackThreadTableName))) {
+        await knex.schema.createTable(AiWritebackThreadTableName, (table) => {
+            table
+                .uuid('ai_writeback_thread_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+            table
+                .uuid('ai_thread_uuid')
+                .notNullable()
+                .unique()
+                .references('ai_thread_uuid')
+                .inTable('ai_thread')
+                .onDelete('CASCADE');
+            table.text('sandbox_id').notNullable();
+            table.text('pr_url').notNullable();
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AiWritebackThreadTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -18,6 +18,7 @@ import { CommercialSlackClient } from './clients/Slack/SlackClient';
 import { AiAgentDocumentModel } from './models/AiAgentDocumentModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
+import { AiWritebackThreadModel } from './models/AiWritebackThreadModel';
 import { CommercialFeatureFlagModel } from './models/CommercialFeatureFlagModel';
 import { CommercialSlackAuthenticationModel } from './models/CommercialSlackAuthenticationModel';
 import { DashboardSummaryModel } from './models/DashboardSummaryModel';
@@ -497,6 +498,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 }),
             aiAgentDocumentModel: ({ database }) =>
                 new AiAgentDocumentModel({ database }),
+            aiWritebackThreadModel: ({ database }) =>
+                new AiWritebackThreadModel({ database }),
             aiOrganizationSettingsModel: ({ database }) =>
                 new AiOrganizationSettingsModel({ database }),
             embedModel: ({ database }) => new EmbedModel({ database }),

--- a/packages/backend/src/ee/models/AiWritebackThreadModel.ts
+++ b/packages/backend/src/ee/models/AiWritebackThreadModel.ts
@@ -1,0 +1,52 @@
+import { Knex } from 'knex';
+import {
+    AiWritebackThreadTable,
+    AiWritebackThreadTableName,
+    DbAiWritebackThread,
+} from '../database/entities/ai';
+
+type Dependencies = {
+    database: Knex;
+};
+
+export class AiWritebackThreadModel {
+    private database: Knex;
+
+    constructor(dependencies: Dependencies) {
+        this.database = dependencies.database;
+    }
+
+    async findByAiThreadUuid(
+        aiThreadUuid: string,
+    ): Promise<DbAiWritebackThread | null> {
+        const row = await this.database<AiWritebackThreadTable>(
+            AiWritebackThreadTableName,
+        )
+            .where('ai_thread_uuid', aiThreadUuid)
+            .first();
+        return row ?? null;
+    }
+
+    async create(data: {
+        aiThreadUuid: string;
+        sandboxId: string;
+        prUrl: string;
+    }): Promise<DbAiWritebackThread> {
+        const [row] = await this.database<AiWritebackThreadTable>(
+            AiWritebackThreadTableName,
+        )
+            .insert({
+                ai_thread_uuid: data.aiThreadUuid,
+                sandbox_id: data.sandboxId,
+                pr_url: data.prUrl,
+            })
+            .returning('*');
+        return row;
+    }
+
+    async deleteByAiThreadUuid(aiThreadUuid: string): Promise<void> {
+        await this.database<AiWritebackThreadTable>(AiWritebackThreadTableName)
+            .where('ai_thread_uuid', aiThreadUuid)
+            .delete();
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -136,6 +136,7 @@ export type ModelManifest = {
     /** An implementation signature for these models are not available at this stage */
     aiAgentModel: unknown;
     aiAgentDocumentModel: unknown;
+    aiWritebackThreadModel: unknown;
     managedAgentModel: unknown;
     aiOrganizationSettingsModel: unknown;
     embedModel: unknown;
@@ -719,6 +720,10 @@ export class ModelRepository
 
     public getAiAgentDocumentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentDocumentModel');
+    }
+
+    public getAiWritebackThreadModel<ModelImplT>(): ModelImplT {
+        return this.getModel('aiWritebackThreadModel');
     }
 
     public getAiOrganizationSettingsModel<ModelImplT>(): ModelImplT {


### PR DESCRIPTION
## Summary

PR 1 of 3 for [PROD-7910](https://linear.app/lightdash/issue/PROD-7910). Adds the persistence layer and GitHub client helper that parts 2 and 3 build on. Pure additions; no callers, no behaviour change.

Closes: PROD-7910

## Changes

**Migration**
- `ai_writeback_thread` (`ai_writeback_thread_uuid` PK, `ai_thread_uuid` unique FK → `ai_thread` `ON DELETE CASCADE`, `sandbox_id`, `pr_url`, `created_at`).

**Backend**
- `DbAiWritebackThread` entity + `AiWritebackThreadTable` registration in \`knex-tables.d.ts\`.
- \`AiWritebackThreadModel\` with \`findByAiThreadUuid\` / \`create\` / \`deleteByAiThreadUuid\`.
- \`ModelRepository\` getter and EE model provider.
- \`updatePullRequest({ owner, repo, pullNumber, title, body, installationId })\` in \`clients/github/Github.ts\`, mirroring \`createPullRequest\`.

## Stack

\`\`\`
main
  │
  ▼
┌─────────────────────────────────────────┐
│ part-1  foundation  (this PR)           │
│ part-2  conversational continuation     │  → #23557
│ part-3  refactor: split service files   │  → #23558
└─────────────────────────────────────────┘
\`\`\`

## Test plan

- [x] \`pnpm -F backend typecheck\` clean
- [x] \`pnpm -F backend migrate\` applies cleanly; \`\\d ai_writeback_thread\` shows expected columns + FK + unique constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)