### PR TITLE
feat: add Google SSO default-state callout and "Using defaults" badge in org SSO panel

### DIFF
--- a/packages/frontend/src/components/UserSettings/OrganizationSso/GoogleSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/GoogleSsoPanel.tsx
@@ -19,11 +19,13 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import { useToggle } from 'react-use';
+import useHealth from '../../../hooks/health/useHealth';
 import {
     useDeleteGoogleSsoConfig,
     useGoogleSsoConfig,
     useUpsertGoogleSsoConfig,
 } from '../../../hooks/organization/useOrganizationSso';
+import Callout from '../../common/Callout';
 import EmptyStateLoader from '../../common/EmptyStateLoader';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
@@ -41,12 +43,16 @@ type FormValues = {
 
 const GoogleSsoPanel: FC = () => {
     const { data: existing, isLoading } = useGoogleSsoConfig();
+    const { data: health } = useHealth();
     const upsert = useUpsertGoogleSsoConfig();
     const deleteConfig = useDeleteGoogleSsoConfig();
     const [deleteOpen, setDeleteOpen] = useState(false);
     const [isOpen, toggleOpen] = useToggle(false);
 
     const isConfigured = !!existing;
+    // Google sign-in is only live on the main login page when the shared
+    // instance OAuth app is configured (AUTH_GOOGLE_ENABLED + client id/secret).
+    const googleEnabledInstanceWide = !!health?.auth.google.enabled;
 
     const form = useForm<FormValues>({
         initialValues: {
@@ -147,10 +153,26 @@ const GoogleSsoPanel: FC = () => {
                             />
                         ) : (
                             <Badge color="gray" variant="outline" size="lg">
-                                Not configured
+                                Using defaults
                             </Badge>
                         )}
                     </Group>
+
+                    {!isConfigured && googleEnabledInstanceWide && (
+                        <Callout
+                            variant="info"
+                            title="Google sign-in is on by default"
+                        >
+                            Everyone in your org can sign in with Google from
+                            the main login page, using Lightdash's shared Google
+                            app. Set up a configuration here to restrict it to
+                            specific email domains or to disable password
+                            sign-in. If another provider (e.g. Okta) is
+                            configured for your domain, it takes over the
+                            post-email sign-in step and Google is hidden there
+                            unless you enable it here.
+                        </Callout>
+                    )}
 
                     {isConfigured ? (
                         <Button


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7976/confusing-default-setting-for-google

<img width="1466" height="576" alt="CleanShot 2026-05-28 at 14 14 35@2x" src="https://github.com/user-attachments/assets/47d2368d-5298-4cf8-970e-40529904ac5a" />

### Description:

When Google SSO is enabled at the instance level (`AUTH_GOOGLE_ENABLED` with client id/secret configured) but no org-specific Google SSO configuration has been set up, the panel now shows an informational callout explaining that Google sign-in is already available to all org members via Lightdash's shared Google app. The callout also clarifies how to restrict sign-in to specific email domains, disable password sign-in, and how the behavior interacts with other configured providers like Okta.

The "Not configured" badge label has also been updated to "Using defaults" to better reflect that the absence of an org-level config doesn't mean Google sign-in is unavailable — it may simply be inheriting the instance-wide defaults.