### PR TITLE
chore(ai-writeback): replace skip-permissions with explicit allowlist

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -30,6 +30,7 @@ import { BaseService } from '../../../services/BaseService';
 import type { DbAiWritebackThread } from '../../database/entities/ai';
 import type { AiWritebackThreadModel } from '../../models/AiWritebackThreadModel';
 import {
+    ALLOWED_TOOLS,
     COMMIT_AUTHOR_EMAIL,
     COMMIT_AUTHOR_NAME,
     CWD,
@@ -562,7 +563,7 @@ export class AiWritebackService extends BaseService {
             `cat ${PROMPT_PATH} | claude -p ${continueFlag}` +
                 `--append-system-prompt-file ${SYSTEM_PROMPT_PATH} ` +
                 '--output-format text ' +
-                '--dangerously-skip-permissions',
+                `--allowedTools "${ALLOWED_TOOLS}"`,
             {
                 cwd: CWD,
                 timeoutMs: RUN_TIMEOUT_MS,

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -24,3 +24,34 @@ export const RUN_TIMEOUT_MS = 10 * 60 * 1000;
 // How long an E2B sandbox stays alive before E2B reaps it. Used both when
 // creating a sandbox and when connecting to a paused one to keep it warm.
 export const SANDBOX_TIMEOUT_MS = 60 * 60 * 1000;
+
+// Temporary copy of `profiles.yml` with Jinja env_var(...) expressions
+// stripped, so `lightdash compile --skip-warehouse-catalog` can parse it
+// without any runtime variables set. Kept off the repo tree so it can't
+// leak into the PR.
+export const TMP_PROFILES_DIR = '/tmp/ld-profiles';
+
+// Fine-grained tool permissions for the Claude Code CLI — used in place of
+// `--dangerously-skip-permissions`. Follows Claude Code's `--allowedTools`
+// syntax: `Tool(specifier)`, where `//path` denotes an absolute filesystem
+// path. The agent only needs:
+//   - read/edit/write/glob/grep over the cloned repo at CWD
+//   - read/write/edit under TMP_PROFILES_DIR (the patched profiles copy)
+//   - write to the two PR metadata files the host reads after the run
+//   - bash scoped to `lightdash compile` and the file ops needed to set up
+//     the temporary profiles dir
+export const ALLOWED_TOOLS = [
+    `Read(/${CWD}/**)`,
+    `Glob(/${CWD}/**)`,
+    `Grep(/${CWD}/**)`,
+    `Edit(/${CWD}/**)`,
+    `Write(/${CWD}/**)`,
+    `Read(/${TMP_PROFILES_DIR}/**)`,
+    `Write(/${TMP_PROFILES_DIR}/**)`,
+    `Edit(/${TMP_PROFILES_DIR}/**)`,
+    `Write(/${PR_TITLE_PATH})`,
+    `Write(/${PR_DESCRIPTION_PATH})`,
+    'Bash(lightdash compile:*)',
+    'Bash(mkdir:*)',
+    'Bash(cp:*)',
+].join(',');

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -1,4 +1,8 @@
-import { PR_DESCRIPTION_PATH, PR_TITLE_PATH } from './constants';
+import {
+    PR_DESCRIPTION_PATH,
+    PR_TITLE_PATH,
+    TMP_PROFILES_DIR,
+} from './constants';
 
 // Instructions prepended to every user prompt. The host owns git, so the agent
 // must not touch it; instead it leaves the PR title/description on disk.
@@ -38,8 +42,8 @@ finish:
    \`dbt_project.yml\` in \`${dbtProjectDir}\`). The directory that contains it
    is the original profiles directory.
 
-3. Prepare a TEMPORARY profiles directory at \`/tmp/ld-profiles\`:
-   - Copy the discovered \`profiles.yml\` to \`/tmp/ld-profiles/profiles.yml\`.
+3. Prepare a TEMPORARY profiles directory at \`${TMP_PROFILES_DIR}\`:
+   - Copy the discovered \`profiles.yml\` to \`${TMP_PROFILES_DIR}/profiles.yml\`.
    - In the COPY only, replace every Jinja \`env_var(...)\` expression — and
      any other Jinja expression that requires runtime values — with a literal
      placeholder string (e.g. \`"placeholder"\`). The goal is a syntactically
@@ -50,7 +54,7 @@ finish:
 
 4. From the repo root, run:
      lightdash compile --skip-warehouse-catalog \\
-       --profiles-dir /tmp/ld-profiles \\
+       --profiles-dir ${TMP_PROFILES_DIR} \\
        --project-dir ${dbtProjectDir}
    Capture the exit code and the last meaningful line of output.
 


### PR DESCRIPTION
Closes: [PROD-7948](https://linear.app/lightdash/issue/PROD-7948/dont-use-dangerously-skip-permissions)

## Summary

The writeback agent currently launches Claude Code with `--dangerously-skip-permissions`, which disables every tool-permission check inside the sandbox. Replace it with `--allowedTools` carrying a minimal allowlist, matching the pattern `AppGenerateService` already uses for its own Claude runner.

## Changes

- `AiWritebackService.ts` — swap `--dangerously-skip-permissions` for `--allowedTools "${ALLOWED_TOOLS}"`.
- `constants.ts` — add `ALLOWED_TOOLS` (the full allowlist) and `TMP_PROFILES_DIR` so the path is named in one place.
- `templates.ts` — reference `TMP_PROFILES_DIR` instead of hard-coding `/tmp/ld-profiles`, so the system prompt and the allowlist can't drift apart.

## Why this is better

- **Bounded blast radius.** The agent can only touch `/home/user/repo/**`, `/tmp/ld-profiles/**`, and the two PR metadata files. A prompt-injected or misbehaving turn can't write outside the sandbox repo or exfiltrate arbitrary files.
- **Bash is explicit.** Only `lightdash compile:*`, `mkdir:*`, and `cp:*` are reachable — exactly what the system prompt instructs the agent to run for the compile-check step.
- **Consistent with `AppGenerateService`.** Both sandboxed Claude runners now configure permissions the same way, so future grants land in one obvious place.

```
Allowed:
  Read/Glob/Grep/Edit/Write   //home/user/repo/**
  Read/Write/Edit             //tmp/ld-profiles/**
  Write                       //tmp/pr_title.txt
  Write                       //tmp/pr_description.md
  Bash                        lightdash compile:*, mkdir:*, cp:*

Blocked (previously implicit allow):
  Read/Write                  anything outside the paths above
  Bash                        anything not in those three prefixes
  WebFetch, WebSearch, Task, NotebookEdit, ...
```

## Test plan

- [ ] Trigger a writeback run from Slack against a test dbt project; confirm the agent completes the `lightdash compile` step and writes `pr_title.txt` + `pr_description.md`.
- [ ] Verify a Bash command outside the allowlist (e.g. `curl`) is rejected inside the sandbox.
- [ ] Verify a resumed conversation (`--continue`) still works under the new flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)