### PR TITLE
feat(ai-agents): redesign chat input toolbar

### DIFF
--- a/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
+++ b/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
@@ -2,7 +2,6 @@ import type { AiModelOption } from '@lightdash/common';
 import {
     Button,
     Menu,
-    rem,
     ScrollArea,
     Stack,
     Text,
@@ -57,10 +56,7 @@ export const ModelSelector: FC<Props> = ({
         >
             <Menu.Target>
                 <Button
-                    variant="subtle"
-                    color="gray"
                     px="xs"
-                    h={rem(36)}
                     {...buttonProps}
                     rightSection={
                         <MantineIcon
@@ -70,7 +66,7 @@ export const ModelSelector: FC<Props> = ({
                         />
                     }
                 >
-                    <Text size="sm" fw={500}>
+                    <Text size="xs" fw={500} c="dimmed">
                         {selectedModel?.displayName ?? 'Select model'}
                     </Text>
                 </Button>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css
@@ -1,0 +1,67 @@
+.target {
+    display: inline-flex;
+    align-items: center;
+    width: 200px;
+    padding: 4px 8px;
+    border-radius: var(--mantine-radius-md);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    background: transparent;
+    box-shadow: var(--mantine-shadow-subtle);
+    cursor: pointer;
+    font-size: var(--mantine-font-size-xs);
+    transition:
+        background-color 120ms ease,
+        border-color 120ms ease;
+}
+
+.target:hover {
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldGray-2);
+    }
+}
+
+.label {
+    flex: 1;
+    text-align: left;
+}
+
+/* Compact: icon-only at rest, no border. On hover / focus / open, the chip
+ * grows a border + light background to match the adjacent model+thinking
+ * group, then snaps back when interaction ends. The default 1px transparent
+ * border reserves the same footprint so the chip doesn't shift on hover. */
+.compact {
+    width: auto;
+    border-color: transparent;
+    box-shadow: none;
+    background: transparent;
+}
+
+.compact:hover,
+.compact:focus-visible,
+.compact[data-open='true'] {
+    border-color: var(--mantine-color-ldGray-2);
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldGray-2);
+    }
+}
+
+.compact .label {
+    flex: none;
+    width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    transition: width 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.compact:hover .label,
+.compact:focus-visible .label,
+.compact[data-open='true'] .label {
+    width: 140px;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -3,27 +3,35 @@ import {
     Center,
     Combobox,
     Group,
-    InputBase,
     Stack,
     Text,
+    UnstyledButton,
     useCombobox,
 } from '@mantine-8/core';
 import {
     IconCheck,
+    IconChevronDown,
     IconCirclePlus,
-    IconSelector,
     IconSparkles,
 } from '@tabler/icons-react';
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useAiRouterConfig } from '../../hooks/useAiRouter';
+import styles from './AgentSelector.module.css';
 import { getAgentOptions, type Agent } from './AgentSelectorUtils';
 
 type Props = {
     agents: Agent[];
     selectedAgent: Agent | 'auto';
     projectUuid: string;
+    /**
+     * Render the target as an icon-only chip; the label reveals on hover,
+     * focus, or while the dropdown is open. Used when toolbar space is
+     * tight (e.g. the chat input).
+     */
+    compact?: boolean;
 };
 
 const AUTO_VALUE = '__auto__';
@@ -32,10 +40,13 @@ export const AgentSelector = ({
     agents,
     selectedAgent,
     projectUuid,
+    compact = false,
 }: Props) => {
     const navigate = useNavigate();
     const { search } = useLocation();
+    const [opened, setOpened] = useState(false);
     const combobox = useCombobox({
+        onOpenedChange: setOpened,
         onDropdownClose: () => combobox.resetSelectedOption(),
     });
 
@@ -77,16 +88,20 @@ export const AgentSelector = ({
             store={combobox}
             onOptionSubmit={handleOptionSubmit}
             withinPortal={false}
+            width={compact ? 260 : 'target'}
+            position="bottom-start"
         >
             <Combobox.Target>
-                <InputBase
-                    w="230px"
-                    component="button"
+                <UnstyledButton
                     type="button"
-                    pointer
                     onClick={() => combobox.toggleDropdown()}
-                    leftSection={
-                        isAuto ? (
+                    className={`${styles.target} ${
+                        compact ? styles.compact : ''
+                    }`}
+                    data-open={opened ? 'true' : undefined}
+                >
+                    <Group gap={6} wrap="nowrap" align="center" w="100%">
+                        {isAuto ? (
                             <Avatar size={22} color="violet" radius="xl">
                                 <MantineIcon
                                     icon={IconSparkles}
@@ -100,22 +115,17 @@ export const AgentSelector = ({
                                 name={selectedAgent.name}
                                 src={selectedAgent.imageUrl}
                             />
-                        )
-                    }
-                    rightSection={<MantineIcon icon={IconSelector} />}
-                    styles={(theme) => ({
-                        input: {
-                            borderColor: theme.colors.ldGray[2],
-                            borderRadius: theme.radius.md,
-                            boxShadow: `var(--mantine-shadow-subtle)`,
-                            fontSize: theme.fontSizes.xs,
-                        },
-                    })}
-                >
-                    <Text size="xs" truncate="end" ml={2}>
-                        {isAuto ? 'Auto' : selectedAgent.name}
-                    </Text>
-                </InputBase>
+                        )}
+                        <Text size="xs" truncate="end" className={styles.label}>
+                            {isAuto ? 'Auto' : selectedAgent.name}
+                        </Text>
+                        <MantineIcon
+                            icon={IconChevronDown}
+                            size="sm"
+                            color="ldGray.6"
+                        />
+                    </Group>
+                </UnstyledButton>
             </Combobox.Target>
 
             <Combobox.Dropdown>
@@ -135,7 +145,7 @@ export const AgentSelector = ({
                                         Auto
                                     </Text>
                                     <Text size="xs" c="dimmed" truncate="end">
-                                        Let AI pick the best agent
+                                        We'll route to the besy-fit agent
                                     </Text>
                                 </Stack>
                                 {isAuto && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -3,6 +3,40 @@
     padding-bottom: var(--mantine-spacing-lg);
 }
 
+/* Bordered shell that hosts the model selector + thinking toggle as a single
+ * segmented control. Inner controls stay borderless (variant="subtle"); the
+ * shell owns the outer border and one hairline divider sits between them. */
+.modelGroup {
+    display: inline-flex;
+    align-items: stretch;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+    background: transparent;
+}
+
+.modelGroup > button {
+    border-radius: 0;
+    border: none;
+}
+
+/* Mantine size="xs" Buttons set min-width for label-bearing buttons; the
+ * icon-only ActionIcon doesn't need it. Keep both square at the ends. */
+.modelGroup > button:first-child {
+    border-top-left-radius: calc(var(--mantine-radius-md) - 1px);
+    border-bottom-left-radius: calc(var(--mantine-radius-md) - 1px);
+}
+
+.modelGroup > button:last-child {
+    border-top-right-radius: calc(var(--mantine-radius-md) - 1px);
+    border-bottom-right-radius: calc(var(--mantine-radius-md) - 1px);
+}
+
+.modelGroupDivider {
+    width: 1px;
+    background: var(--mantine-color-ldGray-2);
+    align-self: stretch;
+}
+
 .inputCard {
     border-radius: var(--mantine-radius-lg);
     overflow: hidden;
@@ -124,20 +158,6 @@
 .disabledBannerVisible .inputCard {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-}
-
-.thinkingButton {
-    font-weight: 500;
-    color: var(--mantine-color-ldGray-7);
-    border-radius: var(--mantine-radius-md);
-}
-
-.thinkingButtonOn {
-    color: var(--mantine-color-indigo-5);
-}
-
-.thinkingButtonOn:hover {
-    color: var(--mantine-color-indigo-5);
 }
 
 /* Minimal mode styles for existing threads */

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -7,8 +7,6 @@ import {
     ActionIcon,
     Anchor,
     Box,
-    Button,
-    Divider,
     Group,
     Paper,
     Switch,
@@ -16,7 +14,12 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { RichTextEditor } from '@mantine/tiptap';
-import { IconArrowUp, IconBrain, IconTerminal2 } from '@tabler/icons-react';
+import {
+    IconArrowUp,
+    IconBulb,
+    IconBulbFilled,
+    IconTerminal2,
+} from '@tabler/icons-react';
 import Mention from '@tiptap/extension-mention';
 import Placeholder from '@tiptap/extension-placeholder';
 import { useEditor, type Editor } from '@tiptap/react';
@@ -584,54 +587,80 @@ export const AgentChatInput = ({
 
                 <Box className={styles.toolbar}>
                     <Box className={styles.toolbarActions}>
+                        {(showModelSelector || onExtendedThinkingChange) && (
+                            <Box className={styles.modelGroup}>
+                                {showModelSelector && (
+                                    <ModelSelector
+                                        models={models}
+                                        value={selectedModelId ?? null}
+                                        onChange={onModelChange}
+                                        variant="subtle"
+                                        color="gray"
+                                        size="xs"
+                                    />
+                                )}
+
+                                {showModelSelector &&
+                                    onExtendedThinkingChange && (
+                                        <div
+                                            className={styles.modelGroupDivider}
+                                        />
+                                    )}
+
+                                {onExtendedThinkingChange && (
+                                    <Tooltip
+                                        multiline
+                                        w={240}
+                                        withArrow
+                                        position="top"
+                                        label="Let the model spend extra reasoning time before answering. Slower but better on complex questions."
+                                    >
+                                        <ActionIcon
+                                            variant={
+                                                extendedThinking
+                                                    ? 'light'
+                                                    : 'subtle'
+                                            }
+                                            color={
+                                                extendedThinking
+                                                    ? 'indigo'
+                                                    : 'gray'
+                                            }
+                                            size={30}
+                                            onClick={() =>
+                                                onExtendedThinkingChange(
+                                                    !extendedThinking,
+                                                )
+                                            }
+                                            aria-label="Toggle extended thinking"
+                                            aria-pressed={extendedThinking}
+                                        >
+                                            <MantineIcon
+                                                icon={
+                                                    extendedThinking
+                                                        ? IconBulbFilled
+                                                        : IconBulb
+                                                }
+                                                size="sm"
+                                                color={
+                                                    extendedThinking
+                                                        ? 'indigo.5'
+                                                        : 'ldGray.6'
+                                                }
+                                            />
+                                        </ActionIcon>
+                                    </Tooltip>
+                                )}
+                            </Box>
+                        )}
+
                         {showAgentSelector && (
                             <AgentSelector
                                 projectUuid={projectUuid!}
                                 agents={agents!}
                                 selectedAgent={selectedAgent!}
+                                compact
                             />
-                        )}
-
-                        {showModelSelector && (
-                            <ModelSelector
-                                models={models}
-                                value={selectedModelId ?? null}
-                                onChange={onModelChange}
-                            />
-                        )}
-
-                        {onExtendedThinkingChange && (
-                            <Group>
-                                <Divider orientation="vertical" />
-                                <Button
-                                    variant="subtle"
-                                    size="compact-sm"
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconBrain}
-                                            color={
-                                                extendedThinking
-                                                    ? 'indigo.5'
-                                                    : 'ldGray.7'
-                                            }
-                                        />
-                                    }
-                                    className={
-                                        styles.thinkingButton +
-                                        ' ' +
-                                        (extendedThinking
-                                            ? styles.thinkingButtonOn
-                                            : '')
-                                    }
-                                    onClick={() =>
-                                        onExtendedThinkingChange(
-                                            !extendedThinking,
-                                        )
-                                    }
-                                >
-                                    Thinking
-                                </Button>
-                            </Group>
                         )}
                     </Box>
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -258,11 +258,6 @@ const AgentsRouterPage = () => {
                             />
                         </Avatar>
                         <Title order={2}>Ask AI</Title>
-                        <Text c="dimmed" size="sm" ta="center" maw={520}>
-                            Ask anything about your data. We&apos;ll route your
-                            question to the right agent — or pin one if
-                            you&apos;d like.
-                        </Text>
                     </Stack>
 
                     <AgentChatInput


### PR DESCRIPTION
## Summary

Reshape the chat input toolbar so the three controls (model, thinking, agent) read as a single, intentional row instead of three loose chips.

**Toolbar order, left to right:**

1. **Model + Thinking** as one bordered segmented control. `ModelSelector` (label + chevron) on the left, an `ActionIcon` thinking toggle on the right, separated by a 1px divider. Inner controls use `variant="subtle"` so only the shell carries a border. Thinking swaps `IconBulb` → `IconBulbFilled` and goes indigo when active.
2. **Agent selector** in `compact` mode. Icon-only at rest (avatar + chevron), bordered + light fill on hover / focus / open — matching the model+thinking shell so the rhyme appears exactly when the user is interacting with it. The selected agent name reveals on an exponential-ease `width` transition (220ms).
3. SQL mode + submit, unchanged.

**Other polish:**

- `AgentSelector` switched to a single `UnstyledButton` target for both modes — full-width on the thread header, compact in the chat input — gated by a `compact` CSS variant. No more conditional `InputBase` branch.
- Hover background is theme-aware via `@mixin light/dark` so dark mode lifts the chip *above* the page background instead of darkening below it.
- Agent selector chevron switched from `IconSelector` to `IconChevronDown` with `ldGray.6` to match the model selector.
- Dropped the `style={{ root: ... }}` no-op on the sidebar's "View more" button (carried over from the original `AgentPage`).

Closes #23451