### PR TITLE
feat(mcp): pass tool titles to registerTool

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -410,6 +410,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpRunAiWritebackTool.name,
             {
+                title: mcpRunAiWritebackTool.title,
                 description: mcpRunAiWritebackTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpRunAiWritebackTool.inputSchema,
@@ -475,6 +476,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpGetLightdashVersionTool.name,
             {
+                title: mcpGetLightdashVersionTool.title,
                 description: mcpGetLightdashVersionTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpGetLightdashVersionTool.inputSchema,
@@ -499,6 +501,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpListExploresTool.name,
             {
+                title: mcpListExploresTool.title,
                 description: mcpListExploresTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpListExploresTool.inputSchema,
@@ -561,6 +564,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpFindExploresTool.name,
             {
+                title: mcpFindExploresTool.title,
                 description: mcpFindExploresTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpFindExploresTool.inputSchema,
@@ -617,6 +621,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpFindFieldsTool.name,
             {
+                title: mcpFindFieldsTool.title,
                 description: mcpFindFieldsTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpFindFieldsTool.inputSchema,
@@ -655,6 +660,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpFindContentTool.name,
             {
+                title: mcpFindContentTool.title,
                 description: mcpFindContentTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpFindContentTool.inputSchema,
@@ -695,6 +701,7 @@ export class McpService extends BaseService {
             this.mcpServer.registerTool(
                 mcpListProjectsTool.name,
                 {
+                    title: mcpListProjectsTool.title,
                     description: mcpListProjectsTool.description,
                     inputSchema: this.getMcpCompatibleSchema(
                         mcpListProjectsTool.inputSchema,
@@ -753,6 +760,7 @@ export class McpService extends BaseService {
             this.mcpServer.registerTool(
                 mcpSetProjectTool.name,
                 {
+                    title: mcpSetProjectTool.title,
                     description: mcpSetProjectTool.description,
                     inputSchema: this.getMcpCompatibleSchema(
                         mcpSetProjectTool.inputSchema,
@@ -841,6 +849,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpGetCurrentProjectTool.name,
             {
+                title: mcpGetCurrentProjectTool.title,
                 description: mcpGetCurrentProjectTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpGetCurrentProjectTool.inputSchema,
@@ -900,6 +909,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpListAgentsTool.name,
             {
+                title: mcpListAgentsTool.title,
                 description: mcpListAgentsTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpListAgentsTool.inputSchema,
@@ -946,6 +956,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpSetAgentTool.name,
             {
+                title: mcpSetAgentTool.title,
                 description: mcpSetAgentTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpSetAgentTool.inputSchema,
@@ -1020,6 +1031,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpClearAgentTool.name,
             {
+                title: mcpClearAgentTool.title,
                 description: mcpClearAgentTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpClearAgentTool.inputSchema,
@@ -1071,6 +1083,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpGetCurrentAgentTool.name,
             {
+                title: mcpGetCurrentAgentTool.title,
                 description: mcpGetCurrentAgentTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpGetCurrentAgentTool.inputSchema,
@@ -1171,6 +1184,7 @@ export class McpService extends BaseService {
             this.mcpServer,
             mcpRunMetricQueryTool.name,
             {
+                title: mcpRunMetricQueryTool.title,
                 description: mcpRunMetricQueryTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpRunMetricQueryTool.inputSchema,
@@ -1386,6 +1400,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpSearchFieldValuesTool.name,
             {
+                title: mcpSearchFieldValuesTool.title,
                 description: mcpSearchFieldValuesTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpSearchFieldValuesTool.inputSchema,
@@ -1517,6 +1532,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpListVerifiedContentTool.name,
             {
+                title: mcpListVerifiedContentTool.title,
                 description: mcpListVerifiedContentTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpListVerifiedContentTool.inputSchema,

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1452,6 +1452,7 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             mcpRunSqlTool.name,
             {
+                title: mcpRunSqlTool.title,
                 description: buildRunSqlDescription(
                     500,
                     this.lightdashConfig.mcp.runSqlMaxLimit,

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -87,6 +87,7 @@ Use table calculations for:
         "type": "object",
       },
       "name": "get_lightdash_version",
+      "title": "Get Lightdash version",
     },
     {
       "agentName": null,
@@ -108,6 +109,7 @@ Usage Tips:
         "type": "object",
       },
       "name": "list_explores",
+      "title": "List explores",
     },
     {
       "agentName": null,
@@ -140,6 +142,7 @@ Output:
         "type": "object",
       },
       "name": "find_explores",
+      "title": "Find explores",
     },
     {
       "agentName": null,
@@ -193,6 +196,7 @@ Usage tips:
         "type": "object",
       },
       "name": "find_fields",
+      "title": "Find fields",
     },
     {
       "agentName": null,
@@ -236,6 +240,7 @@ Usage tips:
         "type": "object",
       },
       "name": "find_content",
+      "title": "Find content",
     },
     {
       "agentName": null,
@@ -247,6 +252,7 @@ Usage tips:
         "type": "object",
       },
       "name": "list_projects",
+      "title": "List projects",
     },
     {
       "agentName": null,
@@ -271,6 +277,7 @@ Usage tips:
         "type": "object",
       },
       "name": "set_project",
+      "title": "Set project",
     },
     {
       "agentName": null,
@@ -282,6 +289,7 @@ Usage tips:
         "type": "object",
       },
       "name": "get_current_project",
+      "title": "Get current project",
     },
     {
       "agentName": null,
@@ -297,6 +305,7 @@ Usage tips:
         "type": "object",
       },
       "name": "list_agents",
+      "title": "List agents",
     },
     {
       "agentName": null,
@@ -315,6 +324,7 @@ Usage tips:
         "type": "object",
       },
       "name": "set_agent",
+      "title": "Set agent",
     },
     {
       "agentName": null,
@@ -326,6 +336,7 @@ Usage tips:
         "type": "object",
       },
       "name": "clear_agent",
+      "title": "Clear agent",
     },
     {
       "agentName": null,
@@ -337,6 +348,7 @@ Usage tips:
         "type": "object",
       },
       "name": "get_current_agent",
+      "title": "Get current agent",
     },
     {
       "agentName": "runQuery",
@@ -5098,6 +5110,7 @@ Empty array or null: single partition (calculations across all rows)., ",
         ],
         "type": "object",
       },
+      "title": "Run query",
     },
     {
       "agentName": null,
@@ -6759,6 +6772,7 @@ Usage Tips:
         "type": "object",
       },
       "name": "search_field_values",
+      "title": "Search field values",
     },
     {
       "agentName": null,
@@ -6849,6 +6863,7 @@ Notes:
         ],
         "type": "object",
       },
+      "title": undefined,
     },
     {
       "agentName": null,
@@ -6860,6 +6875,7 @@ Notes:
         "type": "object",
       },
       "name": "list_verified_content",
+      "title": "List verified content",
     },
     {
       "agentName": null,
@@ -6936,6 +6952,7 @@ Response shape (MCP CallToolResult):
         ],
         "type": "object",
       },
+      "title": "Run AI writeback",
     },
   ],
 }

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -6863,7 +6863,7 @@ Notes:
         ],
         "type": "object",
       },
