### PR TITLE
refactor(ai-router): redesign low-confidence disambiguation picker

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -91,6 +91,7 @@ interface AgentChatInputProps {
     defaultValue?: string;
     onValueChange?: (value: string) => void;
     fullWidth?: boolean;
+    clearOnSubmit?: boolean;
 }
 
 const extractToolHints = (editor: Editor | null): string[] => {
@@ -130,6 +131,7 @@ export const AgentChatInput = ({
     defaultValue,
     onValueChange,
     fullWidth = false,
+    clearOnSubmit = true,
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
@@ -144,6 +146,8 @@ export const AgentChatInput = ({
     loadingRef.current = loading;
     const disabledRef = useRef(disabled);
     disabledRef.current = disabled;
+    const clearOnSubmitRef = useRef(clearOnSubmit);
+    clearOnSubmitRef.current = clearOnSubmit;
 
     // Hide the chip strip while the user is scrolled away from the input.
     // Reappears as they scroll back toward the bottom of the thread — chips
@@ -280,8 +284,10 @@ export const AgentChatInput = ({
                         message: text,
                         toolHints: extractToolHints(ed),
                     });
-                    ed.commands.clearContent();
-                    setValueState('');
+                    if (clearOnSubmitRef.current) {
+                        ed.commands.clearContent();
+                        setValueState('');
+                    }
                     return true;
                 }
                 return false;
@@ -348,8 +354,10 @@ export const AgentChatInput = ({
                 message: chip.label,
                 toolHints: [chip.tool],
             });
-            editor?.commands.clearContent();
-            setValueState('');
+            if (clearOnSubmitRef.current) {
+                editor?.commands.clearContent();
+                setValueState('');
+            }
             trackClick();
         },
         [
@@ -399,8 +407,10 @@ export const AgentChatInput = ({
             message: text,
             toolHints: extractToolHints(ed),
         });
-        ed.commands.clearContent();
-        setValueState('');
+        if (clearOnSubmitRef.current) {
+            ed.commands.clearContent();
+            setValueState('');
+        }
     };
 
     const chipRow = useMemo(() => {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -1,8 +1,13 @@
+.pickerStack {
+    animation: pickerStackIn 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
 .pickerHeader {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--mantine-spacing-sm);
+    animation: pickerItemIn 360ms cubic-bezier(0.16, 1, 0.3, 1) 40ms both;
 }
 
 .candidateButton {
@@ -21,6 +26,23 @@
         background-color 120ms ease-out,
         transform 120ms ease-out;
     text-align: left;
+    animation: pickerItemIn 380ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.candidateButton:nth-of-type(1) {
+    animation-delay: 120ms;
+}
+.candidateButton:nth-of-type(2) {
+    animation-delay: 200ms;
+}
+.candidateButton:nth-of-type(3) {
+    animation-delay: 260ms;
+}
+.candidateButton:nth-of-type(4) {
+    animation-delay: 310ms;
+}
+.candidateButton:nth-of-type(5) {
+    animation-delay: 350ms;
 }
 
 .candidateButton:hover {
@@ -47,6 +69,9 @@
         var(--mantine-color-violet-0),
         rgba(118, 65, 232, 0.12)
     );
+    animation:
+        pickerItemIn 380ms cubic-bezier(0.16, 1, 0.3, 1) 120ms both,
+        recommendedSettle 900ms cubic-bezier(0.16, 1, 0.3, 1) 460ms 1 both;
 }
 
 .candidateButton.recommended:hover {
@@ -81,4 +106,45 @@
 
 .candidateButton.recommended .chevron {
     color: var(--mantine-color-violet-6);
+}
+
+@keyframes pickerStackIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes pickerItemIn {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes recommendedSettle {
+    0% {
+        box-shadow: 0 0 0 0 rgba(118, 65, 232, 0);
+    }
+    45% {
+        box-shadow: 0 0 0 5px rgba(118, 65, 232, 0.14);
+    }
+    100% {
+        box-shadow: 0 0 0 0 rgba(118, 65, 232, 0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pickerStack,
+    .pickerHeader,
+    .candidateButton,
+    .candidateButton.recommended {
+        animation: none;
+    }
 }

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -115,10 +115,10 @@
     width: 100%;
     border-radius: var(--mantine-radius-md);
     border: 1px solid
-        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-3));
     background-color: light-dark(
         var(--mantine-color-white),
-        var(--mantine-color-ldDark-6)
+        var(--mantine-color-ldDark-5)
     );
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
     transition:
@@ -148,11 +148,11 @@
 .candidateButton:hover {
     border-color: light-dark(
         var(--mantine-color-ldGray-4),
-        var(--mantine-color-ldDark-3)
+        var(--mantine-color-ldDark-2)
     );
     background-color: light-dark(
         var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-5)
+        var(--mantine-color-ldDark-4)
     );
 }
 
@@ -163,11 +163,15 @@
 .candidateButton.recommended {
     border-color: light-dark(
         var(--mantine-color-violet-3),
-        var(--mantine-color-violet-7)
+        var(--mantine-color-violet-6)
     );
     background-color: light-dark(
         var(--mantine-color-violet-0),
-        rgba(118, 65, 232, 0.12)
+        color-mix(
+            in oklab,
+            var(--mantine-color-violet-9) 42%,
+            var(--mantine-color-ldDark-5)
+        )
     );
     animation:
         pickerItemIn 380ms cubic-bezier(0.16, 1, 0.3, 1) 120ms both,
@@ -177,18 +181,22 @@
 .candidateButton.recommended:hover {
     border-color: light-dark(
         var(--mantine-color-violet-5),
-        var(--mantine-color-violet-6)
+        var(--mantine-color-violet-5)
     );
     background-color: light-dark(
         var(--mantine-color-violet-1),
-        rgba(118, 65, 232, 0.18)
+        color-mix(
+            in oklab,
+            var(--mantine-color-violet-9) 55%,
+            var(--mantine-color-ldDark-5)
+        )
     );
 }
 
 .chevron {
     color: light-dark(
         var(--mantine-color-ldGray-5),
-        var(--mantine-color-ldGray-6)
+        var(--mantine-color-ldGray-4)
     );
     flex-shrink: 0;
     transition:
@@ -200,12 +208,15 @@
     transform: translateX(2px);
     color: light-dark(
         var(--mantine-color-ldGray-7),
-        var(--mantine-color-ldGray-4)
+        var(--mantine-color-ldGray-2)
     );
 }
 
 .candidateButton.recommended .chevron {
-    color: var(--mantine-color-violet-6);
+    color: light-dark(
+        var(--mantine-color-violet-6),
+        var(--mantine-color-violet-3)
+    );
 }
 
 @keyframes pickerStackIn {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -169,7 +169,7 @@
         var(--mantine-color-violet-0),
         color-mix(
             in oklab,
-            var(--mantine-color-violet-9) 42%,
+            var(--mantine-color-violet-9) 22%,
             var(--mantine-color-ldDark-5)
         )
     );
@@ -187,9 +187,30 @@
         var(--mantine-color-violet-1),
         color-mix(
             in oklab,
-            var(--mantine-color-violet-9) 55%,
+            var(--mantine-color-violet-9) 32%,
             var(--mantine-color-ldDark-5)
         )
+    );
+}
+
+.candidateName {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldGray-0)
+    );
+}
+
+.candidateDescription {
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-3)
+    );
+}
+
+.candidateButton.recommended .candidateDescription {
+    color: light-dark(
+        var(--mantine-color-violet-9),
+        var(--mantine-color-violet-1)
     );
 }
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -1,3 +1,103 @@
+.heroAvatar {
+    position: relative;
+    transition: transform 240ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.heroAvatar::after {
+    content: '';
+    position: absolute;
+    inset: -6px;
+    border-radius: 50%;
+    border: 1px solid var(--mantine-color-violet-4);
+    opacity: 0;
+    pointer-events: none;
+}
+
+.heroAvatarWorking {
+    transform: scale(1.04);
+}
+
+.heroAvatarWorking::after {
+    animation: heroHaloPulse 1600ms cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.heroAvatarWorking .heroSparkles {
+    animation: heroSparkleSpin 3200ms cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+@keyframes heroHaloPulse {
+    0% {
+        transform: scale(0.9);
+        opacity: 0;
+    }
+    35% {
+        opacity: 0.6;
+    }
+    100% {
+        transform: scale(1.45);
+        opacity: 0;
+    }
+}
+
+@keyframes heroSparkleSpin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.routingStatus {
+    animation: routingFadeIn 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.routingDots {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.routingDots span {
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background-color: var(--mantine-color-violet-5);
+    animation: routingDotBlink 1100ms cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+.routingDots span:nth-child(2) {
+    animation-delay: 160ms;
+}
+
+.routingDots span:nth-child(3) {
+    animation-delay: 320ms;
+}
+
+@keyframes routingFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes routingDotBlink {
+    0%,
+    80%,
+    100% {
+        opacity: 0.25;
+        transform: scale(0.85);
+    }
+    40% {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
 .pickerStack {
     animation: pickerStackIn 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
@@ -144,7 +244,14 @@
     .pickerStack,
     .pickerHeader,
     .candidateButton,
-    .candidateButton.recommended {
+    .candidateButton.recommended,
+    .heroAvatar,
+    .heroAvatarWorking,
+    .heroAvatarWorking::after,
+    .heroAvatarWorking .heroSparkles,
+    .routingStatus,
+    .routingDots span {
         animation: none;
+        transform: none;
     }
 }

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -115,10 +115,10 @@
     width: 100%;
     border-radius: var(--mantine-radius-md);
     border: 1px solid
-        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-3));
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
     background-color: light-dark(
         var(--mantine-color-white),
-        var(--mantine-color-ldDark-5)
+        var(--mantine-color-dark-6)
     );
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
     transition:
@@ -147,12 +147,12 @@
 
 .candidateButton:hover {
     border-color: light-dark(
-        var(--mantine-color-ldGray-4),
-        var(--mantine-color-ldDark-2)
+        var(--mantine-color-gray-4),
+        var(--mantine-color-dark-3)
     );
     background-color: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-4)
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-5)
     );
 }
 
@@ -165,14 +165,6 @@
         var(--mantine-color-violet-3),
         var(--mantine-color-violet-6)
     );
-    background-color: light-dark(
-        var(--mantine-color-violet-0),
-        color-mix(
-            in oklab,
-            var(--mantine-color-violet-9) 22%,
-            var(--mantine-color-ldDark-5)
-        )
-    );
     animation:
         pickerItemIn 380ms cubic-bezier(0.16, 1, 0.3, 1) 120ms both,
         recommendedSettle 900ms cubic-bezier(0.16, 1, 0.3, 1) 460ms 1 both;
@@ -183,28 +175,7 @@
         var(--mantine-color-violet-5),
         var(--mantine-color-violet-5)
     );
-    background-color: light-dark(
-        var(--mantine-color-violet-1),
-        color-mix(
-            in oklab,
-            var(--mantine-color-violet-9) 32%,
-            var(--mantine-color-ldDark-5)
-        )
-    );
-}
-
-.candidateName {
-    color: light-dark(
-        var(--mantine-color-ldGray-9),
-        var(--mantine-color-ldGray-0)
-    );
-}
-
-.candidateDescription {
-    color: light-dark(
-        var(--mantine-color-ldGray-6),
-        var(--mantine-color-ldGray-3)
-    );
+    background-color: var(--mantine-color-violet-light);
 }
 
 .candidateButton.recommended .candidateDescription {
@@ -227,10 +198,7 @@
 
 .candidateButton:hover .chevron {
     transform: translateX(2px);
-    color: light-dark(
-        var(--mantine-color-ldGray-7),
-        var(--mantine-color-ldGray-2)
-    );
+    color: var(--mantine-color-ldGray-7);
 }
 
 .candidateButton.recommended .chevron {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -1,0 +1,84 @@
+.pickerHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--mantine-spacing-sm);
+}
+
+.candidateButton {
+    display: block;
+    width: 100%;
+    border-radius: var(--mantine-radius-md);
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-ldDark-6)
+    );
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+    transition:
+        border-color 120ms ease-out,
+        background-color 120ms ease-out,
+        transform 120ms ease-out;
+    text-align: left;
+}
+
+.candidateButton:hover {
+    border-color: light-dark(
+        var(--mantine-color-ldGray-4),
+        var(--mantine-color-ldDark-3)
+    );
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-5)
+    );
+}
+
+.candidateButton:active {
+    transform: translateY(1px);
+}
+
+.candidateButton.recommended {
+    border-color: light-dark(
+        var(--mantine-color-violet-3),
+        var(--mantine-color-violet-7)
+    );
+    background-color: light-dark(
+        var(--mantine-color-violet-0),
+        rgba(118, 65, 232, 0.12)
+    );
+}
+
+.candidateButton.recommended:hover {
+    border-color: light-dark(
+        var(--mantine-color-violet-5),
+        var(--mantine-color-violet-6)
+    );
+    background-color: light-dark(
+        var(--mantine-color-violet-1),
+        rgba(118, 65, 232, 0.18)
+    );
+}
+
+.chevron {
+    color: light-dark(
+        var(--mantine-color-ldGray-5),
+        var(--mantine-color-ldGray-6)
+    );
+    flex-shrink: 0;
+    transition:
+        transform 120ms ease-out,
+        color 120ms ease-out;
+}
+
+.candidateButton:hover .chevron {
+    transform: translateX(2px);
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldGray-4)
+    );
+}
+
+.candidateButton.recommended .chevron {
+    color: var(--mantine-color-violet-6);
+}

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -232,13 +232,15 @@ const AgentsRouterPage = () => {
     }, [phase]);
 
     const isLocked = phase.kind !== 'idle';
