### PR TITLE
feat(ai-router): move agent selector into chat input toolbar

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -1,22 +1,32 @@
 import {
+    Avatar,
     Center,
     Combobox,
     Group,
     InputBase,
+    Stack,
     Text,
     useCombobox,
 } from '@mantine-8/core';
-import { IconCheck, IconCirclePlus, IconSelector } from '@tabler/icons-react';
+import {
+    IconCheck,
+    IconCirclePlus,
+    IconSelector,
+    IconSparkles,
+} from '@tabler/icons-react';
 import { useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiRouterConfig } from '../../hooks/useAiRouter';
 import { getAgentOptions, type Agent } from './AgentSelectorUtils';
 
 type Props = {
     agents: Agent[];
-    selectedAgent: Agent;
+    selectedAgent: Agent | 'auto';
     projectUuid: string;
 };
+
+const AUTO_VALUE = '__auto__';
 
 export const AgentSelector = ({
     agents,
@@ -30,12 +40,24 @@ export const AgentSelector = ({
     });
 
     const agentOptions = getAgentOptions(agents);
+    const isAuto = selectedAgent === 'auto';
+    // Auto is only meaningful when there's more than one agent AND the router
+    // is enabled. Treat any non-`enabled: true` state (loading, error, disabled)
+    // as "no Auto" to avoid flashing the option in and out.
+    const { data: aiRouterConfig } = useAiRouterConfig();
+    const showAutoOption =
+        agents.length > 1 && aiRouterConfig?.enabled === true;
 
     const handleOptionSubmit = (value: string) => {
         if (value === 'new') {
             void navigate(`/projects/${projectUuid}/ai-agents/new`, {
                 viewTransition: true,
             });
+        } else if (value === AUTO_VALUE) {
+            void navigate(
+                { pathname: `/projects/${projectUuid}/ai-agents`, search },
+                { viewTransition: true },
+            );
         } else {
             void navigate(
                 {
@@ -64,11 +86,21 @@ export const AgentSelector = ({
                     pointer
                     onClick={() => combobox.toggleDropdown()}
                     leftSection={
-                        <LightdashUserAvatar
-                            size={22}
-                            name={selectedAgent.name}
-                            src={selectedAgent.imageUrl}
-                        />
+                        isAuto ? (
+                            <Avatar size={22} color="violet" radius="xl">
+                                <MantineIcon
+                                    icon={IconSparkles}
+                                    size="sm"
+                                    color="violet.6"
+                                />
+                            </Avatar>
+                        ) : (
+                            <LightdashUserAvatar
+                                size={22}
+                                name={selectedAgent.name}
+                                src={selectedAgent.imageUrl}
+                            />
+                        )
                     }
                     rightSection={<MantineIcon icon={IconSelector} />}
                     styles={(theme) => ({
@@ -81,12 +113,42 @@ export const AgentSelector = ({
                     })}
                 >
                     <Text size="xs" truncate="end" ml={2}>
-                        {selectedAgent.name}
+                        {isAuto ? 'Auto' : selectedAgent.name}
                     </Text>
                 </InputBase>
             </Combobox.Target>
 
             <Combobox.Dropdown>
+                {showAutoOption && (
+                    <Combobox.Header p={4} pr={6}>
+                        <Combobox.Option value={AUTO_VALUE} p={2}>
+                            <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
+                                <Avatar size={22} color="violet" radius="xl">
+                                    <MantineIcon
+                                        icon={IconSparkles}
+                                        size="sm"
+                                        color="violet.6"
+                                    />
+                                </Avatar>
+                                <Stack gap={0} flex={1} miw={0}>
+                                    <Text size="xs" fw={600} c="violet.7">
+                                        Auto
+                                    </Text>
+                                    <Text size="xs" c="dimmed" truncate="end">
+                                        Let AI pick the best agent
+                                    </Text>
+                                </Stack>
+                                {isAuto && (
+                                    <MantineIcon
+                                        icon={IconCheck}
+                                        size="sm"
+                                        color="violet"
+                                    />
+                                )}
+                            </Group>
+                        </Combobox.Option>
+                    </Combobox.Header>
+                )}
                 <Combobox.Options>
                     {agentOptions.map((item) => (
                         <Combobox.Option
@@ -106,13 +168,14 @@ export const AgentSelector = ({
                                     {item.label}
                                 </Text>
 
-                                {item.value === selectedAgent.uuid && (
-                                    <MantineIcon
-                                        icon={IconCheck}
-                                        size="sm"
-                                        color="violet"
-                                    />
-                                )}
+                                {!isAuto &&
+                                    item.value === selectedAgent.uuid && (
+                                        <MantineIcon
+                                            icon={IconCheck}
+                                            size="sm"
+                                            color="violet"
+                                        />
+                                    )}
                             </Group>
                         </Combobox.Option>
                     ))}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
@@ -1,0 +1,63 @@
+import { Box, Button, Group } from '@mantine-8/core';
+import { IconSettings, IconWindowMinimize } from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+
+type Props = {
+    leftSection?: ReactNode;
+    onMinimize?: () => void;
+    settingsHref?: string;
+};
+
+export const AgentPageHeader: FC<Props> = ({
+    leftSection,
+    onMinimize,
+    settingsHref,
+}) => (
+    <Group align="center" justify="space-between">
+        <Box>{leftSection}</Box>
+        <Group gap="xs">
+            {onMinimize && (
+                <Button
+                    variant="default"
+                    onClick={onMinimize}
+                    leftSection={
+                        <MantineIcon
+                            icon={IconWindowMinimize}
+                            style={{ transform: 'scaleX(-1)' }}
+                        />
+                    }
+                    styles={(theme) => ({
+                        root: {
+                            borderColor: theme.colors.ldGray[2],
+                            boxShadow: `var(--mantine-shadow-subtle)`,
+                            color: theme.colors.ldGray[9],
+                            fontSize: theme.fontSizes.xs,
+                        },
+                    })}
+                >
+                    Minimize
+                </Button>
+            )}
+            {settingsHref && (
+                <Button
+                    component={Link}
+                    variant="default"
+                    to={settingsHref}
+                    leftSection={<MantineIcon icon={IconSettings} />}
+                    styles={(theme) => ({
+                        root: {
+                            borderColor: theme.colors.ldGray[2],
+                            boxShadow: `var(--mantine-shadow-subtle)`,
+                            color: theme.colors.ldGray[9],
+                            fontSize: theme.fontSizes.xs,
+                        },
+                    })}
+                >
+                    Settings
+                </Button>
+            )}
+        </Group>
+    </Group>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
@@ -1,0 +1,231 @@
+import { type AiAgent, type AiAgentThreadSummary } from '@lightdash/common';
+import {
+    Alert,
+    Box,
+    Button,
+    Paper,
+    rem,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+    NavLink,
+} from '@mantine-8/core';
+import {
+    IconBrandSlack,
+    IconChevronDown,
+    IconCirclePlus,
+    IconInfoCircle,
+    IconSparkles,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings';
+import { useAiAgentThreads } from '../../hooks/useProjectAiAgents';
+import { SidebarButton } from './SidebarButton';
+
+const INITIAL_MAX_THREADS = 10;
+const MAX_THREADS_INCREMENT = 10;
+
+type ThreadNavLinkProps = {
+    thread: AiAgentThreadSummary;
+    isActive: boolean;
+    projectUuid: string;
+};
+
+const ThreadNavLink: FC<ThreadNavLinkProps> = ({
+    thread,
+    isActive,
+    projectUuid,
+}) => (
+    <NavLink
+        color="gray"
+        component={Link}
+        key={thread.uuid}
+        to={`/projects/${projectUuid}/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`}
+        px="xs"
+        py={rem(4)}
+        style={(theme) => ({
+            borderRadius: theme.radius.sm,
+        })}
+        label={
+            <Text truncate="end" size="sm" c="ldGray.9">
+                {thread.title || thread.firstMessage.message}
+            </Text>
+        }
+        active={isActive}
+        rightSection={
+            thread.createdFrom === 'slack' && (
+                <Tooltip label={'Threads created in slack are read only'}>
+                    <IconBrandSlack size={18} stroke={1} />
+                </Tooltip>
+            )
+        }
+        viewTransition
+    />
+);
+
+const TrialAlert = () => (
+    <Alert
+        icon={<MantineIcon icon={IconSparkles} />}
+        variant="outline"
+        color="indigo.6"
+        bg="indigo.0"
+        fz="xs"
+        p="xs"
+        title={
+            <Text size="xs" fw={500}>
+                You're currently using Lightdash AI Agents in free trial mode
+            </Text>
+        }
+    >
+        <Button
+            size="compact-xs"
+            variant="light"
+            color="indigo"
+            leftSection={<MantineIcon icon={IconInfoCircle} size="sm" />}
+            component={Link}
+            to="https://docs.lightdash.com/guides/ai-agents"
+            target="_blank"
+        >
+            Learn more
+        </Button>
+    </Alert>
+);
+
+type AgentSidebarProps = {
+    agent: AiAgent;
+    projectUuid: string;
+    threadUuid?: string;
+    isAgentSidebarCollapsed: boolean;
+};
+
+export const AgentSidebar: FC<AgentSidebarProps> = ({
+    agent,
+    projectUuid,
+    threadUuid,
+    isAgentSidebarCollapsed,
+}) => {
+    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
+    const isTrial =
+        aiOrganizationSettingsQuery.isSuccess &&
+        aiOrganizationSettingsQuery.data.isTrial;
+    const { data: threads } = useAiAgentThreads(projectUuid, agent.uuid);
+    const [showMaxItems, setShowMaxItems] = useState(INITIAL_MAX_THREADS);
+
+    return (
+        <Stack gap="md" style={{ flexGrow: 1, overflowY: 'auto' }}>
+            <Box>
+                <SidebarButton
+                    leftSection={<MantineIcon icon={IconCirclePlus} />}
+                    component={Link}
+                    to={`/projects/${projectUuid}/ai-agents/${agent.uuid}/threads`}
+                    size="sm"
+                    {...(!isAgentSidebarCollapsed && {
+                        fullWidth: true,
+                        justify: 'flex-start',
+                    })}
+                >
+                    {isAgentSidebarCollapsed ? '' : 'New thread'}
+                </SidebarButton>
+            </Box>
+
+            {projectUuid && threads && !isAgentSidebarCollapsed && (
+                <Stack gap="xs" style={{ flexGrow: 1, overflowY: 'auto' }}>
+                    <Title
+                        order={6}
+                        c="dimmed"
+                        tt="uppercase"
+                        size="xs"
+                        ml="xs"
+                    >
+                        Recent
+                    </Title>
+
+                    <Stack gap={2}>
+                        {threads.length === 0 && (
+                            <Paper variant="dotted" p="sm">
+                                <Text
+                                    truncate="end"
+                                    size="sm"
+                                    c="ldGray.6"
+                                    ta="center"
+                                >
+                                    No threads yet
+                                </Text>
+                            </Paper>
+                        )}
+
+                        <Box>
+                            {threads.slice(0, showMaxItems).map((thread) => (
+                                <ThreadNavLink
+                                    key={thread.uuid}
+                                    thread={thread}
+                                    isActive={thread.uuid === threadUuid}
+                                    projectUuid={projectUuid}
+                                />
+                            ))}
+                        </Box>
+                    </Stack>
+
+                    <Box>
+                        {threads.length >= showMaxItems && (
+                            <Button
+                                size="compact-xs"
+                                variant="subtle"
+                                onClick={() =>
+                                    setShowMaxItems(
+                                        (s) => s + MAX_THREADS_INCREMENT,
+                                    )
+                                }
+                                leftSection={
+                                    <MantineIcon icon={IconChevronDown} />
+                                }
+                            >
+                                View more
+                            </Button>
+                        )}
+                    </Box>
+                </Stack>
+            )}
+            {isTrial && <TrialAlert />}
+        </Stack>
+    );
+};
+
+type AutoModeSidebarProps = {
+    projectUuid: string;
+    isAgentSidebarCollapsed: boolean;
+};
+
+export const AutoModeSidebar: FC<AutoModeSidebarProps> = ({
+    projectUuid,
+    isAgentSidebarCollapsed,
+}) => {
+    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
+    const isTrial =
+        aiOrganizationSettingsQuery.isSuccess &&
+        aiOrganizationSettingsQuery.data.isTrial;
+
+    return (
+        <Stack gap="md" style={{ flexGrow: 1, overflowY: 'auto' }}>
+            <Box>
+                <SidebarButton
+                    leftSection={<MantineIcon icon={IconCirclePlus} />}
+                    component={Link}
+                    to={`/projects/${projectUuid}/ai-agents`}
+                    size="sm"
+                    {...(!isAgentSidebarCollapsed && {
+                        fullWidth: true,
+                        justify: 'flex-start',
+                    })}
+                >
+                    {isAgentSidebarCollapsed ? '' : 'New thread'}
+                </SidebarButton>
+            </Box>
+
+            {isTrial && <TrialAlert />}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -77,7 +77,7 @@ interface AgentChatInputProps {
     threadUuid?: string;
     latestAssistantMessageUuid?: string;
     agents?: Agent[];
-    selectedAgent?: Agent;
+    selectedAgent?: Agent | 'auto';
     models?: AiModelOption[];
     selectedModelId?: string | null;
     onModelChange?: (modelId: string) => void;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -30,6 +30,8 @@ import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeat
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import { useAgentSuggestions } from '../../hooks/useAgentSuggestions';
+import { AgentSelector } from '../AgentSelector';
+import { type Agent } from '../AgentSelector/AgentSelectorUtils';
 import styles from './AgentChatInput.module.css';
 import { AgentSuggestionChips } from './AgentSuggestionChips';
 import { getAgentSuggestionModes } from './suggestionModes';
@@ -74,6 +76,8 @@ interface AgentChatInputProps {
     agentUuid?: string;
     threadUuid?: string;
     latestAssistantMessageUuid?: string;
+    agents?: Agent[];
+    selectedAgent?: Agent;
     models?: AiModelOption[];
     selectedModelId?: string | null;
     onModelChange?: (modelId: string) => void;
@@ -111,6 +115,8 @@ export const AgentChatInput = ({
     agentUuid,
     threadUuid,
     latestAssistantMessageUuid,
+    agents,
+    selectedAgent,
     models,
     selectedModelId,
     onModelChange,
@@ -186,7 +192,13 @@ export const AgentChatInput = ({
 
     const showModelSelector =
         models && models.length > 1 && onModelChange !== undefined;
-    const isMinimalMode = !showModelSelector;
+    const showAgentSelector = !!(
+        agents &&
+        selectedAgent &&
+        projectUuid &&
+        agents.length > 0
+    );
+    const isMinimalMode = !showModelSelector && !showAgentSelector;
 
     const suggestionsFlag = useServerFeatureFlag(
         FeatureFlags.AiAgentSuggestions,
@@ -572,6 +584,14 @@ export const AgentChatInput = ({
 
                 <Box className={styles.toolbar}>
                     <Box className={styles.toolbarActions}>
+                        {showAgentSelector && (
+                            <AgentSelector
+                                projectUuid={projectUuid!}
+                                agents={agents!}
+                                selectedAgent={selectedAgent!}
+                            />
+                        )}
+
                         {showModelSelector && (
                             <ModelSelector
                                 models={models}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
@@ -1,0 +1,21 @@
+import { type AiRouter, type ApiError } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+
+const ROUTER_BASE = '/org/aiRouter';
+
+const getAiRouterConfig = () =>
+    lightdashApi<AiRouter>({
+        url: ROUTER_BASE,
+        method: 'GET',
+        body: undefined,
+    });
+
+// Returns the org's router configuration. 404 (no config yet) and other
+// failures resolve to `isError`; callers treat that as "router disabled".
+export const useAiRouterConfig = () =>
+    useQuery<AiRouter, ApiError>({
+        queryKey: ['ai-router'],
+        queryFn: getAiRouterConfig,
+        retry: false,
+    });

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -1,222 +1,30 @@
-import { type AiAgent, type AiAgentThreadSummary } from '@lightdash/common';
+import { type AiAgent } from '@lightdash/common';
+import { Box, Loader } from '@mantine-8/core';
+import { useState } from 'react';
 import {
-    Alert,
-    Box,
-    Button,
-    Group,
-    Loader,
-    NavLink,
-    Paper,
-    rem,
-    Stack,
-    Text,
-    Title,
-    Tooltip,
-} from '@mantine-8/core';
-import {
-    IconBrandSlack,
-    IconChevronDown,
-    IconCirclePlus,
-    IconInfoCircle,
-    IconSettings,
-    IconSparkles,
-    IconWindowMinimize,
-} from '@tabler/icons-react';
-import { useState, type FC } from 'react';
-import {
-    Link,
     Navigate,
     Outlet,
     useNavigate,
     useParams,
     useSearchParams,
 } from 'react-router';
-import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
+import { AgentSelector } from '../../features/aiCopilot/components/AgentSelector';
+import { AgentPageHeader } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader';
+import { AgentSidebar } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentSidebar';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
-import { SidebarButton } from '../../features/aiCopilot/components/AiAgentPageLayout/SidebarButton';
 import { launcherSession } from '../../features/aiCopilot/components/Launcher/launcherSession';
 import { useLauncherDock } from '../../features/aiCopilot/components/Launcher/useLauncherDock';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
-import { useAiOrganizationSettings } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import {
     useProjectAiAgent as useAiAgent,
     useAiAgentThread,
-    useAiAgentThreads,
     useProjectAiAgents,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
 import { store as aiAgentStore } from '../../features/aiCopilot/store';
 import { openPanel } from '../../features/aiCopilot/store/aiAgentLauncherSlice';
-
-const INITIAL_MAX_THREADS = 10;
-const MAX_THREADS_INCREMENT = 10;
-
-type ThreadNavLinkProps = {
-    thread: AiAgentThreadSummary;
-    isActive: boolean;
-    projectUuid: string;
-};
-
-const ThreadNavLink: FC<ThreadNavLinkProps> = ({
-    thread,
-    isActive,
-    projectUuid,
-}) => (
-    <NavLink
-        color="gray"
-        component={Link}
-        key={thread.uuid}
-        to={`/projects/${projectUuid}/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`}
-        px="xs"
-        py={rem(4)}
-        style={(theme) => ({
-            borderRadius: theme.radius.sm,
-        })}
-        label={
-            <Text truncate="end" size="sm" c="ldGray.9">
-                {thread.title || thread.firstMessage.message}
-            </Text>
-        }
-        active={isActive}
-        rightSection={
-            thread.createdFrom === 'slack' && (
-                <Tooltip label={'Threads created in slack are read only'}>
-                    <IconBrandSlack size={18} stroke={1} />
-                </Tooltip>
-            )
-        }
-        viewTransition
-    />
-);
-
-const AgentSidebar: FC<{
-    agent: AiAgent;
-    projectUuid: string;
-    threadUuid?: string;
-    isAgentSidebarCollapsed: boolean;
-}> = ({ agent, projectUuid, threadUuid, isAgentSidebarCollapsed }) => {
-    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
-    const isTrial =
-        aiOrganizationSettingsQuery.isSuccess &&
-        aiOrganizationSettingsQuery.data.isTrial;
-    const { data: threads } = useAiAgentThreads(projectUuid, agent.uuid);
-    const [showMaxItems, setShowMaxItems] = useState(INITIAL_MAX_THREADS);
-
-    return (
-        <Stack gap="md" style={{ flexGrow: 1, overflowY: 'auto' }}>
-            <Box>
-                <SidebarButton
-                    leftSection={<MantineIcon icon={IconCirclePlus} />}
-                    component={Link}
-                    to={`/projects/${projectUuid}/ai-agents/${agent.uuid}/threads`}
-                    size="sm"
-                    {...(!isAgentSidebarCollapsed && {
-                        fullWidth: true,
-                        justify: 'flex-start',
-                    })}
-                >
-                    {isAgentSidebarCollapsed ? '' : 'New thread'}
-                </SidebarButton>
-            </Box>
-
-            {projectUuid && threads && !isAgentSidebarCollapsed && (
-                <Stack gap="xs" style={{ flexGrow: 1, overflowY: 'auto' }}>
-                    <Title
-                        order={6}
-                        c="dimmed"
-                        tt="uppercase"
-                        size="xs"
-                        ml="xs"
-                    >
-                        Recent
-                    </Title>
-
-                    <Stack gap={2}>
-                        {threads.length === 0 && (
-                            <Paper variant="dotted" p="sm">
-                                <Text
-                                    truncate="end"
-                                    size="sm"
-                                    c="ldGray.6"
-                                    ta="center"
-                                >
-                                    No threads yet
-                                </Text>
-                            </Paper>
-                        )}
-
-                        <Box>
-                            {threads.slice(0, showMaxItems).map((thread) => (
-                                <ThreadNavLink
-                                    key={thread.uuid}
-                                    thread={thread}
-                                    isActive={thread.uuid === threadUuid}
-                                    projectUuid={projectUuid}
-                                />
-                            ))}
-                        </Box>
-                    </Stack>
-
-                    <Box>
-                        {threads.length >= showMaxItems && (
-                            <Button
-                                size="compact-xs"
-                                variant="subtle"
-                                onClick={() =>
-                                    setShowMaxItems(
-                                        (s) => s + MAX_THREADS_INCREMENT,
-                                    )
-                                }
-                                leftSection={
-                                    <MantineIcon icon={IconChevronDown} />
-                                }
-                                style={{
-                                    root: {
-                                        border: 'none',
-                                    },
-                                }}
-                            >
-                                View more
-                            </Button>
-                        )}
-                    </Box>
-                </Stack>
-            )}
-            {isTrial && (
-                <Alert
-                    icon={<MantineIcon icon={IconSparkles} />}
-                    variant="outline"
-                    color="indigo.6"
-                    bg="indigo.0"
-                    fz="xs"
-                    p="xs"
-                    title={
-                        <Text size="xs" fw={500}>
-                            You're currently using Lightdash AI Agents in free
-                            trial mode
-                        </Text>
-                    }
-                >
-                    <Button
-                        size="compact-xs"
-                        variant="light"
-                        color="indigo"
-                        leftSection={
-                            <MantineIcon icon={IconInfoCircle} size="sm" />
-                        }
-                        component={Link}
-                        to="https://docs.lightdash.com/guides/ai-agents"
-                        target="_blank"
-                    >
-                        Learn more
-                    </Button>
-                </Alert>
-            )}
-        </Stack>
-    );
-};
 
 const AgentPage = () => {
     const { agentUuid, threadUuid, projectUuid } = useParams();
@@ -334,50 +142,23 @@ const AgentPage = () => {
                 />
             }
             Header={
-                <Group align="center" justify="flex-end">
-                    <Group gap="xs">
-                        <Button
-                            variant="default"
-                            onClick={handleMinimize}
-                            leftSection={
-                                <MantineIcon
-                                    icon={IconWindowMinimize}
-                                    style={{ transform: 'scaleX(-1)' }}
-                                />
-                            }
-                            styles={(theme) => ({
-                                root: {
-                                    borderColor: theme.colors.ldGray[2],
-                                    boxShadow: `var(--mantine-shadow-subtle)`,
-                                    color: theme.colors.ldGray[9],
-                                    fontSize: theme.fontSizes.xs,
-                                },
-                            })}
-                        >
-                            Minimize
-                        </Button>
-                        {canManageAgents && (
-                            <Button
-                                component={Link}
-                                variant="default"
-                                to={`/projects/${projectUuid}/ai-agents/${agent.uuid}/edit`}
-                                leftSection={
-                                    <MantineIcon icon={IconSettings} />
-                                }
-                                styles={(theme) => ({
-                                    root: {
-                                        borderColor: theme.colors.ldGray[2],
-                                        boxShadow: `var(--mantine-shadow-subtle)`,
-                                        color: theme.colors.ldGray[9],
-                                        fontSize: theme.fontSizes.xs,
-                                    },
-                                })}
-                            >
-                                Settings
-                            </Button>
-                        )}
-                    </Group>
-                </Group>
+                <AgentPageHeader
+                    leftSection={
+                        threadUuid && agentsList && agentsList.length > 0 ? (
+                            <AgentSelector
+                                projectUuid={projectUuid!}
+                                agents={agentsList}
+                                selectedAgent={agent}
+                            />
+                        ) : undefined
+                    }
+                    onMinimize={handleMinimize}
+                    settingsHref={
+                        canManageAgents
+                            ? `/projects/${projectUuid}/ai-agents/${agent.uuid}/edit`
+                            : undefined
+                    }
+                />
             }
         >
             <Outlet context={{ agent, agents: agentsList ?? [] }} />

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -35,7 +35,6 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
-import { AgentSelector } from '../../features/aiCopilot/components/AgentSelector';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { SidebarButton } from '../../features/aiCopilot/components/AiAgentPageLayout/SidebarButton';
 import { launcherSession } from '../../features/aiCopilot/components/Launcher/launcherSession';
@@ -335,17 +334,7 @@ const AgentPage = () => {
                 />
             }
             Header={
-                <Group align="center" justify="space-between">
-                    <Box>
-                        {agentsList && agentsList.length && (
-                            <AgentSelector
-                                projectUuid={projectUuid!}
-                                agents={agentsList}
-                                selectedAgent={agent}
-                            />
-                        )}
-                    </Box>
-
+                <Group align="center" justify="flex-end">
                     <Group gap="xs">
                         <Button
                             variant="default"
@@ -391,13 +380,14 @@ const AgentPage = () => {
                 </Group>
             }
         >
-            <Outlet context={{ agent }} />
+            <Outlet context={{ agent, agents: agentsList ?? [] }} />
         </AiAgentPageLayout>
     );
 };
 
 export interface AgentContext {
     agent: AiAgent;
+    agents: AiAgent[];
 }
 
 export default AgentPage;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -44,7 +44,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
 
     const agentQuery = useAiAgent(projectUuid!, agentUuid!);
-    const { agent } = useOutletContext<AgentContext>();
+    const { agent, agents } = useOutletContext<AgentContext>();
 
     const canManage = useAiAgentPermission({
         action: 'manage',
@@ -155,6 +155,8 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                 projectUuid={projectUuid}
                 agentUuid={agentUuid}
                 threadUuid={threadUuid}
+                agents={agents}
+                selectedAgent={agent}
                 latestAssistantMessageUuid={
                     [...(thread.messages ?? [])]
                         .reverse()

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -44,7 +44,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
 
     const agentQuery = useAiAgent(projectUuid!, agentUuid!);
-    const { agent, agents } = useOutletContext<AgentContext>();
+    const { agent } = useOutletContext<AgentContext>();
 
     const canManage = useAiAgentPermission({
         action: 'manage',
@@ -155,8 +155,6 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                 projectUuid={projectUuid}
                 agentUuid={agentUuid}
                 threadUuid={threadUuid}
-                agents={agents}
-                selectedAgent={agent}
                 latestAssistantMessageUuid={
                     [...(thread.messages ?? [])]
                         .reverse()

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -1,0 +1,147 @@
+import { Avatar, Center, Stack, Text, Title } from '@mantine-8/core';
+import { IconSparkles } from '@tabler/icons-react';
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { getModelKey } from '../../../components/common/ModelSelector/utils';
+import { AgentPageHeader } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader';
+import { AutoModeSidebar } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentSidebar';
+import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
+import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
+import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
+import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
+import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
+import { useProjectAiAgents } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+
+const AgentsRouterPage = () => {
+    const { projectUuid } = useParams();
+
+    const { data: agents } = useProjectAiAgents({
+        projectUuid: projectUuid!,
+        redirectOnUnauthorized: true,
+    });
+
+    const canManageAgents = useAiAgentPermission({
+        action: 'manage',
+        projectUuid,
+    });
+
+    const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+
+    // The router doesn't have its own agent, so the model lineup is borrowed
+    // from the first agent — this is a prototype stand-in until the backend
+    // picks the model based on the routed agent.
+    const placeholderAgentUuid = agents?.[0]?.uuid;
+    const { data: modelOptions } = useModelOptions({
+        projectUuid,
+        agentUuid: placeholderAgentUuid,
+    });
+
+    const [selectedModelKey, setSelectedModelKey] = useState<string | null>(
+        null,
+    );
+    const [extendedThinking, setExtendedThinking] = useState(false);
+    const [sqlMode, setSqlMode] = useState(false);
+    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+
+    const handleSelectedModelKeyChange = useCallback(
+        (modelKey: string) => {
+            setSelectedModelKey(modelKey);
+            const model = modelOptions?.find(
+                (m) => getModelKey(m) === modelKey,
+            );
+            if (model && !model.supportsReasoning) {
+                setExtendedThinking(false);
+            }
+        },
+        [modelOptions],
+    );
+
+    useEffect(() => {
+        if (modelOptions && !selectedModelKey) {
+            const defaultModel = modelOptions.find((m) => m.default);
+            if (defaultModel) {
+                handleSelectedModelKeyChange(getModelKey(defaultModel));
+            }
+        }
+    }, [modelOptions, selectedModelKey, handleSelectedModelKeyChange]);
+
+    const selectedModel = modelOptions?.find(
+        (m) => getModelKey(m) === selectedModelKey,
+    );
+    const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
+
+    return (
+        <AiAgentPageLayout
+            isAgentSidebarCollapsed={isSidebarCollapsed}
+            setIsAgentSidebarCollapsed={setIsSidebarCollapsed}
+            Sidebar={
+                <AutoModeSidebar
+                    projectUuid={projectUuid!}
+                    isAgentSidebarCollapsed={isSidebarCollapsed}
+                />
+            }
+            Header={
+                <AgentPageHeader
+                    settingsHref={
+                        canManageAgents ? '/ai-agents/admin/agents' : undefined
+                    }
+                />
+            }
+        >
+            <Center h="100%">
+                <Stack
+                    gap="lg"
+                    {...ChatElementsUtils.centeredElementProps}
+                    h="unset"
+                    py="xl"
+                >
+                    <Stack align="center" gap="xxs">
+                        <Avatar size="lg" color="violet" radius="xl">
+                            <MantineIcon
+                                icon={IconSparkles}
+                                size="xl"
+                                color="violet.6"
+                            />
+                        </Avatar>
+                        <Title order={2}>Ask AI</Title>
+                        <Text c="dimmed" size="sm" ta="center" maw={520}>
+                            Ask anything about your data. We&apos;ll route your
+                            question to the right agent — or pin one if
+                            you&apos;d like.
+                        </Text>
+                    </Stack>
+
+                    <AgentChatInput
+                        projectUuid={projectUuid}
+                        agents={agents ?? []}
+                        selectedAgent="auto"
+                        placeholder="Ask anything about your data..."
+                        onSubmit={() => {
+                            // TODO: wire to /route endpoint
+                        }}
+                        models={modelOptions}
+                        selectedModelId={selectedModelKey}
+                        onModelChange={handleSelectedModelKeyChange}
+                        extendedThinking={
+                            showExtendedThinking ? extendedThinking : undefined
+                        }
+                        onExtendedThinkingChange={
+                            showExtendedThinking
+                                ? setExtendedThinking
+                                : undefined
+                        }
+                        sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                        onSqlModeChange={
+                            sqlModeAvailable ? setSqlMode : undefined
+                        }
+                        fullWidth
+                    />
+                </Stack>
+            </Center>
+        </AiAgentPageLayout>
+    );
+};
+
+export default AgentsRouterPage;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
@@ -24,7 +24,7 @@ import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPa
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiOrganizationSettings } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import { useProjectAiAgents } from '../../features/aiCopilot/hooks/useProjectAiAgents';
-import { useGetUserAgentPreferences } from '../../features/aiCopilot/hooks/useUserAgentPreferences';
+import AgentsRouterPage from './AgentsRouterPage';
 
 const AGENT_FEATURES = [
     {
@@ -85,9 +85,6 @@ const AgentsWelcome = () => {
             enabled: isAiCopilotEnabledOrTrial,
         },
     });
-    const userAgentPreferencesQuery = useGetUserAgentPreferences(projectUuid, {
-        enabled: isAiCopilotEnabledOrTrial,
-    });
 
     if (aiOrganizationSettingsQuery.isLoading) {
         return <AiPageLoading />;
@@ -96,30 +93,16 @@ const AgentsWelcome = () => {
         return <Navigate to="/" replace />;
     }
 
-    if (agentsQuery.isError || userAgentPreferencesQuery.isError) {
+    if (agentsQuery.isError) {
         return <div>something went wrong...</div>;
     }
 
-    if (agentsQuery.isLoading || userAgentPreferencesQuery.isLoading) {
+    if (agentsQuery.isLoading) {
         return <AiPageLoading />;
     }
 
-    if (userAgentPreferencesQuery.data?.defaultAgentUuid) {
-        return (
-            <Navigate
-                to={`/projects/${projectUuid}/ai-agents/${userAgentPreferencesQuery.data.defaultAgentUuid}`}
-                replace
-            />
-        );
-    }
-
     if (agentsQuery.data.length > 0) {
-        return (
-            <Navigate
-                to={`/projects/${projectUuid}/ai-agents/${agentsQuery.data[0].uuid}`}
-                replace
-            />
-        );
+        return <AgentsRouterPage />;
     }
 
     return (

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -62,7 +62,7 @@ const AiAgentNewThreadPage: FC = () => {
                     }),
                 ),
         });
-    const { agent } = useOutletContext<AgentContext>();
+    const { agent, agents } = useOutletContext<AgentContext>();
     const { data: verifiedQuestions } = useVerifiedQuestions(
         projectUuid,
         agentUuid,
@@ -262,6 +262,8 @@ const AiAgentNewThreadPage: FC = () => {
                         placeholder={`Ask ${agent.name} anything about your data...`}
                         projectUuid={projectUuid}
                         agentUuid={agent.uuid}
+                        agents={agents}
+                        selectedAgent={agent}
                         models={modelOptions}
                         selectedModelId={selectedModelKey}
                         onModelChange={handleSelectedModelKeyChange}


### PR DESCRIPTION
## Summary

Frontend scaffolding for the router UX.

- **`AgentSelector` supports `selectedAgent: Agent | 'auto'`** — Auto renders a violet sparkle avatar + "Let AI pick the best agent" subtitle inside `Combobox.Header`. Picking Auto navigates to `/projects/:projectUuid/ai-agents` (router landing); picking an agent navigates to its threads (unchanged). Auto is hidden when there is <2 agents OR when the router isn't enabled.
- **New `AgentsRouterPage`** — full-page Ask AI landing at `/projects/:projectUuid/ai-agents` when the router is enabled. Reuses `AiAgentPageLayout`, the chat input, model selector, extended thinking, and SQL mode toggles. No backend wiring here (the input is a no-op; that lands in the next PR).
- **Header / sidebar extraction** — `AgentSidebar`, `AutoModeSidebar`, and `AgentPageHeader` extracted into shared components in `AiAgentPageLayout/`. Both `AgentPage` and `AgentsRouterPage` use them, so the two pages stay visually consistent.
- **Selector placement** — on the agent thread route the selector sits in the page header (`leftSection`); on the new-thread route it sits inside the chat input toolbar.
- **Redirect flow in `AgentsWelcome`** — 0 agents → empty state; 1 agent → navigate directly to that agent (router skipped); 2+ agents + router enabled → render `AgentsRouterPage`; otherwise → user default-agent preference or first agent.
- **`useAiRouterConfig`** — small `GET /org/aiRouter` hook so the redirect flow and `AgentSelector` can read the org's router state.

Closes #23451