### PR TITLE
feat(ai-agent): configurable row cap for run_sql tool (SPK-462)

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -113,6 +113,7 @@ export const aiCopilotConfigSchema = z
         askAiButtonEnabled: z.boolean(),
         embeddingEnabled: z.boolean(),
         maxQueryLimit: z.number().positive(),
+        runSqlMaxLimit: z.number().positive(),
         verifiedAnswerSimilarityThreshold: z
             .number()
             .min(0)

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -227,6 +227,7 @@ export const lightdashConfigMock: LightdashConfig = {
             enabled: false,
             debugLoggingEnabled: false,
             maxQueryLimit: 10000,
+            runSqlMaxLimit: 5000,
             telemetryEnabled: false,
             requiresFeatureFlag: false,
             askAiButtonEnabled: false,
@@ -310,6 +311,7 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     mcp: {
         enabled: true,
+        runSqlMaxLimit: 5000,
     },
     customRoles: {
         enabled: false,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -976,6 +976,10 @@ export const getAiConfig = () => ({
     maxQueryLimit:
         getIntegerFromEnvironmentVariable('AI_COPILOT_MAX_QUERY_LIMIT') ||
         AI_DEFAULT_MAX_QUERY_LIMIT,
+    runSqlMaxLimit:
+        getIntegerFromEnvironmentVariable('AI_COPILOT_RUN_SQL_MAX_LIMIT') ||
+        getIntegerFromEnvironmentVariable('AI_COPILOT_MAX_QUERY_LIMIT') ||
+        AI_DEFAULT_MAX_QUERY_LIMIT,
     verifiedAnswerSimilarityThreshold:
         getFloatFromEnvironmentVariable(
             'AI_VERIFIED_ANSWER_SIMILARITY_THRESHOLD',
@@ -1248,6 +1252,7 @@ export type LightdashConfig = {
     };
     mcp: {
         enabled: boolean;
+        runSqlMaxLimit: number;
     };
     customRoles: {
         enabled: boolean;
@@ -2304,6 +2309,9 @@ export const parseConfig = (): LightdashConfig => {
         updateSetup: getUpdateSetupConfig(),
         mcp: {
             enabled: process.env.MCP_ENABLED === 'true',
+            runSqlMaxLimit:
+                getIntegerFromEnvironmentVariable('MCP_RUN_SQL_MAX_LIMIT') ||
+                AI_DEFAULT_MAX_QUERY_LIMIT,
         },
         customRoles: {
             enabled: process.env.CUSTOM_ROLES_ENABLED === 'true',

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5294,6 +5294,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             findFieldsPageSize: 30,
             getDashboardChartsPageSize: 20,
             maxQueryLimit: this.lightdashConfig.ai.copilot.maxQueryLimit,
+            runSqlMaxLimit: this.lightdashConfig.ai.copilot.runSqlMaxLimit,
             siteUrl: this.lightdashConfig.siteUrl,
             canManageAgent: options.canManageAgent,
             toolHints: options.toolHints ?? [],

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -6,6 +6,7 @@ import {
     CatalogType,
     CommercialFeatureFlags,
     convertAiTableCalcsSchemaToTableCalcs,
+    createToolRunSqlArgsSchema,
     Explore,
     FeatureFlags,
     filterExploreByTags,
@@ -33,7 +34,6 @@ import {
     toolFindFieldsArgsSchema,
     toolRunQueryArgsSchema,
     toolRunQueryArgsSchemaTransformed,
-    toolRunSqlArgsSchema,
     ToolSearchFieldValuesArgs,
     toolSearchFieldValuesArgsSchema,
     UserAttributeValueMap,
@@ -1487,11 +1487,14 @@ export class McpService extends BaseService {
             },
         );
 
+        const runSqlArgsSchema = createToolRunSqlArgsSchema({
+            maxLimit: this.lightdashConfig.mcp.runSqlMaxLimit,
+        });
         this.mcpServer.registerTool(
             McpToolName.RUN_SQL,
             {
-                description: toolRunSqlArgsSchema.description,
-                inputSchema: this.getMcpCompatibleSchema(toolRunSqlArgsSchema),
+                description: runSqlArgsSchema.description,
+                inputSchema: this.getMcpCompatibleSchema(runSqlArgsSchema),
                 outputSchema: {
                     rows: z
                         .array(z.record(z.unknown()))

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -220,6 +220,7 @@ const getAgentTools = (
               siteUrl: args.siteUrl,
               waitForSqlApproval: dependencies.waitForSqlApproval,
               recordSqlApproval: dependencies.recordSqlApproval,
+              maxQueryLimit: args.runSqlMaxLimit,
           })
         : null;
 

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -11,6 +11,7 @@ type MakeToolOptions = {
     autoApproveSqlUserUuid?: string | null;
     waitForSqlApproval?: jest.Mock;
     recordSqlApproval?: jest.Mock;
+    maxQueryLimit?: number;
 };
 
 const executeRunSql = (tool: RunSqlTool, toolCallId: string = 'tool-call-1') =>
@@ -46,6 +47,7 @@ const makeTool = ({
     autoApproveSqlUserUuid = null,
     waitForSqlApproval = jest.fn().mockResolvedValue('approved'),
     recordSqlApproval = jest.fn().mockResolvedValue(true),
+    maxQueryLimit = 5000,
 }: MakeToolOptions = {}) => {
     const dependencies = {
         updateProgress: jest.fn().mockResolvedValue(undefined),
@@ -62,6 +64,7 @@ const makeTool = ({
         recordSqlApproval,
         autoApproveSql,
         autoApproveSqlUserUuid,
+        maxQueryLimit,
     };
 
     return {
@@ -108,6 +111,30 @@ describe('getRunSql', () => {
             'Awaiting approval to run SQL...',
         );
         expect(output.metadata?.status).toBe('success');
+    });
+
+    it('clamps a requested limit above maxQueryLimit when calling runSqlJob', async () => {
+        const { tool, dependencies } = makeTool({
+            autoApproveSql: true,
+            autoApproveSqlUserUuid: 'user-uuid',
+            maxQueryLimit: 2000,
+        });
+
+        await tool.execute!(
+            {
+                sql: 'select 1 as answer',
+                limit: 5000,
+            },
+            {
+                messages: [],
+                toolCallId: 'tool-call-1',
+            },
+        );
+
+        expect(dependencies.runSqlJob).toHaveBeenCalledWith({
+            sql: 'select 1 as answer',
+            limit: 2000,
+        });
     });
 
     it('does not open another approval wait after approval times out', async () => {

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -1,6 +1,6 @@
 import {
+    createToolRunSqlArgsSchema,
     isSlackPrompt,
-    toolRunSqlArgsSchema,
     type AnyType,
 } from '@lightdash/common';
 import { tool } from 'ai';
@@ -28,6 +28,7 @@ type Dependencies = {
     siteUrl: string;
     waitForSqlApproval: WaitForSqlApprovalFn;
     recordSqlApproval: RecordSqlApprovalFn;
+    maxQueryLimit: number;
     autoApproveSql?: boolean;
     autoApproveSqlUserUuid?: string | null;
 };
@@ -75,14 +76,19 @@ export const getRunSql = ({
     siteUrl,
     waitForSqlApproval,
     recordSqlApproval,
+    maxQueryLimit,
     autoApproveSql = false,
     autoApproveSqlUserUuid = null,
 }: Dependencies) => {
     let sqlApprovalTimedOut = false;
 
+    const inputSchema = createToolRunSqlArgsSchema({
+        maxLimit: maxQueryLimit,
+    });
+
     return tool({
-        description: toolRunSqlArgsSchema.description,
-        inputSchema: toolRunSqlArgsSchema,
+        description: inputSchema.description,
+        inputSchema,
         execute: async ({ sql, limit }, { toolCallId }) => {
             if (sqlApprovalTimedOut) {
                 return {
@@ -171,7 +177,7 @@ export const getRunSql = ({
 
                 const { rows, columns, rowCount } = await runSqlJob({
                     sql,
-                    limit,
+                    limit: Math.min(limit, maxQueryLimit),
                 });
 
                 if (rowCount === 0) {

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -89,6 +89,7 @@ export type AiAgentArgs = AnyAiModel & {
     findFieldsPageSize: number;
     getDashboardChartsPageSize: number;
     maxQueryLimit: number;
+    runSqlMaxLimit: number;
     siteUrl: string;
     canManageAgent: boolean;
     toolHints: string[];

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { createToolSchema } from '../toolSchemaBuilder';
 
-const TOOL_RUN_SQL_DESCRIPTION = `Tool: run_sql
+export const DEFAULT_RUN_SQL_LIMIT = 500;
+export const DEFAULT_RUN_SQL_MAX_LIMIT = 5000;
+
+const buildDescription = (
+    defaultLimit: number,
+    maxLimit: number,
+) => `Tool: run_sql
 
 Purpose:
 Execute an arbitrary SQL query against the project's data warehouse and return the results. Successful results can be linked from the final answer with [Open in SQL Runner](#sql-runner-link).
@@ -13,7 +19,7 @@ The query is executed directly against the warehouse, so use the SQL dialect app
 
 Parameters:
 - sql: The SQL query to execute. Must be a valid SELECT statement.
-- limit: Maximum number of rows to return (default 500, max 5000).
+- limit: Maximum number of rows to return (default ${defaultLimit}, max ${maxLimit}).
 
 Response shape (MCP CallToolResult):
 - content: [{ type: "text", text: "<CSV string>" }] — header row + data rows, comma-separated. Provided for human/LLM display and as a fallback.
@@ -35,24 +41,37 @@ Notes:
 - On error, the response has isError: true and content[0].text contains the error message; structuredContent is omitted.
 `;
 
-export const toolRunSqlArgsSchema = createToolSchema({
-    description: TOOL_RUN_SQL_DESCRIPTION,
-})
-    .extend({
-        sql: z
-            .string()
-            .describe('The SQL query to execute against the data warehouse.'),
-        limit: z
-            .number()
-            .int()
-            .positive()
-            .max(5000)
-            .default(500)
-            .describe(
-                'Maximum number of rows to return. Defaults to 500, max 5000.',
-            ),
+type CreateToolRunSqlArgsSchemaOptions = {
+    maxLimit?: number;
+    defaultLimit?: number;
+};
+
+export const createToolRunSqlArgsSchema = ({
+    maxLimit = DEFAULT_RUN_SQL_MAX_LIMIT,
+    defaultLimit = DEFAULT_RUN_SQL_LIMIT,
+}: CreateToolRunSqlArgsSchemaOptions = {}) =>
+    createToolSchema({
+        description: buildDescription(defaultLimit, maxLimit),
     })
-    .build();
+        .extend({
+            sql: z
+                .string()
+                .describe(
+                    'The SQL query to execute against the data warehouse.',
+                ),
+            limit: z
+                .number()
+                .int()
+                .positive()
+                .max(maxLimit)
+                .default(defaultLimit)
+                .describe(
+                    `Maximum number of rows to return. Defaults to ${defaultLimit}, max ${maxLimit}.`,
+                ),
+        })
+        .build();
+
+export const toolRunSqlArgsSchema = createToolRunSqlArgsSchema();
 
 export const toolRunSqlOutputSchema = z.object({
     result: z.string(),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: SPK-462

### Description:

The AI agent's `run_sql` tool had a hard-coded 5000-row cap baked into its Zod schema, so `AI_COPILOT_MAX_QUERY_LIMIT` and other operator settings had no effect. This PR converts `toolRunSqlArgsSchema` into a factory that takes `maxLimit`, wires it from two new config fields, and interpolates the configured max into the tool's description so the LLM sees the real cap.

**Chat agent / suggestion generator** → `ai.copilot.runSqlMaxLimit`, resolved from `AI_COPILOT_RUN_SQL_MAX_LIMIT` → `AI_COPILOT_MAX_QUERY_LIMIT` → `AI_DEFAULT_MAX_QUERY_LIMIT`.

**MCP server** → `mcp.runSqlMaxLimit`, resolved from `MCP_RUN_SQL_MAX_LIMIT` → `AI_DEFAULT_MAX_QUERY_LIMIT` (decoupled from `AI_COPILOT_*` so MCP can be tuned independently).

The tool's `execute()` also clamps defensively with `Math.min(limit, maxQueryLimit)` so a caller that bypasses Zod can't exceed the configured limit; a new unit test pins this behavior.