### PR TITLE
fix(mcp): preserve chart type on explore from mcp artifact

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -113,6 +113,7 @@ import { serializeData } from '../ai/utils/serializeData';
 import { AiAgentService } from '../AiAgentService/AiAgentService';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
 import { AiWritebackService } from '../AiWritebackService/AiWritebackService';
+import { buildMcpExploreConfigState } from './buildMcpExploreConfigState';
 import {
     registerAppResource,
     registerAppTool,
@@ -1344,36 +1345,12 @@ export class McpService extends BaseService {
                         : null;
 
                     // Build "Explore from here" URL
-                    const exploreConfigState = {
-                        tableName: queryTool.queryConfig.exploreName,
-                        metricQuery: {
-                            exploreName: queryTool.queryConfig.exploreName,
-                            dimensions: queryTool.queryConfig.dimensions,
-                            metrics: query.metrics,
-                            sorts: queryTool.queryConfig.sorts,
-                            limit: query.limit,
-                            filters: queryTool.filters ?? {},
-                            additionalMetrics,
-                            tableCalculations: query.tableCalculations,
-                        },
-                        tableConfig: {
-                            columnOrder: Object.keys(results.rows[0] ?? {}),
-                        },
-                        chartConfig: {
-                            type: 'table' as const,
-                            config: {
-                                showColumnCalculation: false,
-                                showRowCalculation: false,
-                                showTableNames: true,
-                                showResultsTotal: false,
-                                showSubtotals: false,
-                                columns: {},
-                                hideRowNumbers: false,
-                                conditionalFormattings: [],
-                                metricsAsRows: false,
-                            },
-                        },
-                    };
+                    const exploreConfigState = buildMcpExploreConfigState({
+                        queryTool,
+                        metricQuery: query,
+                        fieldsMap: results.fields,
+                        columnOrder: Object.keys(results.rows[0] ?? {}),
+                    });
                     const explorePath = `/projects/${projectUuid}/tables/${queryTool.queryConfig.exploreName}`;
                     const exploreParams = `?create_saved_chart_version=${encodeURIComponent(
                         JSON.stringify(exploreConfigState),

--- a/packages/backend/src/ee/services/McpService/buildMcpExploreConfigState.test.ts
+++ b/packages/backend/src/ee/services/McpService/buildMcpExploreConfigState.test.ts
@@ -1,0 +1,107 @@
+import {
+    CartesianSeriesType,
+    ChartType,
+    toolRunQueryArgsSchemaTransformed,
+} from '@lightdash/common';
+import { buildMcpExploreConfigState } from './buildMcpExploreConfigState';
+
+describe('buildMcpExploreConfigState', () => {
+    it('preserves the requested chart type in the saved chart state', () => {
+        const queryTool = toolRunQueryArgsSchemaTransformed.parse({
+            title: 'Enrollments by campus',
+            description: 'Enrollment counts grouped by campus',
+            queryConfig: {
+                exploreName: 'enrollments',
+                dimensions: ['enrollments_campus'],
+                metrics: ['enrollments_count'],
+                sorts: [],
+                limit: 500,
+            },
+            chartConfig: {
+                defaultVizType: 'bar',
+                xAxisDimension: 'enrollments_campus',
+                yAxisMetrics: ['enrollments_count'],
+                groupBy: null,
+                xAxisType: 'category',
+                stackBars: null,
+                lineType: null,
+                funnelDataInput: null,
+                xAxisLabel: 'Campus',
+                yAxisLabel: 'Enrollments',
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
+            },
+            filters: null,
+        });
+
+        const configState = buildMcpExploreConfigState({
+            queryTool,
+            metricQuery: {
+                exploreName: 'enrollments',
+                dimensions: ['enrollments_campus'],
+                metrics: ['enrollments_count'],
+                sorts: [],
+                limit: 500,
+                filters: queryTool.filters,
+                additionalMetrics: [],
+                tableCalculations: [],
+            },
+            fieldsMap: {},
+            columnOrder: ['enrollments_campus', 'enrollments_count'],
+        });
+
+        expect(configState.chartConfig.type).toBe(ChartType.CARTESIAN);
+        expect(configState.chartConfig).toMatchObject({
+            config: {
+                layout: {
+                    xField: 'enrollments_campus',
+                    yField: ['enrollments_count'],
+                },
+                eChartsConfig: {
+                    series: [
+                        {
+                            type: CartesianSeriesType.BAR,
+                            encode: {
+                                xRef: { field: 'enrollments_campus' },
+                                yRef: { field: 'enrollments_count' },
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+    });
+
+    it('defaults to table state when no chart config is provided', () => {
+        const queryTool = toolRunQueryArgsSchemaTransformed.parse({
+            title: 'Enrollment rows',
+            description: 'Enrollment rows by campus',
+            queryConfig: {
+                exploreName: 'enrollments',
+                dimensions: ['enrollments_campus'],
+                metrics: ['enrollments_count'],
+                sorts: [],
+                limit: 500,
+            },
+            filters: null,
+        });
+
+        const configState = buildMcpExploreConfigState({
+            queryTool,
+            metricQuery: {
+                exploreName: 'enrollments',
+                dimensions: ['enrollments_campus'],
+                metrics: ['enrollments_count'],
+                sorts: [],
+                limit: 500,
+                filters: queryTool.filters,
+                additionalMetrics: [],
+                tableCalculations: [],
+            },
+            fieldsMap: {},
+            columnOrder: ['enrollments_campus', 'enrollments_count'],
+        });
+
+        expect(configState.chartConfig).toEqual({ type: ChartType.TABLE });
+    });
+});

--- a/packages/backend/src/ee/services/McpService/buildMcpExploreConfigState.ts
+++ b/packages/backend/src/ee/services/McpService/buildMcpExploreConfigState.ts
@@ -1,0 +1,35 @@
+import {
+    getRunQueryChartConfig,
+    type CreateSavedChartVersion,
+    type ItemsMap,
+    type MetricQuery,
+    type ToolRunQueryArgsTransformed,
+} from '@lightdash/common';
+
+type McpExploreConfigState = Pick<
+    CreateSavedChartVersion,
+    'tableName' | 'metricQuery' | 'tableConfig' | 'chartConfig'
+>;
+
+export const buildMcpExploreConfigState = ({
+    queryTool,
+    metricQuery,
+    fieldsMap,
+    columnOrder,
+}: {
+    queryTool: ToolRunQueryArgsTransformed;
+    metricQuery: MetricQuery;
+    fieldsMap: ItemsMap;
+    columnOrder: string[];
+}): McpExploreConfigState => ({
+    tableName: queryTool.queryConfig.exploreName,
+    metricQuery,
+    tableConfig: {
+        columnOrder,
+    },
+    chartConfig: getRunQueryChartConfig({
+        queryTool,
+        metricQuery,
+        fieldsMap,
+    }),
+});

--- a/packages/common/src/ee/AiAgent/chartConfig/web/index.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/web/index.ts
@@ -1,5 +1,6 @@
 // runQuery tool
 export { getWebAiChartConfig } from './getWebAiChartConfig';
+export { getRunQueryChartConfig } from './runQueryTool/getRunQueryChartConfig';
 
 // shared utils
 export { getAvailableChartTypes } from './shared/getAvailableChartTypes';


### PR DESCRIPTION
Closes: ZAP-451

## Summary
- Replaced the hardcoded table saved-chart state used by MCP "Explore from here" links with shared run-query chart config generation.
- This preserves the original visualization type and axis configuration when opening the Explore view from a Claude-generated chart.
- Added a focused regression test for the MCP explore state builder.

## Testing
- Added unit coverage for the saved-chart state builder to verify bar charts serialize as `cartesian` charts and table fallbacks remain unchanged.
- Not run (full backend test execution was blocked in this worktree because the local test dependencies were not installed).