### PR TITLE
feat(ai-router): add AiRouterModel, AiRouterService and TSOA controller

### DIFF
--- a/packages/backend/src/ee/controllers/aiRouterController.ts
+++ b/packages/backend/src/ee/controllers/aiRouterController.ts
@@ -1,0 +1,159 @@
+import {
+    assertRegisteredAccount,
+    type AiRouterDecisionCommitRequest,
+    type AiRouterDecisionConfidence,
+    type AiRouterRouteRequest,
+    type AiRouterSelectionMode,
+    type ApiAiRouterDecisionCommitResponse,
+    type ApiAiRouterDecisionListResponse,
+    type ApiAiRouterResponse,
+    type ApiAiRouterRouteResponse,
+    type ApiErrorPayload,
+    type UpsertAiRouterRequest,
+} from '@lightdash/common';
+import {
+    Body,
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Put,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { AiRouterService } from '../services/AiRouterService/AiRouterService';
+
+@Route('/api/v1/org/aiRouter')
+@Response<ApiErrorPayload>('default', 'Error')
+export class AiRouterController extends BaseController {
+    /**
+     * Get the AI router configuration for the organization. Returns 404 when the
+     * router has not been configured yet — clients use this to detect first-use.
+     * @summary Get AI router config
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('getAiRouterConfig')
+    async getConfig(
+        @Request() req: express.Request,
+    ): Promise<ApiAiRouterResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.routerService().getConfig(req.account),
+        };
+    }
+
+    /**
+     * Upsert the AI router configuration. Creates the row lazily on first save.
+     * @summary Upsert AI router config
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Put('/')
+    @OperationId('upsertAiRouterConfig')
+    async upsertConfig(
+        @Request() req: express.Request,
+        @Body() body: UpsertAiRouterRequest,
+    ): Promise<ApiAiRouterResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.routerService().upsertConfig(req.account, body),
+        };
+    }
+
+    /**
+     * Route a user prompt to the best candidate agent in the current project.
+     * @summary Route prompt
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/route')
+    @OperationId('routeAiAgent')
+    async route(
+        @Request() req: express.Request,
+        @Body() body: AiRouterRouteRequest,
+    ): Promise<ApiAiRouterRouteResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.routerService().route(req.account, body),
+        };
+    }
+
+    /**
+     * Commit a router decision once the user has resolved it (router
+     * auto-routed and the thread is created, or the user picked an agent
+     * from the picker). Decisions left uncommitted indicate the user
+     * abandoned the flow.
+     * @summary Commit router decision
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/decisions/{decisionUuid}/commit')
+    @OperationId('commitAiRouterDecision')
+    async commit(
+        @Request() req: express.Request,
+        @Path() decisionUuid: string,
+        @Body() body: AiRouterDecisionCommitRequest,
+    ): Promise<ApiAiRouterDecisionCommitResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        await this.routerService().commitDecision(
+            req.account,
+            decisionUuid,
+            body,
+        );
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * List recent routing decisions for the org's router.
+     * @summary List router decisions
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/decisions')
+    @OperationId('listAiRouterDecisions')
+    async listDecisions(
+        @Request() req: express.Request,
+        @Query() confidence?: AiRouterDecisionConfidence,
+        @Query() selectionMode?: AiRouterSelectionMode,
+        @Query() fromDate?: string,
+        @Query() toDate?: string,
+    ): Promise<ApiAiRouterDecisionListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.routerService().listDecisions(req.account, {
+                confidence,
+                selectionMode,
+                fromDate,
+                toDate,
+            }),
+        };
+    }
+
+    private routerService(): AiRouterService {
+        return this.services.getAiRouterService<AiRouterService>();
+    }
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -18,6 +18,7 @@ import { CommercialSlackClient } from './clients/Slack/SlackClient';
 import { AiAgentDocumentModel } from './models/AiAgentDocumentModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
+import { AiRouterModel } from './models/AiRouterModel';
 import { AiWritebackThreadModel } from './models/AiWritebackThreadModel';
 import { CommercialFeatureFlagModel } from './models/CommercialFeatureFlagModel';
 import { CommercialSlackAuthenticationModel } from './models/CommercialSlackAuthenticationModel';
@@ -34,6 +35,7 @@ import { AiAgentAdminService } from './services/AiAgentAdminService';
 import { AiAgentDocumentService } from './services/AiAgentDocumentService';
 import { AiAgentService } from './services/AiAgentService/AiAgentService';
 import { AiOrganizationSettingsService } from './services/AiOrganizationSettingsService';
+import { AiRouterService } from './services/AiRouterService/AiRouterService';
 import { AiService } from './services/AiService/AiService';
 import { AiWritebackService } from './services/AiWritebackService/AiWritebackService';
 import { AppGenerateService } from './services/AppGenerateService/AppGenerateService';
@@ -191,6 +193,13 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AiAgentAdminService({
                     aiAgentModel: models.getAiAgentModel(),
                     lightdashConfig: context.lightdashConfig,
+                }),
+            aiRouterService: ({ models, repository, context }) =>
+                new AiRouterService({
+                    lightdashConfig: context.lightdashConfig,
+                    aiRouterModel: models.getAiRouterModel<AiRouterModel>(),
+                    aiAgentService:
+                        repository.getAiAgentService<AiAgentService>(),
                 }),
             aiAgentDocumentService: ({ models, repository, context }) =>
                 new AiAgentDocumentService({
@@ -502,6 +511,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AiAgentDocumentModel({ database }),
             aiWritebackThreadModel: ({ database }) =>
                 new AiWritebackThreadModel({ database }),
+            aiRouterModel: ({ database }) => new AiRouterModel({ database }),
             aiOrganizationSettingsModel: ({ database }) =>
                 new AiOrganizationSettingsModel({ database }),
             embedModel: ({ database }) => new EmbedModel({ database }),

--- a/packages/backend/src/ee/models/AiRouterModel.ts
+++ b/packages/backend/src/ee/models/AiRouterModel.ts
@@ -1,0 +1,178 @@
+import {
+    NotFoundError,
+    type AiRouter,
+    type AiRouterDecision,
+    type AiRouterDecisionConfidence,
+    type AiRouterDecisionListFilters,
+    type AiRouterSelectionMode,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    AiRouterDecisionTableName,
+    AiRouterTableName,
+    type DbAiRouter,
+    type DbAiRouterDecision,
+} from '../database/entities/aiRouter';
+
+const toAiRouter = (row: DbAiRouter): AiRouter => ({
+    routerUuid: row.ai_router_uuid,
+    organizationUuid: row.organization_uuid,
+    enabled: row.enabled,
+    projectUuids: row.project_uuids,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+});
+
+const toAiRouterDecision = (row: DbAiRouterDecision): AiRouterDecision => ({
+    decisionUuid: row.ai_router_decision_uuid,
+    routerUuid: row.ai_router_uuid,
+    threadUuid: row.thread_uuid,
+    userUuid: row.user_uuid,
+    prompt: row.prompt,
+    suggestedAgentUuid: row.suggested_agent_uuid,
+    chosenAgentUuid: row.chosen_agent_uuid,
+    confidence: row.confidence,
+    reasoning: row.reasoning,
+    candidateAgentUuids: row.candidate_agent_uuids,
+    selectionMode: row.selection_mode,
+    createdAt: row.created_at,
+    committedAt: row.committed_at,
+});
+
+export class AiRouterModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async findByOrganization(
+        organizationUuid: string,
+    ): Promise<AiRouter | null> {
+        const row = await this.database(AiRouterTableName)
+            .where({ organization_uuid: organizationUuid })
+            .first();
+        return row ? toAiRouter(row) : null;
+    }
+
+    async upsert({
+        organizationUuid,
+        enabled,
+        projectUuids,
+    }: {
+        organizationUuid: string;
+        enabled?: boolean;
+        projectUuids?: string[];
+    }): Promise<AiRouter> {
+        const insertPayload: {
+            organization_uuid: string;
+            enabled?: boolean;
+            project_uuids?: string[];
+        } = { organization_uuid: organizationUuid };
+
+        if (enabled !== undefined) insertPayload.enabled = enabled;
+        if (projectUuids !== undefined)
+            insertPayload.project_uuids = projectUuids;
+
+        const updatePayload: Record<string, unknown> = {
+            updated_at: this.database.fn.now(),
+        };
+        if (enabled !== undefined) updatePayload.enabled = enabled;
+        if (projectUuids !== undefined)
+            updatePayload.project_uuids = projectUuids;
+
+        const [row] = await this.database(AiRouterTableName)
+            .insert(insertPayload)
+            .onConflict('organization_uuid')
+            .merge(updatePayload)
+            .returning('*');
+
+        return toAiRouter(row);
+    }
+
+    async createDecision(args: {
+        routerUuid: string;
+        userUuid: string;
+        prompt: string;
+        suggestedAgentUuid: string;
+        confidence: AiRouterDecisionConfidence;
+        reasoning: string;
+        candidateAgentUuids: string[];
+    }): Promise<AiRouterDecision> {
+        const [row] = await this.database(AiRouterDecisionTableName)
+            .insert({
+                ai_router_uuid: args.routerUuid,
+                user_uuid: args.userUuid,
+                prompt: args.prompt,
+                suggested_agent_uuid: args.suggestedAgentUuid,
+                confidence: args.confidence,
+                reasoning: args.reasoning,
+                candidate_agent_uuids: args.candidateAgentUuids,
+            })
+            .returning('*');
+        return toAiRouterDecision(row);
+    }
+
+    async commitDecision(args: {
+        decisionUuid: string;
+        chosenAgentUuid: string;
+        threadUuid: string;
+        selectionMode: AiRouterSelectionMode;
+    }): Promise<AiRouterDecision> {
+        const [row] = await this.database(AiRouterDecisionTableName)
+            .where({ ai_router_decision_uuid: args.decisionUuid })
+            .whereNull('chosen_agent_uuid')
+            .update({
+                chosen_agent_uuid: args.chosenAgentUuid,
+                thread_uuid: args.threadUuid,
+                selection_mode: args.selectionMode,
+                committed_at: this.database.fn.now(),
+            })
+            .returning('*');
+        if (!row) {
+            throw new NotFoundError(
+                `AI router decision ${args.decisionUuid} not found or already committed`,
+            );
+        }
+        return toAiRouterDecision(row);
+    }
+
+    async getDecision(decisionUuid: string): Promise<AiRouterDecision> {
+        const row = await this.database(AiRouterDecisionTableName)
+            .where({ ai_router_decision_uuid: decisionUuid })
+            .first();
+        if (!row) {
+            throw new NotFoundError(
+                `AI router decision ${decisionUuid} not found`,
+            );
+        }
+        return toAiRouterDecision(row);
+    }
+
+    async listDecisions({
+        routerUuid,
+        filters,
+        limit = 100,
+    }: {
+        routerUuid: string;
+        filters?: AiRouterDecisionListFilters;
+        limit?: number;
+    }): Promise<AiRouterDecision[]> {
+        let query = this.database(AiRouterDecisionTableName)
+            .where({ ai_router_uuid: routerUuid })
+            .orderBy('created_at', 'desc')
+            .limit(limit);
+
+        if (filters?.confidence)
+            query = query.andWhere('confidence', filters.confidence);
+        if (filters?.selectionMode)
+            query = query.andWhere('selection_mode', filters.selectionMode);
+        if (filters?.fromDate)
+            query = query.andWhere('created_at', '>=', filters.fromDate);
+        if (filters?.toDate)
+            query = query.andWhere('created_at', '<=', filters.toDate);
+
+        const rows = await query;
+        return rows.map(toAiRouterDecision);
+    }
+}

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6664,7 +6664,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     /**
      * Get available agents for a user with their full context, filtered by access if OAuth is required
      */
-    private async getAvailableAgents(
+    public async getAvailableAgents(
         organizationUuid: string,
         userUuid: string,
         slackSettings: { aiRequireOAuth?: boolean },

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -1,0 +1,235 @@
+import { subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    NotFoundError,
+    ParameterError,
+    type AiRouter,
+    type AiRouterDecision,
+    type AiRouterDecisionListFilters,
+    type AiRouterRouteResponseResult,
+    type AiRouterSelectionMode,
+    type RegisteredAccount,
+    type UpsertAiRouterRequest,
+} from '@lightdash/common';
+import { LightdashConfig } from '../../../config/parseConfig';
+import { BaseService } from '../../../services/BaseService';
+import { type AiRouterModel } from '../../models/AiRouterModel';
+import { selectAgent } from '../ai/agents/agentSelector';
+import { getModel } from '../ai/models';
+import { type AiAgentService } from '../AiAgentService/AiAgentService';
+
+type Deps = {
+    lightdashConfig: LightdashConfig;
+    aiRouterModel: AiRouterModel;
+    aiAgentService: AiAgentService;
+};
+
+export class AiRouterService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly aiRouterModel: AiRouterModel;
+
+    private readonly aiAgentService: AiAgentService;
+
+    constructor({ lightdashConfig, aiRouterModel, aiAgentService }: Deps) {
+        super({ serviceName: 'AiRouterService' });
+        this.lightdashConfig = lightdashConfig;
+        this.aiRouterModel = aiRouterModel;
+        this.aiAgentService = aiAgentService;
+    }
+
+    private static organizationUuidOf(account: RegisteredAccount): string {
+        const organizationUuid = account.organization?.organizationUuid;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not a member of an organization');
+        }
+        return organizationUuid;
+    }
+
+    private assertManageAiAgent(
+        account: RegisteredAccount,
+        organizationUuid: string,
+    ): void {
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot('manage', subject('AiAgent', { organizationUuid }))
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    private assertViewAiAgent(
+        account: RegisteredAccount,
+        organizationUuid: string,
+    ): void {
+        const ability = this.createAuditedAbility(account);
+        if (ability.cannot('view', subject('AiAgent', { organizationUuid }))) {
+            throw new ForbiddenError();
+        }
+    }
+
+    private async getEnabledRouter(
+        organizationUuid: string,
+    ): Promise<AiRouter> {
+        const router =
+            await this.aiRouterModel.findByOrganization(organizationUuid);
+        if (!router || !router.enabled) {
+            throw new NotFoundError('AI router is not enabled');
+        }
+        return router;
+    }
+
+    async getConfig(account: RegisteredAccount): Promise<AiRouter> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertManageAiAgent(account, organizationUuid);
+        const router =
+            await this.aiRouterModel.findByOrganization(organizationUuid);
+        if (!router) {
+            throw new NotFoundError('AI router not configured');
+        }
+        return router;
+    }
+
+    async upsertConfig(
+        account: RegisteredAccount,
+        body: UpsertAiRouterRequest,
+    ): Promise<AiRouter> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertManageAiAgent(account, organizationUuid);
+        return this.aiRouterModel.upsert({
+            organizationUuid,
+            enabled: body.enabled,
+            projectUuids: body.projectUuids,
+        });
+    }
+
+    async listDecisions(
+        account: RegisteredAccount,
+        filters?: AiRouterDecisionListFilters,
+    ): Promise<AiRouterDecision[]> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertManageAiAgent(account, organizationUuid);
+        const router =
+            await this.aiRouterModel.findByOrganization(organizationUuid);
+        if (!router) return [];
+        return this.aiRouterModel.listDecisions({
+            routerUuid: router.routerUuid,
+            filters,
+        });
+    }
+
+    /**
+     * Runs the router for a prompt and persists a pending decision row.
+     * The caller must follow up with {@link commitDecision} once the thread
+     * is created (or never, in which case the row stays uncommitted and
+     * serves as an abandonment signal).
+     *
+     * Requires at least two candidate agents — the frontend short-circuits
+     * the routing UI when there are zero or one accessible agents in scope.
+     */
+    async route(
+        account: RegisteredAccount,
+        { prompt, projectUuid }: { prompt: string; projectUuid: string },
+    ): Promise<AiRouterRouteResponseResult> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertViewAiAgent(account, organizationUuid);
+
+        const router = await this.getEnabledRouter(organizationUuid);
+
+        const candidates = await this.aiAgentService.getAvailableAgents(
+            organizationUuid,
+            account.user.userUuid,
+            { aiRequireOAuth: true },
+            { projectFilter: { projectUuid } },
+        );
+
+        if (candidates.length < 2) {
+            throw new ParameterError(
+                'AI router requires at least two accessible agents',
+            );
+        }
+
+        const { model } = getModel(this.lightdashConfig.ai.copilot);
+        const brain = await selectAgent({ model, candidates, prompt });
+
+        const nextAction =
+            brain.confidence === 'high' && !brain.shouldSkipForwardingQuery
+                ? 'create_thread'
+                : 'show_picker';
+
+        const decision = await this.aiRouterModel.createDecision({
+            routerUuid: router.routerUuid,
+            userUuid: account.user.userUuid,
+            prompt,
+            suggestedAgentUuid: brain.selectedAgentUuid,
+            confidence: brain.confidence,
+            reasoning: brain.reasoning,
+            candidateAgentUuids: candidates.map((c) => c.uuid),
+        });
+
+        return {
+            decision: {
+                decisionUuid: decision.decisionUuid,
+                suggestedAgentUuid: brain.selectedAgentUuid,
+                confidence: brain.confidence,
+                reasoning: brain.reasoning,
+                candidates: candidates.map((c) => ({
+                    agentUuid: c.uuid,
+                    name: c.name,
+                    description: c.description ?? null,
+                })),
+            },
+            nextAction,
+        };
+    }
+
+    /**
+     * Commits a pending decision once the user has resolved it (router
+     * auto-routed and the thread is created, or the user picked an agent
+     * from the picker). Sets the chosen agent, thread linkage, and
+     * derives the selection_mode from the recorded confidence.
+     */
+    async commitDecision(
+        account: RegisteredAccount,
+        decisionUuid: string,
+        {
+            chosenAgentUuid,
+            threadUuid,
+        }: {
+            chosenAgentUuid: string;
+            threadUuid: string;
+        },
+    ): Promise<void> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertViewAiAgent(account, organizationUuid);
+
+        const decision = await this.aiRouterModel.getDecision(decisionUuid);
+        if (decision.userUuid !== account.user.userUuid) {
+            throw new ForbiddenError();
+        }
+        const router =
+            await this.aiRouterModel.findByOrganization(organizationUuid);
+        if (!router || router.routerUuid !== decision.routerUuid) {
+            throw new ForbiddenError();
+        }
+
+        if (!decision.candidateAgentUuids.includes(chosenAgentUuid)) {
+            throw new ParameterError(
+                'Chosen agent was not among the routing candidates',
+            );
+        }
+
+        const selectionMode: AiRouterSelectionMode =
+            decision.confidence === 'high' &&
+            chosenAgentUuid === decision.suggestedAgentUuid
+                ? 'auto_routed'
+                : 'manual_pick';
+
+        await this.aiRouterModel.commitDecision({
+            decisionUuid,
+            chosenAgentUuid,
+            threadUuid,
+            selectionMode,
+        });
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -127,6 +127,8 @@ import { AiAgentDocumentController } from './../ee/controllers/aiAgentDocumentCo
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiController } from './../ee/controllers/aiController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AiRouterController } from './../ee/controllers/aiRouterController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiWritebackController } from './../ee/controllers/AiWritebackController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AppGenerateController } from './../ee/controllers/appGenerateController';
@@ -9405,6 +9407,280 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouter: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                projectUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                enabled: { dataType: 'boolean', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+                routerUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiRouter_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiRouter', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiRouterResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiRouter_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpsertAiRouterRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                projectUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
+                enabled: { dataType: 'boolean' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterDecisionConfidence: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['high'] },
+                { dataType: 'enum', enums: ['medium'] },
+                { dataType: 'enum', enums: ['low'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterDecisionCandidate: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                agentUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterRouteDecision: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                candidates: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiRouterDecisionCandidate',
+                    },
+                    required: true,
+                },
+                reasoning: { dataType: 'string', required: true },
+                confidence: {
+                    ref: 'AiRouterDecisionConfidence',
+                    required: true,
+                },
+                suggestedAgentUuid: { dataType: 'string', required: true },
+                decisionUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterRouteNextAction: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['create_thread'] },
+                { dataType: 'enum', enums: ['show_picker'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterRouteResponseResult: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                nextAction: { ref: 'AiRouterRouteNextAction', required: true },
+                decision: { ref: 'AiRouterRouteDecision', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiRouterRouteResponseResult_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiRouterRouteResponseResult', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiRouterRouteResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiRouterRouteResponseResult_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterRouteRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                projectUuid: { dataType: 'string', required: true },
+                prompt: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiRouterDecisionCommitResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccessEmpty', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterDecisionCommitRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                threadUuid: { dataType: 'string', required: true },
+                chosenAgentUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterSelectionMode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['auto_routed'] },
+                { dataType: 'enum', enums: ['manual_pick'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterDecision: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                committedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdAt: { dataType: 'datetime', required: true },
+                selectionMode: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiRouterSelectionMode' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                candidateAgentUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                reasoning: { dataType: 'string', required: true },
+                confidence: {
+                    ref: 'AiRouterDecisionConfidence',
+                    required: true,
+                },
+                chosenAgentUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                suggestedAgentUuid: { dataType: 'string', required: true },
+                prompt: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+                threadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                routerUuid: { dataType: 'string', required: true },
+                decisionUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiRouterDecision-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiRouterDecision' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiRouterDecisionListResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiRouterDecision-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardSummaryTone: {
         dataType: 'refEnum',
         enums: ['friendly', 'formal', 'direct', 'enthusiastic'],
@@ -11753,11 +12029,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -11815,11 +12091,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -11856,11 +12132,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12412,11 +12688,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12435,11 +12711,11 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -12458,11 +12734,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12477,11 +12753,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12496,11 +12772,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12515,11 +12791,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -24809,7 +25085,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24819,7 +25095,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24829,7 +25105,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -24842,7 +25118,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -25497,7 +25773,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -25507,7 +25783,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -25517,7 +25793,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -25530,7 +25806,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -39054,6 +39330,305 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'listMyApps',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiRouterController_getConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/org/aiRouter',
+        ...fetchMiddlewares<RequestHandler>(AiRouterController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiRouterController.prototype.getConfig,
+        ),
+
+        async function AiRouterController_getConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiRouterController_getConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiRouterController>(AiRouterController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiRouterController_upsertConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpsertAiRouterRequest',
+        },
+    };
+    app.put(
+        '/api/v1/org/aiRouter',
+        ...fetchMiddlewares<RequestHandler>(AiRouterController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiRouterController.prototype.upsertConfig,
+        ),
+
+        async function AiRouterController_upsertConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiRouterController_upsertConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiRouterController>(AiRouterController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiRouterController_route: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'AiRouterRouteRequest',
+        },
+    };
+    app.post(
+        '/api/v1/org/aiRouter/route',
+        ...fetchMiddlewares<RequestHandler>(AiRouterController),
+        ...fetchMiddlewares<RequestHandler>(AiRouterController.prototype.route),
+
+        async function AiRouterController_route(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiRouterController_route,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiRouterController>(AiRouterController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'route',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiRouterController_commit: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        decisionUuid: {
+            in: 'path',
+            name: 'decisionUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'AiRouterDecisionCommitRequest',
+        },
+    };
+    app.post(
+        '/api/v1/org/aiRouter/decisions/:decisionUuid/commit',
+        ...fetchMiddlewares<RequestHandler>(AiRouterController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiRouterController.prototype.commit,
+        ),
+
+        async function AiRouterController_commit(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiRouterController_commit,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiRouterController>(AiRouterController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'commit',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiRouterController_listDecisions: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        confidence: {
+            in: 'query',
+            name: 'confidence',
+            ref: 'AiRouterDecisionConfidence',
+        },
+        selectionMode: {
+            in: 'query',
+            name: 'selectionMode',
+            ref: 'AiRouterSelectionMode',
+        },
+        fromDate: { in: 'query', name: 'fromDate', dataType: 'string' },
+        toDate: { in: 'query', name: 'toDate', dataType: 'string' },
+    };
+    app.get(
+        '/api/v1/org/aiRouter/decisions',
+        ...fetchMiddlewares<RequestHandler>(AiRouterController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiRouterController.prototype.listDecisions,
+        ),
+
+        async function AiRouterController_listDecisions(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiRouterController_listDecisions,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiRouterController>(AiRouterController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listDecisions',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10923,6 +10923,279 @@
             "ApiMyAppsResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__data-ApiAppSummary-Array--pagination_63_-KnexPaginateArgs-and-_totalPageCount-number--totalResults-number___"
             },
+            "AiRouter": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "projectUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "routerUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "createdAt",
+                    "projectUuids",
+                    "enabled",
+                    "organizationUuid",
+                    "routerUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiRouter_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiRouter"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiRouterResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiRouter_"
+            },
+            "UpsertAiRouterRequest": {
+                "properties": {
+                    "projectUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "AiRouterDecisionConfidence": {
+                "type": "string",
+                "enum": ["high", "medium", "low"]
+            },
+            "AiRouterDecisionCandidate": {
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "agentUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["description", "name", "agentUuid"],
+                "type": "object"
+            },
+            "AiRouterRouteDecision": {
+                "properties": {
+                    "candidates": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiRouterDecisionCandidate"
+                        },
+                        "type": "array"
+                    },
+                    "reasoning": {
+                        "type": "string"
+                    },
+                    "confidence": {
+                        "$ref": "#/components/schemas/AiRouterDecisionConfidence"
+                    },
+                    "suggestedAgentUuid": {
+                        "type": "string"
+                    },
+                    "decisionUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "candidates",
+                    "reasoning",
+                    "confidence",
+                    "suggestedAgentUuid",
+                    "decisionUuid"
+                ],
+                "type": "object"
+            },
+            "AiRouterRouteNextAction": {
+                "type": "string",
+                "enum": ["create_thread", "show_picker"]
+            },
+            "AiRouterRouteResponseResult": {
+                "properties": {
+                    "nextAction": {
+                        "$ref": "#/components/schemas/AiRouterRouteNextAction"
+                    },
+                    "decision": {
+                        "$ref": "#/components/schemas/AiRouterRouteDecision"
+                    }
+                },
+                "required": ["nextAction", "decision"],
+                "type": "object"
+            },
+            "ApiSuccess_AiRouterRouteResponseResult_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiRouterRouteResponseResult"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiRouterRouteResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiRouterRouteResponseResult_"
+            },
+            "AiRouterRouteRequest": {
+                "properties": {
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "prompt": {
+                        "type": "string"
+                    }
+                },
+                "required": ["projectUuid", "prompt"],
+                "type": "object"
+            },
+            "ApiAiRouterDecisionCommitResponse": {
+                "$ref": "#/components/schemas/ApiSuccessEmpty"
+            },
+            "AiRouterDecisionCommitRequest": {
+                "properties": {
+                    "threadUuid": {
+                        "type": "string"
+                    },
+                    "chosenAgentUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["threadUuid", "chosenAgentUuid"],
+                "type": "object"
+            },
+            "AiRouterSelectionMode": {
+                "type": "string",
+                "enum": ["auto_routed", "manual_pick"]
+            },
+            "AiRouterDecision": {
+                "properties": {
+                    "committedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "selectionMode": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiRouterSelectionMode"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "candidateAgentUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "reasoning": {
+                        "type": "string"
+                    },
+                    "confidence": {
+                        "$ref": "#/components/schemas/AiRouterDecisionConfidence"
+                    },
+                    "chosenAgentUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "suggestedAgentUuid": {
+                        "type": "string"
+                    },
+                    "prompt": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string"
+                    },
+                    "threadUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "routerUuid": {
+                        "type": "string"
+                    },
+                    "decisionUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "committedAt",
+                    "createdAt",
+                    "selectionMode",
+                    "candidateAgentUuids",
+                    "reasoning",
+                    "confidence",
+                    "chosenAgentUuid",
+                    "suggestedAgentUuid",
+                    "prompt",
+                    "userUuid",
+                    "threadUuid",
+                    "routerUuid",
+                    "decisionUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiRouterDecision-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiRouterDecision"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiRouterDecisionListResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiRouterDecision-Array_"
+            },
             "DashboardSummaryTone": {
                 "enum": ["friendly", "formal", "direct", "enthusiastic"],
                 "type": "string"
@@ -13321,8 +13594,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13380,8 +13653,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13405,19 +13678,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -13663,8 +13923,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "success",
-                                                            "error",
                                                             "rejected",
+                                                            "error",
                                                             "timeout"
                                                         ]
                                                     }
@@ -26044,22 +26304,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -26619,22 +26879,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -35383,7 +35643,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3028.1",
+        "version": "0.3030.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -36781,6 +37041,231 @@
                 "tags": ["Projects"],
                 "security": [],
                 "parameters": []
+            }
+        },
+        "/api/v1/org/aiRouter": {
+            "get": {
+                "operationId": "getAiRouterConfig",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiRouterResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the AI router configuration for the organization. Returns 404 when the\nrouter has not been configured yet — clients use this to detect first-use.",
+                "summary": "Get AI router config",
+                "security": [],
+                "parameters": []
+            },
+            "put": {
+                "operationId": "upsertAiRouterConfig",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiRouterResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Upsert the AI router configuration. Creates the row lazily on first save.",
+                "summary": "Upsert AI router config",
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpsertAiRouterRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/aiRouter/route": {
+            "post": {
+                "operationId": "routeAiAgent",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiRouterRouteResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Route a user prompt to the best candidate agent in the current project.",
+                "summary": "Route prompt",
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AiRouterRouteRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/aiRouter/decisions/{decisionUuid}/commit": {
+            "post": {
+                "operationId": "commitAiRouterDecision",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiRouterDecisionCommitResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Commit a router decision once the user has resolved it (router\nauto-routed and the thread is created, or the user picked an agent\nfrom the picker). Decisions left uncommitted indicate the user\nabandoned the flow.",
+                "summary": "Commit router decision",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "decisionUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AiRouterDecisionCommitRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/aiRouter/decisions": {
+            "get": {
+                "operationId": "listAiRouterDecisions",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiRouterDecisionListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List recent routing decisions for the org's router.",
+                "summary": "List router decisions",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "confidence",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/AiRouterDecisionConfidence"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "selectionMode",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/AiRouterSelectionMode"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "fromDate",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "toDate",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/aiAgents/documents": {

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -139,6 +139,7 @@ export type ModelManifest = {
     aiAgentModel: unknown;
     aiAgentDocumentModel: unknown;
     aiWritebackThreadModel: unknown;
+    aiRouterModel: unknown;
     managedAgentModel: unknown;
     aiOrganizationSettingsModel: unknown;
     embedModel: unknown;
@@ -736,6 +737,10 @@ export class ModelRepository
 
     public getAiWritebackThreadModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiWritebackThreadModel');
+    }
+
+    public getAiRouterModel<ModelImplT>(): ModelImplT {
+        return this.getModel('aiRouterModel');
     }
 
     public getAiOrganizationSettingsModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -138,6 +138,7 @@ interface ServiceManifest {
     aiAgentService: unknown;
     aiAgentAdminService: unknown;
     aiAgentDocumentService: unknown;
+    aiRouterService: unknown;
     aiOrganizationSettingsService: unknown;
     scimService: unknown;
     supportService: unknown;
@@ -1268,6 +1269,10 @@ export class ServiceRepository
         AiAgentDocumentServiceImplT,
     >(): AiAgentDocumentServiceImplT {
         return this.getService('aiAgentDocumentService');
+    }
+
+    public getAiRouterService<AiRouterServiceImplT>(): AiRouterServiceImplT {
+        return this.getService('aiRouterService');
     }
 
     public getRolesService(): RolesService {

--- a/packages/common/src/ee/AiRouter/index.ts
+++ b/packages/common/src/ee/AiRouter/index.ts
@@ -1,0 +1,81 @@
+import { type ApiSuccess, type ApiSuccessEmpty } from '../../types/api/success';
+
+export type AiRouter = {
+    routerUuid: string;
+    organizationUuid: string;
+    enabled: boolean;
+    projectUuids: string[];
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type ApiAiRouterResponse = ApiSuccess<AiRouter>;
+
+export type UpsertAiRouterRequest = {
+    enabled?: boolean;
+    projectUuids?: string[];
+};
+
+export type AiRouterDecisionConfidence = 'high' | 'medium' | 'low';
+
+export type AiRouterSelectionMode = 'auto_routed' | 'manual_pick';
+
+export type AiRouterDecisionCandidate = {
+    agentUuid: string;
+    name: string;
+    description: string | null;
+};
+
+export type AiRouterDecision = {
+    decisionUuid: string;
+    routerUuid: string;
+    threadUuid: string | null;
+    userUuid: string;
+    prompt: string;
+    suggestedAgentUuid: string;
+    chosenAgentUuid: string | null;
+    confidence: AiRouterDecisionConfidence;
+    reasoning: string;
+    candidateAgentUuids: string[];
+    selectionMode: AiRouterSelectionMode | null;
+    createdAt: Date;
+    committedAt: Date | null;
+};
+
+export type AiRouterRouteRequest = {
+    prompt: string;
+    projectUuid: string;
+};
+
+export type AiRouterRouteNextAction = 'create_thread' | 'show_picker';
+
+export type AiRouterRouteDecision = {
+    decisionUuid: string;
+    suggestedAgentUuid: string;
+    confidence: AiRouterDecisionConfidence;
+    reasoning: string;
+    candidates: AiRouterDecisionCandidate[];
+};
+
+export type AiRouterRouteResponseResult = {
+    decision: AiRouterRouteDecision;
+    nextAction: AiRouterRouteNextAction;
+};
+
+export type ApiAiRouterRouteResponse = ApiSuccess<AiRouterRouteResponseResult>;
+
+export type AiRouterDecisionCommitRequest = {
+    chosenAgentUuid: string;
+    threadUuid: string;
+};
+
+export type ApiAiRouterDecisionCommitResponse = ApiSuccessEmpty;
+
+export type AiRouterDecisionListFilters = {
+    confidence?: AiRouterDecisionConfidence;
+    selectionMode?: AiRouterSelectionMode;
+    fromDate?: string;
+    toDate?: string;
+};
+
+export type ApiAiRouterDecisionListResponse = ApiSuccess<AiRouterDecision[]>;

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -1,5 +1,6 @@
 export * from './AiAgent';
 export * from './aiWriteback/types';
+export * from './AiRouter';
 export * from './apps/types';
 export * from './ambientAi';
 export * from './commercialFeatureFlags';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -24,6 +24,10 @@ import type {
     ApiAiGenerateTableCalculationResponse,
     ApiAiGetDashboardSummaryResponse,
     ApiAiOrganizationSettingsResponse,
+    ApiAiRouterDecisionCommitResponse,
+    ApiAiRouterDecisionListResponse,
+    ApiAiRouterResponse,
+    ApiAiRouterRouteResponse,
     ApiAppendInstructionResponse,
     ApiAppImageUploadResponse,
     ApiCreateEvaluationResponse,
@@ -1061,6 +1065,10 @@ type ApiResults =
     | ApiGetChangeResponse['results']
     | ApiAiOrganizationSettingsResponse['results']
     | ApiUpdateAiOrganizationSettingsResponse['results']
+    | ApiAiRouterResponse['results']
+    | ApiAiRouterRouteResponse['results']
+    | ApiAiRouterDecisionCommitResponse['results']
+    | ApiAiRouterDecisionListResponse['results']
     | ApiProjectCompileLogsResponse['results']
     | ApiProjectCompileLogResponse['results']
     | ApiSingleValidationResponse['results']


### PR DESCRIPTION
## Summary

Backend wiring on top of the schema and the shared selector.

- `AiRouterModel` — config get/upsert, create/commit decision, list decisions.
- `AiRouterService`:
  - `getConfig` / `upsertConfig` for the admin page (org-scoped).
  - `route(prompt, projectUuid)` — gated by `getEnabledRouter()`. Requires ≥2 candidate agents; calls `selectAgent`; inserts a pending decision row; returns suggested agent + confidence + candidates + next action (`create_thread` or `show_picker`).
  - `commitDecision(decisionUuid, chosenAgentUuid, threadUuid)` — single atomic update that sets `chosen_agent_uuid`, `thread_uuid`, derives `selection_mode` from confidence + (chosen == suggested), and stamps `committed_at`. Idempotent via a `WHERE chosen_agent_uuid IS NULL` guard. Abandoned decisions stay with `selection_mode IS NULL`.
- `AiRouterController` (TSOA) — `GET/PUT /org/aiRouter`, `POST /org/aiRouter/route`, `POST /org/aiRouter/decisions/:uuid/commit`, `GET /org/aiRouter/decisions`.
- Common types added to the `ApiResults` union so consumers of `lightdashApi<...>` typecheck without casts.

Closes #23451