### PR TITLE
fix(ee): suppress user-error noise and surface timeout context in AI writeback Sentry events

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -13,7 +13,7 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { randomUUID } from 'crypto';
-import { Sandbox } from 'e2b';
+import { CommandExitError, Sandbox, TimeoutError } from 'e2b';
 import type {
     AiWritebackFailureStage,
     LightdashAnalytics,
@@ -858,6 +858,16 @@ export class AiWritebackService extends BaseService {
         let assistantText = '';
         const toolCounts: Record<string, number> = {};
 
+        // Rolling tail of stderr so a non-zero exit / timeout can carry the
+        // actual error text into the Sentry event. The full stderr is already
+        // streamed through the per-chunk debug log; we keep only the last
+        // STDERR_TAIL_BYTES so we never inflate a Sentry payload.
+        const STDERR_TAIL_BYTES = 4096;
+        let stderrTail = '';
+        const appendStderrTail = (chunk: string) => {
+            stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_BYTES);
+        };
+
         const summarizeToolInput = (input: unknown): string => {
             if (input && typeof input === 'object') {
                 const i = input as Record<string, unknown>;
@@ -940,35 +950,84 @@ export class AiWritebackService extends BaseService {
         };
 
         const continueFlag = isResume ? '--continue ' : '';
-        const result = await sandbox.commands.run(
-            `cat ${PROMPT_PATH} | claude -p ${continueFlag}` +
-                `--model ${CLAUDE_MODEL} ` +
-                `--append-system-prompt-file ${SYSTEM_PROMPT_PATH} ` +
-                // stream-json emits one event per line on stdout (assistant
-                // messages, tool_use blocks, tool_results, final cost summary).
-                // --verbose is required by the CLI when combining -p with
-                // stream-json output.
-                '--output-format stream-json --verbose ' +
-                // Claude Code confines Write/Edit to the cwd workspace, so the
-                // agent cannot write the PR metadata to /tmp (it silently falls
-                // back to the repo root) unless /tmp is an added directory.
-                '--add-dir /tmp ' +
-                `--allowedTools "${ALLOWED_TOOLS}"`,
-            {
-                cwd: CWD,
-                timeoutMs: RUN_TIMEOUT_MS,
-                envs: { ANTHROPIC_API_KEY: this.getAnthropicApiKey() },
-                onStdout: (chunk) => {
-                    buffer += chunk;
-                    flushBuffer();
+        let result;
+        try {
+            result = await sandbox.commands.run(
+                `cat ${PROMPT_PATH} | claude -p ${continueFlag}` +
+                    `--model ${CLAUDE_MODEL} ` +
+                    `--append-system-prompt-file ${SYSTEM_PROMPT_PATH} ` +
+                    // stream-json emits one event per line on stdout (assistant
+                    // messages, tool_use blocks, tool_results, final cost summary).
+                    // --verbose is required by the CLI when combining -p with
+                    // stream-json output.
+                    '--output-format stream-json --verbose ' +
+                    // Claude Code confines Write/Edit to the cwd workspace, so the
+                    // agent cannot write the PR metadata to /tmp (it silently falls
+                    // back to the repo root) unless /tmp is an added directory.
+                    '--add-dir /tmp ' +
+                    `--allowedTools "${ALLOWED_TOOLS}"`,
+                {
+                    cwd: CWD,
+                    timeoutMs: RUN_TIMEOUT_MS,
+                    envs: { ANTHROPIC_API_KEY: this.getAnthropicApiKey() },
+                    onStdout: (chunk) => {
+                        buffer += chunk;
+                        flushBuffer();
+                    },
+                    onStderr: (chunk) => {
+                        appendStderrTail(chunk);
+                        this.logger.debug(
+                            `AiWriteback: claude stderr: ${chunk.trimEnd()}`,
+                        );
+                    },
                 },
-                onStderr: (chunk) => {
-                    this.logger.debug(
-                        `AiWriteback: claude stderr: ${chunk.trimEnd()}`,
-                    );
+            );
+        } catch (error) {
+            // e2b throws TimeoutError when RUN_TIMEOUT_MS fires, and
+            // CommandExitError when the claude subprocess returns a non-zero
+            // exit code. Both reach Sentry as the bare message ("exit status
+            // 1") with no stderr — useless for debugging. Capture here so the
+            // rich context (timeout flag, exit code, stderr tail) is attached
+            // before the error bubbles up to the outer wrapSentryTransaction
+            // catch (Sentry's Dedupe integration collapses the two events).
+            const timedOut = error instanceof TimeoutError;
+            const exitCode =
+                error instanceof CommandExitError ? error.exitCode : null;
+            // Prefer the error's stderr (e2b accumulates it server-side and
+            // attaches it to CommandExitError) and fall back to our streamed
+            // tail; both are clipped to STDERR_TAIL_BYTES so the payload stays
+            // small.
+            const errStderr =
+                error instanceof CommandExitError ? (error.stderr ?? '') : '';
+            const stderrSnippet = (errStderr || stderrTail).slice(
+                -STDERR_TAIL_BYTES,
+            );
+            this.logger.error('AI writeback agent subprocess failed', {
+                event: 'ai_writeback.run.agent_failed',
+                sandboxId: sandbox.sandboxId,
+                isResume,
+                timedOut,
+                runTimeoutMs: RUN_TIMEOUT_MS,
+                exitCode,
+                errorMessage: getErrorMessage(error),
+                stderrTail: stderrSnippet || null,
+            });
+            Sentry.captureException(error, {
+                tags: {
+                    errorType: 'AiWritebackAgentSubprocessFailed',
+                    timedOut: String(timedOut),
                 },
-            },
-        );
+                extra: {
+                    sandboxId: sandbox.sandboxId,
+                    isResume,
+                    runTimeoutMs: RUN_TIMEOUT_MS,
+                    exitCode,
+                    stderrTail: stderrSnippet,
+                    toolCounts,
+                },
+            });
+            throw error;
+        }
         // A final line may remain in the buffer if the command output didn't
         // end with a newline (common on timeouts/aborts) — try to parse it but
         // don't fail the run if it's truncated.

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -17,6 +17,10 @@ export const IGNORE_ERRORS = [
     'ReadFileError',
     'AiAgentValidatorError',
     'UserInfoError', // Google oauth2 error when using invalid credentials
+    // Invalid user-supplied parameter (e.g. AI writeback requires a GitHub
+    // dbt connection but the project uses "none") — surfaced to the user,
+    // not a server bug.
+    'ParameterError',
 ];
 
 const spotlightEnabled =


### PR DESCRIPTION
## What

Two adjacent fixes from the #sentry-alerts triage of yesterday's AI writeback failures.

### 1) Stop paging on "AI writeback requires a GitHub dbt connection…"

The message `AI writeback requires a GitHub dbt connection, but this project uses "none"` is thrown by `resolveGithubConnection` as a `ParameterError` (`AiWritebackService.ts:155`). It's a user/config issue surfaced cleanly through the agent reply — not a server bug — but it currently raises a Sentry event because `ParameterError` is not in the global ignore list.

Add `'ParameterError'` to `IGNORE_ERRORS` in `sentry.ts`, alongside the existing user-input siblings (`ForbiddenError`, `AuthorizationError`, `FieldReferenceError`, `NotEnoughResults`, etc.). Sentry filters before send by matching `error.name`; our `ParameterError` class sets `name: 'ParameterError'` (`packages/common/src/types/errors.ts`), so this filters wherever a ParameterError is captured — not just from writeback.

### 2) Surface timeout + stderr context on `CommandExitError: exit status 1`

Yesterday's `LIGHTDASH-BACKEND-CTG` Sentry event was a bare `CommandExitError: exit status 1` from the Claude CLI subprocess — no stderr, no flag for "did this time out". Useless when you're trying to tell "agent guard tripped" from "agent ran for 20 minutes and got killed".

Wrap `sandbox.commands.run` in `runAgentInSandbox` with a try/catch that:

- detects `TimeoutError instanceof` → tags `timedOut: true`
- reads `stderr` off `CommandExitError` (e2b accumulates it server-side and attaches it to the error), falling back to a rolling 4 KB stderr tail buffered from the existing `onStderr` callback
- emits a structured `ai_writeback.run.agent_failed` log with `timedOut`, `runTimeoutMs`, `exitCode`, `errorMessage`, `stderrTail`
- calls `Sentry.captureException` with the same fields as tags + extras, then re-throws

The outer `wrapSentryTransaction` in `AiAgentService` still fires; Sentry's Dedupe integration collapses the two captures and the deeper, richer one wins in the UI.

## Verified locally

With `RUN_TIMEOUT_MS` temporarily lowered to 15s, a writeback prompt produced this log record (rendered as JSON to show every field):

```json
{
  "event": "ai_writeback.run.agent_failed",
  "message": "AI writeback agent subprocess failed",
  "level": "error",
  "timedOut": true,
  "runTimeoutMs": 15000,
  "exitCode": null,
  "errorMessage": "[deadline_exceeded] the operation timed out: This error is likely due to exceeding 'timeoutMs' — ...",
  "stderrTail": null,
  "sandboxId": "ikrexu42wawf7dfgnzlop",
  "isResume": false
}
```

`exitCode: null` is correct for a `TimeoutError` (no subprocess exit). For a real `CommandExitError`, `exitCode` would be the actual code and `stderrTail` would carry the tail. `runTimeoutMs` is included specifically so the on-call can see at a glance whether the timeout fired at the configured ceiling or got interrupted by something else.

The happy-path event chain is unchanged; verified end-to-end with a real hide-dimension writeback that ran cleanly: `run.started` → `sandbox.created` → 9× `run.tool` → `run.summary` → `run.agent_exited` → 5× `run.stage` → `run.completed` → `sandbox.lifecycle(paused)`.

## Re: the investigation doc

Closes the "Diagnostic gap (fixable)" section — `logger.debug` stderr → `stderrTail` on the captured error. Doesn't address the noted Sentry scope pollution (worker.job.task_identifier leaking from a previous `sweepStaleAppLocks` job) — that's a separate worker-level concern best fixed by resetting Sentry scope between graphile tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)