### PR TITLE
feat(ai-router): wire router page to /route and /commit endpoints

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
@@ -1,5 +1,11 @@
-import { type AiRouter, type ApiError } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import {
+    type AiRouter,
+    type AiRouterDecisionCommitRequest,
+    type AiRouterRouteRequest,
+    type AiRouterRouteResponseResult,
+    type ApiError,
+} from '@lightdash/common';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
 
 const ROUTER_BASE = '/org/aiRouter';
@@ -18,4 +24,35 @@ export const useAiRouterConfig = () =>
         queryKey: ['ai-router'],
         queryFn: getAiRouterConfig,
         retry: false,
+    });
+
+const routePrompt = (body: AiRouterRouteRequest) =>
+    lightdashApi<AiRouterRouteResponseResult>({
+        url: `${ROUTER_BASE}/route`,
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+export const useAiRouterRoute = () =>
+    useMutation<AiRouterRouteResponseResult, ApiError, AiRouterRouteRequest>({
+        mutationFn: routePrompt,
+    });
+
+const commitDecision = ({
+    decisionUuid,
+    ...body
+}: { decisionUuid: string } & AiRouterDecisionCommitRequest) =>
+    lightdashApi<undefined>({
+        url: `${ROUTER_BASE}/decisions/${decisionUuid}/commit`,
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+export const useAiRouterCommit = () =>
+    useMutation<
+        undefined,
+        ApiError,
+        { decisionUuid: string } & AiRouterDecisionCommitRequest
+    >({
+        mutationFn: commitDecision,
     });

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -1,7 +1,22 @@
-import { Avatar, Center, Stack, Text, Title } from '@mantine-8/core';
+import {
+    type AiAgentSummary,
+    type AiRouterRouteResponseResult,
+} from '@lightdash/common';
+import {
+    Avatar,
+    Card,
+    Center,
+    Group,
+    SimpleGrid,
+    Stack,
+    Text,
+    Title,
+    UnstyledButton,
+} from '@mantine-8/core';
 import { IconSparkles } from '@tabler/icons-react';
-import { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { getModelKey } from '../../../components/common/ModelSelector/utils';
 import { AgentPageHeader } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader';
@@ -9,13 +24,28 @@ import { AutoModeSidebar } from '../../features/aiCopilot/components/AiAgentPage
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
+import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
+import {
+    useAiRouterCommit,
+    useAiRouterRoute,
+} from '../../features/aiCopilot/hooks/useAiRouter';
 import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
-import { useProjectAiAgents } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import {
+    useCreateAgentThreadMutation,
+    useProjectAiAgents,
+} from '../../features/aiCopilot/hooks/useProjectAiAgents';
+
+type Phase =
+    | { kind: 'idle' }
+    | { kind: 'routing' }
+    | { kind: 'picker'; decision: AiRouterRouteResponseResult }
+    | { kind: 'creating' };
 
 const AgentsRouterPage = () => {
     const { projectUuid } = useParams();
+    const navigate = useNavigate();
 
     const { data: agents } = useProjectAiAgents({
         projectUuid: projectUuid!,
@@ -29,9 +59,6 @@ const AgentsRouterPage = () => {
 
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
-    // The router doesn't have its own agent, so the model lineup is borrowed
-    // from the first agent — this is a prototype stand-in until the backend
-    // picks the model based on the routed agent.
     const placeholderAgentUuid = agents?.[0]?.uuid;
     const { data: modelOptions } = useModelOptions({
         projectUuid,
@@ -71,6 +98,124 @@ const AgentsRouterPage = () => {
         (m) => getModelKey(m) === selectedModelKey,
     );
     const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
+
+    const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
+
+    const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+    const [decisionUuid, setDecisionUuid] = useState<string | null>(null);
+    const [chosenAgentUuid, setChosenAgentUuid] = useState<string | null>(null);
+    const [routedPrompt, setRoutedPrompt] = useState<string>('');
+    const [routedToolHints, setRoutedToolHints] = useState<string[]>([]);
+
+    const agentsByUuid = useMemo(() => {
+        const m = new Map<string, AiAgentSummary>();
+        (agents ?? []).forEach((a) => m.set(a.uuid, a));
+        return m;
+    }, [agents]);
+
+    const route = useAiRouterRoute();
+    const { mutate: commitDecisionMutate } = useAiRouterCommit();
+    const { mutateAsync: createThread } = useCreateAgentThreadMutation(
+        chosenAgentUuid ?? undefined,
+        projectUuid!,
+    );
+
+    const startedDecisionRef = useRef<string | null>(null);
+
+    // Once the router (or the user via picker) has chosen an agent and we've
+    // re-rendered with that agentUuid, fire the thread creation. The mutation
+    // hook is keyed on agentUuid so we have to wait a render before calling it.
+    useEffect(() => {
+        if (
+            phase.kind !== 'creating' ||
+            !chosenAgentUuid ||
+            !decisionUuid ||
+            !routedPrompt
+        ) {
+            return;
+        }
+        if (startedDecisionRef.current === decisionUuid) return;
+        startedDecisionRef.current = decisionUuid;
+
+        void createThread({
+            prompt: routedPrompt,
+            toolHints: routedToolHints,
+        }).then((thread) => {
+            commitDecisionMutate({
+                decisionUuid,
+                chosenAgentUuid,
+                threadUuid: thread.uuid,
+            });
+        });
+    }, [
+        phase.kind,
+        chosenAgentUuid,
+        decisionUuid,
+        routedPrompt,
+        routedToolHints,
+        createThread,
+        commitDecisionMutate,
+    ]);
+
+    const handleSubmit = useCallback(
+        async ({
+            message,
+            toolHints,
+        }: {
+            message: string;
+            toolHints: string[];
+        }) => {
+            if (!projectUuid) return;
+            setPhase({ kind: 'routing' });
+            setRoutedPrompt(message);
+            setRoutedToolHints(toolHints);
+            setPendingPrompt('');
+
+            try {
+                const result = await route.mutateAsync({
+                    prompt: message,
+                    projectUuid,
+                });
+                setDecisionUuid(result.decision.decisionUuid);
+
+                if (result.nextAction === 'create_thread') {
+                    setChosenAgentUuid(result.decision.suggestedAgentUuid);
+                    setPhase({ kind: 'creating' });
+                } else {
+                    setPhase({ kind: 'picker', decision: result });
+                }
+            } catch {
+                // Router unreachable — fall back to the first accessible
+                // agent silently. The draft survives via PendingPromptContext,
+                // which the new-thread page reads on mount.
+                setPhase({ kind: 'idle' });
+                setPendingPrompt(message);
+                setRoutedPrompt('');
+                setRoutedToolHints([]);
+                const fallback = agents?.[0];
+                if (fallback && projectUuid) {
+                    void navigate(
+                        `/projects/${projectUuid}/ai-agents/${fallback.uuid}/threads`,
+                    );
+                }
+            }
+        },
+        [agents, navigate, projectUuid, route, setPendingPrompt],
+    );
+
+    const confirmPick = useCallback((agentUuid: string) => {
+        setChosenAgentUuid(agentUuid);
+        setPhase({ kind: 'creating' });
+    }, []);
+
+    const isLocked = phase.kind !== 'idle';
+
+    const placeholder =
+        phase.kind === 'routing'
+            ? 'Finding the best agent…'
+            : phase.kind === 'creating'
+              ? 'Sending…'
+              : 'Ask anything about your data...';
 
     return (
         <AiAgentPageLayout
@@ -117,10 +262,11 @@ const AgentsRouterPage = () => {
                         projectUuid={projectUuid}
                         agents={agents ?? []}
                         selectedAgent="auto"
-                        placeholder="Ask anything about your data..."
-                        onSubmit={() => {
-                            // TODO: wire to /route endpoint
-                        }}
+                        placeholder={placeholder}
+                        loading={isLocked}
+                        onSubmit={handleSubmit}
+                        defaultValue={pendingPrompt}
+                        onValueChange={setPendingPrompt}
                         models={modelOptions}
                         selectedModelId={selectedModelKey}
                         onModelChange={handleSelectedModelKeyChange}
@@ -138,6 +284,76 @@ const AgentsRouterPage = () => {
                         }
                         fullWidth
                     />
+
+                    {phase.kind === 'picker' && (
+                        <Stack gap="sm">
+                            <Stack align="center" gap={4}>
+                                <Title order={5}>Pick the right agent</Title>
+                                <Text size="sm" c="dimmed" ta="center">
+                                    {phase.decision.decision.reasoning}
+                                </Text>
+                            </Stack>
+                            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+                                {phase.decision.decision.candidates.map((c) => {
+                                    const agent = agentsByUuid.get(c.agentUuid);
+                                    return (
+                                        <UnstyledButton
+                                            key={c.agentUuid}
+                                            onClick={() =>
+                                                confirmPick(c.agentUuid)
+                                            }
+                                        >
+                                            <Card
+                                                withBorder
+                                                radius="md"
+                                                p="sm"
+                                                styles={(theme) => ({
+                                                    root: {
+                                                        borderColor:
+                                                            theme.colors
+                                                                .ldGray[2],
+                                                    },
+                                                })}
+                                            >
+                                                <Group
+                                                    gap="sm"
+                                                    wrap="nowrap"
+                                                    align="flex-start"
+                                                >
+                                                    <LightdashUserAvatar
+                                                        size={32}
+                                                        name={c.name}
+                                                        src={agent?.imageUrl}
+                                                    />
+                                                    <Stack
+                                                        gap={2}
+                                                        miw={0}
+                                                        flex={1}
+                                                    >
+                                                        <Text
+                                                            size="sm"
+                                                            fw={600}
+                                                        >
+                                                            {c.name}
+                                                        </Text>
+                                                        {c.description && (
+                                                            <Text
+                                                                size="xs"
+                                                                c="dimmed"
+                                                                truncate="end"
+                                                            >
+                                                                {c.description}
+                                                            </Text>
+                                                        )}
+                                                    </Stack>
+                                                </Group>
+                                            </Card>
+                                        </UnstyledButton>
+                                    );
+                                })}
+                            </SimpleGrid>
+                        </Stack>
+                    )}
                 </Stack>
             </Center>
         </AiAgentPageLayout>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
@@ -23,7 +23,9 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiOrganizationSettings } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
+import { useAiRouterConfig } from '../../features/aiCopilot/hooks/useAiRouter';
 import { useProjectAiAgents } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import { useGetUserAgentPreferences } from '../../features/aiCopilot/hooks/useUserAgentPreferences';
 import AgentsRouterPage from './AgentsRouterPage';
 
 const AGENT_FEATURES = [
@@ -85,6 +87,10 @@ const AgentsWelcome = () => {
             enabled: isAiCopilotEnabledOrTrial,
         },
     });
+    const userAgentPreferencesQuery = useGetUserAgentPreferences(projectUuid, {
+        enabled: isAiCopilotEnabledOrTrial,
+    });
+    const aiRouterConfigQuery = useAiRouterConfig();
 
     if (aiOrganizationSettingsQuery.isLoading) {
         return <AiPageLoading />;
@@ -93,16 +99,44 @@ const AgentsWelcome = () => {
         return <Navigate to="/" replace />;
     }
 
-    if (agentsQuery.isError) {
+    if (agentsQuery.isError || userAgentPreferencesQuery.isError) {
         return <div>something went wrong...</div>;
     }
 
-    if (agentsQuery.isLoading) {
+    if (
+        agentsQuery.isLoading ||
+        userAgentPreferencesQuery.isLoading ||
+        // Router config: wait until we know whether it's enabled.
+        // 404 / other errors mean "not configured" — that resolves the query.
+        aiRouterConfigQuery.isLoading
+    ) {
         return <AiPageLoading />;
     }
 
-    if (agentsQuery.data.length > 0) {
+    if (agentsQuery.data.length === 0) {
+        // Fall through to the empty state below.
+    } else if (agentsQuery.data.length === 1) {
+        // Only one agent — no routing decision to make.
+        return (
+            <Navigate
+                to={`/projects/${projectUuid}/ai-agents/${agentsQuery.data[0].uuid}`}
+                replace
+            />
+        );
+    } else if (aiRouterConfigQuery.data?.enabled) {
         return <AgentsRouterPage />;
+    } else {
+        // Router disabled or not configured: prior behaviour — prefer the
+        // user's default agent, otherwise the first agent in the list.
+        const defaultAgentUuid =
+            userAgentPreferencesQuery.data?.defaultAgentUuid ??
+            agentsQuery.data[0].uuid;
+        return (
+            <Navigate
+                to={`/projects/${projectUuid}/ai-agents/${defaultAgentUuid}`}
+                replace
+            />
+        );
     }
 
     return (


### PR DESCRIPTION
## Summary

Wires the router page to the `/route` and `/commit` endpoints.

- **New hooks** in `useAiRouter.ts`:
  - `useAiRouterRoute()` — POST `/org/aiRouter/route`. Errors bubble via `mutateAsync` so the caller can fall back gracefully.
  - `useAiRouterCommit()` — POST `/org/aiRouter/decisions/:uuid/commit`. Fire-and-forget telemetry, no toast.
- **`AgentsRouterPage` flow** (state machine: `idle → routing → (creating | picker) → creating`):
  - High confidence (`nextAction = 'create_thread'`) → immediately create the thread for the suggested agent + commit the decision + navigate.
  - Low confidence (`nextAction = 'show_picker'`) → render the candidate grid; on pick, do the same with the chosen agent.
- **Pending-prompt continuity** — the draft is held in `PendingPromptContext`, so typing on the router page and then switching to a specific agent via the selector preserves the text (and vice versa).
- **Graceful degradation** — if `/route` fails, silently navigate to the first accessible agent with the prompt restored. No toast, no questions asked.

Closes #23451