### PR TITLE
chore(ai-writeback): consume per-release e2b template tag (PROD-7970)

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -691,9 +691,9 @@ jobs:
     env:
       E2B_API_KEY: ${{ matrix.region == 'eu' && secrets.E2B_API_KEY_EU || secrets.E2B_API_KEY }}
       E2B_DOMAIN: ${{ matrix.region == 'eu' && 'e2b-juliett.dev' || '' }}
-      E2B_TEMPLATE_NAME: lightdash-ai-writeback
-      E2B_TEMPLATE_TAG: ${{ needs.ai-writeback-template-resolve.outputs.primary_tag }}
-      E2B_TEMPLATE_EXTRA_TAGS: latest
+      E2B_AI_WRITEBACK_TEMPLATE_NAME: lightdash-ai-writeback
+      E2B_AI_WRITEBACK_TEMPLATE_TAG: ${{ needs.ai-writeback-template-resolve.outputs.primary_tag }}
+      E2B_AI_WRITEBACK_TEMPLATE_EXTRA_TAGS: latest
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -734,9 +734,9 @@ jobs:
     env:
       E2B_API_KEY: ${{ matrix.region == 'eu' && secrets.E2B_API_KEY_EU || secrets.E2B_API_KEY }}
       E2B_DOMAIN: ${{ matrix.region == 'eu' && 'e2b-juliett.dev' || '' }}