-      "title": undefined,
+      "title": "Run SQL",
     },
     {
       "agentName": null,

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -7,10 +7,11 @@ import { McpService, McpToolName } from './McpService';
 type RegisteredMcpTool = {
     name: string;
     config: {
-        description?: string;
-        inputSchema?: ZodRawShape;
+        title: string;
+        description: string;
+        inputSchema: ZodRawShape;
+        annotations: Record<string, unknown>;
         outputSchema?: ZodRawShape;
-        annotations?: Record<string, unknown>;
         _meta?: Record<string, unknown>;
     };
 };
@@ -126,6 +127,7 @@ describe('MCP tool contracts', () => {
                 name,
                 agentName:
                     name === McpToolName.RUN_METRIC_QUERY ? 'runQuery' : null,
+                title: config.title,
                 description: config.description,
                 inputSchema: schemaToJson(config.inputSchema),
                 ...(config.outputSchema


### PR DESCRIPTION
## Summary

Every shared tool definition already carries a `title` (e.g. `'Find explores'`, `'Run SQL'`, `'Set project'`), but `McpService` never forwarded it to `mcpServer.registerTool`. The MCP protocol *does* accept `title` as optional metadata for the tool spec — clients (Claude Desktop, etc.) use it as the human-readable display name in tool pickers, separate from the snake_case wire name.

This PR wires `title: xxxTool.title` into all 17 `registerTool` calls and tightens the snapshot test so future drift is caught at CI time.

## Why

- Surfaces nicer display names to MCP clients (`"Find explores"` instead of `"find_explores"` in a UI picker).
- Uses metadata that was already populated on every `defineTool` call — no duplication, no new strings.
- Closes a follow-up from the shared-tool-definitions refactor (#23576).

## Changes

- `McpService.ts` — every `registerTool` config now passes `title: xxxTool.title` (17 places including the `run_sql` registration that uses a custom description builder).
- `mcpToolContracts.snapshot.test.ts` — the mock's `RegisteredMcpTool['config']` type is tightened (`title`, `description`, `inputSchema`, `annotations` now required; only `outputSchema` and `_meta` remain optional), and `title` is captured in the snapshot tuple so any future omission shows up as a snapshot diff.
- Snapshot regenerated.

## Verification

- `pnpm -F backend typecheck` clean
- `pnpm -F backend test -- mcpToolContracts.snapshot agentToolContracts.snapshot` — both snapshots pass; MCP snapshot now includes a `title` field per registered tool.

Closes ZAP-442.