### PR TITLE
fix(snowflake): add session identity context to USE WAREHOUSE failures

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -284,7 +284,7 @@ describe('SnowflakeWarehouseClient.parseError - warehouse access errors', () => 
         );
     });
 
-    it('should return original warehouse error message when SNOWFLAKE_WAREHOUSE_ERROR_MESSAGE is not set', () => {
+    it('should append the configured warehouse to the original error when SNOWFLAKE_WAREHOUSE_ERROR_MESSAGE is not set', () => {
         // Ensure environment variable is not set
         delete process.env.SNOWFLAKE_WAREHOUSE_ERROR_MESSAGE;
 
@@ -299,7 +299,32 @@ describe('SnowflakeWarehouseClient.parseError - warehouse access errors', () => 
         const result = warehouse.parseError(error as any);
 
         expect(result.message).toBe(
-            "No active warehouse selected in the current session. Select an active warehouse with the 'use warehouse' command",
+            `No active warehouse selected in the current session. Select an active warehouse with the 'use warehouse' command (configured warehouse: "TEST_WAREHOUSE")`,
+        );
+    });
+
+    it('should flag missing warehouse credentials when no warehouse is configured on the connection', () => {
+        delete process.env.SNOWFLAKE_WAREHOUSE_ERROR_MESSAGE;
+
+        const warehouseWithoutWarehouse = new SnowflakeWarehouseClient({
+            account: 'test-account',
+            user: 'test-user',
+            password: 'test-password',
+            database: 'test-database',
+        } as CreateSnowflakeCredentials);
+
+        const error = {
+            message:
+                "No active warehouse selected in the current session. Select an active warehouse with the 'use warehouse' command",
+            code: 'SESSION_ERROR',
+            data: { type: 'SESSION_ERROR' },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = warehouseWithoutWarehouse.parseError(error as any);
+
+        expect(result.message).toBe(
+            "No active warehouse selected in the current session. Select an active warehouse with the 'use warehouse' command (no warehouse was configured on the connection — credentials may be missing this field)",
         );
     });
 

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -481,10 +481,41 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             console.debug(
                 `Running snowflake query on warehouse: ${this.connectionOptions.warehouse}`,
             );
-            await this.executeStatements(
-                connection,
-                `USE WAREHOUSE ${this.connectionOptions.warehouse};`,
-            );
+            try {
+                await this.executeStatements(
+                    connection,
+                    `USE WAREHOUSE ${this.connectionOptions.warehouse};`,
+                );
+            } catch (e) {
+                // Best-effort: fetch session identity to attach diagnostic
+                // context (user/role/session_id) to the error. Useful when a
+                // user's session role lacks USAGE on the warehouse — surfaces
+                // the role that needs the grant. Falls back to the raw error
+                // if the identity lookup itself fails.
+                let identityContext = '';
+                try {
+                    const identity = await this.executeStatements(
+                        connection,
+                        `SELECT CURRENT_USER() AS "user", CURRENT_ROLE() AS "role", CURRENT_SESSION() AS "session_id"`,
+                    );
+                    const row = (identity.rows?.[0] ?? {}) as Record<
+                        string,
+                        unknown
+                    >;
+                    identityContext = ` (user=${JSON.stringify(
+                        row.user,
+                    )}, role=${JSON.stringify(
+                        row.role,
+                    )}, session_id=${JSON.stringify(row.session_id)})`;
+                } catch {
+                    // ignore — identity lookup is best-effort only
+                }
+                throw new WarehouseConnectionError(
+                    `Failed to select Snowflake warehouse "${
+                        this.connectionOptions.warehouse
+                    }"${identityContext}: ${getErrorMessage(e)}`,
+                );
+            }
         }
 
         const sessionParams: string[] = [];

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -1215,6 +1215,15 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                     this.formatWarehouseErrorMessage(customErrorMessage);
                 return new WarehouseQueryError(formattedMessage);
             }
+            // Append the warehouse configured on the connection so admins can
+            // tell apart "warehouse was set but Snowflake rejected the
+            // selection" from "no warehouse was configured at all" — the
+            // latter usually means the credentials are missing the field.
+            const configured = this.connectionOptions.warehouse;
+            const detail = configured
+                ? ` (configured warehouse: "${configured}")`
+                : ' (no warehouse was configured on the connection — credentials may be missing this field)';
+            return new WarehouseQueryError(`${originalMessage}${detail}`);
         }
 
         // pull error type from data object


### PR DESCRIPTION
Relates: PROD-7959

### Description:

When a Snowflake session's role lacks `USAGE` on the configured warehouse, `USE WAREHOUSE` fails — but the snowflake-sdk surfaces this downstream as a generic "No active warehouse selected in the current session," hiding both the access-control root cause and the specific role that needs the grant (especially under SSO/SCIM, where the session role differs from the user's `DEFAULT_ROLE`). This PR wraps the `USE WAREHOUSE` call in `SnowflakeWarehouseClient.prepareWarehouse` and, on failure only, does a best-effort lookup of `CURRENT_USER` / `CURRENT_ROLE` / `CURRENT_SESSION` to attach diagnostic context to the rethrown error, so self-hosted admins can map the failure directly to the Snowflake grant that needs fixing. The lookup itself is wrapped in a try/catch and falls back silently to the original error if it fails, and the happy path is unchanged.