### PR TITLE
feat: create dashboard version when editing a dashboard chart

### DIFF
--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -54,7 +54,7 @@ const savedChartData = {
         tableCalculations: [],
     },
     tableName: 'test_table',
-    dashboardUuid: null,
+    dashboardUuid: null as string | null,
     chartConfig: {
         type: 'cartesian',
         config: { eChartsConfig: { xAxis: [], yAxis: [], series: [] } },
@@ -101,6 +101,25 @@ const savedChartModel = {
     get: jest.fn(async () => savedChartData),
     createVersion: jest.fn(async () => savedChartData),
     update: jest.fn(async () => savedChartData),
+    transaction: jest.fn(async (callback) => callback('trx')),
+};
+
+const dashboardData = {
+    uuid: 'dashboard-uuid',
+    tiles: [],
+    filters: {
+        dimensions: [],
+        metrics: [],
+        tableCalculations: [],
+    },
+    parameters: {},
+    tabs: [],
+    config: { isDateZoomDisabled: false },
+};
+
+const dashboardModel = {
+    getByIdOrSlug: jest.fn(async () => dashboardData),
+    addVersion: jest.fn(async () => dashboardData),
 };
 
 const contentVerificationModel = {
@@ -137,7 +156,7 @@ describe('SavedChartService - Content Verification', () => {
         schedulerService: {} as unknown as SchedulerService,
         schedulerClient: {} as unknown as SchedulerClient,
         slackClient: {} as unknown as SlackClient,
-        dashboardModel: {} as unknown as DashboardModel,
+        dashboardModel: dashboardModel as unknown as DashboardModel,
         catalogModel: {} as unknown as CatalogModel,
         permissionsService: {} as unknown as PermissionsService,
         googleDriveClient: {} as unknown as GoogleDriveClient,
@@ -208,6 +227,74 @@ describe('SavedChartService - Content Verification', () => {
                 ContentType.CHART,
                 'chart-uuid',
             );
+        });
+
+        it('should create a dashboard version when editing a dashboard chart', async () => {
+            savedChartModel.get.mockResolvedValueOnce({
+                ...savedChartData,
+                dashboardUuid: 'dashboard-uuid',
+            });
+
+            await service.createVersion(adminUser, 'chart-uuid', {
+                tableName: 'test_table',
+                metricQuery: {
+                    exploreName: 'test',
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                },
+                chartConfig: { type: ChartType.CARTESIAN },
+                tableConfig: { columnOrder: [] },
+            });
+
+            expect(savedChartModel.transaction).toHaveBeenCalledTimes(1);
+            expect(savedChartModel.createVersion).toHaveBeenCalledWith(
+                'chart-uuid',
+                expect.any(Object),
+                adminUser,
+                'trx',
+            );
+            expect(dashboardModel.addVersion).toHaveBeenCalledWith(
+                'dashboard-uuid',
+                {
+                    tiles: dashboardData.tiles,
+                    filters: dashboardData.filters,
+                    parameters: dashboardData.parameters,
+                    tabs: dashboardData.tabs,
+                    config: dashboardData.config,
+                },
+                adminUser,
+                'project-uuid',
+                'trx',
+            );
+            expect(
+                savedChartModel.createVersion.mock.invocationCallOrder[0],
+            ).toBeLessThan(
+                dashboardModel.addVersion.mock.invocationCallOrder[0],
+            );
+        });
+
+        it('should not create a dashboard version when editing a space chart', async () => {
+            await service.createVersion(adminUser, 'chart-uuid', {
+                tableName: 'test_table',
+                metricQuery: {
+                    exploreName: 'test',
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                },
+                chartConfig: { type: ChartType.CARTESIAN },
+                tableConfig: { columnOrder: [] },
+            });
+
+            expect(savedChartModel.transaction).not.toHaveBeenCalled();
+            expect(dashboardModel.addVersion).not.toHaveBeenCalled();
         });
 
         it('should auto-unverify chart when metadata is edited via update', async () => {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -547,6 +547,7 @@ export class SavedChartService
             organizationUuid,
             projectUuid,
             spaceUuid,
+            dashboardUuid,
             metricQuery: {
                 metrics: oldChartMetrics,
                 dimensions: oldChartDimensions,
@@ -637,11 +638,43 @@ export class SavedChartService
             );
         }
 
-        const savedChart = await this.savedChartModel.createVersion(
-            savedChartUuid,
-            data,
-            user,
-        );
+        let savedChart: SavedChartDAO;
+        if (dashboardUuid) {
+            const dashboard =
+                await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+
+            await this.savedChartModel.transaction(async (tx) => {
+                // Rollback picks chart versions with created_at <= dashboard version created_at.
+                // Create the chart version first so the dashboard snapshot can point at it.
+                await this.savedChartModel.createVersion(
+                    savedChartUuid,
+                    data,
+                    user,
+                    tx,
+                );
+                await this.dashboardModel.addVersion(
+                    dashboardUuid,
+                    {
+                        tiles: dashboard.tiles,
+                        filters: dashboard.filters,
+                        parameters: dashboard.parameters,
+                        tabs: dashboard.tabs,
+                        config: dashboard.config,
+                    },
+                    user,
+                    projectUuid,
+                    tx,
+                );
+            });
+
+            savedChart = await this.savedChartModel.get(savedChartUuid);
+        } else {
+            savedChart = await this.savedChartModel.createVersion(
+                savedChartUuid,
+                data,
+                user,
+            );
+        }
 
         // Auto-remove verification when chart content is edited
         await this.contentVerificationModel.unverify(


### PR DESCRIPTION
Closes:

### Description:

When editing a chart that lives on a dashboard (a "dashboard chart"), a new dashboard version is now created atomically alongside the chart version. This ensures that rolling back a dashboard also rolls back any chart edits made to its embedded charts, keeping dashboard snapshots consistent.

The chart version is intentionally created before the dashboard version within the same transaction, since the rollback logic selects chart versions with a `created_at` timestamp less than or equal to the dashboard version's `created_at`.

Charts that live in spaces (non-dashboard charts) are unaffected and continue to create only a chart version as before.

Tests have been added to verify that:
- A dashboard version is created when editing a dashboard chart, with the chart version created first within a transaction.
- No dashboard version is created when editing a space chart.