### PR TITLE
feat(ee): stream AI writeback progress into the Slack "Thinking…" message

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5351,6 +5351,28 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             );
 
         const proposeWriteback: ProposeWritebackFn = async (args) => {
+            // Stream coarse progress back into the agent's "Thinking…" Slack
+            // message so the user can see what the writeback is doing
+            // (Starting sandbox → Cloning project → Discovering models →
+            // Editing models → Compiling project → Committing → …). Web/MCP
+            // callers don't have a message to update, so the callback is
+            // wired only for Slack prompts. Fire-and-forget — a Slack update
+            // failure (rate limit, message deleted, etc.) must never take
+            // down the writeback itself.
+            const slackProgressCallback = isSlackPrompt(prompt)
+                ? (message: string) => {
+                      void this.updateSlackResponseWithProgress(
+                          prompt,
+                          message,
+                      ).catch((err) => {
+                          Logger.debug(
+                              `Failed to update Slack progress for writeback (${message}):`,
+                              err,
+                          );
+                      });
+                  }
+                : undefined;
+
             const result = await wrapSentryTransaction(
                 'AiAgent.proposeWriteback',
                 {},
@@ -5360,6 +5382,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         projectUuid,
                         prompt: args.prompt,
                         aiThreadUuid: prompt.threadUuid,
+                        onProgress: slackProgressCallback,
                     }),
             );
             // On a successful PR open/update, add a green-tick reaction to the

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    assertUnreachable,
     DbtProjectType,
     FeatureFlags,
     ForbiddenError,
