### PR TITLE
feat(ee): show feedback row on AI writeback PR Slack messages

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -239,6 +239,7 @@ const ANSWER_PRODUCING_TOOLS = new Set([
     'runSql',
     'runSavedChart',
     'generateDashboard',
+    'proposeWriteback',
 ]);
 
 // One compact footer: small "How did I do?" header + a single row with


### PR DESCRIPTION
## What

Adds the feedback footer (👍 / 👎 / **View chat in Lightdash**) to the Slack message the AI agent posts when it opens a writeback PR.

Before, that message had only a single **View pull request** button — no way to rate the result, no quick link back into Lightdash for the conversation. Every other answer-producing tool already gets the footer row; writeback was the odd one out.

## Why this change is one line

`getFeedbackBlocks()` already builds the row, and `AiAgentService` already unconditionally spreads `feedbackBlocks` into the message. The footer's visibility is gated by `ANSWER_PRODUCING_TOOLS`, a hard-coded set that did not include `proposeWriteback`. Adding it lights the row up automatically because:

- The writeback success path already sets `metadata.status === 'success'`, which is what the gate checks.
- The upvote / downvote / view-chat-in-Lightdash handlers key off `action_id` strings, not tool type, so they pick up writeback messages without modification.

No new blocks, no new handlers, no new tests required.

## Before / after

**Before** — only the PR link:

```
[markdown summary]
─────────
[View pull request]
```

**After** — feedback row appears alongside:

```
[markdown summary]
─────────
[View pull request]
[👍] [👎] [View chat in Lightdash]
```

## Verified locally

Triggered an end-to-end run against a local Jaffle project:

> @bot In the Jaffle Shop EU project: In the customers model, hide the \`last_name\` dimension from explorers. Open a PR.

The bot opened the PR and the resulting Slack message rendered all four buttons (`View pull request`, `:+1:`, `:-1:`, `View chat in Lightdash`), confirmed by reading the message blocks back through the Slack API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)