### PR TITLE
feat(ai-agents): navigate to dashboard on content tool output and internal link clicks

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -333,7 +333,8 @@ const AssistantBubbleContent: FC<{
     projectUuid: string;
     agentUuid: string;
     mcpServers?: AiMcpServer[];
-}> = ({ message, projectUuid, agentUuid, mcpServers }) => {
+    onInternalLinkClick?: (href: string) => void;
+}> = ({ message, projectUuid, agentUuid, mcpServers, onInternalLinkClick }) => {
     const canManageAgents = useAiAgentPermission({
         action: 'manage',
         projectUuid,
@@ -620,6 +621,9 @@ const AssistantBubbleContent: FC<{
                                                 sqlRunnerLinkState={
                                                     sqlRunnerLinkState
                                                 }
+                                                onInternalLinkClick={
+                                                    onInternalLinkClick
+                                                }
                                             >
                                                 {children}
                                             </ContentLink>
@@ -800,6 +804,9 @@ const AssistantBubbleContent: FC<{
                                                     sqlRunnerLinkState={
                                                         sqlRunnerLinkState
                                                     }
+                                                    onInternalLinkClick={
+                                                        onInternalLinkClick
+                                                    }
                                                 >
                                                     {children}
                                                 </ContentLink>
@@ -845,6 +852,7 @@ type Props = {
     renderArtifactsInline?: boolean;
     showAddToEvalsButton?: boolean;
     mcpServers?: AiMcpServer[];
+    onInternalLinkClick?: (href: string) => void;
 };
 
 export const AssistantBubble: FC<Props> = memo(
@@ -858,6 +866,7 @@ export const AssistantBubble: FC<Props> = memo(
         renderArtifactsInline = false,
         showAddToEvalsButton = false,
         mcpServers,
+        onInternalLinkClick,
     }) => {
         const artifact = useAiAgentStoreSelector(
             (state) => state.aiArtifact.artifact,
@@ -951,6 +960,7 @@ export const AssistantBubble: FC<Props> = memo(
                     projectUuid={projectUuid}
                     agentUuid={agentUuid}
                     mcpServers={mcpServers}
+                    onInternalLinkClick={onInternalLinkClick}
                 />
 
                 {isArtifactAvailable && projectUuid && agentUuid && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -38,6 +38,7 @@ type Props = {
     agentUuid?: string;
     renderArtifactsInline?: boolean;
     showAddToEvalsButton?: boolean;
+    onInternalLinkClick?: (href: string) => void;
 };
 
 const CompactionDivider = () => (
@@ -96,6 +97,7 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
     agentUuid,
     renderArtifactsInline = false,
     showAddToEvalsButton = false,
+    onInternalLinkClick,
 }) => {
     const viewport = useRef<HTMLDivElement>(null);
     const { data: mcpServers } = useAgentAiMcpServers(projectUuid, agentUuid, {
@@ -172,6 +174,9 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                                     showAddToEvalsButton
                                                 }
                                                 mcpServers={mcpServers}
+                                                onInternalLinkClick={
+                                                    onInternalLinkClick
+                                                }
                                                 renderArtifactsInline={
                                                     renderArtifactsInline
                                                 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -15,6 +15,7 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
+import { getInternalNavigationUrl } from '../../utils/isSamePageNavigation';
 import styles from './ContentLink.module.css';
 
 export type SqlRunnerLinkState = {
@@ -30,6 +31,7 @@ type ContentLinkProps = {
     projectUuid: string;
     agentUuid: string;
     sqlRunnerLinkState?: SqlRunnerLinkState | null;
+    onInternalLinkClick?: (href: string) => void;
 };
 
 export const ContentLink: FC<ContentLinkProps> = ({
@@ -40,6 +42,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
     projectUuid,
     agentUuid,
     sqlRunnerLinkState,
+    onInternalLinkClick,
 }) => {
     const dispatch = useAiAgentStoreDispatch();
     const currentArtifact = useAiAgentStoreSelector(
@@ -47,12 +50,25 @@ export const ContentLink: FC<ContentLinkProps> = ({
     );
 
     switch (contentType) {
-        case 'dashboard-link':
+        case 'dashboard-link': {
+            const href = getInternalNavigationUrl(props.href);
+
             return (
                 <Anchor
                     {...props}
+                    href={href}
                     data-content-link="true"
-                    target="_blank"
+                    target={onInternalLinkClick ? undefined : '_blank'}
+                    onClick={(e) => {
+                        if (
+                            onInternalLinkClick &&
+                            typeof href === 'string' &&
+                            href.length > 0
+                        ) {
+                            e.preventDefault();
+                            onInternalLinkClick(href);
+                        }
+                    }}
                     fz="xs"
                     fw={500}
                     c="ldGray.8"
@@ -83,8 +99,10 @@ export const ContentLink: FC<ContentLinkProps> = ({
                     />
                 </Anchor>
             );
+        }
 
         case 'chart-link': {
+            const href = getInternalNavigationUrl(props.href);
             const chartType =
                 'data-chart-type' in props &&
                 typeof props['data-chart-type'] === 'string'
@@ -100,8 +118,19 @@ export const ContentLink: FC<ContentLinkProps> = ({
             return (
                 <Anchor
                     {...props}
+                    href={href}
                     data-content-link="true"
-                    target="_blank"
+                    target={onInternalLinkClick ? undefined : '_blank'}
+                    onClick={(e) => {
+                        if (
+                            onInternalLinkClick &&
+                            typeof href === 'string' &&
+                            href.length > 0
+                        ) {
+                            e.preventDefault();
+                            onInternalLinkClick(href);
+                        }
+                    }}
                     fz="xs"
                     fw={500}
                     c="ldGray.8"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -1,6 +1,7 @@
 import { type AiAgentSummary } from '@lightdash/common';
 import { Center, Group, Loader, Stack, Text } from '@mantine-8/core';
-import { useState, type CSSProperties, type FC } from 'react';
+import { useCallback, useState, type CSSProperties, type FC } from 'react';
+import { useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import useApp from '../../../../../providers/App/useApp';
 import { useAiAgentSqlModeAvailable } from '../../hooks/useAiAgentSqlModeAvailable';
@@ -20,6 +21,12 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
+import { type AiAgentToolOutput } from '../../types';
+import { getDashboardUrlFromContentToolOutput } from '../../utils/getDashboardSlugFromContentToolOutput';
+import {
+    getInternalNavigationUrl,
+    isSamePageNavigation,
+} from '../../utils/isSamePageNavigation';
 import { AiAgentNewThreadMcpConnections } from '../AiAgentNewThreadMcpConnections';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../ChatElements/AgentChatInput';
@@ -34,6 +41,28 @@ type Props = {
     agents: AiAgentSummary[];
     activeThreadId: string | null;
     style?: CSSProperties;
+};
+
+const useNavigateToDashboardToolOutput = (
+    projectUuid: string,
+): ((toolOutput: AiAgentToolOutput) => void) => {
+    const navigate = useNavigate();
+
+    return useCallback(
+        (toolOutput: AiAgentToolOutput) => {
+            const dashboardUrl = getDashboardUrlFromContentToolOutput(
+                projectUuid,
+                toolOutput,
+            );
+            if (!dashboardUrl) return;
+            if (isSamePageNavigation(dashboardUrl, window.location)) return;
+
+            void navigate(getInternalNavigationUrl(dashboardUrl), {
+                viewTransition: true,
+            });
+        },
+        [navigate, projectUuid],
+    );
 };
 
 export const LauncherPanel: FC<Props> = ({
@@ -100,6 +129,13 @@ const NewThreadPanel: FC<{
         dashboardUuid,
     });
 
+    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+    // New threads have no uuid yet — keep the toggle in local state and seed
+    // the per-thread slice entry once the thread is created.
+    const [sqlMode, setSqlMode] = useState(false);
+    const dispatchToStore = useAiAgentStoreDispatch();
+    const handleToolOutput = useNavigateToDashboardToolOutput(projectUuid);
+
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
         useCreateAgentThreadMutation(projectUuid, {
             // Launcher does its own routing via panels/dock — skip the default
@@ -126,13 +162,8 @@ const NewThreadPanel: FC<{
                     }),
                 );
             },
+            onToolOutput: handleToolOutput,
         });
-
-    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
-    // New threads have no uuid yet — keep the toggle in local state and seed
-    // the per-thread slice entry once the thread is created.
-    const [sqlMode, setSqlMode] = useState(false);
-    const dispatchToStore = useAiAgentStoreDispatch();
 
     const handleSubmit = ({
         message,
@@ -232,6 +263,7 @@ const ExistingThreadPanel: FC<{
     style?: CSSProperties;
 }> = ({ projectUuid, agent, agents, threadId, style }) => {
     const { user } = useApp();
+    const navigate = useNavigate();
     const {
         data: thread,
         isLoading: isLoadingThread,
@@ -244,10 +276,24 @@ const ExistingThreadPanel: FC<{
         refetch,
     );
 
+    const handleToolOutput = useNavigateToDashboardToolOutput(projectUuid);
+    const handleInternalLinkClick = useCallback(
+        (href: string) => {
+            if (isSamePageNavigation(href, window.location)) return;
+
+            void navigate(getInternalNavigationUrl(href), {
+                viewTransition: true,
+            });
+        },
+        [navigate],
+    );
+
     const {
         mutateAsync: createAgentThreadMessage,
         isLoading: isCreatingMessage,
-    } = useCreateAgentThreadMessageMutation(projectUuid, agent.uuid, threadId);
+    } = useCreateAgentThreadMessageMutation(projectUuid, agent.uuid, threadId, {
+        onToolOutput: handleToolOutput,
+    });
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const sqlMode = useAiAgentStoreSelector(selectThreadSqlMode(threadId));
@@ -311,6 +357,7 @@ const ExistingThreadPanel: FC<{
                     projectUuid={projectUuid}
                     agentUuid={agent.uuid}
                     renderArtifactsInline
+                    onInternalLinkClick={handleInternalLinkClick}
                 >
                     <AgentChatInput
                         disabled={

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -41,6 +41,7 @@ import { useActiveProject } from '../../../../hooks/useActiveProject';
 import { type UserWithAbility } from '../../../../hooks/user/useUser';
 import useApp from '../../../../providers/App/useApp';
 import { useAiAgentThreadStreamMutation } from '../streaming/useAiAgentThreadStreamMutation';
+import { type AiAgentToolOutput } from '../types';
 import {
     AGENT_AI_MCP_SERVERS_KEY,
     PROJECT_AI_MCP_SERVERS_KEY,
@@ -579,6 +580,7 @@ export const useCreateAgentThreadMutation = (
     projectUuid: string,
     options?: {
         onCreated?: (thread: ApiAiAgentThreadCreateResponse['results']) => void;
+        onToolOutput?: (toolOutput: AiAgentToolOutput) => void;
         // Skip the default `navigate(...)` to the thread page. The launcher
         // uses this because it routes via its own panel/dock instead.
         skipNavigation?: boolean;
@@ -718,6 +720,7 @@ export const useCreateAgentThreadMutation = (
                             thread.uuid,
                         ],
                     }),
+                onToolOutput: options?.onToolOutput,
             });
 
             options?.onCreated?.(thread);
@@ -760,6 +763,9 @@ export const useCreateAgentThreadMessageMutation = (
     projectUuid: string,
     agentUuid: string | undefined,
     threadUuid: string | undefined,
+    options?: {
+        onToolOutput?: (toolOutput: AiAgentToolOutput) => void;
+    },
 ) => {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
@@ -909,6 +915,7 @@ export const useCreateAgentThreadMessageMutation = (
                             threadUuid,
                         ],
                     }),
+                onToolOutput: options?.onToolOutput,
             });
         },
         onError: ({ error }) => {

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -27,6 +27,7 @@ import {
     type StreamPart,
 } from '../store/aiAgentThreadStreamSlice';
 import { useAiAgentStoreDispatch } from '../store/hooks';
+import { type AiAgentToolOutput } from '../types';
 import { useAiAgentThreadStreamAbortController } from './AiAgentThreadStreamAbortControllerContext';
 
 export interface AiAgentThreadStreamOptions {
@@ -38,8 +39,21 @@ export interface AiAgentThreadStreamOptions {
     toolHints?: string[];
     onFinish?: () => void;
     onError?: (error: string) => void;
+    onToolOutput?: (toolOutput: AiAgentToolOutput) => void;
     refetchThread?: () => void;
 }
+
+type StreamToolCallPart = Extract<StreamPart, { type: 'toolCall' }>;
+
+type StreamToolPart = {
+    type: string;
+    toolName?: string;
+    toolCallId: string;
+    input?: unknown;
+    output?: unknown;
+    preliminary?: boolean;
+    state: string;
+};
 
 type McpUnavailableNoticeChunk = UIMessageChunk & {
     type: 'data-mcp-unavailable';
@@ -101,6 +115,49 @@ const getReasoningFromPart = (part: ReasoningUIPart) => {
     }
 };
 
+const getStreamToolPart = (
+    part: UIMessage['parts'][number],
+): StreamToolPart | null => {
+    if (!part.type.startsWith('tool-') && part.type !== 'dynamic-tool') {
+        return null;
+    }
+
+    const toolPart = part as StreamToolPart;
+    return {
+        ...toolPart,
+        toolName:
+            toolPart.type === 'dynamic-tool'
+                ? toolPart.toolName
+                : toolPart.type.slice(5),
+    };
+};
+
+const getStreamToolCallPart = (
+    part: UIMessage['parts'][number],
+): StreamToolCallPart | null => {
+    const toolPart = getStreamToolPart(part);
+    if (
+        !toolPart ||
+        !toolPart.toolName ||
+        !isAiAgentToolName(toolPart.toolName) ||
+        (toolPart.state !== 'input-available' &&
+            toolPart.state !== 'output-available' &&
+            toolPart.state !== 'output-error')
+    ) {
+        return null;
+    }
+
+    const hasOutput = toolPart.state === 'output-available';
+    return {
+        type: 'toolCall',
+        toolCallId: toolPart.toolCallId,
+        toolName: toolPart.toolName,
+        toolArgs: toolPart.input,
+        toolOutput: hasOutput ? toolPart.output : undefined,
+        isPreliminary: hasOutput ? (toolPart.preliminary ?? false) : undefined,
+    };
+};
+
 export const getMcpUnavailableNoticeFromChunk = (
     chunk: UIMessageChunk,
 ): McpUnavailableNoticeChunk['data'] | null => {
@@ -139,6 +196,7 @@ export function useAiAgentThreadStreamMutation() {
             toolHints = [],
             onFinish,
             onError,
+            onToolOutput,
             refetchThread,
         }: AiAgentThreadStreamOptions) => {
             const abortController = new AbortController();
@@ -170,6 +228,7 @@ export function useAiAgentThreadStreamMutation() {
                 const handledToolInputIds = new Set<string>();
                 const handledToolDecisionIds = new Set<string>();
                 const handledToolOutputIds = new Set<string>();
+                const notifiedToolOutputIds = new Set<string>();
 
                 const consumeRawChunks = (async () => {
                     while (true) {
@@ -218,45 +277,10 @@ export function useAiAgentThreadStreamMutation() {
                                 type: 'text',
                                 text: part.text,
                             });
-                        } else if (
-                            part.type.startsWith('tool-') ||
-                            part.type === 'dynamic-tool'
-                        ) {
-                            const toolPart = part as {
-                                type: string;
-                                toolName?: string;
-                                toolCallId: string;
-                                input?: unknown;
-                                output?: unknown;
-                                preliminary?: boolean;
-                                state: string;
-                            };
-                            if (
-                                toolPart.state === 'input-available' ||
-                                toolPart.state === 'output-available' ||
-                                toolPart.state === 'output-error'
-                            ) {
-                                const toolName =
-                                    toolPart.type === 'dynamic-tool'
-                                        ? toolPart.toolName
-                                        : toolPart.type.slice(5);
-
-                                if (toolName && isAiAgentToolName(toolName)) {
-                                    const hasOutput =
-                                        toolPart.state === 'output-available';
-                                    orderedParts.push({
-                                        type: 'toolCall',
-                                        toolCallId: toolPart.toolCallId,
-                                        toolName,
-                                        toolArgs: toolPart.input,
-                                        toolOutput: hasOutput
-                                            ? toolPart.output
-                                            : undefined,
-                                        isPreliminary: hasOutput
-                                            ? (toolPart.preliminary ?? false)
-                                            : undefined,
-                                    });
-                                }
+                        } else {
+                            const toolCallPart = getStreamToolCallPart(part);
+                            if (toolCallPart) {
+                                orderedParts.push(toolCallPart);
                             }
                         }
                     }
@@ -265,6 +289,27 @@ export function useAiAgentThreadStreamMutation() {
                     // Process tool calls from the complete message
                     for (const part of uiMessage.parts) {
                         if (abortController.signal.aborted) return;
+
+                        const toolCallPart = getStreamToolCallPart(part);
+
+                        if (
+                            toolCallPart?.toolOutput !== undefined &&
+                            toolCallPart.isPreliminary !== undefined
+                        ) {
+                            const outputKey = `${toolCallPart.toolCallId}:${String(
+                                toolCallPart.isPreliminary,
+                            )}`;
+                            if (!notifiedToolOutputIds.has(outputKey)) {
+                                notifiedToolOutputIds.add(outputKey);
+                                onToolOutput?.({
+                                    toolName: toolCallPart.toolName,
+                                    toolArgs: toolCallPart.toolArgs,
+                                    toolOutput: toolCallPart.toolOutput,
+                                    isPreliminary: toolCallPart.isPreliminary,
+                                });
+                            }
+                        }
+
                         switch (part.type) {
                             // TODO: this is a temporary solution
                             // there should be a way of leveraging ToolUIPart based on the tools available

--- a/packages/frontend/src/ee/features/aiCopilot/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/types.ts
@@ -1,0 +1,8 @@
+import { type AiAgentToolName } from '@lightdash/common';
+
+export type AiAgentToolOutput = {
+    toolName: AiAgentToolName;
+    toolArgs: unknown;
+    toolOutput: unknown;
+    isPreliminary?: boolean;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/utils/getDashboardSlugFromContentToolOutput.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/getDashboardSlugFromContentToolOutput.ts
@@ -1,0 +1,71 @@
+import { type AiAgentToolOutput } from '../types';
+
+type EditContentToolArgs = {
+    type?: 'dashboard' | 'chart';
+    slug?: string;
+};
+
+type CreateContentToolArgs = {
+    type?: 'dashboard' | 'chart';
+    content?: {
+        slug?: string;
+    };
+};
+
+type ContentToolOutput = {
+    result?: unknown;
+    metadata?: { status?: unknown };
+};
+
+const getSlugFromToolOutput = (toolOutput: unknown): string | null => {
+    const output = toolOutput as ContentToolOutput | undefined;
+    if (output?.metadata?.status !== 'success') return null;
+
+    if (typeof output.result !== 'string') return null;
+
+    try {
+        const content = JSON.parse(output.result) as { slug?: unknown };
+        return typeof content.slug === 'string' && content.slug.length > 0
+            ? content.slug
+            : null;
+    } catch {
+        return null;
+    }
+};
+
+const getDashboardSlugFromContentToolOutput = (
+    toolOutput: AiAgentToolOutput,
+): string | null => {
+    if (toolOutput.isPreliminary) return null;
+
+    switch (toolOutput.toolName) {
+        case 'createContent': {
+            const args = toolOutput.toolArgs as CreateContentToolArgs;
+            if (args.type !== 'dashboard') return null;
+
+            return getSlugFromToolOutput(toolOutput.toolOutput);
+        }
+        case 'editContent': {
+            const args = toolOutput.toolArgs as EditContentToolArgs;
+            if (args.type !== 'dashboard') return null;
+
+            return (
+                getSlugFromToolOutput(toolOutput.toolOutput) ??
+                args.slug ??
+                null
+            );
+        }
+        default:
+            return null;
+    }
+};
+
+export const getDashboardUrlFromContentToolOutput = (
+    projectUuid: string,
+    toolOutput: AiAgentToolOutput,
+): string | null => {
+    const dashboardSlug = getDashboardSlugFromContentToolOutput(toolOutput);
+    return dashboardSlug
+        ? `/projects/${projectUuid}/dashboards/${dashboardSlug}`
+        : null;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/utils/isSamePageNavigation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/isSamePageNavigation.ts
@@ -1,0 +1,80 @@
+import { matchPath } from 'react-router';
+
+type LocationLike = {
+    pathname: string;
+    search: string;
+};
+
+const CONTENT_ROUTE_PATTERNS = [
+    '/projects/:projectUuid/:contentType/:contentUuid',
+    '/projects/:projectUuid/:contentType/:contentUuid/view',
+    '/projects/:projectUuid/:contentType/:contentUuid/view/tabs/:tabUuid',
+    '/minimal/projects/:projectUuid/:contentType/:contentUuid',
+    '/minimal/projects/:projectUuid/:contentType/:contentUuid/view/tabs/:tabUuid',
+];
+
+const getContentRouteIdentity = (pathname: string) => {
+    const match = CONTENT_ROUTE_PATTERNS.map((pattern) =>
+        matchPath(pattern, pathname),
+    ).find(
+        (matchedPath) =>
+            matchedPath?.params.contentType === 'dashboards' ||
+            matchedPath?.params.contentType === 'saved',
+    );
+    if (!match) return null;
+
+    return {
+        projectUuid: match.params.projectUuid,
+        contentType: match.params.contentType,
+        contentUuid: match.params.contentUuid,
+    };
+};
+
+const normalizePathname = (pathname: string): string =>
+    pathname.replace(/\/$/, '');
+
+export function getInternalNavigationUrl(targetUrl: string): string;
+export function getInternalNavigationUrl(
+    targetUrl: unknown,
+): string | undefined;
+export function getInternalNavigationUrl(
+    targetUrl: unknown,
+): string | undefined {
+    if (typeof targetUrl !== 'string' || targetUrl.length === 0) {
+        return undefined;
+    }
+
+    const target = new URL(targetUrl, window.location.origin);
+    const isInternalLightdashPath = /^\/(?:minimal\/)?projects\//.test(
+        target.pathname,
+    );
+
+    if (target.origin === window.location.origin || isInternalLightdashPath) {
+        return `${target.pathname}${target.search}${target.hash}`;
+    }
+
+    return targetUrl;
+}
+
+export const isSamePageNavigation = (
+    targetUrl: string,
+    location: LocationLike,
+): boolean => {
+    const target = new URL(targetUrl, window.location.origin);
+    const currentContent = getContentRouteIdentity(location.pathname);
+    const targetContent = getContentRouteIdentity(target.pathname);
+
+    if (currentContent && targetContent) {
+        return (
+            currentContent.projectUuid === targetContent.projectUuid &&
+            currentContent.contentType === targetContent.contentType &&
+            currentContent.contentUuid === targetContent.contentUuid
+        );
+    }
+
+    return (
+        normalizePathname(target.pathname) ===
+            normalizePathname(location.pathname) &&
+        target.search === location.search
+    );
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -1,6 +1,6 @@
 import { type AiAgent } from '@lightdash/common';
 import { Box, Loader } from '@mantine-8/core';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
     Navigate,
     Outlet,
@@ -25,6 +25,10 @@ import {
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
 import { store as aiAgentStore } from '../../features/aiCopilot/store';
 import { openPanel } from '../../features/aiCopilot/store/aiAgentLauncherSlice';
+import {
+    getInternalNavigationUrl,
+    isSamePageNavigation,
+} from '../../features/aiCopilot/utils/isSamePageNavigation';
 
 const AgentPage = () => {
     const { agentUuid, threadUuid, projectUuid } = useParams();
@@ -58,57 +62,76 @@ const AgentPage = () => {
     const { track } = useTracking();
     const { user } = useApp();
 
-    const handleMinimize = () => {
-        if (!agent || !projectUuid) return;
-        track({
-            name: EventName.AI_AGENT_CHAT_MINIMIZED,
-            properties: {
-                userId: user?.data?.userUuid,
-                organizationId: user?.data?.organizationUuid,
-                projectId: projectUuid,
-                agentUuid: agent.uuid,
-                threadUuid,
-            },
-        });
-        if (threadUuid) {
-            const dockTitle =
-                thread?.title ||
-                thread?.firstMessage?.message ||
-                'Conversation';
-            addDockItem({
-                threadId: threadUuid,
-                agentUuid: agent.uuid,
-                title: dockTitle,
+    const handleMinimize = useCallback(
+        (targetUrl?: string) => {
+            if (!agent || !projectUuid) return;
+            track({
+                name: EventName.AI_AGENT_CHAT_MINIMIZED,
+                properties: {
+                    userId: user?.data?.userUuid,
+                    organizationId: user?.data?.organizationUuid,
+                    projectId: projectUuid,
+                    agentUuid: agent.uuid,
+                    threadUuid,
+                },
             });
-            aiAgentStore.dispatch(
-                openPanel({
+            if (threadUuid) {
+                const dockTitle =
+                    thread?.title ||
+                    thread?.firstMessage?.message ||
+                    'Conversation';
+                addDockItem({
                     threadId: threadUuid,
                     agentUuid: agent.uuid,
-                }),
-            );
-        } else {
-            const chartUuid = searchParams.get('chartUuid');
-            const dashboardUuid = searchParams.get('dashboardUuid');
-            const pendingContext =
-                chartUuid || dashboardUuid
-                    ? {
-                          chartUuid: chartUuid ?? undefined,
-                          dashboardUuid: dashboardUuid ?? undefined,
-                      }
-                    : null;
-            aiAgentStore.dispatch(
-                openPanel({
-                    threadId: null,
-                    agentUuid: agent.uuid,
-                    pendingContext,
-                }),
-            );
-        }
-        void navigate(
-            launcherSession.consumeLastNonAgentUrl() ??
-                `/projects/${projectUuid}/home`,
-        );
-    };
+                    title: dockTitle,
+                });
+                aiAgentStore.dispatch(
+                    openPanel({
+                        threadId: threadUuid,
+                        agentUuid: agent.uuid,
+                    }),
+                );
+            } else {
+                const chartUuid = searchParams.get('chartUuid');
+                const dashboardUuid = searchParams.get('dashboardUuid');
+                const pendingContext =
+                    chartUuid || dashboardUuid
+                        ? {
+                              chartUuid: chartUuid ?? undefined,
+                              dashboardUuid: dashboardUuid ?? undefined,
+                          }
+                        : null;
+                aiAgentStore.dispatch(
+                    openPanel({
+                        threadId: null,
+                        agentUuid: agent.uuid,
+                        pendingContext,
+                    }),
+                );
+            }
+            const restoreUrl =
+                targetUrl ??
+                launcherSession.consumeLastNonAgentUrl() ??
+                `/projects/${projectUuid}/home`;
+            if (!isSamePageNavigation(restoreUrl, window.location)) {
+                void navigate(getInternalNavigationUrl(restoreUrl), {
+                    viewTransition: true,
+                });
+            }
+        },
+        [
+            addDockItem,
+            agent,
+            navigate,
+            projectUuid,
+            searchParams,
+            thread,
+            threadUuid,
+            track,
+            user?.data?.organizationUuid,
+            user?.data?.userUuid,
+        ],
+    );
 
     if (isLoadingAgent) {
         return (
@@ -161,7 +184,15 @@ const AgentPage = () => {
                 />
             }
         >
-            <Outlet context={{ agent, agents: agentsList ?? [] }} />
+            <Outlet
+                context={{
+                    agent,
+                    agents: agentsList ?? [],
+                    isAgentChatMinimized: false,
+                    minimizeAgentChat: handleMinimize,
+                    navigateFromAgentChat: handleMinimize,
+                }}
+            />
         </AiAgentPageLayout>
     );
 };
@@ -169,6 +200,9 @@ const AgentPage = () => {
 export interface AgentContext {
     agent: AiAgent;
     agents: AiAgent[];
+    isAgentChatMinimized: boolean;
+    minimizeAgentChat: (targetUrl?: string) => void;
+    navigateFromAgentChat: (targetUrl: string) => void;
 }
 
 export default AgentPage;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,4 +1,5 @@
 import { Center, Loader } from '@mantine-8/core';
+import { useCallback } from 'react';
 import { useOutletContext, useParams } from 'react-router';
 import useApp from '../../../providers/App/useApp';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
@@ -21,6 +22,8 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../features/aiCopilot/store/hooks';
+import { type AiAgentToolOutput } from '../../features/aiCopilot/types';
+import { getDashboardUrlFromContentToolOutput } from '../../features/aiCopilot/utils/getDashboardSlugFromContentToolOutput';
 import { type AgentContext } from './AgentPage';
 
 const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
@@ -44,12 +47,33 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
 
     const agentQuery = useAiAgent(projectUuid!, agentUuid!);
-    const { agent } = useOutletContext<AgentContext>();
+    const { agent, navigateFromAgentChat } = useOutletContext<AgentContext>();
 
     const canManage = useAiAgentPermission({
         action: 'manage',
         projectUuid,
     });
+
+    const handleToolOutput = useCallback(
+        (toolOutput: AiAgentToolOutput) => {
+            if (!projectUuid) return;
+
+            const dashboardUrl = getDashboardUrlFromContentToolOutput(
+                projectUuid,
+                toolOutput,
+            );
+            if (!dashboardUrl) return;
+
+            navigateFromAgentChat(dashboardUrl);
+        },
+        [navigateFromAgentChat, projectUuid],
+    );
+    const handleInternalLinkClick = useCallback(
+        (href: string) => {
+            navigateFromAgentChat(href);
+        },
+        [navigateFromAgentChat],
+    );
 
     const {
         mutateAsync: createAgentThreadMessage,
@@ -58,6 +82,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         projectUuid!,
         agentUuid,
         threadUuid,
+        { onToolOutput: handleToolOutput },
     );
 
     const { isStreaming, isPending } = usePendingThreadRefetch(
@@ -144,6 +169,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
             projectUuid={projectUuid}
             agentUuid={agentUuid}
             showAddToEvalsButton={canManage}
+            onInternalLinkClick={handleInternalLinkClick}
         >
             <AgentChatInput
                 disabled={inputDisabled}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -31,6 +31,8 @@ import {
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
 import { setThreadSqlMode } from '../../features/aiCopilot/store/aiAgentThreadModeSlice';
 import { useAiAgentStoreDispatch } from '../../features/aiCopilot/store/hooks';
+import { type AiAgentToolOutput } from '../../features/aiCopilot/types';
+import { getDashboardUrlFromContentToolOutput } from '../../features/aiCopilot/utils/getDashboardSlugFromContentToolOutput';
 import { type AgentContext } from './AgentPage';
 
 const AiAgentNewThreadPage: FC = () => {
@@ -49,6 +51,22 @@ const AiAgentNewThreadPage: FC = () => {
     const [sqlMode, setSqlMode] = useState(false);
     const dispatch = useAiAgentStoreDispatch();
 
+    const { agent, agents, navigateFromAgentChat } =
+        useOutletContext<AgentContext>();
+    const handleToolOutput = useCallback(
+        (toolOutput: AiAgentToolOutput) => {
+            if (!projectUuid) return;
+
+            const dashboardUrl = getDashboardUrlFromContentToolOutput(
+                projectUuid,
+                toolOutput,
+            );
+            if (!dashboardUrl) return;
+
+            navigateFromAgentChat(dashboardUrl);
+        },
+        [navigateFromAgentChat, projectUuid],
+    );
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
         useCreateAgentThreadMutation(projectUuid!, {
             // Seed the per-thread slice with the user's choice so subsequent
@@ -61,8 +79,8 @@ const AiAgentNewThreadPage: FC = () => {
                         enabled: sqlModeAvailable && sqlMode,
                     }),
                 ),
+            onToolOutput: handleToolOutput,
         });
-    const { agent, agents } = useOutletContext<AgentContext>();
     const { data: verifiedQuestions } = useVerifiedQuestions(
         projectUuid,
         agentUuid,


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

When the AI agent creates or edits a dashboard, the UI now automatically navigates to that dashboard instead of requiring the user to manually click a link.

This is implemented through a new `onToolOutput` callback that fires during streaming whenever a tool call completes. The `createContent` and `editContent` tool outputs are inspected to extract the resulting dashboard slug, which is then used to construct a navigation URL.

Navigation is handled differently depending on context:
- In the **launcher panel** (floating chat), clicking a dashboard link or receiving a dashboard tool output minimizes the chat and navigates to the dashboard using React Router with a view transition.
- On the **full agent thread page**, the same navigation happens inline via `navigateFromAgentChat`, which is passed down through the outlet context from `AgentPage`.
- In both cases, navigation is skipped if the target URL resolves to the page the user is already on (`isSamePageNavigation`).

Dashboard and chart links rendered inside assistant message bubbles (`ContentLink`) now also support an `onInternalLinkClick` callback. When provided, clicking a link triggers in-app navigation instead of opening a new tab.

Two new utilities are introduced:
- `isSamePageNavigation` — compares a target URL against the current location, with special handling for dashboard/chart route variants (e.g. `/minimal/`, `/view`, `/tabs/...`).
- `getInternalNavigationUrl` — strips the origin from internal Lightdash URLs to produce a relative path suitable for React Router.