-
-    const placeholder =
+    const isWorking = phase.kind === 'routing' || phase.kind === 'creating';
+    const workingLabel =
         phase.kind === 'routing'
-            ? 'Finding the best agent…'
+            ? 'Finding the right agent…'
             : phase.kind === 'creating'
-              ? 'Sending…'
-              : 'Ask anything about your data...';
+              ? 'Opening the conversation…'
+              : null;
+
+    const placeholder = 'Ask anything about your data...';
 
     return (
         <AiAgentPageLayout
@@ -266,11 +268,19 @@ const AgentsRouterPage = () => {
                     py="xl"
                 >
                     <Stack align="center" gap="xxs">
-                        <Avatar size="lg" color="violet" radius="xl">
+                        <Avatar
+                            size="lg"
+                            color="violet"
+                            radius="xl"
+                            className={`${classes.heroAvatar} ${
+                                isWorking ? classes.heroAvatarWorking : ''
+                            }`}
+                        >
                             <MantineIcon
                                 icon={IconSparkles}
                                 size="xl"
                                 color="violet.6"
+                                className={classes.heroSparkles}
                             />
                         </Avatar>
                         <Title order={2}>Ask AI</Title>
@@ -300,8 +310,27 @@ const AgentsRouterPage = () => {
                         onSqlModeChange={
                             sqlModeAvailable ? setSqlMode : undefined
                         }
+                        clearOnSubmit={false}
                         fullWidth
                     />
+
+                    {isWorking && workingLabel && (
+                        <Group
+                            gap={8}
+                            justify="center"
+                            className={classes.routingStatus}
+                            aria-live="polite"
+                        >
+                            <span className={classes.routingDots}>
+                                <span />
+                                <span />
+                                <span />
+                            </span>
+                            <Text size="xs" c="dimmed">
+                                {workingLabel}
+                            </Text>
+                        </Group>
+                    )}
 
                     {phase.kind === 'picker' && (
                         <Stack gap="xs" className={classes.pickerStack}>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -402,9 +402,6 @@ const AgentsRouterPage = () => {
                                                         size="sm"
                                                         fw={600}
                                                         truncate="end"
-                                                        className={
-                                                            classes.candidateName
-                                                        }
                                                     >
                                                         {c.name}
                                                     </Text>
@@ -422,6 +419,7 @@ const AgentsRouterPage = () => {
                                                 {c.description && (
                                                     <Text
                                                         size="xs"
+                                                        c="dimmed"
                                                         truncate="end"
                                                         className={
                                                             classes.candidateDescription

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -304,7 +304,7 @@ const AgentsRouterPage = () => {
                     />
 
                     {phase.kind === 'picker' && (
-                        <Stack gap="xs">
+                        <Stack gap="xs" className={classes.pickerStack}>
                             <div className={classes.pickerHeader}>
                                 <Text size="sm" fw={600}>
                                     Which agent should answer?

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -402,6 +402,9 @@ const AgentsRouterPage = () => {
                                                         size="sm"
                                                         fw={600}
                                                         truncate="end"
+                                                        className={
+                                                            classes.candidateName
+                                                        }
                                                     >
                                                         {c.name}
                                                     </Text>
@@ -419,8 +422,10 @@ const AgentsRouterPage = () => {
                                                 {c.description && (
                                                     <Text
                                                         size="xs"
-                                                        c="dimmed"
                                                         truncate="end"
+                                                        className={
+                                                            classes.candidateDescription
+                                                        }
                                                     >
                                                         {c.description}
                                                     </Text>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -3,17 +3,22 @@ import {
     type AiRouterRouteResponseResult,
 } from '@lightdash/common';
 import {
+    ActionIcon,
     Avatar,
-    Card,
+    Badge,
     Center,
     Group,
-    SimpleGrid,
+    Popover,
     Stack,
     Text,
     Title,
     UnstyledButton,
 } from '@mantine-8/core';
-import { IconSparkles } from '@tabler/icons-react';
+import {
+    IconChevronRight,
+    IconInfoCircle,
+    IconSparkles,
+} from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
@@ -36,6 +41,7 @@ import {
     useCreateAgentThreadMutation,
     useProjectAiAgents,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import classes from './AgentsRouterPage.module.css';
 
 type Phase =
     | { kind: 'idle' }
@@ -215,6 +221,16 @@ const AgentsRouterPage = () => {
         [phase, startThreadForDecision],
     );
 
+    const sortedCandidates = useMemo(() => {
+        if (phase.kind !== 'picker') return [];
+        const { candidates, suggestedAgentUuid } = phase.decision.decision;
+        return [...candidates].sort((a, b) => {
+            if (a.agentUuid === suggestedAgentUuid) return -1;
+            if (b.agentUuid === suggestedAgentUuid) return 1;
+            return 0;
+        });
+    }, [phase]);
+
     const isLocked = phase.kind !== 'idle';
 
     const placeholder =
@@ -288,72 +304,108 @@ const AgentsRouterPage = () => {
                     />
 
                     {phase.kind === 'picker' && (
-                        <Stack gap="sm">
-                            <Stack align="center" gap={4}>
-                                <Title order={5}>Pick the right agent</Title>
-                                <Text size="sm" c="dimmed" ta="center">
-                                    {phase.decision.decision.reasoning}
+                        <Stack gap="xs">
+                            <div className={classes.pickerHeader}>
+                                <Text size="sm" fw={600}>
+                                    Which agent should answer?
                                 </Text>
-                            </Stack>
-                            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
-                                {phase.decision.decision.candidates.map((c) => {
-                                    const agent = agentsByUuid.get(c.agentUuid);
-                                    return (
-                                        <UnstyledButton
-                                            key={c.agentUuid}
-                                            onClick={() =>
-                                                confirmPick(c.agentUuid)
-                                            }
-                                        >
-                                            <Card
-                                                withBorder
-                                                radius="md"
-                                                p="sm"
-                                                styles={(theme) => ({
-                                                    root: {
-                                                        borderColor:
-                                                            theme.colors
-                                                                .ldGray[2],
-                                                    },
-                                                })}
+                                {phase.decision.decision.reasoning && (
+                                    <Popover
+                                        width={280}
+                                        position="bottom-end"
+                                        withArrow
+                                        shadow="md"
+                                    >
+                                        <Popover.Target>
+                                            <ActionIcon
+                                                size="sm"
+                                                variant="subtle"
+                                                color="gray"
+                                                aria-label="Why these agents?"
                                             >
-                                                <Group
-                                                    gap="sm"
-                                                    wrap="nowrap"
-                                                    align="flex-start"
-                                                >
-                                                    <LightdashUserAvatar
-                                                        size={32}
-                                                        name={c.name}
-                                                        src={agent?.imageUrl}
-                                                    />
-                                                    <Stack
-                                                        gap={2}
-                                                        miw={0}
-                                                        flex={1}
+                                                <MantineIcon
+                                                    icon={IconInfoCircle}
+                                                    size={14}
+                                                />
+                                            </ActionIcon>
+                                        </Popover.Target>
+                                        <Popover.Dropdown>
+                                            <Text size="xs" c="dimmed">
+                                                {
+                                                    phase.decision.decision
+                                                        .reasoning
+                                                }
+                                            </Text>
+                                        </Popover.Dropdown>
+                                    </Popover>
+                                )}
+                            </div>
+
+                            {sortedCandidates.map((c) => {
+                                const agent = agentsByUuid.get(c.agentUuid);
+                                const isRecommended =
+                                    c.agentUuid ===
+                                    phase.decision.decision.suggestedAgentUuid;
+                                return (
+                                    <UnstyledButton
+                                        key={c.agentUuid}
+                                        onClick={() => confirmPick(c.agentUuid)}
+                                        className={`${classes.candidateButton} ${
+                                            isRecommended
+                                                ? classes.recommended
+                                                : ''
+                                        }`}
+                                        aria-label={`Send to ${c.name}`}
+                                    >
+                                        <Group
+                                            gap="sm"
+                                            wrap="nowrap"
+                                            align="center"
+                                        >
+                                            <LightdashUserAvatar
+                                                size={32}
+                                                name={c.name}
+                                                src={agent?.imageUrl}
+                                            />
+                                            <Stack gap={2} miw={0} flex={1}>
+                                                <Group gap="xs" wrap="nowrap">
+                                                    <Text
+                                                        size="sm"
+                                                        fw={600}
+                                                        truncate="end"
                                                     >
-                                                        <Text
-                                                            size="sm"
-                                                            fw={600}
+                                                        {c.name}
+                                                    </Text>
+                                                    {isRecommended && (
+                                                        <Badge
+                                                            size="xs"
+                                                            color="violet"
+                                                            variant="light"
+                                                            radius="sm"
                                                         >
-                                                            {c.name}
-                                                        </Text>
-                                                        {c.description && (
-                                                            <Text
-                                                                size="xs"
-                                                                c="dimmed"
-                                                                truncate="end"
-                                                            >
-                                                                {c.description}
-                                                            </Text>
-                                                        )}
-                                                    </Stack>
+                                                            Recommended
+                                                        </Badge>
+                                                    )}
                                                 </Group>
-                                            </Card>
-                                        </UnstyledButton>
-                                    );
-                                })}
-                            </SimpleGrid>
+                                                {c.description && (
+                                                    <Text
+                                                        size="xs"
+                                                        c="dimmed"
+                                                        truncate="end"
+                                                    >
+                                                        {c.description}
+                                                    </Text>
+                                                )}
+                                            </Stack>
+                                            <MantineIcon
+                                                icon={IconChevronRight}
+                                                size={16}
+                                                className={classes.chevron}
+                                            />
+                                        </Group>
+                                    </UnstyledButton>
+                                );
+                            })}
                         </Stack>
                     )}
                 </Stack>


### PR DESCRIPTION
### Description

Redesigns the low-confidence disambiguation picker on the Ask AI router page, then layers entrance motion, a routing-state animation, and a dark-mode contrast pass on top.

**Before:** the router exposed its own reasoning paragraph to the user ("The user is asking a general meta-question and the Jaffle Shop Analyst is a well-described general business agent…"), a 2-column card grid that produced an orphan card whenever there were 3 candidates, and no visible signal that one option was actually the router's recommendation. While routing, the only feedback was the submit button's loading state, and the prompt disappeared from the input on submit.

**After:**

- **Direct framing.** Heading becomes "Which agent should answer?". The LLM reasoning moves behind an info popover so users who want it can see it, instead of it being the loudest text on the page.
- **Vertical list, recommended first.** Candidates render as a sorted stack with the `suggestedAgentUuid` at the top. A subtle violet tint, violet border, and `Recommended` badge mark it. No more orphan card from `SimpleGrid`.
- **Staged entrance after routing.** Header lands at 40 ms, candidates cascade in starting with the recommended row at 120 ms, and a single violet `box-shadow` ring settles around the recommended row when it arrives. `ease-out-expo`, no bounce.
- **Routing has visible motion.** While the router is thinking: the violet hero avatar pulses a halo, the sparkles icon slowly rotates, and a small "Finding the right agent…" status line with three staggered dots appears below the composer. `aria-live="polite"` for screen readers.
- **Prompt persists.** `AgentChatInput` gets a `clearOnSubmit?: boolean` prop (defaults `true` so every other caller is unchanged). The router page passes `false`, so the user keeps seeing their question through `routing` and `creating` phases.
- **Picker surface matches the composer.** Non-recommended cards now use the same `white` / `dark-6` background and `gray-3` / `dark-4` border tokens as the input, so the picker reads as a continuation of the composer rather than a new UI layer. Names use the foreground color and descriptions use Mantine's `dimmed` token. The recommended row keeps its violet tint (a `color-mix(violet-9 22%, dark-5)` so the tint sits on the same elevation plane as its neighbours) and overrides the description to `violet-1` in dark mode where `dimmed` gray would disappear against violet.
- **Accessibility.** `prefers-reduced-motion` disables every animation in the file.

### Test plan

- [ ] Router returning `nextAction: 'show_picker'` with 2 candidates renders the new stack, with the suggested one tinted violet and badged `Recommended`.
- [ ] Router returning `nextAction: 'show_picker'` with 3 candidates no longer produces an orphan card.
- [ ] Clicking a candidate creates the thread for that agent and navigates.
- [ ] Submitting a high-confidence prompt skips the picker, shows the routing animation, and navigates.
- [ ] Prompt text stays visible in the input while routing.
- [ ] Toggle `prefers-reduced-motion`: animations stop, layout still correct.
- [ ] Flip to dark mode: non-recommended card descriptions are readable; recommended card text is readable on the violet surface.
- [ ] Other callers of `AgentChatInput` (agent threads, follow-ups, suggestion chips) still clear the input on submit.