### PR TITLE
feat(ee): Slack bot reactions on agent ack and writeback PR success

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -227,6 +227,11 @@ export class SlackClient {
             'app_mentions:read',
             'files:write',
             'files:read',
+            // Used to react with :eyes: on a user's @mention so they get an
+            // immediate visual ack the bot saw their message. Best-effort —
+            // installs that haven't re-authorized for this scope silently
+            // skip the reaction (see AiAgentService.handleAppMention).
+            'reactions:write',
             // 'channels:join', - Made optional since users can manually add the app to channels
         ];
     }

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -259,6 +259,27 @@ export class SlackClient {
         return without(requiredScopes, ...installationScopes).length === 0;
     }
 
+    /**
+     * Add an emoji reaction to a Slack message. Requires the bot to have the
+     * `reactions:write` scope in the destination workspace; callers should
+     * treat failures (notably `missing_scope` on workspaces that haven't
+     * re-authorized after this scope was added) as non-fatal.
+     */
+    public async addReaction({
+        organizationUuid,
+        channel,
+        timestamp,
+        name,
+    }: {
+        organizationUuid: string;
+        channel: string;
+        timestamp: string;
+        name: string;
+    }): Promise<void> {
+        const webClient = await this.getWebClient(organizationUuid);
+        await webClient.reactions.add({ channel, timestamp, name });
+    }
+
     async getWebClient(organizationUuid: string): Promise<WebClient> {
         if (!this.isEnabled) {
             throw new MissingConfigError('Slack is not configured');

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8356,6 +8356,21 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     }: SlackEventMiddlewareArgs<'app_mention'> & AllMiddlewareArgs) {
         Logger.info(`Got app_mention event ${event.text}`);
 
+        // Best-effort ack reaction — gives the user immediate visual feedback
+        // that the bot saw their @mention, before any auth / agent resolution.
+        // Fire-and-forget: installs that haven't re-authorized to grant
+        // `reactions:write` silently skip the reaction without breaking the
+        // mention flow.
+        void client.reactions
+            .add({
+                channel: event.channel,
+                timestamp: event.ts,
+                name: 'eyes',
+            })
+            .catch((err) => {
+                Logger.debug('Failed to add :eyes: reaction to mention:', err);
+            });
+
         const { teamId } = context;
         if (!teamId || !event.user) {
             return;

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5047,15 +5047,40 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 },
             );
 
-        const proposeWriteback: ProposeWritebackFn = (args) =>
-            wrapSentryTransaction('AiAgent.proposeWriteback', {}, () =>
-                this.aiWritebackService.run({
-                    user,
-                    projectUuid,
-                    prompt: args.prompt,
-                    aiThreadUuid: prompt.threadUuid,
-                }),
+        const proposeWriteback: ProposeWritebackFn = async (args) => {
+            const result = await wrapSentryTransaction(
+                'AiAgent.proposeWriteback',
+                {},
+                () =>
+                    this.aiWritebackService.run({
+                        user,
+                        projectUuid,
+                        prompt: args.prompt,
+                        aiThreadUuid: prompt.threadUuid,
+                    }),
             );
+            // On a successful PR open/update, add a green-tick reaction to the
+            // user's original Slack mention so they see the outcome at a
+            // glance without scrolling through the agent's reply. Best-effort
+            // — installs missing `reactions:write` (or any other transient
+            // failure) silently skip the reaction.
+            if (result.prUrl && isSlackPrompt(prompt)) {
+                void this.slackClient
+                    .addReaction({
+                        organizationUuid,
+                        channel: prompt.slackChannelId,
+                        timestamp: prompt.promptSlackTs,
+                        name: 'white_check_mark',
+                    })
+                    .catch((err) => {
+                        Logger.debug(
+                            'Failed to add :white_check_mark: reaction to writeback mention:',
+                            err,
+                        );
+                    });
+            }
+            return result;
+        };
 
         const listProjects: ListProjectsFn = () =>
             wrapSentryTransaction('AiAgent.listProjects', {}, async () => {
@@ -8360,7 +8385,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         // that the bot saw their @mention, before any auth / agent resolution.
         // Fire-and-forget: installs that haven't re-authorized to grant
         // `reactions:write` silently skip the reaction without breaking the
-        // mention flow.
+        // mention flow. We use the per-event Slack client here rather than
+        // SlackClient.addReaction because we don't yet have the orgUuid at
+        // this point (it's resolved a few lines below).
         void client.reactions
             .add({
                 channel: event.channel,


### PR DESCRIPTION
## Why

When you @mention the Lightdash AI bot in Slack, there are two key moments the user currently has to infer from the bot's prose reply: "did it see me?" and "did it actually open a PR?" Adding two emoji reactions makes both outcomes visible at-a-glance, even when you're scrolling a busy thread or have multiple writebacks in flight.

| Stage | Reaction | Fires from | When |
|---|---|---|---|
| `@mention` received | `:eyes:` | `handleAppMention` (first line, before auth) | ~instant after the message is sent |
| Writeback PR opened/updated | `:white_check_mark:` | `proposeWriteback` dep, gated on `result.prUrl != null` | right after `AiWriteback: updated PR …` |

## What

### `:eyes:` ack reaction
- `client.reactions.add({ channel, timestamp, name: 'eyes' })` at the top of `handleAppMention`, **before** auth and settings lookups, so the ack lands even if a downstream step fails.

### `:white_check_mark:` PR-success reaction
- A small `addReaction` helper on `SlackClient` that wraps `getWebClient(orgUuid) → webClient.reactions.add(...)`, matching the per-org WebClient pattern used by every other method in that class.
- Fired from inside the `proposeWriteback` dep in `getAiAgentDependencies`, gated on **both** `result.prUrl != null` (a PR was actually opened) **and** `isSlackPrompt(prompt)` (web-app invocations have no Slack message to react to).
- Lands on `prompt.promptSlackTs` — the same user message that received `:eyes:` (the timestamp resolves correctly across all writeback entry paths: regular `@mention`, post-picker-click, multi-agent first message; see the audit in the [follow-up comment](#) on this PR).

### Shared design choices
- `reactions:write` added to the required Slack scopes. **Existing installs need to re-authorize** to grant the new scope. Until they do, both reaction calls silently fail with `missing_scope` (logged at debug) — no user-visible regression, the mention flow keeps working.
- Both reactions are fire-and-forget with `.catch(...debug)`. A reaction failure never blocks the mention flow or fails the writeback.

## How verified

End-to-end against a live writeback in `#charlie-agent-test`:

1. Pre-reauth attempt produced the expected debug log: `Failed to add :eyes: reaction to mention: An API error occurred: missing_scope`. Mention flow still worked normally.
2. After re-authorizing the Slack app to grant the new scope, an `@mention` produced `:eyes: × 1 — Lightdash` on the trigger message immediately.
3. A writeback request from the same trigger message ran through to a PR update; once `AiWriteback: updated PR …` fired in the logs, `:white_check_mark: × 1 — Lightdash` appeared on the same trigger message. Final state on the user's message: `:eyes: × 1, :white_check_mark: × 1`.

## Notes

- The reaction fires *before* the auth check in `handleAppMention`. That's deliberate — an unauthorized user still gets confirmation the bot saw the event, rather than total silence followed by an OAuth prompt.
- Multi-agent-channel plain-message handler doesn't add `:eyes:` (only `@mention`-driven paths do today). If a writeback fires from that path the user will see `:white_check_mark:` without a preceding `:eyes:` — fine for now; happy to mirror the `:eyes:` into that handler in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)