-      E2B_TEMPLATE_NAME: lightdash-ai-writeback
-      E2B_TEMPLATE_TAG: ${{ needs.ai-writeback-template-resolve.outputs.primary_tag }}
-      E2B_TEMPLATE_SOURCE_TAG: ${{ needs.ai-writeback-template-resolve.outputs.source_tag }}
+      E2B_AI_WRITEBACK_TEMPLATE_NAME: lightdash-ai-writeback
+      E2B_AI_WRITEBACK_TEMPLATE_TAG: ${{ needs.ai-writeback-template-resolve.outputs.primary_tag }}
+      E2B_AI_WRITEBACK_TEMPLATE_SOURCE_TAG: ${{ needs.ai-writeback-template-resolve.outputs.source_tag }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -363,6 +363,8 @@ export const lightdashConfigMock: LightdashConfig = {
         e2bApiKey: null,
         e2bTemplateName: 'lightdash-data-app',
         e2bTemplateTag: '',
+        e2bAiWritebackTemplateName: 'lightdash-ai-writeback',
+        e2bAiWritebackTemplateTag: '',
     },
     enabledFeatureFlags: new Set<string>(),
     disabledFeatureFlags: new Set<string>(),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1371,6 +1371,14 @@ export type AppRuntimeConfig = {
      * deployments that haven't picked up a version-tagged build yet.
      */
     e2bTemplateTag: string;
+    /**
+     * Separate template name+tag for the AI writeback sandbox. Decoupled from
+     * the data-app template so operators can pin or roll back the writeback
+     * image independently (e.g. roll back writeback without disturbing data
+     * apps). Defaults match the release workflow's build target.
+     */
+    e2bAiWritebackTemplateName: string;
+    e2bAiWritebackTemplateTag: string;
 };
 
 export type IntercomConfig = {
@@ -1589,6 +1597,11 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
         // guarantees this tag exists). Operators can override to roll back
         // or pin during incidents.
         e2bTemplateTag: process.env.E2B_TEMPLATE_TAG ?? (VERSION as string),
+        e2bAiWritebackTemplateName:
+            process.env.E2B_AI_WRITEBACK_TEMPLATE_NAME ||
+            'lightdash-ai-writeback',
+        e2bAiWritebackTemplateTag:
+            process.env.E2B_AI_WRITEBACK_TEMPLATE_TAG ?? (VERSION as string),
     };
 };
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -47,7 +47,6 @@ import {
     RUN_TIMEOUT_MS,
     SANDBOX_TIMEOUT_MS,
     SYSTEM_PROMPT_PATH,
-    TEMPLATE_NAME,
 } from './constants';
 import { buildSystemPrompt } from './templates';
 import type {
@@ -200,14 +199,21 @@ export class AiWritebackService extends BaseService {
         projectUuid: string,
     ): Promise<{ sandbox: Sandbox; durationMs: number }> {
         const start = performance.now();
-        const sandbox = await Sandbox.create(TEMPLATE_NAME, {
+        const { e2bAiWritebackTemplateName, e2bAiWritebackTemplateTag } =
+            this.lightdashConfig.appRuntime;
+        // E2B treats `name` and `name:default` interchangeably, so an empty
+        // tag is fine — it just resolves to the implicit `default` build.
+        const templateRef = e2bAiWritebackTemplateTag
+            ? `${e2bAiWritebackTemplateName}:${e2bAiWritebackTemplateTag}`
+            : e2bAiWritebackTemplateName;
+        const sandbox = await Sandbox.create(templateRef, {
             timeoutMs: SANDBOX_TIMEOUT_MS,
             apiKey: this.getE2bApiKey(),
             lifecycle: { onTimeout: 'pause' },
         });
         const durationMs = AiWritebackService.elapsed(start);
         this.logger.info(
-            `AiWriteback: sandbox created (sandboxId=${sandbox.sandboxId}, project=${projectUuid}, ${durationMs}ms)`,
+            `AiWriteback: sandbox created (sandboxId=${sandbox.sandboxId}, project=${projectUuid}, template=${templateRef}, ${durationMs}ms)`,
         );
         return { sandbox, durationMs };
     }

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -1,5 +1,3 @@
-export const TEMPLATE_NAME = 'lightdash-ai-writeback';
-
 // Where the repo is cloned inside the sandbox, and where the agent runs.
 export const CWD = '/home/user/repo';
 

--- a/sandboxes/ai-writeback/assign-tag.ts
+++ b/sandboxes/ai-writeback/assign-tag.ts
@@ -8,11 +8,11 @@
  * at the build that `:latest` (or another source tag) already references.
  *
  * Inputs (env):
- *   E2B_API_KEY               — required
- *   E2B_TEMPLATE_NAME         — required (e.g. lightdash-ai-writeback)
- *   E2B_TEMPLATE_TAG          — required, the new tag to stamp (e.g. 0.2870.0)
- *   E2B_TEMPLATE_SOURCE_TAG   — required, the source build identifier (e.g. latest)
- *   E2B_TEMPLATE_EXTRA_TAGS   — optional, comma-separated additional tags
+ *   E2B_API_KEY                            — required
+ *   E2B_AI_WRITEBACK_TEMPLATE_NAME         — required (e.g. lightdash-ai-writeback)
+ *   E2B_AI_WRITEBACK_TEMPLATE_TAG          — required, the new tag to stamp (e.g. 0.2870.0)
+ *   E2B_AI_WRITEBACK_TEMPLATE_SOURCE_TAG   — required, the source build identifier (e.g. latest)
+ *   E2B_AI_WRITEBACK_TEMPLATE_EXTRA_TAGS   — optional, comma-separated additional tags
  */
 import { Template } from 'e2b';
 
@@ -26,10 +26,10 @@ const requireEnv = (name: string): string => {
 };
 
 const apiKey = requireEnv('E2B_API_KEY');
-const templateName = requireEnv('E2B_TEMPLATE_NAME');
-const newTag = requireEnv('E2B_TEMPLATE_TAG');
-const sourceTag = requireEnv('E2B_TEMPLATE_SOURCE_TAG');
-const extraTags = (process.env.E2B_TEMPLATE_EXTRA_TAGS || '')
+const templateName = requireEnv('E2B_AI_WRITEBACK_TEMPLATE_NAME');
+const newTag = requireEnv('E2B_AI_WRITEBACK_TEMPLATE_TAG');
+const sourceTag = requireEnv('E2B_AI_WRITEBACK_TEMPLATE_SOURCE_TAG');
+const extraTags = (process.env.E2B_AI_WRITEBACK_TEMPLATE_EXTRA_TAGS || '')
     .split(',')
     .map((t) => t.trim())
     .filter(Boolean);

--- a/sandboxes/ai-writeback/build-sandbox.ts
+++ b/sandboxes/ai-writeback/build-sandbox.ts
@@ -34,10 +34,14 @@ async function main() {
         }).fromDockerfile(dockerfile);
 
         const templateName =
-            process.env.E2B_TEMPLATE_NAME || 'lightdash-ai-writeback';
+            process.env.E2B_AI_WRITEBACK_TEMPLATE_NAME ||
+            'lightdash-ai-writeback';
 
-        const primaryTag = process.env.E2B_TEMPLATE_TAG?.trim() || '';
-        const extraTags = (process.env.E2B_TEMPLATE_EXTRA_TAGS || '')
+        const primaryTag =
+            process.env.E2B_AI_WRITEBACK_TEMPLATE_TAG?.trim() || '';
+        const extraTags = (
+            process.env.E2B_AI_WRITEBACK_TEMPLATE_EXTRA_TAGS || ''
+        )
             .split(',')
             .map((t) => t.trim())
             .filter(Boolean);


### PR DESCRIPTION
Closes: [PROD-7970](https://linear.app/lightdash/issue/PROD-7970/build-e2b-template-on-release)

## Summary

The release workflow already builds and re-tags the `lightdash-ai-writeback` e2b template per release (jobs added in #23507), but the backend was launching sandboxes from the bare template name — so the published tag was unused and prod always resolved to e2b's implicit `:default` build. This PR consumes the per-release tag at runtime, mirroring the data-app pattern (`AppGenerateService.createSandbox`), and lines up the build/retag script env vars with the new runtime config names so both halves share one naming convention end-to-end.

## Changes

- `packages/backend/src/config/parseConfig.ts` — add `e2bAiWritebackTemplateName` / `e2bAiWritebackTemplateTag` to `AppRuntimeConfig`. Tag defaults to the running Lightdash `VERSION`, same trick the data-app template uses.
- `packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts` — `createSandbox` now composes `name:tag` and passes it to `Sandbox.create`; log line includes the resolved ref so it's visible in pm2 / production logs.
- `packages/backend/src/ee/services/AiWritebackService/constants.ts` — drop the now-unused `TEMPLATE_NAME` constant.
- `packages/backend/src/config/lightdashConfig.mock.ts` — add the two new fields so tests typecheck.
- `sandboxes/ai-writeback/build-sandbox.ts` — read `E2B_AI_WRITEBACK_TEMPLATE_NAME` / `_TAG` / `_EXTRA_TAGS` instead of the generic `E2B_TEMPLATE_*` (which still belong to the data-app build).
- `sandboxes/ai-writeback/assign-tag.ts` — same env var rename, plus updated docstring.
- `.github/workflows/post-release.yml` — `ai-writeback-template-build` and `ai-writeback-template-retag` jobs export the renamed env vars.

## Why this is better

- **Per-release rollback works.** Operators can roll back the writeback template independently of data-apps by overriding `E2B_AI_WRITEBACK_TEMPLATE_TAG`; previously this lever didn't exist on the runtime side.
- **No more silent fallback to e2b `:default`.** Production sandboxes are now pinned to the build the release workflow published, instead of whatever `:default` happened to be.
- **Env vars line up end-to-end.** CI build → sandbox script → runtime config all read the same `E2B_AI_WRITEBACK_TEMPLATE_*` names, so there's no name collision with the data-app config sharing the same workflow file.

End-to-end env var flow:

```
CI build job   -> E2B_AI_WRITEBACK_TEMPLATE_NAME=lightdash-ai-writeback
                  E2B_AI_WRITEBACK_TEMPLATE_TAG=<release tag>
                  E2B_AI_WRITEBACK_TEMPLATE_EXTRA_TAGS=latest
build-sandbox  -> reads same vars, builds `name:tag` + tags `latest`
CI retag job   -> E2B_AI_WRITEBACK_TEMPLATE_SOURCE_TAG=latest
                  E2B_AI_WRITEBACK_TEMPLATE_TAG=<new release tag>
assign-tag     -> reads same vars, stamps new tag onto existing build
Backend prod   -> E2B_AI_WRITEBACK_TEMPLATE_TAG=<release version> (default)
                  Sandbox.create("lightdash-ai-writeback:<tag>", ...)
```

## Test plan

- [x] `pnpm -F backend typecheck` and `pnpm -F backend lint` pass.
- [x] Local writeback prompt in Slack creates a sandbox; log line now reads `template=lightdash-ai-writeback` (empty tag in dev → falls back to e2b `:default`, expected).
- [ ] On the first release after merge, confirm the `ai-writeback-template-{build,retag}` jobs publish/stamp the matching tag in both `us` and `eu` e2b regions.
- [ ] Confirm a production sandbox launched after that release logs `template=lightdash-ai-writeback:<version>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)