@@ -198,6 +199,38 @@ export class AiWritebackService extends BaseService {
 
     private static elapsed(start: number): number {
         return Math.round(performance.now() - start);
+    }
+
+    /**
+     * Map an internal lifecycle stage to the short progress string surfaced
+     * to the user (e.g. via the Slack bot's "Thinking…" message). One source
+     * of truth so the wording stays consistent if a stage is renamed later.
+     * Keep the strings short — Slack renders them in a single context line.
+     */
+    private static progressTextForStage(
+        stage: AiWritebackFailureStage,
+    ): string {
+        switch (stage) {
+            case 'install':
+                return 'Setting up';
+            case 'sandbox':
+                return 'Starting sandbox';
+            case 'clone':
+                return 'Cloning project';
+            case 'agent':
+                return 'Working on changes';
+            case 'commit':
+                return 'Committing changes';
+            case 'push':
+                return 'Pushing to GitHub';
+            case 'pull_request':
+                return 'Opening pull request';
+            default:
+                return assertUnreachable(
+                    stage,
+                    `Unknown AiWritebackFailureStage: ${String(stage)}`,
+                );
+        }
     }
 
     private async createSandbox(
@@ -416,8 +449,22 @@ export class AiWritebackService extends BaseService {
      *   branch (updates the existing PR), pause the sandbox again.
      */
     async run(args: AiWritebackRunArgs): Promise<AiWritebackRunResult> {
-        const { user, projectUuid, prompt, aiThreadUuid } = args;
+        const { user, projectUuid, prompt, aiThreadUuid, onProgress } = args;
         const runStartedAt = performance.now();
+
+        // Wrap the optional onProgress in a try/catch so a misbehaving caller
+        // (e.g. a Slack `chat.update` 429 that wasn't caught upstream) can
+        // never take down the writeback run itself. Progress is best-effort.
+        const reportProgress = (message: string): void => {
+            if (!onProgress) return;
+            try {
+                onProgress(message);
+            } catch (error) {
+                this.logger.debug(
+                    `AiWriteback: onProgress threw — ignoring: ${getErrorMessage(error)}`,
+                );
+            }
+        };
 
         const turn = await this.prepareTurn({
             user,
@@ -451,6 +498,7 @@ export class AiWritebackService extends BaseService {
             });
             failureStage = stage;
             stageStartedAt = now;
+            reportProgress(AiWritebackService.progressTextForStage(stage));
         };
 
         let sandbox: Sandbox | undefined;
@@ -479,6 +527,7 @@ export class AiWritebackService extends BaseService {
                 projectName: turn.projectName,
                 repository,
                 isResume: turn.isResume,
+                reportProgress,
             });
 
             const {
@@ -824,6 +873,7 @@ export class AiWritebackService extends BaseService {
         projectName,
         repository,
         isResume,
+        reportProgress,
     }: {
         sandbox: Sandbox;
         prompt: string;
@@ -831,6 +881,7 @@ export class AiWritebackService extends BaseService {
         projectName: string;
         repository: string;
         isResume: boolean;
+        reportProgress: (message: string) => void;
     }): Promise<{ stdout: string; exitCode: number }> {
         const repoContext = await this.gatherRepoContext(
             sandbox,
@@ -867,6 +918,43 @@ export class AiWritebackService extends BaseService {
         const appendStderrTail = (chunk: string) => {
             stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_BYTES);
         };
+
+        // Map a single agent tool call to a coarse "phase" so we can stream
+        // semantic progress to the user without firing once per tool. The
+        // ordering — discover → edit → compile — matches the order an
+        // attentive viewer would describe the work, but the agent itself
+        // is free to interleave; we just announce each phase the first time
+        // we see it.
+        type AgentPhase = 'discovering' | 'editing' | 'compiling';
+        const phaseProgressText: Record<AgentPhase, string> = {
+            discovering: 'Discovering models',
+            editing: 'Editing models',
+            compiling: 'Compiling project',
+        };
+        const classifyTool = (
+            name: string,
+            input: unknown,
+        ): AgentPhase | null => {
+            if (name === 'Bash') {
+                const command =
+                    input && typeof input === 'object'
+                        ? (input as { command?: unknown }).command
+                        : undefined;
+                if (
+                    typeof command === 'string' &&
+                    command.includes('lightdash compile')
+                ) {
+                    return 'compiling';
+                }
+                return null;
+            }
+            if (name === 'Edit' || name === 'Write') return 'editing';
+            if (name === 'Read' || name === 'Glob' || name === 'Grep') {
+                return 'discovering';
+            }
+            return null;
+        };
+        const seenPhases = new Set<AgentPhase>();
 
         const summarizeToolInput = (input: unknown): string => {
             if (input && typeof input === 'object') {
@@ -919,6 +1007,11 @@ export class AiWritebackService extends BaseService {
                                 toolName: block.name,
                                 summary: summarizeToolInput(block.input),
                             });
+                            const phase = classifyTool(block.name, block.input);
+                            if (phase && !seenPhases.has(phase)) {
+                                seenPhases.add(phase);
+                                reportProgress(phaseProgressText[phase]);
+                            }
                         }
                     }
                 }

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -34,4 +34,12 @@ export type AiWritebackRunArgs = {
     projectUuid: string;
     prompt: string;
     aiThreadUuid?: string;
+    /**
+     * Fired with a short, user-facing progress message each time the run
+     * advances through a meaningful phase (e.g. "Starting sandbox",
+     * "Discovering models"). Fire-and-forget — the callback should not throw
+     * and the service does not await it. Used by callers that surface
+     * progress live (the Slack agent updates its "Thinking…" message).
+     */
+    onProgress?: (message: string) => void;
 };


### PR DESCRIPTION
## What

Live-update the AI agent's Slack "Thinking…" message as the writeback walks through its lifecycle, instead of leaving it static for 1-3 minutes. The user now sees what's actually happening:

```
Thinking… → Starting sandbox → Cloning project → Working on changes
         → Discovering models → Editing models → Compiling project
         → Committing changes → Pushing to GitHub → Opening pull request
         → [final reply]
```

## How

Two complementary signals drive the updates, riding on infrastructure that already existed:

### 1. Lifecycle-stage transitions
`AiWritebackService.run`'s `setStage` callback already fires at every meaningful phase boundary (`install → sandbox → clone → agent → commit → push → pull_request`) — it's how we already log structured `ai_writeback.run.stage` events. A new `progressTextForStage` helper maps each stage to a user-facing string. One source of truth so wording stays consistent if a stage is renamed; `assertUnreachable` catches missing cases at compile time.

### 2. Tool-classification during the agent stage
The agent stage is the long one (~80s of the run). We already parse the Claude CLI's stream-json `tool_use` events to log per-tool calls. Now we *also* classify each into a coarse phase:

| Tool | Phase | Slack text |
|---|---|---|
| `Read` / `Glob` / `Grep` | discovering | "Discovering models" |
| `Edit` / `Write` | editing | "Editing models" |
| `Bash` containing `lightdash compile` | compiling | "Compiling project" |
| anything else | — | (no emission) |

A `seenPhases` `Set` ensures we only fire the *first* occurrence of each phase. A 9-tool run emits 3 phase messages, not 9 — which is the right shape anyway because the 5-second Slack rate-limit throttler would coalesce close-together updates and the user can't read 9 status changes regardless.

### Plumbing
- `AiWritebackRunArgs` gets an optional `onProgress?: (message: string) => void`. Service is Slack-agnostic — MCP and web callers just don't pass it and see no behavior change.
- Internally the service wraps the consumer's callback in a try/catch (`reportProgress`) so even a synchronously-throwing onProgress can't take down the run.
- In `AiAgentService.proposeWriteback`, the callback is wired *only* for Slack prompts via the existing `isSlackPrompt` type guard, calling the existing `updateSlackResponseWithProgress` method. Fire-and-forget; errors are caught and logged at debug.

The slack-update path already handles `chat.update` and rate-limit throttling via `SlackClient`, so no new infrastructure is needed.

## Verified locally

End-to-end Jaffle Shop EU hide-dimension writeback. The 139.7-second timeline from the structured logs:

```
16:16:51  run.started
16:16:52  stage: install → sandbox       → "Starting sandbox"
16:16:53  sandbox.created
16:16:53  stage: sandbox → clone          → "Cloning project"
16:16:56  stage: clone → agent            → "Working on changes"
16:17:07  tool: Read orders.yml           → "Discovering models" (phase: discovering)
16:17:15  tool: Read orders.sql           → (no emission — same phase)
16:17:29  tool: Read schema.yml           → (no emission)
16:17:39  tool: Read customer_order...    → (no emission)
16:17:56  tool: Edit orders.yml           → "Editing models" (phase: editing)
16:17:58  tool: Read profiles.yml         → (no emission)
16:18:00  tool: Bash cp profiles          → (no emission — not compile)
16:18:03  tool: Bash mkdir + cp           → (no emission)
16:18:07  tool: Bash "lightdash compile…" → "Compiling project" (phase: compiling)
16:18:09  tool: Bash "lightdash compile…" → (no emission — same phase)
16:18:12  tool: Bash "lightdash compile…" → (no emission)
16:19:04  run.summary
16:19:05  run.agent_exited
16:19:05  stage: agent → commit           → "Committing changes"
16:19:06  stage: commit → push            → "Pushing to GitHub"
16:19:08  stage: push → pull_request      → "Opening pull request"
16:19:11  run.completed (prCreated=true)
```

**Nine progress messages over 139s** = roughly one every 15 seconds, comfortably below the Slack rate-limit floor of one update every 5s. The throttler will silently coalesce the three rapid-fire end-of-run transitions (commit → push → pull_request fired within 3s), and the user always sees the latest phase — which is the correct UX outcome.

Happy path otherwise unchanged; the existing analytics/logs/Sentry behaviour is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)