### PR TITLE
fix(prod-7941): push date and user predicates into user-activity CTE

### DIFF
--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -150,6 +150,8 @@ query_executed AS (
     left join ${SpaceTableName} s on s.space_id  = sq.space_id
     left join projects on projects.project_id = s.project_id
   WHERE  projects.project_uuid = '${projectUuid}'
+    AND acv.timestamp >= CURRENT_DATE - interval '42 days'
+    AND acv.user_uuid in ('${userUuids.join(`','`)}')
   GROUP BY 1, 2
 ),
 stg AS (


### PR DESCRIPTION
## Summary

- Adds two redundant `WHERE` predicates to the `query_executed` CTE in `AnalyticsModelSql.dateUserViewsGrid` so postgres scans only the relevant slice of `analytics_chart_views` instead of aggregating its entire history before the downstream `LEFT JOIN` filters it.
- Strictly semantically equivalent — the predicates match what the existing join already enforces — but it lets the planner use the `analytics_chart_views(timestamp)` index added in migration `20230202114455`.

## Why

PROD-7941: Customer's Cloud SQL CPU pinned at 99% for ~65 min on 2026-05-26 20:10–21:15 UTC. Same pattern hit on 2026-05-14 (peak 97%, sustained 80-90% for ~4h). Investigation traced it to `GET /api/v1/analytics/user-activity/<projectUuid>` (single requests took 27–50 minutes during the spike, multiple concurrent loads compounded). Postgres logs showed three parallel workers each writing ~170 MB temp files for the `dateUserViewsGrid` CTE.

The root cause is that `query_executed` does `COUNT(DISTINCT chart_uuid) GROUP BY date, user_uuid` over `analytics_chart_views` filtered only by `project_uuid` — no date or user bound. For large customers this aggregates millions of rows just to feed a 42-day × N-user LEFT JOIN that throws most of them away.

## Equivalence

- `users_date_grid` already constrains the join to dates in `[CURRENT_DATE - 42 days, CURRENT_DATE]` and `user_uuid IN (userUuids)`.
- `stg.LEFT JOIN query_executed ON user_uuid AND date` discards any `query_executed` rows that don't match a grid row.
- Adding the same two predicates to `query_executed.WHERE` removes those rows before aggregation. `COUNT(DISTINCT chart_uuid)` is per `(date, user_uuid)` bucket, so per-bucket totals are unaffected by which other buckets exist.
- NULL `acv.user_uuid` rows were already excluded by the JOIN; the new `IN (...)` filter excludes them the same way.
- Empty `userUuids[]` already produced invalid SQL in `users_date_grid`, so this PR does not introduce a new failure mode.

## Test plan

- [ ] Open the per-project User Activity page on a non-trivial project; verify charts (weekly querying users, weekly average queries) render the same values as before
- [ ] Inspect query plan on a representative DB — confirm `analytics_chart_views(timestamp)` index is used
- [ ] Watch Cloud SQL CPU after deploy; the next user-activity load should not produce 170MB temp file spills

## Related

- Linear: PROD-7941
- Follow-up (not in this PR): add per-pod single-flight + short TTL cache to `AnalyticsModel.getUserActivity`, gated behind `EXPERIMENTAL_CACHE`, to mitigate concurrent-load amplification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)