### PR TITLE
feat: add organization domain verification with OTP email flow and SSO routing integration

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -134,6 +134,10 @@ import {
     OrganizationDesignsTableName,
 } from '../database/entities/organizationDesigns';
 import {
+    OrganizationDomainVerificationsTable,
+    OrganizationDomainVerificationsTableName,
+} from '../database/entities/organizationDomainVerifications';
+import {
     OrganizationMembershipsTable,
     OrganizationMembershipsTableName,
 } from '../database/entities/organizationMemberships';
@@ -480,6 +484,7 @@ declare module 'knex/types/tables' {
         [OrganizationAllowedEmailDomainProjectsTableName]: OrganizationAllowedEmailDomainProjectsTable;
         [OrganizationSettingsTableName]: OrganizationSettingsTable;
         [OrganizationSsoConfigurationsTableName]: OrganizationSsoConfigurationsTable;
+        [OrganizationDomainVerificationsTableName]: OrganizationDomainVerificationsTable;
         [ValidationTableName]: ValidationTable;
         [GroupTableName]: GroupTable;
         [GroupMembershipTableName]: GroupMembershipTable;

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -885,6 +885,31 @@ export default class EmailClient {
         });
     }
 
+    async sendDomainVerificationEmail({
+        recipient,
+        passcode,
+        domain,
+    }: {
+        recipient: string;
+        passcode: string;
+        domain: string;
+    }): Promise<void> {
+        const subject = `Verify your domain ${domain}`;
+        const text = `Verify that your organization owns ${domain} by entering the following passcode in Lightdash: ${passcode}`;
+        return this.sendEmail({
+            to: recipient,
+            subject,
+            template: 'domainVerification',
+            context: {
+                passcode,
+                domain,
+                title: subject,
+                host: this.lightdashConfig.siteUrl,
+            },
+            text,
+        });
+    }
+
     public async sendSchedulerModifiedByOtherUserEmail({
         recipient,
         modifyingUserName,

--- a/packages/backend/src/clients/EmailClient/templates/domainVerification.html
+++ b/packages/backend/src/clients/EmailClient/templates/domainVerification.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width" />
+        <meta name="x-apple-disable-message-reformatting" />
+    </head>
+    <body
+        style="
+            min-width: 100%;
+            margin: 0;
+            padding: 0;
+            background-color: #292929;
+            font-family: BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+                Arial, sans-serif;
+        "
+    >
+        <table
+            role="presentation"
+            width="100%"
+            cellpadding="0"
+            cellspacing="0"
+            border="0"
+            style="background-color: #292929"
+        >
+            <tr>
+                <td align="center" style="padding: 40px 16px">
+                    <table
+                        role="presentation"
+                        width="440"
+                        cellpadding="0"
+                        cellspacing="0"
+                        border="0"
+                        style="width: 440px; max-width: 100%"
+                    >
+                        <tr>
+                            <td
+                                style="
+                                    background-color: #7262ff;
+                                    padding: 20px;
+                                    border-radius: 4px 4px 0 0;
+                                "
+                            >
+                                <img
+                                    src="{{logoSrc}}"
+                                    width="122"
+                                    alt="Lightdash"
+                                    style="display: block; border: 0"
+                                />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td
+                                style="
+                                    background-color: #f7f7f9;
+                                    padding: 40px;
+                                    border-radius: 0 0 4px 4px;
+                                    text-align: center;
+                                "
+                            >
+                                <h1
+                                    style="
+                                        margin: 0;
+                                        font-size: 16px;
+                                        font-weight: 500;
+                                        color: #121212;
+                                    "
+                                >
+                                    Verify your domain
+                                </h1>
+                                <p
+                                    style="
+                                        margin: 24px 0 8px;
+                                        font-size: 14px;
+                                        color: #8c8182;
+                                    "
+                                >
+                                    Your one time passcode is:
+                                </p>
+                                <p
+                                    style="
+                                        margin: 0 0 24px;
+                                        font-size: 32px;
+                                        font-weight: 500;
+                                        letter-spacing: 4px;
+                                        color: #7262ff;
+                                    "
+                                >
+                                    {{passcode}}
+                                </p>
+                                <p style="margin: 0; font-size: 14px; color: #8c8182">
+                                    Enter this code in Lightdash to verify that
+                                    your organization owns
+                                    <b>{{domain}}</b>. This code is valid for
+                                    <b>15 minutes</b>. If you didn't request
+                                    this, you can ignore this email.
+                                </p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="padding: 24px; text-align: center">
+                                <a
+                                    href="https://www.lightdash.com/"
+                                    target="_blank"
+                                    style="
+                                        font-size: 12px;
+                                        font-weight: 700;
+                                        color: #878787;
+                                        text-decoration: none;
+                                    "
+                                    >Lightdash</a
+                                >
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </body>
+</html>

--- a/packages/backend/src/database/entities/organizationDomainVerifications.ts
+++ b/packages/backend/src/database/entities/organizationDomainVerifications.ts
@@ -1,0 +1,50 @@
+import { Knex } from 'knex';
+
+export const OrganizationDomainVerificationsTableName =
+    'organization_domain_verifications';
+
+export type DbOrganizationDomainVerification = {
+    domain_verification_uuid: string;
+    organization_uuid: string;
+    domain: string;
+    verified_at: Date | null;
+    verified_by_user_uuid: string | null;
+    passcode: string | null;
+    passcode_created_at: Date | null;
+    number_of_attempts: number;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DbOrganizationDomainVerificationIn = Pick<
+    DbOrganizationDomainVerification,
+    'organization_uuid' | 'domain'
+> &
+    Partial<
+        Pick<
+            DbOrganizationDomainVerification,
+            | 'verified_at'
+            | 'verified_by_user_uuid'
+            | 'passcode'
+            | 'passcode_created_at'
+            | 'number_of_attempts'
+        >
+    >;
+
+export type DbOrganizationDomainVerificationUpdate = Partial<
+    Pick<
+        DbOrganizationDomainVerification,
+        | 'verified_at'
+        | 'verified_by_user_uuid'
+        | 'passcode'
+        | 'passcode_created_at'
+        | 'number_of_attempts'
+        | 'updated_at'
+    >
+>;
+
+export type OrganizationDomainVerificationsTable = Knex.CompositeTableType<
+    DbOrganizationDomainVerification,
+    DbOrganizationDomainVerificationIn,
+    DbOrganizationDomainVerificationUpdate
+>;

--- a/packages/backend/src/database/migrations/20260527140753_create_organization_domain_verifications.ts
+++ b/packages/backend/src/database/migrations/20260527140753_create_organization_domain_verifications.ts
@@ -1,0 +1,63 @@
+import { Knex } from 'knex';
+
+const ORGANIZATION_DOMAIN_VERIFICATIONS_TABLE =
+    'organization_domain_verifications';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(
+        ORGANIZATION_DOMAIN_VERIFICATIONS_TABLE,
+        (table) => {
+            table
+                .uuid('domain_verification_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+            table
+                .uuid('organization_uuid')
+                .notNullable()
+                .references('organization_uuid')
+                .inTable('organizations')
+                .onDelete('CASCADE')
+                .index();
+            table.string('domain').notNullable();
+            // null while a challenge is pending; set once the domain is verified
+            table.timestamp('verified_at', { useTz: false }).nullable();
+            table
+                .uuid('verified_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('SET NULL')
+                .index();
+            // bcrypt hash of the pending passcode, cleared once verified
+            table.string('passcode').nullable();
+            table.timestamp('passcode_created_at', { useTz: false }).nullable();
+            table.integer('number_of_attempts').notNullable().defaultTo(0);
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .timestamp('updated_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+
+            // One row per org+domain (pending or verified)
+            table.unique(['organization_uuid', 'domain']);
+        },
+    );
+
+    // Globally unique verified domains — first organization to verify a domain
+    // owns it. Partial index so multiple orgs can have pending challenges for
+    // the same domain, but only one can hold the verified row.
+    await knex.raw(
+        `CREATE UNIQUE INDEX organization_domain_verifications_verified_domain_unique
+         ON ${ORGANIZATION_DOMAIN_VERIFICATIONS_TABLE} (domain)
+         WHERE verified_at IS NOT NULL`,
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(
+        ORGANIZATION_DOMAIN_VERIFICATIONS_TABLE,
+    );
+}

--- a/packages/backend/src/ee/controllers/OrganizationDomainVerificationController.ts
+++ b/packages/backend/src/ee/controllers/OrganizationDomainVerificationController.ts
@@ -1,0 +1,125 @@
+import {
+    ApiDomainVerificationStatusResponse,
+    ApiErrorPayload,
+    ApiSuccessEmpty,
+    ApiVerifiedDomainsResponse,
+    assertRegisteredAccount,
+    ConfirmDomainVerification,
+    RequestDomainVerification,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Request,
+    Response,
+    Route,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+
+@Route('/api/v1/org/domains')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Organizations')
+export class OrganizationDomainVerificationController extends BaseController {
+    /**
+     * Lists the domains the current organization has verified ownership of.
+     * @summary List verified domains
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/')
+    @OperationId('ListVerifiedDomains')
+    async listVerifiedDomains(
+        @Request() req: express.Request,
+    ): Promise<ApiVerifiedDomainsResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationDomainVerificationService()
+            .listVerifiedDomains(req.account);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Sends a one-time passcode to an address at the domain to begin verifying
+     * ownership. The domain must not be a public email provider and must not
+     * already be verified by another organization.
+     * @summary Request domain verification
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Post('/verify')
+    @OperationId('RequestDomainVerification')
+    async requestVerification(
+        @Request() req: express.Request,
+        @Body() body: RequestDomainVerification,
+    ): Promise<ApiDomainVerificationStatusResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationDomainVerificationService()
+            .requestVerification(req.account, body);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Confirms a domain verification passcode. On success the domain is marked
+     * verified for the organization.
+     * @summary Confirm domain verification
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Post('/confirm')
+    @OperationId('ConfirmDomainVerification')
+    async confirmVerification(
+        @Request() req: express.Request,
+        @Body() body: ConfirmDomainVerification,
+    ): Promise<ApiDomainVerificationStatusResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationDomainVerificationService()
+            .confirmVerification(req.account, body);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Removes a verified domain and strips it from any SSO provider that routed
+     * to it.
+     * @summary Delete verified domain
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Delete('/{domain}')
+    @OperationId('DeleteVerifiedDomain')
+    async deleteVerifiedDomain(
+        @Request() req: express.Request,
+        @Path() domain: string,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getOrganizationDomainVerificationService()
+            .deleteVerifiedDomain(req.account, domain);
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -141,6 +141,8 @@ import { EmbedController } from './../ee/controllers/embedController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ManagedAgentController } from './../ee/controllers/managedAgentController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { OrganizationDomainVerificationController } from './../ee/controllers/OrganizationDomainVerificationController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationSsoController } from './../ee/controllers/OrganizationSsoController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationWarehouseCredentialsController } from './../ee/controllers/OrganizationWarehouseCredentialsController';
@@ -11715,6 +11717,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['editContent'] },
                 { dataType: 'enum', enums: ['improveContext'] },
                 { dataType: 'enum', enums: ['loadSkill'] },
+                { dataType: 'enum', enums: ['proposeWriteback'] },
                 { dataType: 'enum', enums: ['runSavedChart'] },
                 { dataType: 'enum', enums: ['listWarehouseTables'] },
                 { dataType: 'enum', enums: ['describeWarehouseTable'] },
@@ -12430,11 +12433,11 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -17247,6 +17250,148 @@ const models: TsoaRoute.Models = {
         type: { ref: 'Partial_OrganizationSsoMethodFlags_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VerifiedDomain: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                verifiedByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                verifiedAt: { dataType: 'datetime', required: true },
+                domain: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiVerifiedDomainsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'VerifiedDomain' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmailOneTimePassword: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                numberOfAttempts: { dataType: 'double', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_EmailStatusExpiring.otp_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                otp: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'intersection',
+                            subSchemas: [
+                                { ref: 'EmailOneTimePassword' },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        isMaxAttempts: {
+                                            dataType: 'boolean',
+                                            required: true,
+                                        },
+                                        isExpired: {
+                                            dataType: 'boolean',
+                                            required: true,
+                                        },
+                                        expiresAt: {
+                                            dataType: 'datetime',
+                                            required: true,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        { dataType: 'undefined' },
+                    ],
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DomainVerificationStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Pick_EmailStatusExpiring.otp_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        isVerified: { dataType: 'boolean', required: true },
+                        domain: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDomainVerificationStatusResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'DomainVerificationStatus', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RequestDomainVerification: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                challengeEmail: { dataType: 'string', required: true },
+                domain: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ConfirmDomainVerification: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                passcode: { dataType: 'string', required: true },
+                domain: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Role: {
         dataType: 'refAlias',
         type: {
@@ -18388,18 +18533,6 @@ const models: TsoaRoute.Models = {
                 { ref: 'ActivateUserWithInviteCode' },
                 { ref: 'CreateUserArgs' },
             ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    EmailOneTimePassword: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                numberOfAttempts: { dataType: 'double', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-            },
             validators: {},
         },
     },
@@ -44699,6 +44832,256 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'deleteGoogleConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationDomainVerificationController_listVerifiedDomains: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/org/domains',
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationDomainVerificationController,
+        ),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationDomainVerificationController.prototype
+                .listVerifiedDomains,
+        ),
+
+        async function OrganizationDomainVerificationController_listVerifiedDomains(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationDomainVerificationController_listVerifiedDomains,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationDomainVerificationController>(
+                        OrganizationDomainVerificationController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listVerifiedDomains',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationDomainVerificationController_requestVerification: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'RequestDomainVerification',
+        },
+    };
+    app.post(
+        '/api/v1/org/domains/verify',
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationDomainVerificationController,
+        ),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationDomainVerificationController.prototype
+                .requestVerification,
+        ),
+
+        async function OrganizationDomainVerificationController_requestVerification(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationDomainVerificationController_requestVerification,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationDomainVerificationController>(
+                        OrganizationDomainVerificationController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'requestVerification',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationDomainVerificationController_confirmVerification: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ConfirmDomainVerification',
+        },
+    };
+    app.post(
+        '/api/v1/org/domains/confirm',
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationDomainVerificationController,
+        ),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationDomainVerificationController.prototype
+                .confirmVerification,
+        ),
+
+        async function OrganizationDomainVerificationController_confirmVerification(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationDomainVerificationController_confirmVerification,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationDomainVerificationController>(
+                        OrganizationDomainVerificationController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'confirmVerification',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationDomainVerificationController_deleteVerifiedDomain: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        domain: {
+            in: 'path',
+            name: 'domain',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.delete(
+        '/api/v1/org/domains/:domain',
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationDomainVerificationController,
+        ),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationDomainVerificationController.prototype
+                .deleteVerifiedDomain,
+        ),
+
+        async function OrganizationDomainVerificationController_deleteVerifiedDomain(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationDomainVerificationController_deleteVerifiedDomain,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationDomainVerificationController>(
+                        OrganizationDomainVerificationController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteVerifiedDomain',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13294,6 +13294,7 @@
                     "editContent",
                     "improveContext",
                     "loadSkill",
+                    "proposeWriteback",
                     "runSavedChart",
                     "listWarehouseTables",
                     "describeWarehouseTable",
@@ -13647,8 +13648,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "rejected",
                                                             "success",
+                                                            "rejected",
                                                             "timeout"
                                                         ]
                                                     }
@@ -18214,6 +18215,158 @@
             "UpsertGoogleSsoConfig": {
                 "$ref": "#/components/schemas/Partial_OrganizationSsoMethodFlags_"
             },
+            "VerifiedDomain": {
+                "properties": {
+                    "verifiedByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "verifiedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "domain": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "verifiedByUserUuid",
+                    "verifiedAt",
+                    "domain",
+                    "organizationUuid"
+                ],
+                "type": "object",
+                "description": "A domain an organization has proven it owns (via a one-time passcode sent to\nan address at the domain). Verified domains are globally unique — the first\norganization to verify a domain owns it."
+            },
+            "ApiVerifiedDomainsResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/VerifiedDomain"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "EmailOneTimePassword": {
+                "properties": {
+                    "numberOfAttempts": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "Number of times the passcode has been attempted"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Time that the passcode was created"
+                    }
+                },
+                "required": ["numberOfAttempts", "createdAt"],
+                "type": "object"
+            },
+            "Pick_EmailStatusExpiring.otp_": {
+                "properties": {
+                    "otp": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/EmailOneTimePassword"
+                            },
+                            {
+                                "properties": {
+                                    "isMaxAttempts": {
+                                        "type": "boolean"
+                                    },
+                                    "isExpired": {
+                                        "type": "boolean"
+                                    },
+                                    "expiresAt": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    }
+                                },
+                                "required": [
+                                    "isMaxAttempts",
+                                    "isExpired",
+                                    "expiresAt"
+                                ],
+                                "type": "object"
+                            }
+                        ],
+                        "description": "One time passcode information\nIf there is no active passcode, this will be undefined"
+                    }
+                },
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "DomainVerificationStatus": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_EmailStatusExpiring.otp_"
+                    },
+                    {
+                        "properties": {
+                            "isVerified": {
+                                "type": "boolean"
+                            },
+                            "domain": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["isVerified", "domain"],
+                        "type": "object"
+                    }
+                ],
+                "description": "Verification status of a single domain. Mirrors {@link EmailStatusExpiring}:\n`otp` is present only while a pending one-time passcode challenge exists."
+            },
+            "ApiDomainVerificationStatusResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/DomainVerificationStatus"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "RequestDomainVerification": {
+                "properties": {
+                    "challengeEmail": {
+                        "type": "string"
+                    },
+                    "domain": {
+                        "type": "string"
+                    }
+                },
+                "required": ["challengeEmail", "domain"],
+                "type": "object",
+                "description": "Request to verify a domain. `challengeEmail` must be an address at `domain`;\na one-time passcode is sent there and confirmed via\n{@link ConfirmDomainVerification}."
+            },
+            "ConfirmDomainVerification": {
+                "properties": {
+                    "passcode": {
+                        "type": "string"
+                    },
+                    "domain": {
+                        "type": "string"
+                    }
+                },
+                "required": ["passcode", "domain"],
+                "type": "object"
+            },
             "Role": {
                 "properties": {
                     "updatedAt": {
@@ -19324,22 +19477,6 @@
                         "$ref": "#/components/schemas/CreateUserArgs"
                     }
                 ]
-            },
-            "EmailOneTimePassword": {
-                "properties": {
-                    "numberOfAttempts": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "Number of times the passcode has been attempted"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Time that the passcode was created"
-                    }
-                },
-                "required": ["numberOfAttempts", "createdAt"],
-                "type": "object"
             },
             "EmailStatus": {
                 "properties": {
@@ -35219,7 +35356,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3022.1",
+        "version": "0.3024.4",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -40593,6 +40730,163 @@
                 "tags": ["Organizations"],
                 "security": [],
                 "parameters": []
+            }
+        },
+        "/api/v1/org/domains": {
+            "get": {
+                "operationId": "ListVerifiedDomains",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiVerifiedDomainsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Lists the domains the current organization has verified ownership of.",
+                "summary": "List verified domains",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/org/domains/verify": {
+            "post": {
+                "operationId": "RequestDomainVerification",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDomainVerificationStatusResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Sends a one-time passcode to an address at the domain to begin verifying\nownership. The domain must not be a public email provider and must not\nalready be verified by another organization.",
+                "summary": "Request domain verification",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RequestDomainVerification"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/domains/confirm": {
+            "post": {
+                "operationId": "ConfirmDomainVerification",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDomainVerificationStatusResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Confirms a domain verification passcode. On success the domain is marked\nverified for the organization.",
+                "summary": "Confirm domain verification",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ConfirmDomainVerification"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/domains/{domain}": {
+            "delete": {
+                "operationId": "DeleteVerifiedDomain",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Removes a verified domain and strips it from any SSO provider that routed\nto it.",
+                "summary": "Delete verified domain",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "domain",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v2/orgs/{orgUuid}/roles": {

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -30,6 +30,7 @@ import { OnboardingModel } from './OnboardingModel/OnboardingModel';
 import { OpenIdIdentityModel } from './OpenIdIdentitiesModel';
 import { OrganizationAllowedEmailDomainsModel } from './OrganizationAllowedEmailDomainsModel';
 import { OrganizationDesignModel } from './OrganizationDesignModel';
+import { OrganizationDomainVerificationModel } from './OrganizationDomainVerificationModel';
 import { OrganizationMemberProfileModel } from './OrganizationMemberProfileModel';
 import { OrganizationModel } from './OrganizationModel';
 import { OrganizationSettingsModel } from './OrganizationSettingsModel';
@@ -94,6 +95,7 @@ export type ModelManifest = {
     organizationDesignModel: OrganizationDesignModel;
     organizationMemberProfileModel: OrganizationMemberProfileModel;
     organizationModel: OrganizationModel;
+    organizationDomainVerificationModel: OrganizationDomainVerificationModel;
     organizationSettingsModel: OrganizationSettingsModel;
     organizationSsoModel: OrganizationSsoModel;
     organizationWarehouseCredentialsModel: OrganizationWarehouseCredentialsModel;
@@ -421,6 +423,16 @@ export class ModelRepository
         return this.getModel(
             'organizationModel',
             () => new OrganizationModel(this.database, this.lightdashConfig),
+        );
+    }
+
+    public getOrganizationDomainVerificationModel(): OrganizationDomainVerificationModel {
+        return this.getModel(
+            'organizationDomainVerificationModel',
+            () =>
+                new OrganizationDomainVerificationModel({
+                    database: this.database,
+                }),
         );
     }
 

--- a/packages/backend/src/models/OrganizationDomainVerificationModel.ts
+++ b/packages/backend/src/models/OrganizationDomainVerificationModel.ts
@@ -1,0 +1,212 @@
+import { NotFoundError, VerifiedDomain } from '@lightdash/common';
+import bcrypt from 'bcrypt';
+import { Knex } from 'knex';
+import {
+    DbOrganizationDomainVerification,
+    OrganizationDomainVerificationsTableName,
+} from '../database/entities/organizationDomainVerifications';
+
+const mapVerifiedDomain = (
+    row: DbOrganizationDomainVerification,
+): VerifiedDomain => ({
+    organizationUuid: row.organization_uuid,
+    domain: row.domain,
+    // Only verified rows are mapped, so verified_at is non-null.
+    verifiedAt: row.verified_at!,
+    verifiedByUserUuid: row.verified_by_user_uuid,
+});
+
+/**
+ * Pending OTP challenge for a domain — the fields needed to confirm a passcode.
+ */
+type PendingChallenge = {
+    passcode: string | null;
+    createdAt: Date | null;
+    numberOfAttempts: number;
+};
+
+export class OrganizationDomainVerificationModel {
+    readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    /** Verified domains owned by an organization. */
+    async findVerifiedDomains(
+        organizationUuid: string,
+    ): Promise<VerifiedDomain[]> {
+        const rows = await this.database(
+            OrganizationDomainVerificationsTableName,
+        )
+            .where('organization_uuid', organizationUuid)
+            .whereNotNull('verified_at')
+            .orderBy('domain');
+        return rows.map(mapVerifiedDomain);
+    }
+
+    async findByOrgAndDomain(
+        organizationUuid: string,
+        domain: string,
+    ): Promise<DbOrganizationDomainVerification | undefined> {
+        return this.database(OrganizationDomainVerificationsTableName)
+            .where('organization_uuid', organizationUuid)
+            .andWhere('domain', domain.toLowerCase())
+            .first();
+    }
+
+    /**
+     * The organization that owns a verified domain, if any. Used to enforce
+     * global first-verified-wins before issuing a new challenge.
+     */
+    async findVerifiedDomainOwner(
+        domain: string,
+    ): Promise<{ organizationUuid: string } | undefined> {
+        const row = await this.database(
+            OrganizationDomainVerificationsTableName,
+        )
+            .where('domain', domain.toLowerCase())
+            .whereNotNull('verified_at')
+            .first('organization_uuid');
+        return row ? { organizationUuid: row.organization_uuid } : undefined;
+    }
+
+    /**
+     * Creates or refreshes a pending OTP challenge for an org+domain. The
+     * passcode is bcrypt-hashed before storage and the attempt counter / clock
+     * are reset, mirroring {@link EmailModel.createPrimaryEmailOtp}.
+     */
+    async upsertChallenge({
+        organizationUuid,
+        domain,
+        passcode,
+    }: {
+        organizationUuid: string;
+        domain: string;
+        passcode: string;
+    }): Promise<{ createdAt: Date; numberOfAttempts: number }> {
+        const hashedPasscode = await bcrypt.hash(
+            passcode,
+            await bcrypt.genSalt(),
+        );
+        const now = new Date();
+        const [row] = await this.database(
+            OrganizationDomainVerificationsTableName,
+        )
+            .insert({
+                organization_uuid: organizationUuid,
+                domain: domain.toLowerCase(),
+                passcode: hashedPasscode,
+                passcode_created_at: now,
+                number_of_attempts: 0,
+            })
+            .onConflict(['organization_uuid', 'domain'])
+            .merge({
+                passcode: hashedPasscode,
+                passcode_created_at: now,
+                number_of_attempts: 0,
+                updated_at: now,
+            })
+            .returning(['passcode_created_at', 'number_of_attempts']);
+        return {
+            createdAt: row.passcode_created_at ?? now,
+            numberOfAttempts: row.number_of_attempts,
+        };
+    }
+
+    /**
+     * Compares a passcode against the stored hash for an org+domain's pending
+     * challenge. Throws {@link NotFoundError} when there is no pending challenge
+     * or the passcode does not match (mirrors
+     * {@link EmailModel.getPrimaryEmailStatusByUserAndOtp}). On match, returns
+     * the challenge clock + attempts so the caller can check expiry/lockout.
+     */
+    async verifyChallengePasscode({
+        organizationUuid,
+        domain,
+        passcode,
+    }: {
+        organizationUuid: string;
+        domain: string;
+        passcode: string;
+    }): Promise<{ createdAt: Date; numberOfAttempts: number }> {
+        const row = await this.database(
+            OrganizationDomainVerificationsTableName,
+        )
+            .where('organization_uuid', organizationUuid)
+            .andWhere('domain', domain.toLowerCase())
+            .whereNull('verified_at')
+            .first<PendingChallenge | undefined>(
+                'passcode',
+                this.database.ref('passcode_created_at').as('createdAt'),
+                this.database.ref('number_of_attempts').as('numberOfAttempts'),
+            );
+        const match =
+            row !== undefined &&
+            row.createdAt !== null &&
+            (await bcrypt.compare(passcode, row.passcode ?? ''));
+        if (!match || !row || row.createdAt === null) {
+            throw new NotFoundError(
+                'No matching domain verification challenge',
+            );
+        }
+        return {
+            createdAt: row.createdAt,
+            numberOfAttempts: row.numberOfAttempts,
+        };
+    }
+
+    async incrementChallengeAttempts({
+        organizationUuid,
+        domain,
+    }: {
+        organizationUuid: string;
+        domain: string;
+    }): Promise<void> {
+        await this.database(OrganizationDomainVerificationsTableName)
+            .where('organization_uuid', organizationUuid)
+            .andWhere('domain', domain.toLowerCase())
+            .whereNull('verified_at')
+            .increment('number_of_attempts', 1);
+    }
+
+    /**
+     * Marks an existing pending challenge as verified. Relies on the partial
+     * unique index `UNIQUE(domain) WHERE verified_at IS NOT NULL` to reject the
+     * write if another organization verified the domain first — the caller
+     * should translate that DB conflict into a friendly error.
+     */
+    async markChallengeVerified({
+        organizationUuid,
+        domain,
+        verifiedByUserUuid,
+    }: {
+        organizationUuid: string;
+        domain: string;
+        verifiedByUserUuid: string;
+    }): Promise<void> {
+        await this.database(OrganizationDomainVerificationsTableName)
+            .where('organization_uuid', organizationUuid)
+            .andWhere('domain', domain.toLowerCase())
+            .update({
+                verified_at: new Date(),
+                verified_by_user_uuid: verifiedByUserUuid,
+                passcode: null,
+                passcode_created_at: null,
+                updated_at: new Date(),
+            });
+    }
+
+    async deleteVerification({
+        organizationUuid,
+        domain,
+    }: {
+        organizationUuid: string;
+        domain: string;
+    }): Promise<void> {
+        await this.database(OrganizationDomainVerificationsTableName)
+            .where('organization_uuid', organizationUuid)
+            .andWhere('domain', domain.toLowerCase())
+            .delete();
+    }
+}

--- a/packages/backend/src/models/OrganizationSsoModel.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.ts
@@ -9,6 +9,7 @@ import {
     UnexpectedServerError,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { OrganizationDomainVerificationsTableName } from '../database/entities/organizationDomainVerifications';
 import { OrganizationSsoConfigurationsTableName } from '../database/entities/organizationSsoConfigurations';
 import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
 
@@ -44,7 +45,31 @@ export type OrganizationGoogleMethod = {
     allowPassword: boolean;
 };
 
-const ALLOWED_EMAIL_DOMAINS_TABLE = 'organization_allowed_email_domains';
+/**
+ * Restricts an SSO-config query to rows whose organization has verified the
+ * given (already-normalized) domain. Uses an EXISTS against
+ * {@link OrganizationDomainVerificationsTableName}, which has a partial unique
+ * index on `(domain) WHERE verified_at IS NOT NULL` — so this is an indexed
+ * lookup that resolves the domain to at most one owning organization.
+ */
+const verifiedDomainExists =
+    (database: Knex, normalized: string) => (builder: Knex.QueryBuilder) => {
+        void builder.whereExists((qb) => {
+            void qb
+                .select(database.raw('1'))
+                .from(OrganizationDomainVerificationsTableName)
+                .whereRaw(
+                    `${OrganizationDomainVerificationsTableName}.organization_uuid = ${OrganizationSsoConfigurationsTableName}.organization_uuid`,
+                )
+                .andWhere(
+                    `${OrganizationDomainVerificationsTableName}.domain`,
+                    normalized,
+                )
+                .whereNotNull(
+                    `${OrganizationDomainVerificationsTableName}.verified_at`,
+                );
+        });
+    };
 
 export class OrganizationSsoModel {
     private readonly database: Knex;
@@ -95,16 +120,21 @@ export class OrganizationSsoModel {
     }
 
     /**
-     * Restricts a query to rows whose effective whitelist includes the given
-     * (already-normalized) domain. The "effective whitelist" is the row's own
-     * `email_domains` when `override_email_domains = true`, else the org's
-     * `allowed_email_domains` list. Assumes the query has already left-joined
-     * {@link ALLOWED_EMAIL_DOMAINS_TABLE}.
+     * Restricts a query to rows that route the given (already-normalized,
+     * already-verified) domain. When `override_email_domains = false` the
+     * method routes ALL of the org's verified domains, so it matches; when
+     * `true` the domain must be in the method's own `email_domains` subset.
+     * Pair with {@link verifiedDomainExists}, which guarantees the domain is
+     * verified for the org in the first place.
      */
     private static emailDomainMatchClause(normalized: string) {
         return (builder: Knex.QueryBuilder) => {
             void builder
-                .where((subOverride) => {
+                .where(
+                    `${OrganizationSsoConfigurationsTableName}.override_email_domains`,
+                    false,
+                )
+                .orWhere((subOverride) => {
                     void subOverride
                         .where(
                             `${OrganizationSsoConfigurationsTableName}.override_email_domains`,
@@ -114,36 +144,22 @@ export class OrganizationSsoModel {
                             `? = ANY (${OrganizationSsoConfigurationsTableName}.email_domains)`,
                             [normalized],
                         );
-                })
-                .orWhere((subInherit) => {
-                    void subInherit
-                        .where(
-                            `${OrganizationSsoConfigurationsTableName}.override_email_domains`,
-                            false,
-                        )
-                        .whereRaw(
-                            `? = ANY (${ALLOWED_EMAIL_DOMAINS_TABLE}.email_domains)`,
-                            [normalized],
-                        );
                 });
         };
     }
 
     /**
-     * Finds all enabled SSO methods whose effective whitelist includes the
-     * email's domain.
+     * Finds all enabled SSO methods that route the email's domain — i.e. the
+     * domain is verified for the method's org and (for override methods) is in
+     * the method's subset.
      */
     async findEnabledMethodsForEmailDomain(
         emailDomain: string,
     ): Promise<OrganizationSsoMethod<OrganizationSsoProvider>[]> {
         const normalized = emailDomain.toLowerCase();
         const rows = await this.database(OrganizationSsoConfigurationsTableName)
-            .leftJoin(
-                ALLOWED_EMAIL_DOMAINS_TABLE,
-                `${OrganizationSsoConfigurationsTableName}.organization_uuid`,
-                `${ALLOWED_EMAIL_DOMAINS_TABLE}.organization_uuid`,
-            )
             .where(`${OrganizationSsoConfigurationsTableName}.enabled`, true)
+            .andWhere(verifiedDomainExists(this.database, normalized))
             .andWhere(OrganizationSsoModel.emailDomainMatchClause(normalized))
             .select(`${OrganizationSsoConfigurationsTableName}.*`);
 
@@ -171,15 +187,11 @@ export class OrganizationSsoModel {
     ): Promise<OrganizationGoogleMethod[]> {
         const normalized = emailDomain.toLowerCase();
         const rows = await this.database(OrganizationSsoConfigurationsTableName)
-            .leftJoin(
-                ALLOWED_EMAIL_DOMAINS_TABLE,
-                `${OrganizationSsoConfigurationsTableName}.organization_uuid`,
-                `${ALLOWED_EMAIL_DOMAINS_TABLE}.organization_uuid`,
-            )
             .where(
                 `${OrganizationSsoConfigurationsTableName}.provider`,
                 OrganizationSsoProvider.GOOGLE,
             )
+            .andWhere(verifiedDomainExists(this.database, normalized))
             .andWhere(OrganizationSsoModel.emailDomainMatchClause(normalized))
             .select(`${OrganizationSsoConfigurationsTableName}.*`);
 

--- a/packages/backend/src/services/OrganizationDomainVerificationService/OrganizationDomainVerificationService.ts
+++ b/packages/backend/src/services/OrganizationDomainVerificationService/OrganizationDomainVerificationService.ts
@@ -1,0 +1,337 @@
+import { subject } from '@casl/ability';
+import {
+    DomainVerificationStatus,
+    FeatureFlags,
+    ForbiddenError,
+    getEmailDomain,
+    isPublicEmailProviderDomain,
+    isValidEmailAddress,
+    NotFoundError,
+    ParameterError,
+    VerifiedDomain,
+    type RegisteredAccount,
+} from '@lightdash/common';
+import EmailClient from '../../clients/EmailClient/EmailClient';
+import { LightdashConfig } from '../../config/parseConfig';
+import { DbOrganizationDomainVerification } from '../../database/entities/organizationDomainVerifications';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
+import { OrganizationDomainVerificationModel } from '../../models/OrganizationDomainVerificationModel';
+import {
+    generateOneTimePasscode,
+    isOtpExpired,
+    isOtpMaxAttempts,
+    otpExpirationDate,
+    resendCooldownRemainingSeconds,
+} from '../../utils/oneTimePasscode';
+import { BaseService } from '../BaseService';
+
+type OrganizationDomainVerificationServiceArguments = {
+    lightdashConfig: LightdashConfig;
+    organizationDomainVerificationModel: OrganizationDomainVerificationModel;
+    featureFlagModel: FeatureFlagModel;
+    emailClient: EmailClient;
+};
+
+// Same shape check used by OrganizationSsoService — guards against typos like
+// trailing dots or whitespace inside the domain.
+const VALID_DOMAIN_REGEX =
+    /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+const isUniqueViolation = (error: unknown): boolean =>
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { code?: string }).code === '23505';
+
+export class OrganizationDomainVerificationService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly organizationDomainVerificationModel: OrganizationDomainVerificationModel;
+
+    private readonly featureFlagModel: FeatureFlagModel;
+
+    private readonly emailClient: EmailClient;
+
+    constructor({
+        lightdashConfig,
+        organizationDomainVerificationModel,
+        featureFlagModel,
+        emailClient,
+    }: OrganizationDomainVerificationServiceArguments) {
+        super({ serviceName: 'OrganizationDomainVerificationService' });
+        this.lightdashConfig = lightdashConfig;
+        this.organizationDomainVerificationModel =
+            organizationDomainVerificationModel;
+        this.featureFlagModel = featureFlagModel;
+        this.emailClient = emailClient;
+    }
+
+    /**
+     * Domain verification gates the per-organization SSO settings, so it shares
+     * the same feature flag.
+     */
+    private async assertFeatureEnabled(
+        account: RegisteredAccount,
+    ): Promise<void> {
+        const flag = await this.featureFlagModel.get({
+            user: {
+                userUuid: account.user.userUuid,
+                organizationUuid: account.organization?.organizationUuid,
+                organizationName: account.organization?.name,
+            },
+            featureFlagId: FeatureFlags.SsoOrganizationSettings,
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError(
+                'Per-organization SSO settings are not enabled for this organization',
+            );
+        }
+    }
+
+    private assertCanManageOrganization(account: RegisteredAccount): string {
+        const organizationUuid = account.organization?.organizationUuid;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        return organizationUuid;
+    }
+
+    private static normalizeDomain(domain: string): string {
+        const normalized = domain.trim().toLowerCase();
+        if (!VALID_DOMAIN_REGEX.test(normalized)) {
+            throw new ParameterError(`Invalid domain format: ${domain}`);
+        }
+        if (isPublicEmailProviderDomain(normalized)) {
+            throw new ParameterError(
+                `${normalized} is a public email provider and can't be verified. Use a domain that identifies your organization.`,
+            );
+        }
+        return normalized;
+    }
+
+    private static toStatus(
+        row: DbOrganizationDomainVerification,
+    ): DomainVerificationStatus {
+        const isVerified = row.verified_at !== null;
+        const createdAt = row.passcode_created_at;
+        return {
+            domain: row.domain,
+            isVerified,
+            otp:
+                !isVerified && createdAt
+                    ? {
+                          createdAt,
+                          numberOfAttempts: row.number_of_attempts,
+                          expiresAt: otpExpirationDate(createdAt),
+                          isExpired: isOtpExpired(createdAt),
+                          isMaxAttempts: isOtpMaxAttempts(
+                              row.number_of_attempts,
+                          ),
+                      }
+                    : undefined,
+        };
+    }
+
+    async listVerifiedDomains(
+        account: RegisteredAccount,
+    ): Promise<VerifiedDomain[]> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageOrganization(account);
+        return this.organizationDomainVerificationModel.findVerifiedDomains(
+            organizationUuid,
+        );
+    }
+
+    /**
+     * Sends a one-time passcode to an address at the domain. Rejects public
+     * providers and domains already verified by another organization.
+     */
+    async requestVerification(
+        account: RegisteredAccount,
+        { domain, challengeEmail }: { domain: string; challengeEmail: string },
+    ): Promise<DomainVerificationStatus> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageOrganization(account);
+        const normalizedDomain =
+            OrganizationDomainVerificationService.normalizeDomain(domain);
+
+        const trimmedChallengeEmail = challengeEmail.trim();
+        if (!isValidEmailAddress(trimmedChallengeEmail)) {
+            throw new ParameterError(
+                `${challengeEmail} is not a valid email address`,
+            );
+        }
+        let challengeEmailDomain: string;
+        try {
+            challengeEmailDomain = getEmailDomain(trimmedChallengeEmail);
+        } catch {
+            throw new ParameterError(
+                `${challengeEmail} is not a valid email address`,
+            );
+        }
+        if (challengeEmailDomain !== normalizedDomain) {
+            throw new ParameterError(
+                `The verification email must be an address at ${normalizedDomain}`,
+            );
+        }
+
+        const owner =
+            await this.organizationDomainVerificationModel.findVerifiedDomainOwner(
+                normalizedDomain,
+            );
+        if (owner && owner.organizationUuid !== organizationUuid) {
+            throw new ParameterError(
+                `${normalizedDomain} has already been verified by another organization.`,
+            );
+        }
+
+        const existing =
+            await this.organizationDomainVerificationModel.findByOrgAndDomain(
+                organizationUuid,
+                normalizedDomain,
+            );
+        if (existing?.verified_at) {
+            // Already verified by this organization — nothing to do.
+            return OrganizationDomainVerificationService.toStatus(existing);
+        }
+        // Throttle resends: a fresh code can't be minted until the cooldown
+        // since the last one has elapsed.
+        if (existing?.passcode_created_at) {
+            const wait = resendCooldownRemainingSeconds(
+                existing.passcode_created_at,
+            );
+            if (wait > 0) {
+                throw new ParameterError(
+                    `Please wait ${wait} second${
+                        wait === 1 ? '' : 's'
+                    } before requesting another code.`,
+                );
+            }
+        }
+
+        const passcode = generateOneTimePasscode(this.lightdashConfig.mode);
+        const { createdAt, numberOfAttempts } =
+            await this.organizationDomainVerificationModel.upsertChallenge({
+                organizationUuid,
+                domain: normalizedDomain,
+                passcode,
+            });
+        await this.emailClient.sendDomainVerificationEmail({
+            recipient: trimmedChallengeEmail,
+            passcode,
+            domain: normalizedDomain,
+        });
+
+        return {
+            domain: normalizedDomain,
+            isVerified: false,
+            otp: {
+                createdAt,
+                numberOfAttempts,
+                expiresAt: otpExpirationDate(createdAt),
+                isExpired: isOtpExpired(createdAt),
+                isMaxAttempts: isOtpMaxAttempts(numberOfAttempts),
+            },
+        };
+    }
+
+    /**
+     * Confirms a passcode. On a valid, non-expired, non-locked-out passcode the
+     * domain is marked verified; a wrong code increments the attempt counter.
+     * Mirrors {@link UserService.getPrimaryEmailStatus}.
+     */
+    async confirmVerification(
+        account: RegisteredAccount,
+        { domain, passcode }: { domain: string; passcode: string },
+    ): Promise<DomainVerificationStatus> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageOrganization(account);
+        const normalizedDomain =
+            OrganizationDomainVerificationService.normalizeDomain(domain);
+
+        try {
+            const challenge =
+                await this.organizationDomainVerificationModel.verifyChallengePasscode(
+                    {
+                        organizationUuid,
+                        domain: normalizedDomain,
+                        passcode,
+                    },
+                );
+            if (
+                !isOtpExpired(challenge.createdAt) &&
+                !isOtpMaxAttempts(challenge.numberOfAttempts)
+            ) {
+                try {
+                    await this.organizationDomainVerificationModel.markChallengeVerified(
+                        {
+                            organizationUuid,
+                            domain: normalizedDomain,
+                            verifiedByUserUuid: account.user.userUuid,
+                        },
+                    );
+                } catch (error) {
+                    if (isUniqueViolation(error)) {
+                        throw new ParameterError(
+                            `${normalizedDomain} has already been verified by another organization.`,
+                        );
+                    }
+                    throw error;
+                }
+            }
+        } catch (error) {
+            // Wrong/expired passcode — count the attempt, mirroring email OTP.
+            if (error instanceof NotFoundError) {
+                await this.organizationDomainVerificationModel.incrementChallengeAttempts(
+                    {
+                        organizationUuid,
+                        domain: normalizedDomain,
+                    },
+                );
+            } else {
+                throw error;
+            }
+        }
+
+        const row =
+            await this.organizationDomainVerificationModel.findByOrgAndDomain(
+                organizationUuid,
+                normalizedDomain,
+            );
+        if (!row) {
+            throw new NotFoundError(
+                `No verification in progress for ${normalizedDomain}`,
+            );
+        }
+        return OrganizationDomainVerificationService.toStatus(row);
+    }
+
+    /**
+     * Removes a verified (or pending) domain. SSO routing re-validates against
+     * the verified registry on every login, so any stale entry left in a
+     * provider's `email_domains` subset is inert (it can't route a domain that
+     * is no longer verified) — no cross-table sync is needed.
+     */
+    async deleteVerifiedDomain(
+        account: RegisteredAccount,
+        domain: string,
+    ): Promise<void> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageOrganization(account);
+        const normalizedDomain =
+            OrganizationDomainVerificationService.normalizeDomain(domain);
+
+        await this.organizationDomainVerificationModel.deleteVerification({
+            organizationUuid,
+            domain: normalizedDomain,
+        });
+    }
+}

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
@@ -8,6 +8,7 @@ import {
     GenericOidcSsoConfigSummary,
     GoogleSsoConfig,
     GoogleSsoConfigSummary,
+    isPublicEmailProviderDomain,
     NotFoundError,
     OktaSsoConfig,
     OktaSsoConfigSummary,
@@ -27,6 +28,7 @@ import {
 import { LightdashConfig } from '../../config/parseConfig';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
+import { OrganizationDomainVerificationModel } from '../../models/OrganizationDomainVerificationModel';
 import {
     OrganizationSsoMethod,
     OrganizationSsoModel,
@@ -39,6 +41,7 @@ type OrganizationSsoServiceArguments = {
     lightdashConfig: LightdashConfig;
     organizationSsoModel: OrganizationSsoModel;
     organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
+    organizationDomainVerificationModel: OrganizationDomainVerificationModel;
     featureFlagModel: FeatureFlagModel;
     userModel: UserModel;
 };
@@ -111,6 +114,8 @@ export class OrganizationSsoService extends BaseService {
 
     private readonly organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
 
+    private readonly organizationDomainVerificationModel: OrganizationDomainVerificationModel;
+
     private readonly featureFlagModel: FeatureFlagModel;
 
     private readonly userModel: UserModel;
@@ -119,6 +124,7 @@ export class OrganizationSsoService extends BaseService {
         lightdashConfig,
         organizationSsoModel,
         organizationAllowedEmailDomainsModel,
+        organizationDomainVerificationModel,
         featureFlagModel,
         userModel,
     }: OrganizationSsoServiceArguments) {
@@ -127,6 +133,8 @@ export class OrganizationSsoService extends BaseService {
         this.organizationSsoModel = organizationSsoModel;
         this.organizationAllowedEmailDomainsModel =
             organizationAllowedEmailDomainsModel;
+        this.organizationDomainVerificationModel =
+            organizationDomainVerificationModel;
         this.featureFlagModel = featureFlagModel;
         this.userModel = userModel;
     }
@@ -149,24 +157,6 @@ export class OrganizationSsoService extends BaseService {
         }
     }
 
-    /**
-     * Domains no single organization should ever be able to claim.
-     * Not exhaustive — covers the obvious public providers and corporate
-     * domains we know can't legitimately belong to a single Lightdash org.
-     */
-    private static readonly DISALLOWED_DOMAINS = new Set([
-        'gmail.com',
-        'googlemail.com',
-        'google.com',
-        'microsoft.com',
-        'onmicrosoft.com',
-        'outlook.com',
-        'hotmail.com',
-        'live.com',
-        'yahoo.com',
-        'icloud.com',
-    ]);
-
     private static validateEmailDomains(domains: string[]): void {
         const normalized = domains.map((d) => d.trim().toLowerCase());
 
@@ -184,14 +174,42 @@ export class OrganizationSsoService extends BaseService {
             );
         }
 
-        const disallowed = normalized.filter((d) =>
-            OrganizationSsoService.DISALLOWED_DOMAINS.has(d),
-        );
+        // Public providers (gmail, outlook, …) can never belong to one org —
+        // see the shared blocklist in @lightdash/common.
+        const disallowed = normalized.filter(isPublicEmailProviderDomain);
         if (disallowed.length > 0) {
             throw new ParameterError(
                 `These domains can't be claimed: ${disallowed.join(
                     ', ',
                 )}. Use a domain or subdomain that identifies your organization.`,
+            );
+        }
+    }
+
+    /**
+     * A provider may only route email domains the organization has proven it
+     * owns. Verified domains are the source of truth for SSO routing; this is
+     * the server-side backstop behind the verified-domain picker in the UI.
+     */
+    private async assertEmailDomainsVerified(
+        organizationUuid: string,
+        domains: string[],
+    ): Promise<void> {
+        const verified = new Set(
+            (
+                await this.organizationDomainVerificationModel.findVerifiedDomains(
+                    organizationUuid,
+                )
+            ).map((d) => d.domain),
+        );
+        const unverified = domains
+            .map((d) => d.trim().toLowerCase())
+            .filter((d) => !verified.has(d));
+        if (unverified.length > 0) {
+            throw new ParameterError(
+                `These domains must be verified before they can be used for SSO: ${unverified.join(
+                    ', ',
+                )}. Verify them in Settings → Verified domains.`,
             );
         }
     }
@@ -259,6 +277,12 @@ export class OrganizationSsoService extends BaseService {
 
         if (data.emailDomains && data.emailDomains.length > 0) {
             OrganizationSsoService.validateEmailDomains(data.emailDomains);
+            if (data.overrideEmailDomains) {
+                await this.assertEmailDomainsVerified(
+                    organizationUuid,
+                    data.emailDomains,
+                );
+            }
         }
 
         const existing = await this.organizationSsoModel.findMethod(
@@ -360,6 +384,12 @@ export class OrganizationSsoService extends BaseService {
 
         if (data.emailDomains && data.emailDomains.length > 0) {
             OrganizationSsoService.validateEmailDomains(data.emailDomains);
+            if (data.overrideEmailDomains) {
+                await this.assertEmailDomainsVerified(
+                    organizationUuid,
+                    data.emailDomains,
+                );
+            }
         }
 
         const existing = await this.organizationSsoModel.findMethod(
@@ -460,6 +490,12 @@ export class OrganizationSsoService extends BaseService {
 
         if (data.emailDomains && data.emailDomains.length > 0) {
             OrganizationSsoService.validateEmailDomains(data.emailDomains);
+            if (data.overrideEmailDomains) {
+                await this.assertEmailDomainsVerified(
+                    organizationUuid,
+                    data.emailDomains,
+                );
+            }
         }
 
         const existing = await this.organizationSsoModel.findMethod(
@@ -557,6 +593,12 @@ export class OrganizationSsoService extends BaseService {
 
         if (data.emailDomains && data.emailDomains.length > 0) {
             OrganizationSsoService.validateEmailDomains(data.emailDomains);
+            if (data.overrideEmailDomains) {
+                await this.assertEmailDomainsVerified(
+                    organizationUuid,
+                    data.emailDomains,
+                );
+            }
         }
 
         const existing = await this.organizationSsoModel.findMethod(
@@ -647,6 +689,12 @@ export class OrganizationSsoService extends BaseService {
 
         if (data.emailDomains && data.emailDomains.length > 0) {
             OrganizationSsoService.validateEmailDomains(data.emailDomains);
+            if (data.overrideEmailDomains) {
+                await this.assertEmailDomainsVerified(
+                    organizationUuid,
+                    data.emailDomains,
+                );
+            }
         }
 
         const config: GoogleSsoConfig = {};

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -37,6 +37,7 @@ import { NotificationsService } from './NotificationsService/NotificationsServic
 import { OAuthService } from './OAuthService/OAuthService';
 import { OrganizationAccessService } from './OrganizationAccessService/OrganizationAccessService';
 import { OrganizationDesignService } from './OrganizationDesignService/OrganizationDesignService';
+import { OrganizationDomainVerificationService } from './OrganizationDomainVerificationService/OrganizationDomainVerificationService';
 import { OrganizationService } from './OrganizationService/OrganizationService';
 import { OrganizationSettingsService } from './OrganizationSettingsService/OrganizationSettingsService';
 import { OrganizationSsoService } from './OrganizationSsoService/OrganizationSsoService';
@@ -93,6 +94,7 @@ interface ServiceManifest {
     organizationService: OrganizationService;
     organizationSettingsService: OrganizationSettingsService;
     organizationSsoService: OrganizationSsoService;
+    organizationDomainVerificationService: OrganizationDomainVerificationService;
     organizationAccessService: OrganizationAccessService;
     preAggregateMaterializationService: PreAggregateMaterializationService;
     persistentDownloadFileService: PersistentDownloadFileService;
@@ -569,8 +571,24 @@ export class ServiceRepository
                     organizationSsoModel: this.models.getOrganizationSsoModel(),
                     organizationAllowedEmailDomainsModel:
                         this.models.getOrganizationAllowedEmailDomainsModel(),
+                    organizationDomainVerificationModel:
+                        this.models.getOrganizationDomainVerificationModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
                     userModel: this.models.getUserModel(),
+                }),
+        );
+    }
+
+    public getOrganizationDomainVerificationService(): OrganizationDomainVerificationService {
+        return this.getService(
+            'organizationDomainVerificationService',
+            () =>
+                new OrganizationDomainVerificationService({
+                    lightdashConfig: this.context.lightdashConfig,
+                    organizationDomainVerificationModel:
+                        this.models.getOrganizationDomainVerificationModel(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
+                    emailClient: this.clients.getEmailClient(),
                 }),
         );
     }

--- a/packages/backend/src/utils/oneTimePasscode.test.ts
+++ b/packages/backend/src/utils/oneTimePasscode.test.ts
@@ -1,0 +1,79 @@
+import { LightdashMode } from '@lightdash/common';
+import {
+    EMAIL_ONE_TIME_PASSCODE_EXPIRY_SECONDS,
+    EMAIL_ONE_TIME_PASSCODE_MAX_ATTEMPTS,
+    EMAIL_ONE_TIME_PASSCODE_RESEND_COOLDOWN_SECONDS,
+    generateOneTimePasscode,
+    isOtpExpired,
+    isOtpMaxAttempts,
+    otpExpirationDate,
+    resendCooldownRemainingSeconds,
+} from './oneTimePasscode';
+
+describe('oneTimePasscode', () => {
+    describe('generateOneTimePasscode', () => {
+        it('returns 000000 in DEV and PR modes', () => {
+            expect(generateOneTimePasscode(LightdashMode.DEV)).toBe('000000');
+            expect(generateOneTimePasscode(LightdashMode.PR)).toBe('000000');
+        });
+
+        it('returns a zero-padded 6-digit code otherwise', () => {
+            const code = generateOneTimePasscode(LightdashMode.DEFAULT);
+            expect(code).toMatch(/^\d{6}$/);
+        });
+    });
+
+    describe('otpExpirationDate', () => {
+        it('adds the expiry window to the creation time', () => {
+            const createdAt = new Date('2026-01-01T00:00:00.000Z');
+            expect(otpExpirationDate(createdAt).getTime()).toBe(
+                createdAt.getTime() +
+                    EMAIL_ONE_TIME_PASSCODE_EXPIRY_SECONDS * 1000,
+            );
+        });
+    });
+
+    describe('isOtpExpired', () => {
+        it('is false for a freshly created passcode', () => {
+            expect(isOtpExpired(new Date())).toBe(false);
+        });
+
+        it('is true once the expiry window has passed', () => {
+            const old = new Date(
+                Date.now() -
+                    (EMAIL_ONE_TIME_PASSCODE_EXPIRY_SECONDS + 1) * 1000,
+            );
+            expect(isOtpExpired(old)).toBe(true);
+        });
+    });
+
+    describe('isOtpMaxAttempts', () => {
+        it('locks out at the max attempt count', () => {
+            expect(
+                isOtpMaxAttempts(EMAIL_ONE_TIME_PASSCODE_MAX_ATTEMPTS - 1),
+            ).toBe(false);
+            expect(isOtpMaxAttempts(EMAIL_ONE_TIME_PASSCODE_MAX_ATTEMPTS)).toBe(
+                true,
+            );
+        });
+    });
+
+    describe('resendCooldownRemainingSeconds', () => {
+        it('returns 0 once the cooldown has elapsed', () => {
+            const old = new Date(
+                Date.now() -
+                    (EMAIL_ONE_TIME_PASSCODE_RESEND_COOLDOWN_SECONDS + 1) *
+                        1000,
+            );
+            expect(resendCooldownRemainingSeconds(old)).toBe(0);
+        });
+
+        it('returns the remaining seconds for a fresh passcode', () => {
+            const remaining = resendCooldownRemainingSeconds(new Date());
+            expect(remaining).toBeGreaterThan(0);
+            expect(remaining).toBeLessThanOrEqual(
+                EMAIL_ONE_TIME_PASSCODE_RESEND_COOLDOWN_SECONDS,
+            );
+        });
+    });
+});

--- a/packages/backend/src/utils/oneTimePasscode.ts
+++ b/packages/backend/src/utils/oneTimePasscode.ts
@@ -1,0 +1,51 @@
+import { LightdashMode } from '@lightdash/common';
+import { randomInt } from 'crypto';
+
+/**
+ * Shared one-time passcode (OTP) settings and helpers, reused by primary-email
+ * verification (UserService) and domain-ownership verification. A passcode is a
+ * 6-digit code, valid for 15 minutes, with at most 5 confirmation attempts.
+ */
+export const EMAIL_ONE_TIME_PASSCODE_EXPIRY_SECONDS = 60 * 15;
+export const EMAIL_ONE_TIME_PASSCODE_MAX_ATTEMPTS = 5;
+/**
+ * Minimum gap between issuing passcodes for the same challenge. Throttles
+ * resends so a fresh code can't be minted on demand — which would otherwise
+ * reset the attempt lockout and turn the endpoint into an email-bomb / brute
+ * force amplifier.
+ */
+export const EMAIL_ONE_TIME_PASSCODE_RESEND_COOLDOWN_SECONDS = 30;
+
+/**
+ * Generates a 6-digit passcode. In DEV/PR mode it is always `000000` so local
+ * and preview environments can verify without a real inbox.
+ */
+export const generateOneTimePasscode = (mode: LightdashMode): string =>
+    mode === LightdashMode.PR || mode === LightdashMode.DEV
+        ? '000000'
+        : randomInt(999999).toString().padStart(6, '0');
+
+export const otpExpirationDate = (createdAt: Date): Date =>
+    new Date(
+        createdAt.getTime() + EMAIL_ONE_TIME_PASSCODE_EXPIRY_SECONDS * 1000,
+    );
+
+export const isOtpExpired = (createdAt: Date): boolean =>
+    otpExpirationDate(createdAt) < new Date();
+
+export const isOtpMaxAttempts = (numberOfAttempts: number): boolean =>
+    numberOfAttempts >= EMAIL_ONE_TIME_PASSCODE_MAX_ATTEMPTS;
+
+/**
+ * Seconds the caller must still wait before another passcode may be issued for
+ * a challenge created at `passcodeCreatedAt`. Returns 0 once the cooldown has
+ * elapsed.
+ */
+export const resendCooldownRemainingSeconds = (
+    passcodeCreatedAt: Date,
+): number => {
+    const elapsedMs = Date.now() - passcodeCreatedAt.getTime();
+    const remainingMs =
+        EMAIL_ONE_TIME_PASSCODE_RESEND_COOLDOWN_SECONDS * 1000 - elapsedMs;
+    return remainingMs > 0 ? Math.ceil(remainingMs / 1000) : 0;
+};

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -134,6 +134,7 @@ export * from './types/oauth';
 export * from './types/openIdIdentity';
 export * from './types/organization';
 export * from './types/organizationAccess';
+export * from './types/organizationDomainVerification';
 export * from './types/organizationMemberProfile';
 export * from './types/organizationSettings';
 export * from './types/organizationSso';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -145,6 +145,10 @@ import {
 } from './organization';
 import { type OrganizationAccess } from './organizationAccess';
 import {
+    type DomainVerificationStatus,
+    type VerifiedDomain,
+} from './organizationDomainVerification';
+import {
     type ApiOrganizationMemberProfiles,
     type OrganizationMemberProfile,
     type OrganizationMemberRole,
@@ -946,6 +950,8 @@ type ApiResults =
     | UpdateAllowedEmailDomains
     | UserAllowedOrganization[]
     | EmailStatusExpiring
+    | DomainVerificationStatus
+    | VerifiedDomain[]
     | ApiScheduledDownloadCsv
     | PinnedItems
     | ViewStatistics

--- a/packages/common/src/types/organizationDomainVerification.ts
+++ b/packages/common/src/types/organizationDomainVerification.ts
@@ -1,0 +1,47 @@
+import { type EmailStatusExpiring } from './email';
+
+/**
+ * A domain an organization has proven it owns (via a one-time passcode sent to
+ * an address at the domain). Verified domains are globally unique — the first
+ * organization to verify a domain owns it.
+ */
+export type VerifiedDomain = {
+    organizationUuid: string;
+    domain: string;
+    verifiedAt: Date;
+    verifiedByUserUuid: string | null;
+};
+
+/**
+ * Verification status of a single domain. Mirrors {@link EmailStatusExpiring}:
+ * `otp` is present only while a pending one-time passcode challenge exists.
+ */
+export type DomainVerificationStatus = Pick<EmailStatusExpiring, 'otp'> & {
+    domain: string;
+    isVerified: boolean;
+};
+
+/**
+ * Request to verify a domain. `challengeEmail` must be an address at `domain`;
+ * a one-time passcode is sent there and confirmed via
+ * {@link ConfirmDomainVerification}.
+ */
+export type RequestDomainVerification = {
+    domain: string;
+    challengeEmail: string;
+};
+
+export type ConfirmDomainVerification = {
+    domain: string;
+    passcode: string;
+};
+
+export type ApiVerifiedDomainsResponse = {
+    status: 'ok';
+    results: VerifiedDomain[];
+};
+
+export type ApiDomainVerificationStatusResponse = {
+    status: 'ok';
+    results: DomainVerificationStatus;
+};

--- a/packages/common/src/utils/email.test.ts
+++ b/packages/common/src/utils/email.test.ts
@@ -1,5 +1,9 @@
 /* eslint-disable no-useless-escape */
-import { getEmailDomain } from './email';
+import {
+    getEmailDomain,
+    isPublicEmailProviderDomain,
+    validateOrganizationEmailDomains,
+} from './email';
 
 describe('getEmailDomain', () => {
     it('should return the correct domain for a valid email', () => {
@@ -89,5 +93,44 @@ describe('getEmailDomain', () => {
         expect(getEmailDomain("!#$%&'*+-/=?^_`{}|~@example.org")).toBe(
             'example.org',
         );
+    });
+});
+
+describe('isPublicEmailProviderDomain', () => {
+    it('flags public providers (including former SSO-only entries)', () => {
+        expect(isPublicEmailProviderDomain('gmail.com')).toBe(true);
+        expect(isPublicEmailProviderDomain('outlook.com')).toBe(true);
+        expect(isPublicEmailProviderDomain('icloud.com')).toBe(true);
+        // Consolidated from OrganizationSsoService.DISALLOWED_DOMAINS
+        expect(isPublicEmailProviderDomain('google.com')).toBe(true);
+        expect(isPublicEmailProviderDomain('microsoft.com')).toBe(true);
+        expect(isPublicEmailProviderDomain('onmicrosoft.com')).toBe(true);
+    });
+
+    it('is case-insensitive and trims', () => {
+        expect(isPublicEmailProviderDomain('GMAIL.COM')).toBe(true);
+        expect(isPublicEmailProviderDomain('  Gmail.com ')).toBe(true);
+    });
+
+    it('does not flag corporate domains', () => {
+        expect(isPublicEmailProviderDomain('acme.com')).toBe(false);
+        expect(isPublicEmailProviderDomain('lightdash.com')).toBe(false);
+    });
+});
+
+describe('validateOrganizationEmailDomains', () => {
+    it('returns undefined when all domains are allowed', () => {
+        expect(
+            validateOrganizationEmailDomains(['acme.com', 'acme.io']),
+        ).toBeUndefined();
+    });
+
+    it('returns an error listing public providers', () => {
+        expect(validateOrganizationEmailDomains(['gmail.com'])).toContain(
+            'gmail.com',
+        );
+        expect(
+            validateOrganizationEmailDomains(['acme.com', 'outlook.com']),
+        ).toContain('outlook.com');
     });
 });

--- a/packages/common/src/utils/email.ts
+++ b/packages/common/src/utils/email.ts
@@ -10,8 +10,24 @@ export const getEmailDomain = (email: string): string => {
     return domains[1].toLowerCase();
 };
 
-const EMAIL_PROVIDER_LIST = [
+/**
+ * Single source of truth for public / consumer email-provider domains that no
+ * single organization can legitimately own. Used to block these domains from
+ * being claimed as an organization email domain (auto-join) AND from being
+ * verified as an SSO routing domain — receiving an OTP at e.g. `gmail.com`
+ * proves nothing about owning the provider.
+ *
+ * Seeded from the previous `EMAIL_PROVIDER_LIST` here plus the corporate
+ * domains that `OrganizationSsoService` separately blocked. Can be expanded
+ * from a maintained list (e.g. Kickbox `free-email-domains`) if needed — keep
+ * it a vendored static set, never a runtime fetch.
+ */
+export const PUBLIC_EMAIL_PROVIDER_DOMAINS = new Set([
     'gmail.com',
+    'googlemail.com',
+    'google.com',
+    'microsoft.com',
+    'onmicrosoft.com',
     'yahoo.com',
     'hotmail.com',
     'aol.com',
@@ -42,7 +58,6 @@ const EMAIL_PROVIDER_LIST = [
     'live.fr',
     'verizon.net',
     'live.co.uk',
-    'googlemail.com',
     'yahoo.es',
     'ig.com.br',
     'live.nl',
@@ -59,10 +74,14 @@ const EMAIL_PROVIDER_LIST = [
     'sky.com',
     'blueyonder.co.uk',
     'icloud.com',
-];
+]);
 
-const isEmailProviderDomain = (domain: string): boolean =>
-    EMAIL_PROVIDER_LIST.includes(domain);
+/**
+ * Whether a domain is a public/consumer email provider that no single
+ * organization can own. Normalizes case before checking.
+ */
+export const isPublicEmailProviderDomain = (domain: string): boolean =>
+    PUBLIC_EMAIL_PROVIDER_DOMAINS.has(domain.trim().toLowerCase());
 
 const VALID_EMAIL_DOMAIN_REGEX = /^[a-zA-Z0-9][\w.-]+\.\w{2,4}/g;
 export const isValidEmailDomain = (value: string) =>
@@ -70,7 +89,7 @@ export const isValidEmailDomain = (value: string) =>
 
 export const validateOrganizationEmailDomains = (domains: string[]) => {
     const invalidDomains = domains.filter((domain) =>
-        isEmailProviderDomain(domain),
+        isPublicEmailProviderDomain(domain),
     );
 
     if (!invalidDomains.length) {

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/AzureAdSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/AzureAdSsoPanel.tsx
@@ -8,7 +8,6 @@ import {
     PasswordInput,
     Stack,
     Switch,
-    TagsInput,
     Text,
     TextInput,
     Title,
@@ -22,7 +21,6 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import { useToggle } from 'react-use';
-import { useAllowedEmailDomains } from '../../../hooks/organization/useAllowedDomains';
 import {
     useAzureAdSsoConfig,
     useDeleteAzureAdSsoConfig,
@@ -34,6 +32,7 @@ import MantineModal from '../../common/MantineModal';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { MICROSOFT_LOGO } from '../../common/ThirdPartySignInButton/ssoProviderLogos';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
+import SsoMethodDomainsField from './SsoMethodDomainsField';
 
 type FormValues = {
     oauth2ClientId: string;
@@ -47,7 +46,6 @@ type FormValues = {
 
 const AzureAdSsoPanel: FC = () => {
     const { data: existing, isLoading } = useAzureAdSsoConfig();
-    const { data: allowedEmailDomains } = useAllowedEmailDomains();
     const upsert = useUpsertAzureAdSsoConfig();
     const deleteConfig = useDeleteAzureAdSsoConfig();
     const [deleteOpen, setDeleteOpen] = useState(false);
@@ -101,8 +99,6 @@ const AzureAdSsoPanel: FC = () => {
         existing?.emailDomains,
         existing?.allowPassword,
     ]);
-
-    const orgDomains = allowedEmailDomains?.emailDomains ?? [];
 
     const handleSubmit = form.onSubmit((values) => {
         upsert.mutate({
@@ -256,45 +252,26 @@ const AzureAdSsoPanel: FC = () => {
                                     <Title order={6} mt="md">
                                         Discovery
                                     </Title>
-                                    <Checkbox
-                                        label="Override organization's allowed email domains"
-                                        description="When unchecked, users matching any of the organization's allowed email domains see this method."
-                                        checked={
+                                    <SsoMethodDomainsField
+                                        providerLabel="Azure AD"
+                                        override={
                                             form.values.overrideEmailDomains
                                         }
-                                        onChange={(event) =>
+                                        onOverrideChange={(value) =>
                                             form.setFieldValue(
                                                 'overrideEmailDomains',
-                                                event.currentTarget.checked,
+                                                value,
                                             )
                                         }
+                                        domains={form.values.emailDomains}
+                                        onDomainsChange={(domains) =>
+                                            form.setFieldValue(
+                                                'emailDomains',
+                                                domains,
+                                            )
+                                        }
+                                        error={form.errors.emailDomains}
                                     />
-                                    {form.values.overrideEmailDomains ? (
-                                        <TagsInput
-                                            label="Email domains for this method"
-                                            description="Only users whose email domain matches one of these will see Azure AD. Domains are case-insensitive."
-                                            placeholder="microsoft.com, contoso.com"
-                                            value={form.values.emailDomains}
-                                            onChange={(domains) =>
-                                                form.setFieldValue(
-                                                    'emailDomains',
-                                                    domains,
-                                                )
-                                            }
-                                            error={form.errors.emailDomains}
-                                            clearable
-                                        />
-                                    ) : (
-                                        <Text size="sm" c="dimmed">
-                                            Using organization's allowed email
-                                            domains:{' '}
-                                            {orgDomains.length > 0 ? (
-                                                <b>{orgDomains.join(', ')}</b>
-                                            ) : (
-                                                <i>none configured</i>
-                                            )}
-                                        </Text>
-                                    )}
 
                                     <Title order={6} mt="md">
                                         Password sign-in

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.tsx
@@ -7,7 +7,6 @@ import {
     PasswordInput,
     Stack,
     Switch,
-    TagsInput,
     Text,
     TextInput,
     ThemeIcon,
@@ -23,7 +22,6 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import { useToggle } from 'react-use';
-import { useAllowedEmailDomains } from '../../../hooks/organization/useAllowedDomains';
 import {
     useDeleteGenericOidcSsoConfig,
     useGenericOidcSsoConfig,
@@ -34,6 +32,7 @@ import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
+import SsoMethodDomainsField from './SsoMethodDomainsField';
 
 type FormValues = {
     clientId: string;
@@ -48,7 +47,6 @@ type FormValues = {
 
 const GenericOidcSsoPanel: FC = () => {
     const { data: existing, isLoading } = useGenericOidcSsoConfig();
-    const { data: allowedEmailDomains } = useAllowedEmailDomains();
     const upsert = useUpsertGenericOidcSsoConfig();
     const deleteConfig = useDeleteGenericOidcSsoConfig();
     const [deleteOpen, setDeleteOpen] = useState(false);
@@ -107,8 +105,6 @@ const GenericOidcSsoPanel: FC = () => {
         existing?.emailDomains,
         existing?.allowPassword,
     ]);
-
-    const orgDomains = allowedEmailDomains?.emailDomains ?? [];
 
     const handleSubmit = form.onSubmit((values) => {
         upsert.mutate({
@@ -271,45 +267,26 @@ const GenericOidcSsoPanel: FC = () => {
                                     <Title order={6} mt="md">
                                         Discovery
                                     </Title>
-                                    <Checkbox
-                                        label="Override organization's allowed email domains"
-                                        description="When unchecked, users matching any of the organization's allowed email domains see this method."
-                                        checked={
+                                    <SsoMethodDomainsField
+                                        providerLabel="OpenID Connect"
+                                        override={
                                             form.values.overrideEmailDomains
                                         }
-                                        onChange={(event) =>
+                                        onOverrideChange={(value) =>
                                             form.setFieldValue(
                                                 'overrideEmailDomains',
-                                                event.currentTarget.checked,
+                                                value,
                                             )
                                         }
+                                        domains={form.values.emailDomains}
+                                        onDomainsChange={(domains) =>
+                                            form.setFieldValue(
+                                                'emailDomains',
+                                                domains,
+                                            )
+                                        }
+                                        error={form.errors.emailDomains}
                                     />
-                                    {form.values.overrideEmailDomains ? (
-                                        <TagsInput
-                                            label="Email domains for this method"
-                                            description="Only users whose email domain matches one of these will see OpenID Connect. Domains are case-insensitive."
-                                            placeholder="acme.com, acme.io"
-                                            value={form.values.emailDomains}
-                                            onChange={(domains) =>
-                                                form.setFieldValue(
-                                                    'emailDomains',
-                                                    domains,
-                                                )
-                                            }
-                                            error={form.errors.emailDomains}
-                                            clearable
-                                        />
-                                    ) : (
-                                        <Text size="sm" c="dimmed">
-                                            Using organization's allowed email
-                                            domains:{' '}
-                                            {orgDomains.length > 0 ? (
-                                                <b>{orgDomains.join(', ')}</b>
-                                            ) : (
-                                                <i>none configured</i>
-                                            )}
-                                        </Text>
-                                    )}
 
                                     <Title order={6} mt="md">
                                         Password sign-in

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/GoogleSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/GoogleSsoPanel.tsx
@@ -7,7 +7,6 @@ import {
     Image,
     Stack,
     Switch,
-    TagsInput,
     Text,
     Title,
 } from '@mantine-8/core';
@@ -20,7 +19,6 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import { useToggle } from 'react-use';
-import { useAllowedEmailDomains } from '../../../hooks/organization/useAllowedDomains';
 import {
     useDeleteGoogleSsoConfig,
     useGoogleSsoConfig,
@@ -32,6 +30,7 @@ import MantineModal from '../../common/MantineModal';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { GOOGLE_LOGO } from '../../common/ThirdPartySignInButton/ssoProviderLogos';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
+import SsoMethodDomainsField from './SsoMethodDomainsField';
 
 type FormValues = {
     enabled: boolean;
@@ -42,7 +41,6 @@ type FormValues = {
 
 const GoogleSsoPanel: FC = () => {
     const { data: existing, isLoading } = useGoogleSsoConfig();
-    const { data: allowedEmailDomains } = useAllowedEmailDomains();
     const upsert = useUpsertGoogleSsoConfig();
     const deleteConfig = useDeleteGoogleSsoConfig();
     const [deleteOpen, setDeleteOpen] = useState(false);
@@ -80,8 +78,6 @@ const GoogleSsoPanel: FC = () => {
         existing?.emailDomains,
         existing?.allowPassword,
     ]);
-
-    const orgDomains = allowedEmailDomains?.emailDomains ?? [];
 
     const handleSubmit = form.onSubmit((values) => {
         upsert.mutate({
@@ -191,45 +187,26 @@ const GoogleSsoPanel: FC = () => {
                             <form onSubmit={handleSubmit}>
                                 <Stack>
                                     <Title order={6}>Discovery</Title>
-                                    <Checkbox
-                                        label="Override organization's allowed email domains"
-                                        description="When unchecked, users matching any of the organization's allowed email domains see this method."
-                                        checked={
+                                    <SsoMethodDomainsField
+                                        providerLabel="Google"
+                                        override={
                                             form.values.overrideEmailDomains
                                         }
-                                        onChange={(event) =>
+                                        onOverrideChange={(value) =>
                                             form.setFieldValue(
                                                 'overrideEmailDomains',
-                                                event.currentTarget.checked,
+                                                value,
                                             )
                                         }
+                                        domains={form.values.emailDomains}
+                                        onDomainsChange={(domains) =>
+                                            form.setFieldValue(
+                                                'emailDomains',
+                                                domains,
+                                            )
+                                        }
+                                        error={form.errors.emailDomains}
                                     />
-                                    {form.values.overrideEmailDomains ? (
-                                        <TagsInput
-                                            label="Email domains for this method"
-                                            description="Only users whose email domain matches one of these will see Google. Domains are case-insensitive."
-                                            placeholder="acme.com, acme.io"
-                                            value={form.values.emailDomains}
-                                            onChange={(domains) =>
-                                                form.setFieldValue(
-                                                    'emailDomains',
-                                                    domains,
-                                                )
-                                            }
-                                            error={form.errors.emailDomains}
-                                            clearable
-                                        />
-                                    ) : (
-                                        <Text size="sm" c="dimmed">
-                                            Using organization's allowed email
-                                            domains:{' '}
-                                            {orgDomains.length > 0 ? (
-                                                <b>{orgDomains.join(', ')}</b>
-                                            ) : (
-                                                <i>none configured</i>
-                                            )}
-                                        </Text>
-                                    )}
 
                                     <Title order={6} mt="md">
                                         Password sign-in

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/OktaSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/OktaSsoPanel.tsx
@@ -8,7 +8,6 @@ import {
     PasswordInput,
     Stack,
     Switch,
-    TagsInput,
     Text,
     TextInput,
     Title,
@@ -22,7 +21,6 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import { useToggle } from 'react-use';
-import { useAllowedEmailDomains } from '../../../hooks/organization/useAllowedDomains';
 import {
     useDeleteOktaSsoConfig,
     useOktaSsoConfig,
@@ -34,6 +32,7 @@ import MantineModal from '../../common/MantineModal';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { OKTA_LOGO } from '../../common/ThirdPartySignInButton/ssoProviderLogos';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
+import SsoMethodDomainsField from './SsoMethodDomainsField';
 
 type FormValues = {
     oauth2Issuer: string;
@@ -50,7 +49,6 @@ type FormValues = {
 
 const OktaSsoPanel: FC = () => {
     const { data: existing, isLoading } = useOktaSsoConfig();
-    const { data: allowedEmailDomains } = useAllowedEmailDomains();
     const upsert = useUpsertOktaSsoConfig();
     const deleteConfig = useDeleteOktaSsoConfig();
     const [deleteOpen, setDeleteOpen] = useState(false);
@@ -115,8 +113,6 @@ const OktaSsoPanel: FC = () => {
         existing?.emailDomains,
         existing?.allowPassword,
     ]);
-
-    const orgDomains = allowedEmailDomains?.emailDomains ?? [];
 
     const handleSubmit = form.onSubmit((values) => {
         upsert.mutate({
@@ -298,45 +294,26 @@ const OktaSsoPanel: FC = () => {
                                     <Title order={6} mt="md">
                                         Discovery
                                     </Title>
-                                    <Checkbox
-                                        label="Override organization's allowed email domains"
-                                        description="When unchecked, users matching any of the organization's allowed email domains see this method."
-                                        checked={
+                                    <SsoMethodDomainsField
+                                        providerLabel="Okta"
+                                        override={
                                             form.values.overrideEmailDomains
                                         }
-                                        onChange={(event) =>
+                                        onOverrideChange={(value) =>
                                             form.setFieldValue(
                                                 'overrideEmailDomains',
-                                                event.currentTarget.checked,
+                                                value,
                                             )
                                         }
+                                        domains={form.values.emailDomains}
+                                        onDomainsChange={(domains) =>
+                                            form.setFieldValue(
+                                                'emailDomains',
+                                                domains,
+                                            )
+                                        }
+                                        error={form.errors.emailDomains}
                                     />
-                                    {form.values.overrideEmailDomains ? (
-                                        <TagsInput
-                                            label="Email domains for this method"
-                                            description="Only users whose email domain matches one of these will see Okta. Domains are case-insensitive."
-                                            placeholder="acme.com, acme.io"
-                                            value={form.values.emailDomains}
-                                            onChange={(domains) =>
-                                                form.setFieldValue(
-                                                    'emailDomains',
-                                                    domains,
-                                                )
-                                            }
-                                            error={form.errors.emailDomains}
-                                            clearable
-                                        />
-                                    ) : (
-                                        <Text size="sm" c="dimmed">
-                                            Using organization's allowed email
-                                            domains:{' '}
-                                            {orgDomains.length > 0 ? (
-                                                <b>{orgDomains.join(', ')}</b>
-                                            ) : (
-                                                <i>none configured</i>
-                                            )}
-                                        </Text>
-                                    )}
 
                                     <Title order={6} mt="md">
                                         Password sign-in

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/OneLoginSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/OneLoginSsoPanel.tsx
@@ -8,7 +8,6 @@ import {
     PasswordInput,
     Stack,
     Switch,
-    TagsInput,
     Text,
     TextInput,
     Title,
@@ -22,7 +21,6 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import { useToggle } from 'react-use';
-import { useAllowedEmailDomains } from '../../../hooks/organization/useAllowedDomains';
 import {
     useDeleteOneLoginSsoConfig,
     useOneLoginSsoConfig,
@@ -34,6 +32,7 @@ import MantineModal from '../../common/MantineModal';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { ONELOGIN_LOGO } from '../../common/ThirdPartySignInButton/ssoProviderLogos';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
+import SsoMethodDomainsField from './SsoMethodDomainsField';
 
 type FormValues = {
     oauth2Issuer: string;
@@ -47,7 +46,6 @@ type FormValues = {
 
 const OneLoginSsoPanel: FC = () => {
     const { data: existing, isLoading } = useOneLoginSsoConfig();
-    const { data: allowedEmailDomains } = useAllowedEmailDomains();
     const upsert = useUpsertOneLoginSsoConfig();
     const deleteConfig = useDeleteOneLoginSsoConfig();
     const [deleteOpen, setDeleteOpen] = useState(false);
@@ -101,8 +99,6 @@ const OneLoginSsoPanel: FC = () => {
         existing?.emailDomains,
         existing?.allowPassword,
     ]);
-
-    const orgDomains = allowedEmailDomains?.emailDomains ?? [];
 
     const handleSubmit = form.onSubmit((values) => {
         upsert.mutate({
@@ -254,45 +250,26 @@ const OneLoginSsoPanel: FC = () => {
                                     <Title order={6} mt="md">
                                         Discovery
                                     </Title>
-                                    <Checkbox
-                                        label="Override organization's allowed email domains"
-                                        description="When unchecked, users matching any of the organization's allowed email domains see this method."
-                                        checked={
+                                    <SsoMethodDomainsField
+                                        providerLabel="OneLogin"
+                                        override={
                                             form.values.overrideEmailDomains
                                         }
-                                        onChange={(event) =>
+                                        onOverrideChange={(value) =>
                                             form.setFieldValue(
                                                 'overrideEmailDomains',
-                                                event.currentTarget.checked,
+                                                value,
                                             )
                                         }
+                                        domains={form.values.emailDomains}
+                                        onDomainsChange={(domains) =>
+                                            form.setFieldValue(
+                                                'emailDomains',
+                                                domains,
+                                            )
+                                        }
+                                        error={form.errors.emailDomains}
                                     />
-                                    {form.values.overrideEmailDomains ? (
-                                        <TagsInput
-                                            label="Email domains for this method"
-                                            description="Only users whose email domain matches one of these will see OneLogin. Domains are case-insensitive."
-                                            placeholder="acme.com, acme.io"
-                                            value={form.values.emailDomains}
-                                            onChange={(domains) =>
-                                                form.setFieldValue(
-                                                    'emailDomains',
-                                                    domains,
-                                                )
-                                            }
-                                            error={form.errors.emailDomains}
-                                            clearable
-                                        />
-                                    ) : (
-                                        <Text size="sm" c="dimmed">
-                                            Using organization's allowed email
-                                            domains:{' '}
-                                            {orgDomains.length > 0 ? (
-                                                <b>{orgDomains.join(', ')}</b>
-                                            ) : (
-                                                <i>none configured</i>
-                                            )}
-                                        </Text>
-                                    )}
 
                                     <Title order={6} mt="md">
                                         Password sign-in

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/SsoMethodDomainsField.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/SsoMethodDomainsField.tsx
@@ -1,0 +1,95 @@
+import { Anchor, Checkbox, MultiSelect, Stack, Text } from '@mantine-8/core';
+import { type FC, type ReactNode } from 'react';
+import { Link } from 'react-router';
+import { useVerifiedDomains } from '../../../hooks/organization/useOrganizationDomainVerification';
+
+type Props = {
+    providerLabel: string;
+    override: boolean;
+    onOverrideChange: (override: boolean) => void;
+    domains: string[];
+    onDomainsChange: (domains: string[]) => void;
+    error?: ReactNode;
+};
+
+const verifiedDomainsLink = (
+    <Anchor component={Link} to="/generalSettings/verifiedDomains" size="xs">
+        Verified domains
+    </Anchor>
+);
+
+/**
+ * Discovery email-domain control for an SSO method. A method only ever routes
+ * domains the organization has verified. By default (`override = false`) it
+ * routes ALL of the org's verified domains; toggling override restricts it to a
+ * selected subset. Verified domains are the single source of truth — the same
+ * rule is enforced server-side.
+ */
+const SsoMethodDomainsField: FC<Props> = ({
+    providerLabel,
+    override,
+    onOverrideChange,
+    domains,
+    onDomainsChange,
+    error,
+}) => {
+    const { data: verifiedDomains, isInitialLoading } = useVerifiedDomains();
+    const options = (verifiedDomains ?? []).map((d) => d.domain);
+    const hasVerifiedDomains = options.length > 0;
+
+    return (
+        <Stack gap="xs">
+            <Checkbox
+                label="Restrict to specific verified domains"
+                description={`When off, all of your organization's verified domains route to ${providerLabel}.`}
+                checked={override}
+                onChange={(event) =>
+                    onOverrideChange(event.currentTarget.checked)
+                }
+            />
+            {override ? (
+                <MultiSelect
+                    label="Verified domains for this method"
+                    description={
+                        hasVerifiedDomains ? (
+                            `Only users whose email domain matches one of these will see ${providerLabel}.`
+                        ) : (
+                            <Text span size="xs">
+                                Verify a domain in {verifiedDomainsLink} before
+                                you can route it to {providerLabel}.
+                            </Text>
+                        )
+                    }
+                    placeholder={
+                        hasVerifiedDomains
+                            ? 'Select verified domains'
+                            : undefined
+                    }
+                    data={options}
+                    value={domains}
+                    onChange={onDomainsChange}
+                    error={error}
+                    disabled={!hasVerifiedDomains || isInitialLoading}
+                    clearable
+                />
+            ) : (
+                <Text size="sm" c="dimmed">
+                    {hasVerifiedDomains ? (
+                        <>
+                            All of your organization's verified domains route to{' '}
+                            {providerLabel}: <b>{options.join(', ')}</b>
+                        </>
+                    ) : (
+                        <Text span size="sm" c="dimmed">
+                            No verified domains yet. Verify a domain in{' '}
+                            {verifiedDomainsLink} to route it to {providerLabel}
+                            .
+                        </Text>
+                    )}
+                </Text>
+            )}
+        </Stack>
+    );
+};
+
+export default SsoMethodDomainsField;

--- a/packages/frontend/src/components/UserSettings/VerifiedDomains/AddVerifiedDomainModal.tsx
+++ b/packages/frontend/src/components/UserSettings/VerifiedDomains/AddVerifiedDomainModal.tsx
@@ -1,0 +1,228 @@
+import { type DomainVerificationStatus } from '@lightdash/common';
+import { Button, PinInput, Stack, Text, TextInput } from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconWorldCheck } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import Countdown, { zeroPad } from 'react-countdown';
+import {
+    useConfirmDomainVerification,
+    useRequestDomainVerification,
+} from '../../../hooks/organization/useOrganizationDomainVerification';
+import Callout from '../../common/Callout';
+import MantineModal from '../../common/MantineModal';
+
+const attemptMessage = (
+    otp: DomainVerificationStatus['otp'],
+): string | null => {
+    if (!otp || otp.numberOfAttempts === 0) return null;
+    if (otp.isExpired) {
+        return 'Your code expired. Resend a new verification email.';
+    }
+    if (otp.isMaxAttempts) {
+        return "That code doesn't match. You've used all your attempts — resend a new code.";
+    }
+    return "That code doesn't match the one we sent. Try again.";
+};
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+};
+
+/**
+ * Two-step "verify a domain by email" flow: enter a domain + an address at it,
+ * receive a one-time passcode, then confirm it. Mounted only while open, so its
+ * state resets each time it is reopened.
+ */
+const AddVerifiedDomainModal: FC<Props> = ({ opened, onClose }) => {
+    const requestVerification = useRequestDomainVerification();
+    const confirmVerification = useConfirmDomainVerification();
+
+    // The domain whose passcode we're collecting, plus its latest OTP status.
+    const [pending, setPending] = useState<{
+        domain: string;
+        challengeEmail: string;
+        status: DomainVerificationStatus;
+    } | null>(null);
+    const [code, setCode] = useState('');
+    // Set when the countdown reaches zero — server flags are a fetch-time
+    // snapshot, so this is what locks the input live on expiry.
+    const [expired, setExpired] = useState(false);
+
+    const form = useForm<{ domain: string; challengeEmail: string }>({
+        initialValues: { domain: '', challengeEmail: '' },
+        validate: {
+            domain: (value) =>
+                value.trim().length === 0 ? 'Enter a domain' : null,
+        },
+    });
+
+    const handleRequest = form.onSubmit(async (values) => {
+        const domain = values.domain.trim().toLowerCase();
+        const challengeEmail =
+            values.challengeEmail.trim() || `admin@${domain}`;
+        try {
+            const status = await requestVerification.mutateAsync({
+                domain,
+                challengeEmail,
+            });
+            if (status.isVerified) {
+                onClose();
+                return;
+            }
+            setCode('');
+            setExpired(false);
+            setPending({ domain, challengeEmail, status });
+        } catch {
+            // error toast is shown by the mutation's onError
+        }
+    });
+
+    const handleConfirm = async () => {
+        if (!pending || code.length < 6) return;
+        try {
+            const status = await confirmVerification.mutateAsync({
+                domain: pending.domain,
+                passcode: code,
+            });
+            if (status.isVerified) {
+                onClose();
+            } else {
+                setPending({ ...pending, status });
+                setCode('');
+            }
+        } catch {
+            // error toast is shown by the mutation's onError
+        }
+    };
+
+    const handleResend = async () => {
+        if (!pending) return;
+        try {
+            const status = await requestVerification.mutateAsync({
+                domain: pending.domain,
+                challengeEmail: pending.challengeEmail,
+            });
+            setCode('');
+            setExpired(false);
+            setPending({ ...pending, status });
+        } catch {
+            // error toast is shown by the mutation's onError
+        }
+    };
+
+    const otp = pending?.status.otp;
+    const isLockedOut = expired || !!otp?.isExpired || !!otp?.isMaxAttempts;
+    const error = attemptMessage(otp);
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title={pending ? `Verify ${pending.domain}` : 'Add domain'}
+            icon={IconWorldCheck}
+            cancelLabel="Cancel"
+            actions={
+                pending ? (
+                    <>
+                        <Button
+                            variant="default"
+                            loading={requestVerification.isLoading}
+                            onClick={handleResend}
+                        >
+                            Resend code
+                        </Button>
+                        <Button
+                            loading={confirmVerification.isLoading}
+                            disabled={code.length < 6 || isLockedOut}
+                            onClick={handleConfirm}
+                        >
+                            Verify domain
+                        </Button>
+                    </>
+                ) : (
+                    <Button
+                        loading={requestVerification.isLoading}
+                        onClick={() => handleRequest()}
+                    >
+                        Send verification code
+                    </Button>
+                )
+            }
+        >
+            {pending ? (
+                <Stack gap="xs">
+                    <Text size="sm" c="dimmed">
+                        Enter the 6-digit code we sent to{' '}
+                        <Text span fw={500}>
+                            {pending.challengeEmail}
+                        </Text>{' '}
+                        to verify{' '}
+                        <Text span fw={500}>
+                            {pending.domain}
+                        </Text>
+                        .
+                    </Text>
+                    <PinInput
+                        aria-label="Domain verification code"
+                        length={6}
+                        oneTimeCode
+                        value={code}
+                        onChange={setCode}
+                        disabled={isLockedOut}
+                        autoFocus
+                    />
+                    {error && (
+                        <Text c="red.7" size="sm">
+                            {error}
+                        </Text>
+                    )}
+                    {otp && !isLockedOut && (
+                        <Countdown
+                            key={otp.expiresAt.toString()}
+                            date={otp.expiresAt}
+                            onComplete={() => setExpired(true)}
+                            renderer={({ minutes, seconds, completed }) =>
+                                completed ? (
+                                    <Callout
+                                        variant="warning"
+                                        title="Your verification code has expired."
+                                    >
+                                        Resend a new code to continue.
+                                    </Callout>
+                                ) : (
+                                    <Text c="dimmed" size="sm">
+                                        Code expires in {zeroPad(minutes)}:
+                                        {zeroPad(seconds)}
+                                    </Text>
+                                )
+                            }
+                        />
+                    )}
+                </Stack>
+            ) : (
+                <form onSubmit={handleRequest}>
+                    <Stack gap="md">
+                        <TextInput
+                            label="Domain"
+                            placeholder="acme.com"
+                            description="The domain your organization owns."
+                            data-autofocus
+                            {...form.getInputProps('domain')}
+                        />
+                        <TextInput
+                            label="Send code to"
+                            placeholder={`admin@${
+                                form.values.domain.trim() || 'your-domain.com'
+                            }`}
+                            description="An email address at this domain."
+                            {...form.getInputProps('challengeEmail')}
+                        />
+                    </Stack>
+                </form>
+            )}
+        </MantineModal>
+    );
+};
+
+export default AddVerifiedDomainModal;

--- a/packages/frontend/src/components/UserSettings/VerifiedDomains/VerifiedDomainsPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/VerifiedDomains/VerifiedDomainsPanel.tsx
@@ -1,0 +1,166 @@
+import {
+    Badge,
+    Button,
+    Group,
+    Menu,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import {
+    IconCircleCheck,
+    IconMail,
+    IconPlus,
+    IconTrash,
+    IconWorld,
+    IconWorldCheck,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import {
+    useDeleteVerifiedDomain,
+    useVerifiedDomains,
+} from '../../../hooks/organization/useOrganizationDomainVerification';
+import EmptyStateLoader from '../../common/EmptyStateLoader';
+import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
+import { SettingsCard } from '../../common/Settings/SettingsCard';
+import AddVerifiedDomainModal from './AddVerifiedDomainModal';
+
+const VerifiedDomainsPanel: FC = () => {
+    const { data: verifiedDomains, isInitialLoading } = useVerifiedDomains();
+    const deleteDomain = useDeleteVerifiedDomain();
+    const [domainToDelete, setDomainToDelete] = useState<string | null>(null);
+    const [addOpen, setAddOpen] = useState(false);
+
+    return (
+        <SettingsCard p="lg">
+            <Stack gap="md">
+                <Group gap="sm" wrap="nowrap" align="flex-start">
+                    <MantineIcon icon={IconWorldCheck} size="lg" />
+                    <Stack gap={2}>
+                        <Title order={5}>Verified domains</Title>
+                        <Text c="dimmed" size="sm" maw={520}>
+                            Verify the domains your organization owns. Verified
+                            domains can be routed to your SSO providers.
+                        </Text>
+                    </Stack>
+                </Group>
+
+                {isInitialLoading ? (
+                    <EmptyStateLoader mih={60} />
+                ) : (
+                    <Stack gap="xs">
+                        {(verifiedDomains ?? []).length === 0 ? (
+                            <Text size="sm" c="dimmed">
+                                No verified domains yet.
+                            </Text>
+                        ) : (
+                            (verifiedDomains ?? []).map((d) => (
+                                <Group
+                                    key={d.domain}
+                                    justify="space-between"
+                                    wrap="nowrap"
+                                >
+                                    <Group gap="xs" wrap="nowrap">
+                                        <MantineIcon
+                                            icon={IconCircleCheck}
+                                            color="green"
+                                        />
+                                        <Text fw={500}>{d.domain}</Text>
+                                        <Badge
+                                            color="green"
+                                            variant="light"
+                                            size="sm"
+                                        >
+                                            Verified
+                                        </Badge>
+                                    </Group>
+                                    <Button
+                                        variant="subtle"
+                                        color="red"
+                                        size="compact-sm"
+                                        leftSection={
+                                            <MantineIcon icon={IconTrash} />
+                                        }
+                                        onClick={() =>
+                                            setDomainToDelete(d.domain)
+                                        }
+                                    >
+                                        Remove
+                                    </Button>
+                                </Group>
+                            ))
+                        )}
+                    </Stack>
+                )}
+
+                <Menu position="bottom-start" withinPortal>
+                    <Menu.Target>
+                        <Button
+                            w="fit-content"
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                        >
+                            Add domain
+                        </Button>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        <Menu.Label>Verify ownership with</Menu.Label>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconMail} />}
+                            onClick={() => setAddOpen(true)}
+                        >
+                            Email
+                        </Menu.Item>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconWorld} />}
+                            disabled
+                            rightSection={
+                                <Badge size="xs" variant="light" color="gray">
+                                    Soon
+                                </Badge>
+                            }
+                        >
+                            DNS (TXT record)
+                        </Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
+            </Stack>
+
+            {addOpen && (
+                <AddVerifiedDomainModal
+                    opened
+                    onClose={() => setAddOpen(false)}
+                />
+            )}
+
+            {domainToDelete && (
+                <MantineModal
+                    opened
+                    onClose={() => setDomainToDelete(null)}
+                    title="Remove verified domain"
+                    icon={IconWorldCheck}
+                    cancelLabel="Cancel"
+                    actions={
+                        <Button
+                            color="red"
+                            loading={deleteDomain.isLoading}
+                            onClick={async () => {
+                                await deleteDomain.mutateAsync(domainToDelete);
+                                setDomainToDelete(null);
+                            }}
+                        >
+                            Remove
+                        </Button>
+                    }
+                >
+                    <Text>
+                        Removing <b>{domainToDelete}</b> will stop routing it to
+                        any SSO provider. You can verify it again later.
+                    </Text>
+                </MantineModal>
+            )}
+        </SettingsCard>
+    );
+};
+
+export default VerifiedDomainsPanel;

--- a/packages/frontend/src/hooks/organization/useOrganizationDomainVerification.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationDomainVerification.ts
@@ -1,0 +1,107 @@
+import {
+    type ApiError,
+    type ConfirmDomainVerification,
+    type DomainVerificationStatus,
+    type RequestDomainVerification,
+    type VerifiedDomain,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+import useToaster from '../toaster/useToaster';
+
+const QUERY_KEY = ['organization_verified_domains'];
+
+const getVerifiedDomains = async () =>
+    lightdashApi<VerifiedDomain[]>({
+        url: '/org/domains',
+        method: 'GET',
+        body: undefined,
+    });
+
+const requestDomainVerification = async (data: RequestDomainVerification) =>
+    lightdashApi<DomainVerificationStatus>({
+        url: '/org/domains/verify',
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+
+const confirmDomainVerification = async (data: ConfirmDomainVerification) =>
+    lightdashApi<DomainVerificationStatus>({
+        url: '/org/domains/confirm',
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+
+const deleteVerifiedDomain = async (domain: string) =>
+    lightdashApi<undefined>({
+        url: `/org/domains/${encodeURIComponent(domain)}`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useVerifiedDomains = () =>
+    useQuery<VerifiedDomain[], ApiError>({
+        queryKey: QUERY_KEY,
+        queryFn: getVerifiedDomains,
+    });
+
+export const useRequestDomainVerification = () => {
+    const { showToastApiError } = useToaster();
+    return useMutation<
+        DomainVerificationStatus,
+        ApiError,
+        RequestDomainVerification
+    >(requestDomainVerification, {
+        mutationKey: ['organization_verified_domains', 'verify'],
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to send verification code',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useConfirmDomainVerification = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<
+        DomainVerificationStatus,
+        ApiError,
+        ConfirmDomainVerification
+    >(confirmDomainVerification, {
+        mutationKey: ['organization_verified_domains', 'confirm'],
+        onSuccess: async (status) => {
+            if (status.isVerified) {
+                await queryClient.invalidateQueries(QUERY_KEY);
+                showToastSuccess({
+                    title: `${status.domain} verified`,
+                });
+            }
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to verify domain',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useDeleteVerifiedDomain = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<undefined, ApiError, string>(deleteVerifiedDomain, {
+        mutationKey: ['organization_verified_domains', 'delete'],
+        onSuccess: async () => {
+            await queryClient.invalidateQueries(QUERY_KEY);
+            showToastSuccess({ title: 'Verified domain removed' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to remove verified domain',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -33,6 +33,7 @@ import {
     IconUsers,
     IconUserShield,
     IconVariable,
+    IconWorldCheck,
 } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import {
@@ -77,6 +78,7 @@ import SlackSettingsPanel from '../components/UserSettings/SlackSettingsPanel';
 import SocialLoginsPanel from '../components/UserSettings/SocialLoginsPanel';
 import UserAttributesPanel from '../components/UserSettings/UserAttributesPanel';
 import UsersAndGroupsPanel from '../components/UserSettings/UsersAndGroupsPanel';
+import VerifiedDomainsPanel from '../components/UserSettings/VerifiedDomains/VerifiedDomainsPanel';
 import { useAiOrganizationSettings } from '../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import ScimAccessTokensPanel from '../ee/features/scim/components/ScimAccessTokensPanel';
 import { ServiceAccountsPage } from '../ee/features/serviceAccounts';
@@ -478,6 +480,16 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/oauthClients',
                 element: <OAuthClientsPanel />,
+            });
+        }
+
+        if (
+            user?.ability.can('manage', 'Organization') &&
+            isSsoOrganizationSettingsEnabled
+        ) {
+            allowedRoutes.push({
+                path: '/verifiedDomains',
+                element: <VerifiedDomainsPanel />,
             });
         }
 
@@ -896,6 +908,20 @@ const Settings: FC = () => {
                                         }
                                     />
                                 )}
+
+                                {user.ability.can('manage', 'Organization') &&
+                                    isSsoOrganizationSettingsEnabled && (
+                                        <RouterNavLink
+                                            label="Verified domains"
+                                            exact
+                                            to="/generalSettings/verifiedDomains"
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconWorldCheck}
+                                                />
+                                            }
+                                        />
+                                    )}
 
                                 {user.ability.can('manage', 'Organization') &&
                                     isSsoOrganizationSettingsEnabled && (


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7516/domain-verification
Closes: https://linear.app/lightdash/issue/PROD-7216/add-organization-level-domain-allowlist-settings

<img width="945" height="401" alt="CleanShot 2026-05-28 at 09 19 19" src="https://github.com/user-attachments/assets/d9a42251-e267-46d5-b992-b170075f25ac" />

<img width="934" height="399" alt="CleanShot 2026-05-27 at 16 43 55" src="https://github.com/user-attachments/assets/0acfcc75-b6f2-4e84-acdb-64a3e8518524" />

<img width="936" height="173" alt="CleanShot 2026-05-27 at 16 44 30" src="https://github.com/user-attachments/assets/6a901fe2-9b4b-45b6-8d05-9c53306dd1e4" />
<img width="750" height="150" alt="CleanShot 2026-05-27 at 16 44 54" src="https://github.com/user-attachments/assets/31430a83-de63-4ac2-af48-8a1c747fdfc7" />

### Description:

Introduces organization domain verification — a flow that lets organization admins prove they own a domain by receiving a one-time passcode at an address on that domain. Verified domains become the single source of truth for SSO routing, replacing the previous approach of routing based on the organization's allowed email domains list.

**Backend:**
- New `organization_domain_verifications` table with a partial unique index on `(domain) WHERE verified_at IS NOT NULL`, enforcing a global first-verified-wins rule so only one organization can hold a verified domain at a time.
- `OrganizationDomainVerificationModel` handles challenge upserts (bcrypt-hashed passcodes), attempt tracking, passcode comparison, and marking domains as verified.
- `OrganizationDomainVerificationService` orchestrates the full lifecycle: requesting a challenge (sends a branded email via a new `domainVerification` email template), confirming a passcode, listing verified domains, and deleting a domain. Rejects public email providers and domains already claimed by another org.
- `OrganizationSsoModel` now joins against `organization_domain_verifications` instead of `organization_allowed_email_domains` when resolving which SSO methods to offer for a given email domain. Methods with `override_email_domains = false` route all of the org's verified domains; methods with `override_email_domains = true` route only the configured subset.
- `OrganizationSsoService` validates that any domains added to an override subset are already verified by the organization.
- Shared OTP helpers (`generateOneTimePasscode`, `isOtpExpired`, `isOtpMaxAttempts`, `otpExpirationDate`) extracted into a reusable utility with unit tests.
- `isPublicEmailProviderDomain` consolidated into `@lightdash/common`, merging the previous `EMAIL_PROVIDER_LIST` with the separate blocklist that lived in `OrganizationSsoService`.
- New REST endpoints under `GET/POST/DELETE /api/v1/org/domains` with full OpenAPI/tsoa definitions.

**Frontend:**
- New **Verified Domains** settings panel (`/generalSettings/verifiedDomains`) where admins can add a domain (entering a challenge email), enter the 6-digit code with a live countdown timer, and remove verified domains.
- SSO method panels (Google, Okta, Azure AD, OneLogin, Generic OIDC) now use a shared `SsoMethodDomainsField` component. The override toggle switches from a free-text tags input to a `MultiSelect` restricted to the organization's verified domains, with a link to the verified domains page when none exist.