### PR TITLE
feat(ee): structured logs + Sentry capture for AI writeback runs

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -11,6 +11,7 @@ import {
     type DbtProjectConfig,
     type SessionUser,
 } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import { randomUUID } from 'crypto';
 import { Sandbox } from 'e2b';
 import type {
@@ -212,9 +213,13 @@ export class AiWritebackService extends BaseService {
             lifecycle: { onTimeout: 'pause' },
         });
         const durationMs = AiWritebackService.elapsed(start);
-        this.logger.info(
-            `AiWriteback: sandbox created (sandboxId=${sandbox.sandboxId}, project=${projectUuid}, template=${templateRef}, ${durationMs}ms)`,
-        );
+        this.logger.info('AI writeback sandbox created', {
+            event: 'ai_writeback.sandbox.created',
+            sandboxId: sandbox.sandboxId,
+            projectUuid,
+            template: templateRef,
+            durationMs,
+        });
         return { sandbox, durationMs };
     }
 
@@ -226,13 +231,20 @@ export class AiWritebackService extends BaseService {
             const start = performance.now();
             await sandbox.pause();
             const durationMs = AiWritebackService.elapsed(start);
-            this.logger.info(
-                `AiWriteback: sandbox paused (sandboxId=${sandbox.sandboxId}, project=${projectUuid}, ${durationMs}ms)`,
-            );
+            this.logger.info('AI writeback sandbox paused', {
+                event: 'ai_writeback.sandbox.lifecycle',
+                action: 'paused',
+                sandboxId: sandbox.sandboxId,
+                projectUuid,
+                durationMs,
+            });
         } catch (error) {
-            this.logger.warn(
-                `AiWriteback: failed to pause sandbox (sandboxId=${sandbox.sandboxId}, project=${projectUuid}): ${getErrorMessage(error)}`,
-            );
+            this.logger.warn('AI writeback failed to pause sandbox', {
+                event: 'ai_writeback.sandbox.pause_failed',
+                sandboxId: sandbox.sandboxId,
+                projectUuid,
+                errorMessage: getErrorMessage(error),
+            });
         }
     }
 
@@ -246,9 +258,13 @@ export class AiWritebackService extends BaseService {
             timeoutMs: SANDBOX_TIMEOUT_MS,
         });
         const durationMs = AiWritebackService.elapsed(start);
-        this.logger.info(
-            `AiWriteback: sandbox resumed (sandboxId=${sandbox.sandboxId}, project=${projectUuid}, ${durationMs}ms)`,
-        );
+        this.logger.info('AI writeback sandbox resumed', {
+            event: 'ai_writeback.sandbox.lifecycle',
+            action: 'resumed',
+            sandboxId: sandbox.sandboxId,
+            projectUuid,
+            durationMs,
+        });
         return { sandbox, durationMs };
     }
 
