### PR TITLE
fix(ai-writeback): skip repo discovery by injecting file listing

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -44,10 +44,12 @@ import {
     PR_TITLE_OPEN,
     PR_TITLE_PATH,
     PROMPT_PATH,
+    REPO_CONTEXT_TIMEOUT_MS,
     RUN_TIMEOUT_MS,
     SANDBOX_TIMEOUT_MS,
     SYSTEM_PROMPT_PATH,
 } from './constants';
+import { buildGatherRepoContextScript } from './scripts';
 import { buildSystemPrompt } from './templates';
 import type {
     AiWritebackRunArgs,
@@ -59,6 +61,8 @@ import type {
 } from './types';
 
 export type { AiWritebackRunArgs } from './types';
+
+const GATHER_REPO_CONTEXT_SANDBOX_PATH = '/tmp/gather-repo-context.sh';
 
 type AiWritebackServiceDeps = {
     lightdashConfig: LightdashConfig;
@@ -703,6 +707,47 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
+     * Pre-compute a dbt project snapshot (project file, file tree, models/
+     * YAML) so the agent doesn't burn turns rediscovering them. Returns null
+     * on any failure — the run continues without the context block.
+     */
+    private async gatherRepoContext(
+        sandbox: Sandbox,
+        projectSubPath: string,
+    ): Promise<string | null> {
+        const start = performance.now();
+        try {
+            await sandbox.files.write(
+                GATHER_REPO_CONTEXT_SANDBOX_PATH,
+                buildGatherRepoContextScript(projectSubPath),
+            );
+            const result = await sandbox.commands.run(
+                `bash ${GATHER_REPO_CONTEXT_SANDBOX_PATH}`,
+                {
+                    cwd: CWD,
+                    timeoutMs: REPO_CONTEXT_TIMEOUT_MS,
+                },
+            );
+            if (result.exitCode !== 0) {
+                this.logger.warn(
+                    `AiWriteback: gatherRepoContext exited non-zero (exit=${result.exitCode}) — running without context`,
+                );
+                return null;
+            }
+            const bytes = Buffer.byteLength(result.stdout, 'utf8');
+            this.logger.info(
+                `AiWriteback: repo context gathered (sandboxId=${sandbox.sandboxId}, bytes=${bytes}, ${AiWritebackService.elapsed(start)}ms)`,
+            );
+            return result.stdout;
+        } catch (error) {
+            this.logger.warn(
+                `AiWriteback: gatherRepoContext failed — running without context: ${getErrorMessage(error)}`,
+            );
+            return null;
+        }
+    }
+
+    /**
      * Write the system + user prompts to disk and pipe the user prompt into
      * the Claude Code CLI. On resume, `--continue` picks up the most recent
      * Claude session in `CWD` (preserved across pause/resume on the sandbox
@@ -727,9 +772,17 @@ export class AiWritebackService extends BaseService {
         repository: string;
         isResume: boolean;
     }): Promise<{ stdout: string; exitCode: number }> {
+        const repoContext = await this.gatherRepoContext(
+            sandbox,
+            projectSubPath,
+        );
         await sandbox.files.write(
             SYSTEM_PROMPT_PATH,
-            buildSystemPrompt(projectSubPath, { projectName, repository }),
+            buildSystemPrompt(projectSubPath, {
+                projectName,
+                repository,
+                repoContext,
+            }),
         );
         await sandbox.files.write(PROMPT_PATH, prompt);
 

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -80,3 +80,8 @@ export const ALLOWED_TOOLS = [
 // snapshot rather than the CLI default so runs stay deterministic across
 // Claude Code releases.
 export const CLAUDE_MODEL = 'claude-sonnet-4-6';
+
+// Ceiling on the gather pass itself. The shell pipeline is sub-second on
+// typical repos; this guards against an unusually large checkout taking long
+// enough to eat into the agent budget.
+export const REPO_CONTEXT_TIMEOUT_MS = 30 * 1000;

--- a/packages/backend/src/ee/services/AiWritebackService/scripts.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/scripts.ts
@@ -1,0 +1,20 @@
+/**
+ * Bash scripts that the host writes into the sandbox at runtime. Each export
+ * is a function returning the rendered script body so call sites get
+ * type-checked variable substitution and JSON-safe quoting at the boundary.
+ */
+
+/**
+ * Pre-compute a dbt project file listing for the AI writeback agent: every
+ * `*.sql` / `*.yml` / `*.yaml` path under the project, sorted. The agent
+ * reads the listing as `<repo_context>` in its system prompt and `Read`s
+ * individual files on demand.
+ */
+export const buildGatherRepoContextScript = (projectSubPath: string): string =>
+    `
+cd ${JSON.stringify(projectSubPath)} || { echo "(could not enter ${projectSubPath})"; exit 0; }
+
+find . \\( -name target -o -name dbt_packages -o -name logs -o -name .git \\) -prune -o \\
+  -type f \\( -name "*.sql" -o -name "*.yml" -o -name "*.yaml" \\) -print \\
+  | LC_ALL=C sort
+`;

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -25,7 +25,11 @@ import {
 // the patched file into the PR.
 export const buildSystemPrompt = (
     dbtProjectDir: string,
-    context: { projectName: string; repository: string },
+    context: {
+        projectName: string;
+        repository: string;
+        repoContext: string | null;
+    },
 ): string =>
     `
 You are an autonomous coding agent working inside a checkout of a git repository.
@@ -42,7 +46,24 @@ You are an autonomous coding agent working inside a checkout of a git repository
 - The dbt project lives at \`${dbtProjectDir}\` (relative to the repo root, which
   is your working directory).
 - Do NOT commit, push, or run any git commands — the host handles git.
+${
+    context.repoContext
+        ? `
+## Repo context (pre-computed)
 
+The block below is the full sorted listing of every \`.sql\`/\`.yml\`/\`.yaml\`
+file under the dbt project. Treat it as the authoritative inventory.
+
+- Consult this block FIRST when you need to find a model or schema file.
+- Do NOT run \`find\`, \`ls\`, or \`Glob\` to re-discover paths that already
+  appear here. \`Read\` files directly when you need their contents.
+
+<repo_context>
+${context.repoContext}
+</repo_context>
+`
+        : ''
+}
 If you made any file changes, perform ALL of these follow-up steps before you
 finish:
 


### PR DESCRIPTION
Closes: [PROD-7983](https://linear.app/lightdash/issue/PROD-7983/give-file-structure-to-model-to-reduce-discovery-steps)

## Summary

Slack writeback turns take ~8–10 min, and an instrumented trace showed ~3.5 min of every successful run is the agent running `find` / `grep` / `Glob` / `Read` to discover paths and layout. This PR gives the agent a pre-computed sorted listing of every `.sql`/`.yml`/`.yaml` file under the dbt project as part of its system prompt, and tells it to consult that listing before exploring.

## Root cause

The agent ran cold. The system prompt described the *project* (name, repo, dbt sub-folder) but contained nothing about the actual file tree, so the agent burned tool calls rediscovering the layout on every turn. From a real run (job `222746`, analytics instance, 9 min 44 s agent stage):

```
95 tool calls, 9m02s of inter-tool gaps
Bash: 52  | Read: 20  | Write: 4  | Grep: 11  | Glob: 7
First 3m28s = exploratory phase (find/grep/ls/Glob hunting for "orders" / "tiger" / "salesbricks")
```

So roughly 35% of the agent's time was spent on something the host already had cheap access to.

## Fix

Right after the sandbox is set up and before the Claude Code CLI is invoked, the host writes a small bash script into the sandbox and runs it. The script `cd`s into the dbt project sub-folder and `find`s every `.sql`/`.yml`/`.yaml` path (excluding `target`/`dbt_packages`/`logs`/`.git`), sorted. The output is injected into the agent's system prompt under a `<repo_context>` block with explicit "consult this first" rules.

- `packages/backend/src/ee/services/AiWritebackService/scripts.ts` *(new)* — `buildGatherRepoContextScript(projectSubPath)` returns the bash body. Path interpolated via `JSON.stringify` so unescaped characters can't break the shell.
- `AiWritebackService.ts` — new private `gatherRepoContext` called as the first step of `runAgentInSandbox`. Wrapped in try/catch with a `null` fallback so a gather failure never blocks the agent run.
- `templates.ts` — `buildSystemPrompt` accepts `repoContext: string | null` and conditionally inlines a `## Repo context (pre-computed)` section with the listing inside `<repo_context>` tags.
- `constants.ts` — `REPO_CONTEXT_TIMEOUT_MS = 30s` ceiling on the gather (script is sub-second on real repos; this guards against pathological cases).

The script only lists paths — no file contents. The agent reads what it needs via its existing `Read` tool. SQL bodies were considered for inlining but skipped: collectively they can be large, and most runs only touch one or two files anyway.

## Before

Stage timings from three successful runs on the same project (`21eef0b9-…`), today, all triggered via Slack:

```
job 222688  agent stage: 520 837 ms  (8m 41s)
job 222702  agent stage: 505 726 ms  (8m 26s)
job 222746  agent stage: 583 544 ms  (9m 44s)
```

Every other stage (install/sandbox/clone/commit/push) was sub-2 s. Earlier today, two runs on the same prompt also hit the `RUN_TIMEOUT_MS = 10 min` ceiling and failed with `deadline_exceeded`.

## After

Local dev run on the jaffle demo logs:

```
AiWriteback: repo context gathered (sandboxId=…, bytes=N, Xms)
```

The script is sub-second on typical projects and the system prompt now carries the file inventory the agent used to spend minutes rediscovering. Expected steady-state win: ~2–3 min off the agent stage. We'll measure on the first few prod runs after merge — the production log line is the same format and grep-able.

## Test plan

- [x] `pnpm -F backend typecheck` and `pnpm -F backend lint` pass.
- [x] Local writeback prompt in Slack produces the `repo context gathered` log line.
- [ ] On the first few prod runs after merge, sample 3 jobs and confirm agent stage <8 min on prompts comparable to the baseline.
- [ ] Confirm the gather failure path (e.g. invalid `projectSubPath`) returns `null` and the agent still runs — the system prompt simply omits the `<repo_context>` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)