### PR TITLE
fix: route transitive type:number wrappers of sum_distinct through dedup CTE

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -2616,6 +2616,171 @@ export const METRIC_QUERY_AVERAGE_DISTINCT_NO_DIMS: CompiledMetricQuery = {
     compiledCustomDimensions: [],
 };
 
+// PROD-7893: type:number wrappers over sum_distinct metrics, plus a transitive rate.
+export const EXPLORE_WITH_SUM_DISTINCT_WRAPPER: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'transfers',
+    label: 'transfers',
+    baseTable: 'transfers',
+    tags: [],
+    joinedTables: [],
+    tables: {
+        transfers: {
+            name: 'transfers',
+            label: 'transfers',
+            database: 'db',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."transfers"',
+            primaryKey: ['client_id'],
+            dimensions: {
+                client_id: {
+                    type: DimensionType.STRING,
+                    name: 'client_id',
+                    label: 'Client ID',
+                    table: 'transfers',
+                    tableLabel: 'transfers',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.client_id',
+                    compiledSql: '"transfers".client_id',
+                    tablesReferences: ['transfers'],
+                    hidden: false,
+                },
+                date: {
+                    type: DimensionType.DATE,
+                    name: 'date',
+                    label: 'Date',
+                    table: 'transfers',
+                    tableLabel: 'transfers',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.date',
+                    compiledSql: '"transfers".date',
+                    tablesReferences: ['transfers'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                total_corridor_transfers: {
+                    type: MetricType.SUM_DISTINCT,
+                    fieldType: FieldType.METRIC,
+                    table: 'transfers',
+                    tableLabel: 'transfers',
+                    name: 'total_corridor_transfers',
+                    label: 'Total corridor transfers',
+                    sql: '${TABLE}.total_daily_corridor_transfers',
+                    compiledSql:
+                        'SUM("transfers".total_daily_corridor_transfers)',
+                    compiledValueSql:
+                        '"transfers".total_daily_corridor_transfers',
+                    compiledDistinctKeys: [
+                        '"transfers".client_id',
+                        '"transfers".date',
+                    ],
+                    tablesReferences: ['transfers'],
+                    hidden: false,
+                },
+                total_residual_transfers: {
+                    type: MetricType.SUM_DISTINCT,
+                    fieldType: FieldType.METRIC,
+                    table: 'transfers',
+                    tableLabel: 'transfers',
+                    name: 'total_residual_transfers',
+                    label: 'Total residual transfers',
+                    sql: '${TABLE}.total_daily_residual_transfers',
+                    compiledSql:
+                        'SUM("transfers".total_daily_residual_transfers)',
+                    compiledValueSql:
+                        '"transfers".total_daily_residual_transfers',
+                    compiledDistinctKeys: ['"transfers".client_id'],
+                    tablesReferences: ['transfers'],
+                    hidden: false,
+                },
+                total_inbound_contacts: {
+                    type: MetricType.COUNT_DISTINCT,
+                    fieldType: FieldType.METRIC,
+                    table: 'transfers',
+                    tableLabel: 'transfers',
+                    name: 'total_inbound_contacts',
+                    label: 'Total inbound contacts',
+                    sql: '${TABLE}.contact_id',
+                    compiledSql: 'COUNT(DISTINCT "transfers".contact_id)',
+                    tablesReferences: ['transfers'],
+                    hidden: false,
+                },
+                total_transfers: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'transfers',
+                    tableLabel: 'transfers',
+                    name: 'total_transfers',
+                    label: 'Total transfers',
+                    sql: '${total_corridor_transfers} + ${total_residual_transfers}',
+                    compiledSql:
+                        '(SUM("transfers".total_daily_corridor_transfers)) + (SUM("transfers".total_daily_residual_transfers))',
+                    tablesReferences: ['transfers'],
+                    hidden: false,
+                },
+                transfer_inbound_contact_rate: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'transfers',
+                    tableLabel: 'transfers',
+                    name: 'transfer_inbound_contact_rate',
+                    label: 'Transfer inbound contact rate',
+                    sql: '${total_inbound_contacts} / nullif(${total_transfers}, 0)',
+                    compiledSql:
+                        '(COUNT(DISTINCT "transfers".contact_id)) / nullif(((SUM("transfers".total_daily_corridor_transfers)) + (SUM("transfers".total_daily_residual_transfers))), 0)',
+                    tablesReferences: ['transfers'],
+                    hidden: false,
+                },
+            },
+            lineageGraph: {},
+        },
+    },
+};
+
+export const METRIC_QUERY_SUM_DISTINCT_WRAPPER_DIRECT: CompiledMetricQuery = {
+    exploreName: 'transfers',
+    dimensions: ['transfers_date'],
+    metrics: ['transfers_total_transfers'],
+    filters: {},
+    sorts: [{ fieldId: 'transfers_date', descending: false }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+export const METRIC_QUERY_SUM_DISTINCT_WRAPPER_TRANSITIVE: CompiledMetricQuery =
+    {
+        exploreName: 'transfers',
+        dimensions: ['transfers_date'],
+        metrics: ['transfers_transfer_inbound_contact_rate'],
+        filters: {},
+        sorts: [{ fieldId: 'transfers_date', descending: false }],
+        limit: 10,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+export const METRIC_QUERY_SUM_DISTINCT_WRAPPER_MIXED: CompiledMetricQuery = {
+    exploreName: 'transfers',
+    dimensions: ['transfers_date'],
+    metrics: [
+        'transfers_total_transfers',
+        'transfers_transfer_inbound_contact_rate',
+    ],
+    filters: {},
+    sorts: [{ fieldId: 'transfers_date', descending: false }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
 // Expected: SELECT uses DATE_TRUNC (zoomed), but WHERE uses raw column
 export const METRIC_QUERY_WITH_DATE_ZOOM_FILTER_SQL = `SELECT
   DATE_TRUNC('month', "orders".created_at) AS "orders_created_at",

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1037,28 +1037,101 @@ export class MetricQueryBuilder {
         );
         if (ddMetricIds.size === 0) return new Set();
 
-        const result = new Set<string>();
+        // Propagate transitively through chains like A -> B -> sum_distinct (PROD-7893).
+        const nonAggRefs = new Map<string, Set<string>>();
         for (const metricId of allMetricIds) {
             try {
                 const metric = this.getMetricFromId(metricId);
                 if (isNonAggregateMetric(metric)) {
-                    const refs = parseAllReferences(metric.sql, metric.table);
-                    for (const ref of refs) {
-                        const refId = getItemId({
-                            table: ref.refTable,
-                            name: ref.refName,
-                        });
-                        if (ddMetricIds.has(refId)) {
-                            result.add(metricId);
-                            break;
-                        }
+                    const refIds = new Set<string>();
+                    for (const ref of parseAllReferences(
+                        metric.sql,
+                        metric.table,
+                    )) {
+                        refIds.add(
+                            getItemId({
+                                table: ref.refTable,
+                                name: ref.refName,
+                            }),
+                        );
                     }
+                    nonAggRefs.set(metricId, refIds);
                 }
             } catch {
                 // skip
             }
         }
+
+        const result = new Set<string>();
+        let changed = true;
+        while (changed) {
+            changed = false;
+            for (const [metricId, refIds] of nonAggRefs) {
+                if (!result.has(metricId)) {
+                    for (const refId of refIds) {
+                        if (ddMetricIds.has(refId) || result.has(refId)) {
+                            result.add(metricId);
+                            changed = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
         return result;
+    }
+
+    // Topo sort so wrappers are rewritten before metrics that reference them.
+    private topoSortNonAggDdMetrics(metricIds: Set<string>): string[] {
+        const ids = Array.from(metricIds);
+        const deps = new Map<string, Set<string>>();
+        for (const id of ids) {
+            const set = new Set<string>();
+            try {
+                const metric = this.getMetricFromId(id);
+                for (const ref of parseAllReferences(
+                    metric.sql,
+                    metric.table,
+                )) {
+                    const refId = getItemId({
+                        table: ref.refTable,
+                        name: ref.refName,
+                    });
+                    if (metricIds.has(refId) && refId !== id) {
+                        set.add(refId);
+                    }
+                }
+            } catch {
+                // skip
+            }
+            deps.set(id, set);
+        }
+        const ordered: string[] = [];
+        const remaining = new Set(ids);
+        while (remaining.size > 0) {
+            const ready = ids.filter(
+                (id) =>
+                    remaining.has(id) &&
+                    Array.from(deps.get(id) ?? []).every(
+                        (dep) => !remaining.has(dep),
+                    ),
+            );
+            if (ready.length === 0) {
+                // Cycle — emit the rest in input order.
+                for (const id of ids) {
+                    if (remaining.has(id)) {
+                        ordered.push(id);
+                        remaining.delete(id);
+                    }
+                }
+                break;
+            }
+            for (const id of ready) {
+                ordered.push(id);
+                remaining.delete(id);
+            }
+        }
+        return ordered;
     }
 
     private getMetricsSQL(): {
@@ -1841,6 +1914,7 @@ export class MetricQueryBuilder {
     private replaceMetricReferencesWithCteReferences(
         metric: CompiledMetric,
         metricCtes: Array<{ name: string; metrics: string[] }>,
+        nonAggRewriteMap?: Map<string, string>,
     ): string {
         const { explore, warehouseSqlBuilder } = this.args;
         const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
@@ -1903,6 +1977,13 @@ export class MetricQueryBuilder {
                 );
                 if (containingCte) {
                     return `${containingCte.name}.${fieldQuoteChar}${itemId}${fieldQuoteChar}`;
+                }
+
+                // Inline another non-aggregate metric already rewritten in the same outer
+                // SELECT (PROD-7893). Parens preserve precedence in callers like nullif().
+                const inlinedNonAgg = nonAggRewriteMap?.get(itemId);
+                if (inlinedNonAgg) {
+                    return `(${inlinedNonAgg})`;
                 }
 
                 // Check if it's a dimension — resolve to CTE alias
@@ -4265,13 +4346,18 @@ export class MetricQueryBuilder {
             ];
             const ddFieldQuoteChar =
                 this.args.warehouseSqlBuilder.getFieldQuoteChar();
-            for (const metricId of nonAggDdMetricIds) {
+            const orderedNonAggDdIds =
+                this.topoSortNonAggDdMetrics(nonAggDdMetricIds);
+            const nonAggRewriteMap = new Map<string, string>();
+            for (const metricId of orderedNonAggDdIds) {
                 const metric = this.getMetricFromId(metricId);
                 const rewrittenSql =
                     this.replaceMetricReferencesWithCteReferences(
                         metric,
                         ddCteMap,
+                        nonAggRewriteMap,
                     );
+                nonAggRewriteMap.set(metricId, rewrittenSql);
                 nonAggDdSelects.push(
                     `  ${rewrittenSql} AS ${ddFieldQuoteChar}${metricId}${ddFieldQuoteChar}`,
                 );

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
@@ -256,6 +256,173 @@ LIMIT
   10"
 `;
 
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a type:number metric that transitively references sum_distinct metrics through another type:number wrapper 1`] = `
+"WITH
+  dd_transfers_total_corridor_transfers AS (
+    SELECT
+      "transfers_date",
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "transfers_total_corridor_transfers"
+    FROM
+      (
+        SELECT
+          "transfers".date AS "transfers_date",
+          "transfers".total_daily_corridor_transfers AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "transfers".client_id,
+              "transfers".date
+            ORDER BY
+              "transfers".total_daily_corridor_transfers
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."transfers" AS "transfers"
+      ) __dd_sub
+    GROUP BY
+      1
+  ),
+  dd_transfers_total_residual_transfers AS (
+    SELECT
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "transfers_total_residual_transfers"
+    FROM
+      (
+        SELECT
+          "transfers".total_daily_residual_transfers AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "transfers".client_id
+            ORDER BY
+              "transfers".total_daily_residual_transfers
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."transfers" AS "transfers"
+      ) __dd_sub
+  ),
+  dd_base AS (
+    SELECT
+      "transfers".date AS "transfers_date",
+      COUNT(DISTINCT "transfers".contact_id) AS "transfers_total_inbound_contacts"
+    FROM
+      "db"."schema"."transfers" AS "transfers"
+    GROUP BY
+      1
+  )
+SELECT
+  dd_base.*,
+  dd_transfers_total_corridor_transfers."transfers_total_corridor_transfers" AS "transfers_total_corridor_transfers",
+  dd_transfers_total_residual_transfers."transfers_total_residual_transfers" AS "transfers_total_residual_transfers",
+  dd_transfers_total_corridor_transfers."transfers_total_corridor_transfers" + dd_transfers_total_residual_transfers."transfers_total_residual_transfers" AS "transfers_total_transfers",
+  dd_base."transfers_total_inbound_contacts" / nullif(
+    (
+      dd_transfers_total_corridor_transfers."transfers_total_corridor_transfers" + dd_transfers_total_residual_transfers."transfers_total_residual_transfers"
+    ),
+    0
+  ) AS "transfers_transfer_inbound_contact_rate"
+FROM
+  dd_base
+  INNER JOIN dd_transfers_total_corridor_transfers ON (
+    dd_base."transfers_date" = dd_transfers_total_corridor_transfers."transfers_date"
+    OR (
+      dd_base."transfers_date" IS NULL
+      AND dd_transfers_total_corridor_transfers."transfers_date" IS NULL
+    )
+  )
+  CROSS JOIN dd_transfers_total_residual_transfers
+ORDER BY
+  "transfers_date"
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a type:number metric that wraps two sum_distinct metrics 1`] = `
+"WITH
+  dd_transfers_total_corridor_transfers AS (
+    SELECT
+      "transfers_date",
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "transfers_total_corridor_transfers"
+    FROM
+      (
+        SELECT
+          "transfers".date AS "transfers_date",
+          "transfers".total_daily_corridor_transfers AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "transfers".client_id,
+              "transfers".date
+            ORDER BY
+              "transfers".total_daily_corridor_transfers
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."transfers" AS "transfers"
+      ) __dd_sub
+    GROUP BY
+      1
+  ),
+  dd_transfers_total_residual_transfers AS (
+    SELECT
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "transfers_total_residual_transfers"
+    FROM
+      (
+        SELECT
+          "transfers".total_daily_residual_transfers AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "transfers".client_id
+            ORDER BY
+              "transfers".total_daily_residual_transfers
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."transfers" AS "transfers"
+      ) __dd_sub
+  ),
+  dd_base AS (
+    SELECT
+      "transfers".date AS "transfers_date"
+    FROM
+      "db"."schema"."transfers" AS "transfers"
+    GROUP BY
+      1
+  )
+SELECT
+  dd_base.*,
+  dd_transfers_total_corridor_transfers."transfers_total_corridor_transfers" AS "transfers_total_corridor_transfers",
+  dd_transfers_total_residual_transfers."transfers_total_residual_transfers" AS "transfers_total_residual_transfers",
+  dd_transfers_total_corridor_transfers."transfers_total_corridor_transfers" + dd_transfers_total_residual_transfers."transfers_total_residual_transfers" AS "transfers_total_transfers"
+FROM
+  dd_base
+  INNER JOIN dd_transfers_total_corridor_transfers ON (
+    dd_base."transfers_date" = dd_transfers_total_corridor_transfers."transfers_date"
+    OR (
+      dd_base."transfers_date" IS NULL
+      AND dd_transfers_total_corridor_transfers."transfers_date" IS NULL
+    )
+  )
+  CROSS JOIN dd_transfers_total_residual_transfers
+ORDER BY
+  "transfers_date"
+LIMIT
+  10"
+`;
+
 exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for an average-distinct query with dimensions not in distinct_keys 1`] = `
 "WITH
   dd_orders_avg_shipping_cost AS (
@@ -352,6 +519,93 @@ FROM
   dd_orders_avg_shipping_cost
 ORDER BY
   "orders_avg_shipping_cost" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for both wrapper and transitive-rate metrics selected together 1`] = `
+"WITH
+  dd_transfers_total_corridor_transfers AS (
+    SELECT
+      "transfers_date",
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "transfers_total_corridor_transfers"
+    FROM
+      (
+        SELECT
+          "transfers".date AS "transfers_date",
+          "transfers".total_daily_corridor_transfers AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "transfers".client_id,
+              "transfers".date
+            ORDER BY
+              "transfers".total_daily_corridor_transfers
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."transfers" AS "transfers"
+      ) __dd_sub
+    GROUP BY
+      1
+  ),
+  dd_transfers_total_residual_transfers AS (
+    SELECT
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "transfers_total_residual_transfers"
+    FROM
+      (
+        SELECT
+          "transfers".total_daily_residual_transfers AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "transfers".client_id
+            ORDER BY
+              "transfers".total_daily_residual_transfers
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."transfers" AS "transfers"
+      ) __dd_sub
+  ),
+  dd_base AS (
+    SELECT
+      "transfers".date AS "transfers_date",
+      COUNT(DISTINCT "transfers".contact_id) AS "transfers_total_inbound_contacts"
+    FROM
+      "db"."schema"."transfers" AS "transfers"
+    GROUP BY
+      1
+  )
+SELECT
+  dd_base.*,
+  dd_transfers_total_corridor_transfers."transfers_total_corridor_transfers" AS "transfers_total_corridor_transfers",
+  dd_transfers_total_residual_transfers."transfers_total_residual_transfers" AS "transfers_total_residual_transfers",
+  dd_transfers_total_corridor_transfers."transfers_total_corridor_transfers" + dd_transfers_total_residual_transfers."transfers_total_residual_transfers" AS "transfers_total_transfers",
+  dd_base."transfers_total_inbound_contacts" / nullif(
+    (
+      dd_transfers_total_corridor_transfers."transfers_total_corridor_transfers" + dd_transfers_total_residual_transfers."transfers_total_residual_transfers"
+    ),
+    0
+  ) AS "transfers_transfer_inbound_contact_rate"
+FROM
+  dd_base
+  INNER JOIN dd_transfers_total_corridor_transfers ON (
+    dd_base."transfers_date" = dd_transfers_total_corridor_transfers."transfers_date"
+    OR (
+      dd_base."transfers_date" IS NULL
+      AND dd_transfers_total_corridor_transfers."transfers_date" IS NULL
+    )
+  )
+  CROSS JOIN dd_transfers_total_residual_transfers
+ORDER BY
+  "transfers_date"
 LIMIT
   10"
 `;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/distinctQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/distinctQueries.test.ts
@@ -1,6 +1,7 @@
 import {
     EXPLORE_WITH_AVERAGE_DISTINCT,
     EXPLORE_WITH_SUM_DISTINCT,
+    EXPLORE_WITH_SUM_DISTINCT_WRAPPER,
     METRIC_QUERY_AVERAGE_DISTINCT_NO_DIMS,
     METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
     METRIC_QUERY_SUM_DISTINCT_MULTI_KEY_FULLY_JOINABLE,
@@ -8,6 +9,9 @@ import {
     METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
     METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
     METRIC_QUERY_SUM_DISTINCT_WITH_JOINABLE_DIM,
+    METRIC_QUERY_SUM_DISTINCT_WRAPPER_DIRECT,
+    METRIC_QUERY_SUM_DISTINCT_WRAPPER_MIXED,
+    METRIC_QUERY_SUM_DISTINCT_WRAPPER_TRANSITIVE,
 } from '../MetricQueryBuilder.mock';
 import { buildQuery } from './helpers';
 
@@ -89,6 +93,37 @@ describe('MetricQueryBuilder snapshot: distinct queries', () => {
             buildQuery({
                 explore: EXPLORE_WITH_AVERAGE_DISTINCT,
                 compiledMetricQuery: METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // PROD-7893: wrapper resolves to dd CTE refs, not raw SUM(...).
+    test('matches snapshot for a type:number metric that wraps two sum_distinct metrics', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_SUM_DISTINCT_WRAPPER,
+                compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_WRAPPER_DIRECT,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // PROD-7893: transitive rate (rate -> wrapper -> sum_distinct) resolves to dd CTE refs.
+    test('matches snapshot for a type:number metric that transitively references sum_distinct metrics through another type:number wrapper', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_SUM_DISTINCT_WRAPPER,
+                compiledMetricQuery:
+                    METRIC_QUERY_SUM_DISTINCT_WRAPPER_TRANSITIVE,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // PROD-7893: both wrappers selected — exercises topo ordering.
+    test('matches snapshot for both wrapper and transitive-rate metrics selected together', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_SUM_DISTINCT_WRAPPER,
+                compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_WRAPPER_MIXED,
             }),
         ).toMatchSnapshot();
     });


### PR DESCRIPTION
Closes: PROD-7893

### Description:

When a `type: number` metric transitively referenced a `sum_distinct` / `average_distinct` metric through another `type: number` wrapper, its SQL was inlined as raw `SUM(...)` against the underlying column inside `dd_base`, ignoring the deduplicated CTEs Lightdash already generated alongside. The detection (`getNonAggregateMetricsReferencingDistinct`) was non-transitive, so wrappers-of-wrappers fell through to `ExploreCompiler.compileMetricSql` and recomputed values inflated by the row duplication that `sum_distinct` was meant to neutralise. This PR makes the detection transitive, topo-sorts the affected non-aggregate metrics, and threads a running rewrite map through `replaceMetricReferencesWithCteReferences` so each dependent inlines its dependency's already-rewritten dedup-CTE SQL instead of falling back to raw aggregates. Snapshot tests cover direct, transitive, and mixed selections.