@@ -397,15 +413,19 @@ export class AiWritebackService extends BaseService {
      */
     async run(args: AiWritebackRunArgs): Promise<AiWritebackRunResult> {
         const { user, projectUuid, prompt, aiThreadUuid } = args;
-
-        this.logger.info(
-            `AiWriteback: agent run started (projectUuid=${projectUuid}, aiThreadUuid=${aiThreadUuid})`,
-        );
+        const runStartedAt = performance.now();
 
         const turn = await this.prepareTurn({
             user,
             projectUuid,
             aiThreadUuid,
+        });
+
+        this.logger.info('AI writeback run started', {
+            event: 'ai_writeback.run.started',
+            projectUuid,
+            aiThreadUuid: aiThreadUuid ?? null,
+            isResume: turn.isResume,
         });
 
         const repository = `${turn.githubConnection.owner}/${turn.githubConnection.repo}`;
@@ -418,13 +438,13 @@ export class AiWritebackService extends BaseService {
             const now = Date.now();
             // Log every transition so a run reads as a timeline in the logs and
             // a stall is immediately attributable to the stage it happened in.
-            this.logger.info(
-                `AiWriteback: stage '${failureStage}' done in ${
-                    now - stageStartedAt
-                }ms → entering '${stage}' (aiThreadUuid=${
-                    aiThreadUuid ?? 'none'
-                })`,
-            );
+            this.logger.info('AI writeback stage complete', {
+                event: 'ai_writeback.run.stage',
+                aiThreadUuid: aiThreadUuid ?? null,
+                stage: failureStage,
+                nextStage: stage,
+                durationMs: now - stageStartedAt,
+            });
             failureStage = stage;
             stageStartedAt = now;
         };
@@ -470,7 +490,19 @@ export class AiWritebackService extends BaseService {
             // and surface the failure to the caller.
             if (agent.exitCode !== 0) {
                 this.logger.warn(
-                    `AiWriteback: agent exited non-zero (sandboxId=${sandbox.sandboxId}, exit=${agent.exitCode}) — skipping PR`,
+                    'AI writeback agent exited non-zero, skipping PR',
+                    {
+                        event: 'ai_writeback.run.failed',
+                        projectUuid,
+                        aiThreadUuid: aiThreadUuid ?? null,
+                        sandboxId: sandbox.sandboxId,
+                        failureStage,
+                        exitCode: agent.exitCode,
+                        errorMessage: 'Agent CLI exited non-zero',
+                        totalDurationMs: Math.round(
+                            performance.now() - runStartedAt,
+                        ),
+                    },
                 );
                 tracker.completed({
                     exitCode: agent.exitCode,
@@ -504,6 +536,19 @@ export class AiWritebackService extends BaseService {
                 prCreated: applied.prCreated,
             });
 
+            this.logger.info('AI writeback run completed', {
+                event: 'ai_writeback.run.completed',
+                projectUuid,
+                aiThreadUuid: aiThreadUuid ?? null,
+                sandboxId: sandbox.sandboxId,
+                isResume: turn.isResume,
+                exitCode: agent.exitCode,
+                hasChanges,
+                prCreated: applied.prCreated,
+                prUrl: applied.prUrl ?? null,
+                totalDurationMs: Math.round(performance.now() - runStartedAt),
+            });
+
             return {
                 output: sanitizedStdout,
                 exitCode: agent.exitCode,
@@ -512,11 +557,26 @@ export class AiWritebackService extends BaseService {
                 repository,
             };
         } catch (error) {
-            this.logger.error(
-                `AiWriteback: failed during stage '${failureStage}' (sandboxId=${
-                    sandbox?.sandboxId ?? 'none'
-                }): ${getErrorMessage(error)}`,
-            );
+            this.logger.error('AI writeback run failed', {
+                event: 'ai_writeback.run.failed',
+                projectUuid,
+                aiThreadUuid: aiThreadUuid ?? null,
+                sandboxId: sandbox?.sandboxId ?? null,
+                failureStage,
+                errorMessage: getErrorMessage(error),
+                totalDurationMs: Math.round(performance.now() - runStartedAt),
+            });
+            Sentry.captureException(error, {
+                tags: {
+                    errorType: 'AiWritebackRunFailed',
+                    failureStage,
+                },
+                extra: {
+                    projectUuid,
+                    aiThreadUuid: aiThreadUuid ?? null,
+                    sandboxId: sandbox?.sandboxId ?? null,
+                },
+            });
             tracker.failed(failureStage, error);
             throw error;
         } finally {
@@ -790,17 +850,23 @@ export class AiWritebackService extends BaseService {
                         ) {
                             toolCounts[block.name] =
                                 (toolCounts[block.name] ?? 0) + 1;
-                            this.logger.info(
-                                `AiWriteback: tool ${block.name} ${summarizeToolInput(block.input)} (sandboxId=${sandbox.sandboxId})`,
-                            );
+                            this.logger.info('AI writeback agent tool call', {
+                                event: 'ai_writeback.run.tool',
+                                sandboxId: sandbox.sandboxId,
+                                toolName: block.name,
+                                summary: summarizeToolInput(block.input),
+                            });
                         }
                     }
                 }
                 if (messageText) assistantText = messageText;
             } else if (e.type === 'result') {
-                this.logger.info(
-                    `AiWriteback: agent run summary (sandboxId=${sandbox.sandboxId}, cost_usd=${e.total_cost_usd ?? 'n/a'}, tools=${JSON.stringify(toolCounts)})`,
-                );
+                this.logger.info('AI writeback agent run summary', {
+                    event: 'ai_writeback.run.summary',
+                    sandboxId: sandbox.sandboxId,
+                    costUsd: e.total_cost_usd ?? null,
+                    toolCounts,
+                });
             }
         };
 
@@ -863,9 +929,12 @@ export class AiWritebackService extends BaseService {
             }
             buffer = '';
         }
-        this.logger.info(
-            `AiWriteback: agent run completed (sandboxId=${sandbox.sandboxId}, exit=${result.exitCode}, isResume=${isResume})`,
-        );
+        this.logger.info('AI writeback agent CLI exited', {
+            event: 'ai_writeback.run.agent_exited',
+            sandboxId: sandbox.sandboxId,
+            exitCode: result.exitCode,
+            isResume,
+        });
         return { stdout: assistantText, exitCode: result.exitCode };
     }
 


