### PR TITLE
feat(ai-writeback): conversational continuation (part-2)

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1368,6 +1368,9 @@ export type AiWritebackStartedEvent = BaseTrack & {
         projectId: string;
         owner: string;
         repo: string;
+        // Whether this turn resumed an existing conversation (and its sandbox)
+        // rather than starting a fresh one.
+        isResume: boolean;
     };
 };
 
@@ -1379,6 +1382,7 @@ export type AiWritebackCompletedEvent = BaseTrack & {
         projectId: string;
         owner: string;
         repo: string;
+        isResume: boolean;
         exitCode: number;
         // Whether the agent changed any files. When false no PR is opened.
         hasChanges: boolean;
@@ -1405,6 +1409,7 @@ export type AiWritebackFailedEvent = BaseTrack & {
         projectId: string;
         owner: string;
         repo: string;
+        isResume: boolean;
         failureStage: AiWritebackFailureStage;
         errorMessage: string;
         totalDurationMs: number;

--- a/packages/backend/src/ee/controllers/AiWritebackController.ts
+++ b/packages/backend/src/ee/controllers/AiWritebackController.ts
@@ -69,11 +69,11 @@ export class AiWritebackController extends BaseController {
         }
         const { prompt } = parsed.data;
         this.setStatus(200);
-        const result = await this.getAiWritebackService().run(
-            toSessionUser(req.account),
+        const result = await this.getAiWritebackService().run({
+            user: toSessionUser(req.account),
             projectUuid,
-            { prompt },
-        );
+            prompt,
+        });
         return {
             status: 'ok',
             results: result,

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -90,6 +90,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     featureFlagModel: models.getFeatureFlagModel(),
                     githubAppInstallationsModel:
                         models.getGithubAppInstallationsModel(),
+                    aiWritebackThreadModel:
+                        models.getAiWritebackThreadModel<AiWritebackThreadModel>(),
                 }),
             appGenerateService: ({ context, models, clients, repository }) =>
                 new AppGenerateService({

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5037,8 +5037,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         const proposeWriteback: ProposeWritebackFn = (args) =>
             wrapSentryTransaction('AiAgent.proposeWriteback', {}, () =>
-                this.aiWritebackService.run(user, projectUuid, {
+                this.aiWritebackService.run({
+                    user,
+                    projectUuid,
                     prompt: args.prompt,
+                    aiThreadUuid: prompt.threadUuid,
                 }),
             );
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -11,6 +11,7 @@ import {
     type DbtProjectConfig,
     type SessionUser,
 } from '@lightdash/common';
+import { randomUUID } from 'crypto';
 import { Sandbox } from 'e2b';
 import type {
     AiWritebackFailureStage,
@@ -19,12 +20,48 @@ import type {
 import {
     createPullRequest,
     getInstallationToken,
+    updatePullRequest,
 } from '../../../clients/github/Github';
 import type { LightdashConfig } from '../../../config/parseConfig';
 import type { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import type { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import type { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../../services/BaseService';
+import type { DbAiWritebackThread } from '../../database/entities/ai';
+import type { AiWritebackThreadModel } from '../../models/AiWritebackThreadModel';
+
+type GithubConnection = {
+    owner: string;
+    repo: string;
+    projectSubPath: string;
+};
+
+type GithubInstallation = {
+    installationId: string;
+    token: string;
+};
+
+type SetStage = (stage: AiWritebackFailureStage) => void;
+
+type TurnContext = {
+    organizationUuid: string;
+    githubConnection: GithubConnection;
+    existingRow: DbAiWritebackThread | null;
+    isResume: boolean;
+};
+
+type AppliedChanges = {
+    prUrl: string | null;
+    prCreated: boolean;
+    pauseOnExit: boolean;
+};
+
+export type AiWritebackRunArgs = {
+    user: SessionUser;
+    projectUuid: string;
+    prompt: string;
+    aiThreadUuid?: string;
+};
 
 const TEMPLATE_NAME = 'lightdash-ai-writeback';
 
@@ -50,6 +87,10 @@ const COMMIT_AUTHOR_EMAIL = 'developers@lightdash.com';
 // the duration, so keep this well under typical load-balancer/proxy timeouts.
 const RUN_TIMEOUT_MS = 10 * 60 * 1000;
 
+// How long an E2B sandbox stays alive before E2B reaps it. Used both when
+// creating a sandbox and when connecting to a paused one to keep it warm.
+const SANDBOX_TIMEOUT_MS = 60 * 60 * 1000;
+
 // Instructions prepended to every user prompt. The host owns git, so the agent
 // must not touch it; instead it leaves the PR title/description on disk.
 //
@@ -59,13 +100,13 @@ const RUN_TIMEOUT_MS = 10 * 60 * 1000;
 // rather than discovering it, so the compile targets the project the prompt is
 // actually about.
 //
-// When the agent makes file changes it must also run \`lightdash compile\` so the
+// When the agent makes file changes it must also run `lightdash compile` so the
 // host (and reviewer) can see whether the resulting dbt project still parses.
 // The compile uses --skip-warehouse-catalog so no live warehouse connection is
 // needed; profiles.yml is patched in a temporary copy (env_var(...) and other
 // Jinja expressions stripped) so dbt's profile-parsing step doesn't fail on
 // unset variables. The original profiles.yml in the checkout must NOT be
-// touched — \`git add --all\` runs after the agent and would otherwise sweep
+// touched — `git add --all` runs after the agent and would otherwise sweep
 // the patched file into the PR.
 const buildSystemPrompt = (dbtProjectDir: string): string =>
     `
@@ -123,6 +164,7 @@ type AiWritebackServiceDeps = {
     projectModel: ProjectModel;
     featureFlagModel: FeatureFlagModel;
     githubAppInstallationsModel: GithubAppInstallationsModel;
+    aiWritebackThreadModel: AiWritebackThreadModel;
 };
 
 export class AiWritebackService extends BaseService {
@@ -136,12 +178,15 @@ export class AiWritebackService extends BaseService {
 
     private readonly githubAppInstallationsModel: GithubAppInstallationsModel;
 
+    private readonly aiWritebackThreadModel: AiWritebackThreadModel;
+
     constructor({
         lightdashConfig,
         analytics,
         projectModel,
         featureFlagModel,
         githubAppInstallationsModel,
+        aiWritebackThreadModel,
     }: AiWritebackServiceDeps) {
         super({ serviceName: 'AiWritebackService' });
         this.lightdashConfig = lightdashConfig;
@@ -149,6 +194,7 @@ export class AiWritebackService extends BaseService {
         this.projectModel = projectModel;
         this.featureFlagModel = featureFlagModel;
         this.githubAppInstallationsModel = githubAppInstallationsModel;
+        this.aiWritebackThreadModel = aiWritebackThreadModel;
     }
 
     private async assertEnabled(user: SessionUser): Promise<void> {
@@ -221,24 +267,80 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
-     * Resolve a GitHub App installation access token for the user's
-     * organization. The token authenticates the in-sandbox clone/push and the
-     * pull request creation. Throws if no installation exists.
+     * Resolve a GitHub App installation access token for the organization.
+     * The token authenticates the in-sandbox clone/push and the pull request
+     * creation. Throws if no installation exists.
      */
     private async getGithubInstallation(
-        user: SessionUser,
-    ): Promise<{ installationId: string; token: string }> {
-        if (!isUserWithOrg(user)) {
-            throw new ForbiddenError('User is not part of an organization');
-        }
+        organizationUuid: string,
+    ): Promise<GithubInstallation> {
         // getInstallationId throws NotFoundError when the org hasn't connected
         // the GitHub App (via /generalSettings/integrations).
         const installationId =
             await this.githubAppInstallationsModel.getInstallationId(
-                user.organizationUuid,
+                organizationUuid,
             );
-        const token = await getInstallationToken(installationId!);
-        return { installationId: installationId!, token };
+        if (!installationId) {
+            throw new ForbiddenError(
+                'GitHub App is not installed for this organization',
+            );
+        }
+        const token = await getInstallationToken(installationId);
+        return { installationId, token };
+    }
+
+    private static elapsed(start: number): number {
+        return Math.round(performance.now() - start);
+    }
+
+    private async createSandbox(
+        projectUuid: string,
+    ): Promise<{ sandbox: Sandbox; durationMs: number }> {
+        const start = performance.now();
+        const sandbox = await Sandbox.create(TEMPLATE_NAME, {
+            timeoutMs: SANDBOX_TIMEOUT_MS,
+            apiKey: this.getE2bApiKey(),
+            lifecycle: { onTimeout: 'pause' },
+        });
+        const durationMs = AiWritebackService.elapsed(start);
+        this.logger.info(
+            `AiWriteback: sandbox created (sandboxId=${sandbox.sandboxId}, project=${projectUuid}, ${durationMs}ms)`,
+        );
+        return { sandbox, durationMs };
+    }
+
+    private async pauseSandbox(
+        sandbox: Sandbox,
+        projectUuid: string,
+    ): Promise<void> {
+        try {
+            const start = performance.now();
+            await sandbox.pause();
+            const durationMs = AiWritebackService.elapsed(start);
+            this.logger.info(
+                `AiWriteback: sandbox paused (sandboxId=${sandbox.sandboxId}, project=${projectUuid}, ${durationMs}ms)`,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `AiWriteback: failed to pause sandbox (sandboxId=${sandbox.sandboxId}, project=${projectUuid}): ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
+    private async resumeSandbox(
+        sandboxId: string,
+        projectUuid: string,
+    ): Promise<{ sandbox: Sandbox; durationMs: number }> {
+        const start = performance.now();
+        const sandbox = await Sandbox.connect(sandboxId, {
+            apiKey: this.getE2bApiKey(),
+            timeoutMs: SANDBOX_TIMEOUT_MS,
+        });
+        const durationMs = AiWritebackService.elapsed(start);
+        this.logger.info(
+            `AiWriteback: sandbox resumed (sandboxId=${sandbox.sandboxId}, project=${projectUuid}, ${durationMs}ms)`,
+        );
+        return { sandbox, durationMs };
     }
 
     /** Read a file the agent may or may not have written, with a fallback. */
@@ -257,230 +359,568 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
-     * Synchronously spin up a sandbox, clone the target repo, run the given
-     * prompt through the Claude Code CLI, and — if the agent changed any files
-     * — branch/commit/push and open a pull request. Returns the agent's text
-     * output and the PR URL (or null when there were no changes). The sandbox
-     * is always killed before returning so we never leak running containers.
+     * Synchronously run a writeback turn through the Claude Code CLI and a
+     * PR against the project's GitHub repo.
+     *
+     * - **One-shot** (no `aiThreadUuid`): create a fresh sandbox, clone, run
+     *   the agent, open a PR if there are changes, then kill the sandbox.
+     * - **First conversational turn** (`aiThreadUuid` provided, no row): same
+     *   as one-shot, but if a PR is opened the sandbox is paused (rather than
+     *   killed) and an `ai_writeback_thread` row is recorded for resume.
+     * - **Follow-up turn** (`aiThreadUuid` matches an existing row): resume
+     *   the stored sandbox (repo + branch already checked out, prior Claude
+     *   session preserved), run the agent with `--continue`, push to the same
+     *   branch (updates the existing PR), pause the sandbox again.
      */
-    async run(
-        user: SessionUser,
-        projectUuid: string,
-        { prompt }: { prompt: string },
-    ): Promise<AiWritebackRunResult> {
+    async run(args: AiWritebackRunArgs): Promise<AiWritebackRunResult> {
+        const { user, projectUuid, prompt, aiThreadUuid } = args;
+
+        console.log(args);
+        const turn = await this.prepareTurn({
+            user,
+            projectUuid,
+            aiThreadUuid,
+        });
+
+        const tracker = this.startTracking({ user, projectUuid, turn });
+
+        let failureStage: AiWritebackFailureStage = 'install';
+        const setStage: SetStage = (stage) => {
+            failureStage = stage;
+        };
+
+        let sandbox: Sandbox | undefined;
+        // Default to preserving a resumed sandbox through failures — its
+        // sandbox_id is referenced by an ai_writeback_thread row and killing
+        // it would poison the row for every future turn. Fresh turns have no
+        // such row, so the default kill is fine.
+        let pauseOnExit = turn.isResume;
+        try {
+            const github = await this.getGithubInstallation(
+                turn.organizationUuid,
+            );
+            sandbox = await this.acquireSandbox({
+                projectUuid,
+                githubConnection: turn.githubConnection,
+                token: github.token,
+                existingRow: turn.existingRow,
+                setStage,
+            });
+
+            setStage('agent');
+            const agent = await this.runAgentInSandbox({
+                sandbox,
+                prompt,
+                projectSubPath: turn.githubConnection.projectSubPath,
+                isResume: turn.isResume,
+            });
+
+            const { hasChanges } = await sandbox.git.status(CWD);
+
+            // The agent crashed mid-run. The working tree may be in a
+            // partial/inconsistent state, so skip the push/PR side-effects
+            // and surface the failure to the caller.
+            if (agent.exitCode !== 0) {
+                this.logger.warn(
+                    `AiWriteback: agent exited non-zero (sandboxId=${sandbox.sandboxId}, exit=${agent.exitCode}) — skipping PR`,
+                );
+                tracker.completed({
+                    exitCode: agent.exitCode,
+                    hasChanges,
+                    prCreated: false,
+                });
+                return {
+                    output: agent.stdout,
+                    exitCode: agent.exitCode,
+                    prUrl: turn.existingRow?.pr_url ?? null,
+                };
+            }
+
+            const applied = await this.applyAgentChanges({
+                sandbox,
+                github,
+                hasChanges,
+                turn,
+                aiThreadUuid,
+                setStage,
+            });
+            pauseOnExit = applied.pauseOnExit;
+
+            tracker.completed({
+                exitCode: agent.exitCode,
+                hasChanges,
+                prCreated: applied.prCreated,
+            });
+
+            return {
+                output: agent.stdout,
+                exitCode: agent.exitCode,
+                prUrl: applied.prUrl,
+            };
+        } catch (error) {
+            tracker.failed(failureStage, error);
+            throw error;
+        } finally {
+            if (sandbox) {
+                await this.releaseSandbox(sandbox, pauseOnExit, projectUuid);
+            }
+        }
+    }
+
+    /**
+     * Pre-flight: enforce the feature flag, the project view permission, and
+     * resolve everything from the request that doesn't require a sandbox.
+     */
+    private async prepareTurn({
+        user,
+        projectUuid,
+        aiThreadUuid,
+    }: {
+        user: SessionUser;
+        projectUuid: string;
+        aiThreadUuid: string | undefined;
+    }): Promise<TurnContext> {
         await this.assertEnabled(user);
 
-        // Confirm the project exists and the user can view it before spending
-        // money on a sandbox. Permission is enforced with an explicit CASL
-        // check via the audited ability. The full project also carries the dbt
-        // connection we resolve the target repo and sub-folder from.
         const project = await this.projectModel.get(projectUuid);
-        if (
-            this.createAuditedAbility(user).cannot(
-                'view',
-                subject('Project', {
-                    organizationUuid: project.organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
+        const canView = this.createAuditedAbility(user).can(
+            'view',
+            subject('Project', {
+                organizationUuid: project.organizationUuid,
+                projectUuid,
+            }),
+        );
+        if (!canView) {
             throw new ForbiddenError();
         }
-
-        // The repo to clone/PR against and the dbt project dir to compile come
-        // from the project's connection — never from the caller.
-        const { owner, repo, projectSubPath } =
-            AiWritebackService.resolveGithubConnection(project.dbtConnection);
 
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+
+        const githubConnection = AiWritebackService.resolveGithubConnection(
+            project.dbtConnection,
+        );
+
+        // Resume only when both the caller supplied a thread uuid AND we
+        // have a stored sandbox for it. Otherwise we start fresh.
+        const existingRow = aiThreadUuid
+            ? await this.aiWritebackThreadModel.findByAiThreadUuid(aiThreadUuid)
+            : null;
+
+        return {
+            organizationUuid: user.organizationUuid,
+            githubConnection,
+            existingRow,
+            isResume: existingRow !== null,
+        };
+    }
+
+    /**
+     * Fire the `ai_writeback.started` event and return bound `completed` /
+     * `failed` closures so the inline analytics calls stay out of `run()`.
+     */
+    private startTracking({
+        user,
+        projectUuid,
+        turn,
+    }: {
+        user: SessionUser;
+        projectUuid: string;
+        turn: TurnContext;
+    }) {
         const eventBase = {
-            organizationId: user.organizationUuid,
+            organizationId: turn.organizationUuid,
             projectId: projectUuid,
-            owner,
-            repo,
+            owner: turn.githubConnection.owner,
+            repo: turn.githubConnection.repo,
+            isResume: turn.isResume,
         };
         const startedAt = Date.now();
+
         this.analytics.track({
             event: 'ai_writeback.started',
             userId: user.userUuid,
             properties: eventBase,
         });
 
-        // Track the current pipeline stage so a failure is attributed to it.
-        let stage: AiWritebackFailureStage = 'install';
-        let sandbox: Sandbox | undefined;
-        try {
-            const { installationId, token } =
-                await this.getGithubInstallation(user);
-
-            const e2bApiKey = this.getE2bApiKey();
-            const anthropicApiKey = this.getAnthropicApiKey();
-
-            stage = 'sandbox';
-            sandbox = await Sandbox.create(TEMPLATE_NAME, {
-                apiKey: e2bApiKey,
-                timeoutMs: RUN_TIMEOUT_MS,
-            });
-            this.logger.info(
-                `AiWriteback: sandbox created (sandboxId=${sandbox.sandboxId}, project=${projectUuid})`,
-            );
-
-            stage = 'clone';
-            // Clone over HTTPS using the installation token as the password.
-            const cloneUrl = `https://${REPO_HOST}/${owner}/${repo}.git`;
-            await sandbox.git.clone(cloneUrl, {
-                path: CWD,
-                username: GIT_USERNAME,
-                password: token,
-            });
-
-            // The default branch is whatever got checked out by the clone — it
-            // becomes the PR base.
-            const baseStatus = await sandbox.git.status(CWD);
-            const baseBranch = baseStatus.currentBranch ?? 'main';
-
-            // Write the system prompt and the user prompt to separate files so
-            // arbitrary content (quotes, newlines, shell metacharacters) can't
-            // break the command line. The system prompt is passed via
-            // --append-system-prompt-file; only the user prompt is piped in.
-            await sandbox.files.write(
-                SYSTEM_PROMPT_PATH,
-                buildSystemPrompt(projectSubPath),
-            );
-            await sandbox.files.write(PROMPT_PATH, prompt);
-
-            stage = 'agent';
-            // Run the agent inside the repo so its edits land on the checkout.
-            const result = await sandbox.commands.run(
-                `cat ${PROMPT_PATH} | claude -p ` +
-                    `--append-system-prompt-file ${SYSTEM_PROMPT_PATH} ` +
-                    '--output-format text ' +
-                    '--dangerously-skip-permissions',
-                {
-                    cwd: CWD,
-                    timeoutMs: RUN_TIMEOUT_MS,
-                    envs: { ANTHROPIC_API_KEY: anthropicApiKey },
-                    onStderr: (chunk) => {
-                        this.logger.debug(
-                            `AiWriteback: claude stderr: ${chunk.trimEnd()}`,
-                        );
-                    },
-                },
-            );
-
-            this.logger.info(
-                `AiWriteback: run completed (sandboxId=${sandbox.sandboxId}, exit=${result.exitCode})`,
-            );
-
-            const status = await sandbox.git.status(CWD);
-            if (!status.hasChanges) {
-                this.logger.info(
-                    `AiWriteback: no file changes — skipping PR (sandboxId=${sandbox.sandboxId})`,
-                );
+        return {
+            completed: (props: {
+                exitCode: number;
+                hasChanges: boolean;
+                prCreated: boolean;
+            }) =>
                 this.analytics.track({
                     event: 'ai_writeback.completed',
                     userId: user.userUuid,
                     properties: {
                         ...eventBase,
-                        exitCode: result.exitCode,
-                        hasChanges: false,
-                        prCreated: false,
+                        ...props,
                         totalDurationMs: Date.now() - startedAt,
                     },
-                });
-                return {
-                    output: result.stdout,
-                    exitCode: result.exitCode,
-                    prUrl: null,
-                };
+                }),
+            failed: (stage: AiWritebackFailureStage, error: unknown) =>
+                this.analytics.track({
+                    event: 'ai_writeback.failed',
+                    userId: user.userUuid,
+                    properties: {
+                        ...eventBase,
+                        failureStage: stage,
+                        errorMessage: getErrorMessage(error),
+                        totalDurationMs: Date.now() - startedAt,
+                    },
+                }),
+        };
+    }
+
+    /**
+     * Return a running sandbox with the repo present at `CWD`. Resume the
+     * stored sandbox when an existing conversation row is provided; otherwise
+     * create a fresh sandbox and clone the repo into it.
+     */
+    private async acquireSandbox({
+        projectUuid,
+        githubConnection,
+        token,
+        existingRow,
+        setStage,
+    }: {
+        projectUuid: string;
+        githubConnection: GithubConnection;
+        token: string;
+        existingRow: DbAiWritebackThread | null;
+        setStage: SetStage;
+    }): Promise<Sandbox> {
+        setStage('sandbox');
+
+        if (existingRow) {
+            try {
+                const { sandbox } = await this.resumeSandbox(
+                    existingRow.sandbox_id,
+                    projectUuid,
+                );
+                return sandbox;
+            } catch (error) {
+                // The persisted sandbox is gone (reaped by E2B, or some other
+                // permanent failure). Clear the row so the next turn starts
+                // fresh instead of looping on the same dead reference.
+                this.logger.warn(
+                    `AiWriteback: failed to resume sandbox ${existingRow.sandbox_id} — clearing conversation row (ai_thread_uuid=${existingRow.ai_thread_uuid}): ${getErrorMessage(error)}`,
+                );
+                await this.aiWritebackThreadModel.deleteByAiThreadUuid(
+                    existingRow.ai_thread_uuid,
+                );
+                throw new ParameterError(
+                    'This writeback conversation has expired. Please start a new one.',
+                );
             }
+        }
 
-            const title = await AiWritebackService.readOptionalFile(
-                sandbox,
-                PR_TITLE_PATH,
-                'AI writeback changes',
-            );
-            const description = await AiWritebackService.readOptionalFile(
-                sandbox,
-                PR_DESCRIPTION_PATH,
-                'Changes generated by the Lightdash AI writeback agent.',
-            );
+        const { sandbox } = await this.createSandbox(projectUuid);
 
-            const branch = `lightdash-ai-writeback/${Date.now()}`;
-            stage = 'commit';
-            await sandbox.git.createBranch(CWD, branch);
-            await sandbox.git.add(CWD, { all: true });
-            await sandbox.git.commit(CWD, title, {
-                authorName: COMMIT_AUTHOR_NAME,
-                authorEmail: COMMIT_AUTHOR_EMAIL,
-            });
-            stage = 'push';
-            await sandbox.git.push(CWD, {
-                remote: 'origin',
-                branch,
-                setUpstream: true,
+        setStage('clone');
+        // Clone over HTTPS using the installation token as the password.
+        await sandbox.git.clone(
+            `https://${REPO_HOST}/${githubConnection.owner}/${githubConnection.repo}.git`,
+            {
+                path: CWD,
                 username: GIT_USERNAME,
                 password: token,
-            });
+            },
+        );
+        return sandbox;
+    }
 
-            stage = 'pull_request';
-            const pr = await createPullRequest({
-                owner,
-                repo,
-                title,
-                body: description,
-                head: branch,
-                base: baseBranch,
-                installationId,
-            });
+    /**
+     * Write the system + user prompts to disk and pipe the user prompt into
+     * the Claude Code CLI. On resume, `--continue` picks up the most recent
+     * Claude session in `CWD` (preserved across pause/resume on the sandbox
+     * filesystem).
+     *
+     * Prompts are written to files — rather than passed as arguments — so
+     * arbitrary content (quotes, newlines, shell metacharacters) can't break
+     * the command line.
+     */
+    private async runAgentInSandbox({
+        sandbox,
+        prompt,
+        projectSubPath,
+        isResume,
+    }: {
+        sandbox: Sandbox;
+        prompt: string;
+        projectSubPath: string;
+        isResume: boolean;
+    }): Promise<{ stdout: string; exitCode: number }> {
+        await sandbox.files.write(
+            SYSTEM_PROMPT_PATH,
+            buildSystemPrompt(projectSubPath),
+        );
+        await sandbox.files.write(PROMPT_PATH, prompt);
 
-            this.logger.info(
-                `AiWriteback: opened PR ${pr.html_url} (sandboxId=${sandbox.sandboxId})`,
-            );
-
-            this.analytics.track({
-                event: 'ai_writeback.completed',
-                userId: user.userUuid,
-                properties: {
-                    ...eventBase,
-                    exitCode: result.exitCode,
-                    hasChanges: true,
-                    prCreated: true,
-                    totalDurationMs: Date.now() - startedAt,
-                },
-            });
-
-            return {
-                output: result.stdout,
-                exitCode: result.exitCode,
-                prUrl: pr.html_url,
-            };
-        } catch (error) {
-            this.analytics.track({
-                event: 'ai_writeback.failed',
-                userId: user.userUuid,
-                properties: {
-                    ...eventBase,
-                    failureStage: stage,
-                    errorMessage: getErrorMessage(error),
-                    totalDurationMs: Date.now() - startedAt,
-                },
-            });
-            throw error;
-        } finally {
-            if (sandbox) {
-                try {
-                    await sandbox.kill();
-                } catch (error) {
-                    this.logger.warn(
-                        `AiWriteback: failed to kill sandbox ${sandbox.sandboxId}: ${getErrorMessage(
-                            error,
-                        )}`,
+        const continueFlag = isResume ? '--continue ' : '';
+        const result = await sandbox.commands.run(
+            `cat ${PROMPT_PATH} | claude -p ${continueFlag}` +
+                `--append-system-prompt-file ${SYSTEM_PROMPT_PATH} ` +
+                '--output-format text ' +
+                '--dangerously-skip-permissions',
+            {
+                cwd: CWD,
+                timeoutMs: RUN_TIMEOUT_MS,
+                envs: { ANTHROPIC_API_KEY: this.getAnthropicApiKey() },
+                onStderr: (chunk) => {
+                    this.logger.debug(
+                        `AiWriteback: claude stderr: ${chunk.trimEnd()}`,
                     );
-                }
-            }
+                },
+            },
+        );
+        this.logger.info(
+            `AiWriteback: agent run completed (sandboxId=${sandbox.sandboxId}, exit=${result.exitCode}, isResume=${isResume})`,
+        );
+        return { stdout: result.stdout, exitCode: result.exitCode };
+    }
+
+    /**
+     * Translate the agent's effect on the working tree into the right
+     * GitHub side-effect and decide whether the sandbox should outlive this
+     * turn. Three branches, no nesting:
+     *
+     * 1. No changes — nothing to push. Existing PR (if any) is the answer;
+     *    keep the sandbox warm only when resuming.
+     * 2. Resume + changes — push to the checked-out branch; existing PR
+     *    auto-updates on GitHub.
+     * 3. Fresh + changes — branch, commit, push, open the PR; persist the
+     *    conversation row if the caller supplied an `aiThreadUuid`.
+     */
+    private async applyAgentChanges({
+        sandbox,
+        github,
+        hasChanges,
+        turn,
+        aiThreadUuid,
+        setStage,
+    }: {
+        sandbox: Sandbox;
+        github: GithubInstallation;
+        hasChanges: boolean;
+        turn: TurnContext;
+        aiThreadUuid: string | undefined;
+        setStage: SetStage;
+    }): Promise<AppliedChanges> {
+        if (!hasChanges) {
+            this.logger.info(
+                `AiWriteback: no file changes — skipping PR (sandboxId=${sandbox.sandboxId})`,
+            );
+            return {
+                prUrl: turn.existingRow?.pr_url ?? null,
+                prCreated: false,
+                pauseOnExit: turn.isResume,
+            };
+        }
+
+        if (turn.existingRow) {
+            await AiWritebackService.updateExistingPullRequest({
+                sandbox,
+                existingRow: turn.existingRow,
+                githubConnection: turn.githubConnection,
+                installationId: github.installationId,
+                token: github.token,
+                setStage,
+            });
+            this.logger.info(
+                `AiWriteback: updated PR ${turn.existingRow.pr_url} (sandboxId=${sandbox.sandboxId})`,
+            );
+            return {
+                prUrl: turn.existingRow.pr_url,
+                prCreated: false,
+                pauseOnExit: true,
+            };
+        }
+
+        const prUrl = await AiWritebackService.openInitialPullRequest({
+            sandbox,
+            githubConnection: turn.githubConnection,
+            token: github.token,
+            installationId: github.installationId,
+            setStage,
+        });
+        this.logger.info(
+            `AiWriteback: opened PR ${prUrl} (sandboxId=${sandbox.sandboxId})`,
+        );
+
+        if (aiThreadUuid) {
+            await this.aiWritebackThreadModel.create({
+                aiThreadUuid,
+                sandboxId: sandbox.sandboxId,
+                prUrl,
+            });
+        }
+
+        return {
+            prUrl,
+            prCreated: true,
+            pauseOnExit: aiThreadUuid !== undefined,
+        };
+    }
+
+    /**
+     * First conversational/one-shot turn that produced changes: read the
+     * agent's chosen PR title/description, create a feature branch, commit,
+     * push, and open a new pull request. Returns the new PR's URL.
+     */
+    private static async openInitialPullRequest({
+        sandbox,
+        githubConnection,
+        token,
+        installationId,
+        setStage,
+    }: {
+        sandbox: Sandbox;
+        githubConnection: GithubConnection;
+        token: string;
+        installationId: string;
+        setStage: SetStage;
+    }): Promise<string> {
+        // The current branch right after clone is the default branch — that
+        // becomes the PR base. Capture it before we branch off.
+        const baseBranch =
+            (await sandbox.git.status(CWD)).currentBranch ?? 'main';
+
+        const title = await AiWritebackService.readOptionalFile(
+            sandbox,
+            PR_TITLE_PATH,
+            'AI writeback changes',
+        );
+        const description = await AiWritebackService.readOptionalFile(
+            sandbox,
+            PR_DESCRIPTION_PATH,
+            'Changes generated by the Lightdash AI writeback agent.',
+        );
+
+        const branch = `lightdash-ai-writeback/${randomUUID()}`;
+
+        setStage('commit');
+        await sandbox.git.createBranch(CWD, branch);
+        await sandbox.git.add(CWD, { all: true });
+        await sandbox.git.commit(CWD, title, {
+            authorName: COMMIT_AUTHOR_NAME,
+            authorEmail: COMMIT_AUTHOR_EMAIL,
+        });
+
+        setStage('push');
+        await sandbox.git.push(CWD, {
+            remote: 'origin',
+            branch,
+            setUpstream: true,
+            username: GIT_USERNAME,
+            password: token,
+        });
+
+        setStage('pull_request');
+        const pr = await createPullRequest({
+            owner: githubConnection.owner,
+            repo: githubConnection.repo,
+            title,
+            body: description,
+            head: branch,
+            base: baseBranch,
+            installationId,
+        });
+        return pr.html_url;
+    }
+
+    /**
+     * Resume turn that produced changes: the feature branch is already
+     * checked out from the prior turn. Read the agent's refreshed PR
+     * title/description, commit + push to that branch (existing PR picks up
+     * the commits automatically), then patch the PR's title and body so the
+     * GitHub view stays in sync with the latest agent output.
+     */
+    private static async updateExistingPullRequest({
+        sandbox,
+        existingRow,
+        githubConnection,
+        installationId,
+        token,
+        setStage,
+    }: {
+        sandbox: Sandbox;
+        existingRow: DbAiWritebackThread;
+        githubConnection: GithubConnection;
+        installationId: string;
+        token: string;
+        setStage: SetStage;
+    }): Promise<void> {
+        const title = await AiWritebackService.readOptionalFile(
+            sandbox,
+            PR_TITLE_PATH,
+            'AI writeback follow-up',
+        );
+        const description = await AiWritebackService.readOptionalFile(
+            sandbox,
+            PR_DESCRIPTION_PATH,
+            'Follow-up changes from the Lightdash AI writeback agent.',
+        );
+
+        setStage('commit');
+        await sandbox.git.add(CWD, { all: true });
+        await sandbox.git.commit(CWD, title, {
+            authorName: COMMIT_AUTHOR_NAME,
+            authorEmail: COMMIT_AUTHOR_EMAIL,
+        });
+
+        setStage('push');
+        await sandbox.git.push(CWD, {
+            remote: 'origin',
+            username: GIT_USERNAME,
+            password: token,
+        });
+
+        setStage('pull_request');
+        await updatePullRequest({
+            owner: githubConnection.owner,
+            repo: githubConnection.repo,
+            pullNumber: AiWritebackService.parsePullNumber(existingRow.pr_url),
+            title,
+            body: description,
+            installationId,
+        });
+    }
+
+    /** Extract the numeric PR id from a github.com/owner/repo/pull/<n> URL. */
+    private static parsePullNumber(prUrl: string): number {
+        const last = prUrl.split('/').pop();
+        const n = last ? Number(last) : NaN;
+        if (!Number.isInteger(n) || n <= 0) {
+            throw new ParameterError(
+                `Could not parse pull request number from URL: ${prUrl}`,
+            );
+        }
+        return n;
+    }
+
+    /**
+     * Final sandbox disposition. Pause to preserve it for the next turn, or
+     * kill (with a soft-fail log) to free resources for non-resumable runs.
+     */
+    private async releaseSandbox(
+        sandbox: Sandbox,
+        shouldPause: boolean,
+        projectUuid: string,
+    ): Promise<void> {
+        if (shouldPause) {
+            await this.pauseSandbox(sandbox, projectUuid);
+            return;
+        }
+        try {
+            await sandbox.kill();
+        } catch (error) {
+            this.logger.warn(
+                `AiWriteback: failed to kill sandbox ${sandbox.sandboxId}: ${getErrorMessage(
+                    error,
+                )}`,
+            );
         }
     }
 }

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -418,11 +418,11 @@ export class McpService extends BaseService {
                 );
 
                 try {
-                    const result = await this.aiWritebackService.run(
+                    const result = await this.aiWritebackService.run({
                         user,
                         projectUuid,
-                        { prompt: args.prompt },
-                    );
+                        prompt: args.prompt,
+                    });
 
                     const summary = result.prUrl
                         ? `AI writeback complete. Pull request opened: ${result.prUrl}`


### PR DESCRIPTION
## Summary

PR 2 of 3 for [PROD-7910](https://linear.app/lightdash/issue/PROD-7910). Lets users iterate on an existing writeback PR through follow-up turns: same Slack thread → same sandbox → same branch → same PR (updated in place rather than a new PR opened each time).

Stacks on top of #23556 (model + \`updatePullRequest\` helper).

Closes: PROD-7910

## How it works

- \`AiWritebackService.run\` accepts an optional \`aiThreadUuid\`.
- Three paths, gated by that arg and the existence of an \`ai_writeback_thread\` row:
  - **One-shot** (no \`aiThreadUuid\`): fresh sandbox, optional PR, kill on exit.
  - **First conversational turn** (uuid given, no row): fresh sandbox; if a PR opens, persist \`{sandbox_id, pr_url}\` and pause the sandbox.
  - **Follow-up turn** (uuid + row): \`resumeSandbox\`, \`claude --continue\` (session preserved on the paused sandbox's filesystem), push to the existing branch, patch the PR's title/body via \`updatePullRequest\`, pause again.
- \`proposeWriteback\` in \`AiAgentService\` forwards the agent's \`prompt.threadUuid\` automatically. Controller and MCP entry points stay one-shot.

## Safety / correctness

- \`pauseOnExit = turn.isResume\` default — a transient mid-turn failure during a resume preserves the sandbox so the next attempt can recover, instead of killing it and orphaning the row.
- \`acquireSandbox\` catches a reaped-sandbox \`Sandbox.connect\` failure, deletes the orphaned row, and surfaces a clear "conversation expired" error. Self-healing on access.
- Agent exit-code branch: non-zero \`claude\` exit short-circuits before any git/PR side effects.
- Branch names use \`randomUUID()\` to eliminate timestamp collisions.
- All three \`AiWriteback*Event\` analytics types gain \`isResume: boolean\`.

## Lifecycle

\`\`\`
run({aiThreadUuid?}) → prepareTurn → startTracking
                                          │
                        ┌─────────────────┴─────────────────┐
                        ▼                                   ▼
                acquireSandbox                     no aiThreadUuid?
                (resume | create+clone)             one-shot, kill
                        │
                        ▼
                runAgentInSandbox (claude [--continue])
                        │
                        ▼
                applyAgentChanges
                  ├─ no changes  → keep existing PR
                  ├─ resume      → push + updatePullRequest
                  └─ fresh       → branch + createPullRequest + persist row
                        │
                        ▼
                releaseSandbox  (pause if resumable, else kill)
\`\`\`

## Test plan

- [x] \`pnpm -F backend typecheck\` clean
- [x] \`pnpm -F backend lint\` clean
- [ ] Manual: first turn opens PR; second turn in same thread pushes additional commit + updates PR title/body in GitHub
- [ ] Manual: kill the sandbox out-of-band, send a follow-up — expect "conversation expired" message and a fresh PR on the next try
- [ ] Behind \`AiWriteback\` feature flag (off by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)