### PR TITLE
refactor(ai-agents): move agentUuid from useCreateAgentThreadMutation hook param to mutate args

### DIFF
--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -79,16 +79,17 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
         },
     });
 
-    const { mutateAsync: createAgentThread } = useCreateAgentThreadMutation(
-        selectedAgent?.uuid,
-        projectUuid,
-    );
+    const { mutateAsync: createAgentThread } =
+        useCreateAgentThreadMutation(projectUuid);
 
     const handleSubmit = form.onSubmit(async (values) => {
         if (!selectedAgent) {
             void navigate(`/projects/${projectUuid}/ai-agents`);
         } else {
-            await createAgentThread({ prompt: values.prompt.trim() });
+            await createAgentThread({
+                agentUuid: selectedAgent.uuid,
+                prompt: values.prompt.trim(),
+            });
         }
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -101,7 +101,7 @@ const NewThreadPanel: FC<{
     });
 
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
-        useCreateAgentThreadMutation(agent.uuid, projectUuid, {
+        useCreateAgentThreadMutation(projectUuid, {
             // Launcher does its own routing via panels/dock — skip the default
             // page navigation that other surfaces want.
             skipNavigation: true,
@@ -142,6 +142,7 @@ const NewThreadPanel: FC<{
         toolHints: string[];
     }) => {
         void createAgentThread({
+            agentUuid: agent.uuid,
             prompt: message,
             context: contextInput.length > 0 ? contextInput : undefined,
             optimisticContext:

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -531,19 +531,16 @@ const generateAgentThreadTitle = async (
         body: JSON.stringify({}),
     });
 
-const useGenerateAgentThreadTitleMutation = (
-    projectUuid: string,
-    agentUuid: string,
-) => {
+const useGenerateAgentThreadTitleMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
     return useMutation<
         ApiAiAgentThreadGenerateTitleResponse['results'],
         ApiError,
-        { threadUuid: string }
+        { agentUuid: string; threadUuid: string }
     >({
-        mutationFn: ({ threadUuid }) =>
+        mutationFn: ({ agentUuid, threadUuid }) =>
             generateAgentThreadTitle(projectUuid, agentUuid, threadUuid),
-        onSuccess: (data, { threadUuid }) => {
+        onSuccess: (data, { agentUuid, threadUuid }) => {
             queryClient.setQueryData(
                 [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', 'user'],
                 (
@@ -579,7 +576,6 @@ const createAgentThread = async (
     });
 
 export const useCreateAgentThreadMutation = (
-    agentUuid: string | undefined,
     projectUuid: string,
     options?: {
         onCreated?: (thread: ApiAiAgentThreadCreateResponse['results']) => void;
@@ -592,48 +588,51 @@ export const useCreateAgentThreadMutation = (
     const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
     const { user } = useApp();
-    const { data: agent } = useProjectAiAgent(projectUuid, agentUuid);
     const { streamMessage } = useAiAgentThreadStreamMutation();
     const { mutateAsync: generateThreadTitle } =
-        useGenerateAgentThreadTitleMutation(projectUuid!, agentUuid!);
+        useGenerateAgentThreadTitleMutation(projectUuid);
 
     return useMutation<
         ApiAiAgentThreadCreateResponse['results'],
         ApiError,
         ApiAiAgentThreadCreateRequest & {
+            agentUuid: string;
             optimisticContext?: AiPromptContext;
             enableSqlMode?: boolean;
             toolHints?: string[];
         }
     >({
         mutationFn: ({
+            agentUuid,
             optimisticContext: _optimisticContext,
             enableSqlMode: _enableSqlMode,
             toolHints: _toolHints,
             ...data
-        }) =>
-            agentUuid
-                ? createAgentThread(projectUuid, agentUuid, data)
-                : Promise.reject(),
+        }) => createAgentThread(projectUuid, agentUuid, data),
         onSuccess: async (thread, variables) => {
+            const { agentUuid } = variables;
             // Invalidate both user-specific and all-users thread queries
             await queryClient.invalidateQueries({
                 queryKey: [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads'],
             });
 
-            void generateThreadTitle({ threadUuid: thread.uuid });
+            void generateThreadTitle({ agentUuid, threadUuid: thread.uuid });
+
+            // The agent is loaded by whichever page kicked off this mutation —
+            // read it from the cache instead of re-fetching here.
+            const agent = queryClient.getQueryData<
+                ApiAiAgentResponse['results']
+            >([PROJECT_AI_AGENTS_KEY, projectUuid, agentUuid]);
 
             queryClient.setQueryData(
                 [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', thread.uuid],
                 () => {
-                    if (!agentUuid) {
-                        return undefined;
-                    }
+                    if (!agent) return undefined;
 
                     return {
                         createdFrom: 'web_app',
                         firstMessage: thread.firstMessage,
-                        agentUuid: agentUuid,
+                        agentUuid,
                         uuid: thread.uuid,
                         title: null,
                         titleGeneratedAt: null,
@@ -643,7 +642,7 @@ export const useCreateAgentThreadMutation = (
                             thread.firstMessage.uuid,
                             thread.firstMessage.message,
                             user!.data!,
-                            agent!,
+                            agent,
                             // Prefer the caller's resolved metadata (name,
                             // chartKind) if provided so the pinned card
                             // renders correctly in the optimistic state.

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -14,7 +14,7 @@ import {
     UnstyledButton,
 } from '@mantine-8/core';
 import { IconSparkles } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -40,7 +40,12 @@ import {
 type Phase =
     | { kind: 'idle' }
     | { kind: 'routing' }
-    | { kind: 'picker'; decision: AiRouterRouteResponseResult }
+    | {
+          kind: 'picker';
+          decision: AiRouterRouteResponseResult;
+          prompt: string;
+          toolHints: string[];
+      }
     | { kind: 'creating' };
 
 const AgentsRouterPage = () => {
@@ -102,10 +107,6 @@ const AgentsRouterPage = () => {
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
 
     const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
-    const [decisionUuid, setDecisionUuid] = useState<string | null>(null);
-    const [chosenAgentUuid, setChosenAgentUuid] = useState<string | null>(null);
-    const [routedPrompt, setRoutedPrompt] = useState<string>('');
-    const [routedToolHints, setRoutedToolHints] = useState<string[]>([]);
 
     const agentsByUuid = useMemo(() => {
         const m = new Map<string, AiAgentSummary>();
@@ -116,46 +117,30 @@ const AgentsRouterPage = () => {
     const route = useAiRouterRoute();
     const { mutate: commitDecisionMutate } = useAiRouterCommit();
     const { mutateAsync: createThread } = useCreateAgentThreadMutation(
-        chosenAgentUuid ?? undefined,
         projectUuid!,
     );
 
-    const startedDecisionRef = useRef<string | null>(null);
-
-    // Once the router (or the user via picker) has chosen an agent and we've
-    // re-rendered with that agentUuid, fire the thread creation. The mutation
-    // hook is keyed on agentUuid so we have to wait a render before calling it.
-    useEffect(() => {
-        if (
-            phase.kind !== 'creating' ||
-            !chosenAgentUuid ||
-            !decisionUuid ||
-            !routedPrompt
-        ) {
-            return;
-        }
-        if (startedDecisionRef.current === decisionUuid) return;
-        startedDecisionRef.current = decisionUuid;
-
-        void createThread({
-            prompt: routedPrompt,
-            toolHints: routedToolHints,
-        }).then((thread) => {
+    const startThreadForDecision = useCallback(
+        async (args: {
+            agentUuid: string;
+            decisionUuid: string;
+            prompt: string;
+            toolHints: string[];
+        }) => {
+            const thread = await createThread({
+                agentUuid: args.agentUuid,
+                prompt: args.prompt,
+                toolHints: args.toolHints,
+            });
+            // Fire-and-forget telemetry — the user is already navigating away.
             commitDecisionMutate({
-                decisionUuid,
-                chosenAgentUuid,
+                decisionUuid: args.decisionUuid,
+                chosenAgentUuid: args.agentUuid,
                 threadUuid: thread.uuid,
             });
-        });
-    }, [
-        phase.kind,
-        chosenAgentUuid,
-        decisionUuid,
-        routedPrompt,
-        routedToolHints,
-        createThread,
-        commitDecisionMutate,
-    ]);
+        },
+        [createThread, commitDecisionMutate],
+    );
 
     const handleSubmit = useCallback(
         async ({
@@ -167,8 +152,6 @@ const AgentsRouterPage = () => {
         }) => {
             if (!projectUuid) return;
             setPhase({ kind: 'routing' });
-            setRoutedPrompt(message);
-            setRoutedToolHints(toolHints);
             setPendingPrompt('');
 
             try {
@@ -176,13 +159,22 @@ const AgentsRouterPage = () => {
                     prompt: message,
                     projectUuid,
                 });
-                setDecisionUuid(result.decision.decisionUuid);
 
                 if (result.nextAction === 'create_thread') {
-                    setChosenAgentUuid(result.decision.suggestedAgentUuid);
                     setPhase({ kind: 'creating' });
+                    await startThreadForDecision({
+                        agentUuid: result.decision.suggestedAgentUuid,
+                        decisionUuid: result.decision.decisionUuid,
+                        prompt: message,
+                        toolHints,
+                    });
                 } else {
-                    setPhase({ kind: 'picker', decision: result });
+                    setPhase({
+                        kind: 'picker',
+                        decision: result,
+                        prompt: message,
+                        toolHints,
+                    });
                 }
             } catch {
                 // Router unreachable — fall back to the first accessible
@@ -190,8 +182,6 @@ const AgentsRouterPage = () => {
                 // which the new-thread page reads on mount.
                 setPhase({ kind: 'idle' });
                 setPendingPrompt(message);
-                setRoutedPrompt('');
-                setRoutedToolHints([]);
                 const fallback = agents?.[0];
                 if (fallback && projectUuid) {
                     void navigate(
@@ -200,13 +190,30 @@ const AgentsRouterPage = () => {
                 }
             }
         },
-        [agents, navigate, projectUuid, route, setPendingPrompt],
+        [
+            agents,
+            navigate,
+            projectUuid,
+            route,
+            setPendingPrompt,
+            startThreadForDecision,
+        ],
     );
 
-    const confirmPick = useCallback((agentUuid: string) => {
-        setChosenAgentUuid(agentUuid);
-        setPhase({ kind: 'creating' });
-    }, []);
+    const confirmPick = useCallback(
+        async (agentUuid: string) => {
+            if (phase.kind !== 'picker') return;
+            const { decision, prompt, toolHints } = phase;
+            setPhase({ kind: 'creating' });
+            await startThreadForDecision({
+                agentUuid,
+                decisionUuid: decision.decision.decisionUuid,
+                prompt,
+                toolHints,
+            });
+        },
+        [phase, startThreadForDecision],
+    );
 
     const isLocked = phase.kind !== 'idle';
 

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -50,7 +50,7 @@ const AiAgentNewThreadPage: FC = () => {
     const dispatch = useAiAgentStoreDispatch();
 
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
-        useCreateAgentThreadMutation(agentUuid, projectUuid!, {
+        useCreateAgentThreadMutation(projectUuid!, {
             // Seed the per-thread slice with the user's choice so subsequent
             // prompts in this thread default to the same state. Navigation
             // still happens (we only override the slice, not the routing).
@@ -108,8 +108,10 @@ const AiAgentNewThreadPage: FC = () => {
 
     const onSubmit = useCallback(
         ({ message, toolHints }: { message: string; toolHints: string[] }) => {
+            if (!agentUuid) return;
             setPendingPrompt('');
             void createAgentThread({
+                agentUuid,
                 prompt: message,
                 context: contextInput.length > 0 ? contextInput : undefined,
                 optimisticContext:
@@ -128,6 +130,7 @@ const AiAgentNewThreadPage: FC = () => {
             });
         },
         [
+            agentUuid,
             setPendingPrompt,
             createAgentThread,
             contextInput,


### PR DESCRIPTION
## Summary

Cleanup motivated by the router page — `useCreateAgentThreadMutation` used to take `agentUuid` at hook-construction time, which forced callers that didn't know the agent up front (the router) to plumb a state machine + `useEffect` + ref guard just to fire one mutation.

`agentUuid` is now passed in the mutate args instead. Same for `useGenerateAgentThreadTitleMutation`.

- Inside the hook, the optimistic-message agent is read from the query client cache (`queryClient.getQueryData([PROJECT_AI_AGENTS_KEY, projectUuid, agentUuid])`) instead of via a nested `useProjectAiAgent` call.
- Call sites updated: `LauncherPanel`, `AiSearchBox`, `AiAgentNewThreadPage`, `AgentsRouterPage`.
- `AgentsRouterPage` collapses: dropped `useEffect`, `useRef` guard, and the `chosenAgentUuid`/`routedPrompt`/`routedToolHints`/`decisionUuid` state fields. `handleSubmit` is now a single straight-line async function; `confirmPick` reads the prompt + tool hints off the discriminated `picker` phase.

Closes #23451