### PR DESCRIPTION
## What

Convert the lifecycle log calls in `AiWritebackService` from string-formatted to wide-event structured form, and add `Sentry.captureException` on the catch path.

This is step 1 of the AI writeback observability plan — laying the foundation for a GCP Cloud Logging dashboard that filters on `jsonPayload.event=~"ai_writeback\\."` across runs, sandboxes, and failures.

## Why this shape

The existing pattern (used by `AiAgentReviewClassifierService.ts:510`) is a human-readable message string plus a meta object. Winston's `json` format (production) merges the meta object at the top level of the JSON record — every field becomes a `jsonPayload.*` selector in Cloud Logging, queryable by widgets without extracting from a string.

Verified locally with a winston JSON-format repro:

```
{"event":"ai_writeback.run.completed","exitCode":0,"hasChanges":true,"isResume":false,
 "level":"info","message":"AI writeback run completed","prCreated":true,
 "prUrl":"https://github.com/x/y/pull/22","projectUuid":"abc","sandboxId":"sb-xyz",
 "totalDurationMs":96123}
```

## Events emitted

| Event | Fields | Dashboard use |
|---|---|---|
| `ai_writeback.run.started` | `projectUuid`, `aiThreadUuid`, `isResume` | runs/hour, runs by project, resume vs fresh |
| `ai_writeback.run.stage` | `stage`, `nextStage`, `durationMs`, `aiThreadUuid` | p50/p95/p99 stage timings |
| `ai_writeback.run.tool` | `sandboxId`, `toolName`, `summary` | tool call mix |
| `ai_writeback.run.summary` | `sandboxId`, `costUsd`, `toolCounts` | cost per day, tool mix |
| `ai_writeback.run.agent_exited` | `sandboxId`, `exitCode`, `isResume` | agent-CLI exit timing |
| `ai_writeback.run.completed` | `sandboxId`, `exitCode`, `isResume`, `hasChanges`, `prCreated`, `prUrl`, `totalDurationMs` | run duration distribution, success counts |
| `ai_writeback.run.failed` | `failureStage`, `exitCode`, `errorMessage`, `totalDurationMs` (+ ids) | failure rate, failures by stage, top error messages — fires for **both** caught exceptions **and** non-zero agent exits |
| `ai_writeback.sandbox.created` | `sandboxId`, `projectUuid`, `template`, `durationMs` | cold-start distribution |
| `ai_writeback.sandbox.lifecycle` | `action: 'paused'\|'resumed'`, `sandboxId`, `projectUuid`, `durationMs` | resume vs cold-start timing, with `action` facet |
| `ai_writeback.sandbox.pause_failed` | `sandboxId`, `projectUuid`, `errorMessage` (warn level) | pause-failure rate (not in plan, but cheap consistency) |

`run.failed` fires twice over the run if applicable (once on agent non-zero exit, once on caught exception in the same try block), but that's the right shape for a `failed / started` ratio because a non-zero exit IS a failure as far as the dashboard cares.

## Sentry

Previously the writeback flow had **no** `Sentry.captureException` calls anywhere. Caught errors in `run()` now report via Sentry with `errorType: AiWritebackRunFailed` and tags for `failureStage`, plus `projectUuid` / `aiThreadUuid` / `sandboxId` as extras. Modelled on `AiAgentService.ts:1103`.

## Compatibility

Existing analytics events (`ai_writeback.started/completed/failed` via the `startTracking` tracker → Rudderstack) are **untouched** so downstream consumers see no change. Per the plan, log refactor and analytics are separate concerns.

A handful of lower-signal in-flow logs (PR-metadata resolution, staging, clone done, "no changes — skipping PR", "opened PR \<url\>") are intentionally left as string format — they're not dashboard inputs and converting them would just inflate the diff.

## Verified locally

Ran an end-to-end writeback against Jaffle Shop EU (`hide \`customer_id\` in customers`). Full ordered event trace from one run (96s wall-clock):

```
14:47:56  run.started
14:47:57  run.stage (install → sandbox)
14:47:57  sandbox.created
14:47:57  run.stage (sandbox → clone)
14:48:01  run.stage (clone → agent)
14:48:11-39  run.tool (×9)
14:49:27  run.summary
14:49:27  run.agent_exited
14:49:27  run.stage (agent → commit)
14:49:28  run.stage (commit → push)
14:49:30  run.stage (push → pull_request)
14:49:32  run.completed
14:49:33  sandbox.lifecycle (paused)
```

Typecheck + lint clean.

## Next

Once deployed to beta, build the dashboard against the new event field names (step 3 of the plan), then mirror to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)