### PR TITLE
feat(ai-agents): display token usage tooltip on message model indicator

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -2841,6 +2841,7 @@ export class AiAgentModel {
                     | 'human_feedback'
                     | 'saved_query_uuid'
                     | 'model_config'
+                    | 'token_usage'
                 > &
                     Pick<DbUser, 'user_uuid'> &
                     Pick<DbAiThread, 'ai_thread_uuid'> &
@@ -2862,6 +2863,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.human_feedback`,
                 `${AiPromptTableName}.saved_query_uuid`,
                 `${AiPromptTableName}.model_config`,
+                `${AiPromptTableName}.token_usage`,
                 `${UserTableName}.user_uuid`,
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiSlackPromptTableName}.slack_user_id`,
@@ -2953,6 +2955,7 @@ export class AiAgentModel {
                 artifacts: artifacts ?? null,
                 referencedArtifacts: referencedArtifacts ?? null,
                 modelConfig: row.model_config,
+                tokenUsage: row.token_usage,
                 toolCalls: toolCalls
                     .filter((tc) => isAiAgentToolName(tc.tool_name))
                     .map((tc) => this.parseToolCall(tc)),
@@ -3528,6 +3531,7 @@ export class AiAgentModel {
                     | 'human_feedback'
                     | 'saved_query_uuid'
                     | 'model_config'
+                    | 'token_usage'
                 > &
                     Pick<DbUser, 'user_uuid'> &
                     Pick<DbAiThread, 'ai_thread_uuid'> &
@@ -3549,6 +3553,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.human_feedback`,
                 `${AiPromptTableName}.saved_query_uuid`,
                 `${AiPromptTableName}.model_config`,
+                `${AiPromptTableName}.token_usage`,
                 `${UserTableName}.user_uuid`,
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiSlackPromptTableName}.slack_user_id`,
@@ -3677,6 +3682,7 @@ export class AiAgentModel {
                     artifacts: artifacts.length > 0 ? artifacts : null,
                     referencedArtifacts,
                     modelConfig: row.model_config,
+                    tokenUsage: row.token_usage,
                     toolCalls: toolCalls
                         .filter((tc) => isAiAgentToolName(tc.tool_name))
                         .map((tc) => this.parseToolCall(tc)),

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -87,6 +87,7 @@ describe('AI context compaction helpers', () => {
                 artifacts: null,
                 referencedArtifacts: null,
                 modelConfig: null,
+                tokenUsage: null,
             },
         ]);
 

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -19,6 +19,7 @@ import { type AiEvalRunResultAssessment } from './aiEvalAssessment';
 import {
     type AiPromptContext,
     type AiPromptContextInput,
+    type AiPromptTokenUsage,
 } from './requestTypes';
 import { type AgentToolOutput } from './schemas';
 import { ToolNameSchema } from './schemas/visualizations';
@@ -248,6 +249,7 @@ export type AiAgentMessageAssistant = {
         modelProvider: string;
         reasoning?: boolean;
     } | null;
+    tokenUsage: AiPromptTokenUsage | null;
 };
 
 export type AiAgentMessage<TUser extends AiAgentUser = AiAgentUser> =

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -1173,6 +1173,7 @@ export const AssistantBubble: FC<Props> = memo(
                             projectUuid={projectUuid}
                             agentUuid={agentUuid}
                             modelConfig={message.modelConfig}
+                            totalTokens={message.tokenUsage?.totalTokens}
                         />
                     </Group>
                 )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageModelIndicator.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageModelIndicator.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@mantine-8/core';
+import { Badge, Tooltip } from '@mantine-8/core';
 import { useMemo, type FC } from 'react';
 import { useModelOptions } from '../../hooks/useModelOptions';
 
@@ -6,12 +6,14 @@ interface Props {
     projectUuid: string;
     agentUuid: string;
     modelConfig: { modelName: string; modelProvider: string } | null;
+    totalTokens?: number | null;
 }
 
 export const MessageModelIndicator: FC<Props> = ({
     projectUuid,
     agentUuid,
     modelConfig,
+    totalTokens,
 }) => {
     const { data: modelOptions } = useModelOptions({
         projectUuid,
@@ -29,9 +31,17 @@ export const MessageModelIndicator: FC<Props> = ({
 
     if (!modelDisplayName) return null;
 
-    return (
+    const badge = (
         <Badge variant="transparent" color="gray" size="sm">
             {modelDisplayName}
         </Badge>
+    );
+
+    if (typeof totalTokens !== 'number') return badge;
+
+    return (
+        <Tooltip label={`Tokens used: ${totalTokens.toLocaleString()}`}>
+            {badge}
+        </Tooltip>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -494,6 +494,7 @@ const createOptimisticMessages = (
             artifacts: null,
             referencedArtifacts: null,
             modelConfig: null,
+            tokenUsage: null,
         },
     ];
 };


### PR DESCRIPTION
Closes:

### Description:

Adds token usage tracking to AI agent messages. The `token_usage` field is now fetched from the database and included in the `AiAgentMessageAssistant` type as `tokenUsage`.

In the chat UI, the model indicator badge shown beneath each assistant message now displays a tooltip with the total token count (e.g. "Tokens used: 1,234") when token usage data is available for that message.