### PR TITLE
chore(ai): add propose writeback snapshot

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3937,6 +3937,62 @@ Even if only the part is being changed, make sure to pass the entire value with 
     },
   },
   {
+    "description": "Open a pull request that modifies the dbt project / Lightdash semantic layer for this project. Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata. Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent / proposeChange for those). The writeback agent runs in an isolated sandbox, edits the repo, runs \`lightdash compile\`, and opens a pull request. The call is synchronous and can take several minutes.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Open a pull request that modifies the dbt project / Lightdash semantic layer for this project. Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata. Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent / proposeChange for those). The writeback agent runs in an isolated sandbox, edits the repo, runs \`lightdash compile\`, and opens a pull request. The call is synchronous and can take several minutes.",
+      "properties": {
+        "prompt": {
+          "description": "A focused, self-contained natural-language instruction for the writeback agent describing exactly which files in the dbt project to change and how. The writeback agent does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). Do not include preamble or pleasantries.",
+          "minLength": 1,
+          "type": "string",
+        },
+      },
+      "required": [
+        "prompt",
+      ],
+      "type": "object",
+    },
+    "name": "proposeWriteback",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "prUrl": {
+              "type": [
+                "string",
+                "null",
+              ],
+            },
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
     "description": "Read a dashboard or chart as JSON using its slug. Call this before editing.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -15,6 +15,7 @@ import { getListKnowledgeDocuments } from './listKnowledgeDocuments';
 import { getListWarehouseTables } from './listWarehouseTables';
 import { getLoadSkill } from './loadSkill';
 import { getProposeChange } from './proposeChange';
+import { getProposeWriteback } from './proposeWriteback';
 import { getReadContent } from './readContent';
 import { getRunQuery } from './runQuery';
 import { getRunSavedChart } from './runSavedChart';
@@ -122,6 +123,9 @@ const makeAgentTools = () => {
         proposeChange: getProposeChange({
             createChange: noop,
             getExploreCompiler: noop,
+        }),
+        proposeWriteback: getProposeWriteback({
+            proposeWriteback: noop,
         }),
         readContent: getReadContent({ readContent: noop }),
         runQuery: getRunQuery({


### PR DESCRIPTION
Adds proposeWriteback to the AI agent tool contract snapshot so writeback tool schema changes are covered.