### PR TITLE
fix(slack): always provide top-level text fallback for chat.postMessage

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -177,6 +177,39 @@ const lightdashLogLevelToSlackLogLevel = (
     }
 };
 
+/**
+ * Walk a Block Kit payload looking for the first piece of text we can use as
+ * the top-level `text` fallback (push notifications, screen readers, etc.).
+ * Returns `undefined` when nothing usable is found — the caller picks a
+ * generic fallback.
+ */
+const pickFallbackText = (
+    blocks: ChatPostMessageArguments['blocks'],
+): string | undefined => {
+    if (!blocks) {
+        return undefined;
+    }
+    for (const block of blocks) {
+        // Section / header blocks store text at `block.text.text`. Context
+        // blocks store an array under `block.elements`. We accept either.
+        const b = block as {
+            text?: { text?: string } | string;
+            elements?: ReadonlyArray<{ text?: string }>;
+        };
+        if (typeof b.text === 'string' && b.text.length > 0) {
+            return b.text;
+        }
+        if (b.text && typeof b.text !== 'string' && b.text.text) {
+            return b.text.text;
+        }
+        const elementText = b.elements?.find((el) => el.text)?.text;
+        if (elementText) {
+            return elementText;
+        }
+    }
+    return undefined;
+};
+
 export class SlackClient {
     slackAuthenticationModel: SlackAuthenticationModel;
 
@@ -907,11 +940,21 @@ export class SlackClient {
             channel,
         );
 
+        // Slack requires a top-level `text` even when `blocks` is provided —
+        // it's the fallback shown in push notifications, screen readers, etc.
+        // Derive one from the first textual block when the caller hasn't set
+        // it explicitly, so we never trip the "missing text" Bolt warning.
+        const text =
+            slackMessageArgs.text ??
+            pickFallbackText(slackMessageArgs.blocks) ??
+            'New message from Lightdash';
+
         return webClient.chat
             .postMessage({
                 ...(appProfilePhotoUrl ? { icon_url: appProfilePhotoUrl } : {}),
                 channel: resolvedChannel,
                 ...slackMessageArgs,
+                text,
             })
             .catch((e) => {
                 if (getSlackErrorCode(e) === 'invalid_blocks') {


### PR DESCRIPTION
## Summary

\`SlackClient.postMessage\` was forwarding \`blocks\`-only payloads to Slack without a top-level \`text\`. The Bolt runtime warns on every such call:

\`\`\`
[WARN] bolt-app The top-level \`text\` argument is missing in the request payload for a chat.postMessage call
\`\`\`

Slack uses \`text\` as the fallback in push notifications, screen readers, and any context that can't render Block Kit. The wrapper now always sends one, derived in priority order:

1. The caller's explicit \`text\` (unchanged).
2. The first textual content found by walking \`blocks\` — section / header \`text.text\`, or the first \`elements[].text\` for context blocks.
3. A generic \`'New message from Lightdash'\` fallback.

## Why a wrapper-level fix

\`SlackClient.postMessage\` is the single chokepoint for ~10+ callers across \`AiAgentService\` and elsewhere. Fixing it here removes the warning everywhere and gives screen-reader users a meaningful preview without touching every caller. Callers that already pass \`text\` keep their behaviour.

## Test plan

- [x] \`pnpm -F backend typecheck\` clean
- [x] \`pnpm -F backend lint\` clean
- [ ] Manual: send a Slack notification via the AI agent — confirm the Bolt warning no longer appears in API logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)