### PR TITLE
chore(ai-writeback): pin claude model to claude-sonnet-4-6

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -31,6 +31,7 @@ import type { DbAiWritebackThread } from '../../database/entities/ai';
 import type { AiWritebackThreadModel } from '../../models/AiWritebackThreadModel';
 import {
     ALLOWED_TOOLS,
+    CLAUDE_MODEL,
     COMMIT_AUTHOR_EMAIL,
     COMMIT_AUTHOR_NAME,
     CWD,
@@ -561,6 +562,7 @@ export class AiWritebackService extends BaseService {
         const continueFlag = isResume ? '--continue ' : '';
         const result = await sandbox.commands.run(
             `cat ${PROMPT_PATH} | claude -p ${continueFlag}` +
+                `--model ${CLAUDE_MODEL} ` +
                 `--append-system-prompt-file ${SYSTEM_PROMPT_PATH} ` +
                 '--output-format text ' +
                 `--allowedTools "${ALLOWED_TOOLS}"`,

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -55,3 +55,8 @@ export const ALLOWED_TOOLS = [
     'Bash(mkdir:*)',
     'Bash(cp:*)',
 ].join(',');
+
+// Anthropic model used for the writeback agent. Pinned to a specific Sonnet
+// snapshot rather than the CLI default so runs stay deterministic across
+// Claude Code releases.
+export const CLAUDE_MODEL = 'claude-sonnet-4-6';


### PR DESCRIPTION
Closes: [PROD-7951](https://linear.app/lightdash/issue/PROD-7951/use-sonnet-explicitly)

## Summary

The writeback agent currently invokes `claude` with no `--model` flag, so the model in use is whatever the Claude Code CLI defaults to at the time. That default shifts between CLI releases, which makes writeback behaviour non-deterministic and hard to reason about during incident reviews.

Pin the model to a specific Sonnet snapshot via a named constant, mirroring how `AppGenerateService` already passes `--model` to its own claude runner.

## Changes

- `constants.ts` — add `CLAUDE_MODEL = 'claude-sonnet-4-6'`, with a comment explaining why it's pinned rather than an env var or alias.
- `AiWritebackService.ts` — pass `--model ${CLAUDE_MODEL}` inside `runAgentInSandbox`.

## Why this is better

- **Deterministic across CLI upgrades.** A writeback run today and one in three months land on the same model unless we deliberately bump the constant — so regressions point at our code, not at the CLI's default drift.
- **Visible in source.** Reviewers can tell which model the agent runs on by reading `constants.ts`, without checking Claude Code release notes or sandbox env.
- **Consistent with `AppGenerateService`.** Both sandboxed Claude runners now name their model in the same place.

```
Before:  claude -p --append-system-prompt-file … --output-format text --dangerously-skip-permissions
                  ^ implicit default — varies across CLI releases

After:   claude -p --model claude-sonnet-4-6 --append-system-prompt-file … …
                  ^ pinned in constants.ts
```

## Notes

Touches the same `runAgentInSandbox` call as #23564 (the `--allowedTools` swap). The two PRs are independent edits to that command string; whichever lands second needs a trivial conflict fix.

## Test plan

- [ ] Trigger a writeback run from Slack and confirm the agent completes and the claude stderr shows Sonnet was used.
- [ ] Locally change `CLAUDE_MODEL` to another model id, re-run, and confirm the new value takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)