### PR TITLE
fix(prod-7445): drop malformed empty dashboard filters on upload and warn in lint

### DIFF
--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -1,10 +1,10 @@
-import { DashboardAsCode } from '@lightdash/common';
+import { DashboardAsCode, FilterOperator } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { testHelpers } from './download';
 
-const { getDashboardChartSlugs } = testHelpers;
+const { getDashboardChartSlugs, sanitizeDashboardForUpload } = testHelpers;
 
 type LooseDashboard = DashboardAsCode & { needsUpdating: boolean };
 
@@ -109,5 +109,105 @@ describe('getDashboardChartSlugs', () => {
         ]);
         const slugs = await getDashboardChartSlugs([], tmpDir, [loose]);
         expect(slugs).toEqual(['real-chart']);
+    });
+});
+
+describe('sanitizeDashboardForUpload (PROD-7445)', () => {
+    const makeDashboard = (dimensions: unknown[]): DashboardAsCode =>
+        ({
+            name: 'd',
+            slug: 'd',
+            spaceSlug: 's',
+            version: 1,
+            tiles: [],
+            tabs: [],
+            filters: {
+                dimensions,
+                metrics: [],
+                tableCalculations: [],
+            },
+        }) as unknown as DashboardAsCode;
+
+    const validFilter = {
+        operator: FilterOperator.EQUALS,
+        disabled: false,
+        values: ['x'],
+        label: 'valid',
+        target: { fieldId: 'a', tableName: 't' },
+    };
+    const malformed = {
+        operator: FilterOperator.EQUALS,
+        disabled: false,
+        values: [],
+        label: 'malformed',
+        target: { fieldId: 'b', tableName: 't' },
+    };
+    const notNullFilter = {
+        operator: FilterOperator.NOT_NULL,
+        disabled: false,
+        values: [],
+        label: 'notNull',
+        target: { fieldId: 'c', tableName: 't' },
+    };
+
+    it('drops malformed dimension filters', () => {
+        const result = sanitizeDashboardForUpload(makeDashboard([malformed]));
+        expect(result.droppedFilters).toBe(1);
+        expect(result.dashboard.filters?.dimensions).toEqual([]);
+    });
+
+    it('keeps valid filters and notNull (no-value-required) filters', () => {
+        const result = sanitizeDashboardForUpload(
+            makeDashboard([validFilter, notNullFilter]),
+        );
+        expect(result.droppedFilters).toBe(0);
+        expect(result.dashboard.filters?.dimensions).toHaveLength(2);
+    });
+
+    it('drops only the malformed filter when mixed', () => {
+        const result = sanitizeDashboardForUpload(
+            makeDashboard([validFilter, malformed, notNullFilter]),
+        );
+        expect(result.droppedFilters).toBe(1);
+        const kept = result.dashboard.filters?.dimensions ?? [];
+        expect(kept).toHaveLength(2);
+        expect(kept).toEqual(
+            expect.arrayContaining([validFilter, notNullFilter]),
+        );
+    });
+
+    it('is a no-op when there are no filters', () => {
+        const dashboard = {
+            name: 'd',
+            slug: 'd',
+            spaceSlug: 's',
+            version: 1,
+            tiles: [],
+            tabs: [],
+        } as unknown as DashboardAsCode;
+        const result = sanitizeDashboardForUpload(dashboard);
+        expect(result.droppedFilters).toBe(0);
+        expect(result.dashboard).toBe(dashboard);
+    });
+
+    it('drops malformed filters from metrics and tableCalculations too', () => {
+        const dashboard = {
+            name: 'd',
+            slug: 'd',
+            spaceSlug: 's',
+            version: 1,
+            tiles: [],
+            tabs: [],
+            filters: {
+                dimensions: [malformed],
+                metrics: [malformed],
+                tableCalculations: [malformed],
+            },
+        } as unknown as DashboardAsCode;
+        const result = sanitizeDashboardForUpload(dashboard);
+        expect(result.droppedFilters).toBe(3);
+        expect(result.dashboard.filters?.dimensions).toEqual([]);
+        expect(result.dashboard.filters?.metrics).toEqual([]);
+        expect(result.dashboard.filters?.tableCalculations).toEqual([]);
     });
 });

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -14,6 +14,7 @@ import {
     DashboardAsCode,
     generateSlug,
     getErrorMessage,
+    isMalformedEmptyDashboardFilter,
     LightdashError,
     Project,
     PromotionAction,
@@ -1089,6 +1090,59 @@ const isSqlChart = (
     item: ChartAsCode | DashboardAsCode | SqlChartAsCode,
 ): item is SqlChartAsCode => 'sql' in item && !('tableName' in item);
 
+/**
+ * Strip malformed empty dashboard filters before upload.
+ *
+ * `disabled: false, values: []` on an operator that needs values is a no-op
+ * in the UI but still overrides chart-level filters at runtime, which surprises
+ * users. We drop these on upload so they don't get persisted, across all three
+ * filter buckets (dimensions, metrics, tableCalculations). The runtime override
+ * behaviour (PROD-7445) is intentional and left untouched.
+ */
+const sanitizeDashboardForUpload = (
+    dashboard: DashboardAsCode,
+): { dashboard: DashboardAsCode; droppedFilters: number } => {
+    const existing = dashboard.filters;
+    if (!existing) {
+        return { dashboard, droppedFilters: 0 };
+    }
+    const { dimensions, metrics, tableCalculations } = existing;
+    const keptDimensions = dimensions?.filter(
+        (f) => !isMalformedEmptyDashboardFilter(f),
+    );
+    const keptMetrics = metrics?.filter(
+        (f) => !isMalformedEmptyDashboardFilter(f),
+    );
+    const keptTableCalculations = tableCalculations?.filter(
+        (f) => !isMalformedEmptyDashboardFilter(f),
+    );
+    const droppedFilters =
+        (dimensions ? dimensions.length - (keptDimensions?.length ?? 0) : 0) +
+        (metrics ? metrics.length - (keptMetrics?.length ?? 0) : 0) +
+        (tableCalculations
+            ? tableCalculations.length - (keptTableCalculations?.length ?? 0)
+            : 0);
+    if (droppedFilters === 0) {
+        return { dashboard, droppedFilters: 0 };
+    }
+    return {
+        dashboard: {
+            ...dashboard,
+            filters: {
+                ...existing,
+                ...(keptDimensions !== undefined && {
+                    dimensions: keptDimensions,
+                }),
+                ...(keptMetrics !== undefined && { metrics: keptMetrics }),
+                ...(keptTableCalculations !== undefined && {
+                    tableCalculations: keptTableCalculations,
+                }),
+            },
+        },
+        droppedFilters,
+    };
+};
+
 const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
     item: T & { needsUpdating: boolean },
     type: 'charts' | 'dashboards',
@@ -1117,13 +1171,27 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
             ? `/api/v1/projects/${projectId}/sqlCharts/${item.slug}/code`
             : `/api/v1/projects/${projectId}/${type}/${item.slug}/code`;
 
+        let payload: ChartAsCode | DashboardAsCode | SqlChartAsCode = item;
+        if (type === 'dashboards') {
+            const { dashboard: sanitized, droppedFilters } =
+                sanitizeDashboardForUpload(item as DashboardAsCode);
+            if (droppedFilters > 0) {
+                GlobalState.log(
+                    styles.warning(
+                        `Dropped ${droppedFilters} malformed empty dashboard filter(s) from "${item.name}" before upload (disabled:false, values:[], operator requires values). Run \`lightdash lint\` to find these in your YAML.`,
+                    ),
+                );
+            }
+            payload = sanitized;
+        }
+
         const upsertData = await lightdashApi<
             ApiChartAsCodeUpsertResponse['results']
         >({
             method: 'POST',
             url: endpoint,
             body: JSON.stringify({
-                ...item,
+                ...payload,
                 skipSpaceCreate,
                 publicSpaceCreate,
                 force,
@@ -1628,4 +1696,5 @@ export const uploadHandler = async (
 
 export const testHelpers = {
     getDashboardChartSlugs,
+    sanitizeDashboardForUpload,
 };

--- a/packages/cli/src/handlers/lint.test.ts
+++ b/packages/cli/src/handlers/lint.test.ts
@@ -1,0 +1,110 @@
+import { FilterOperator } from '@lightdash/common';
+import { findMalformedDashboardFilters } from './lint';
+
+describe('findMalformedDashboardFilters (PROD-7445)', () => {
+    const filter = (overrides: Record<string, unknown> = {}) => ({
+        operator: FilterOperator.EQUALS,
+        disabled: false,
+        values: [],
+        label: 'Promo code',
+        target: { fieldId: 'orders_promo_code', tableName: 'orders' },
+        ...overrides,
+    });
+
+    const dashboard = (dimensions: unknown[]) => ({
+        version: 1,
+        name: 'd',
+        slug: 'd',
+        spaceSlug: 's',
+        tiles: [],
+        filters: { dimensions, metrics: [], tableCalculations: [] },
+    });
+
+    it('flags the malformed-empty filter shape from the ticket', () => {
+        const warnings = findMalformedDashboardFilters(dashboard([filter()]));
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].keyword).toBe('malformedEmptyDashboardFilter');
+        expect(warnings[0].instancePath).toBe('/filters/dimensions/0');
+        expect(warnings[0].message).toContain('orders_promo_code');
+    });
+
+    it('does not flag disabled filters (UI "any value" shape)', () => {
+        const warnings = findMalformedDashboardFilters(
+            dashboard([filter({ disabled: true })]),
+        );
+        expect(warnings).toEqual([]);
+    });
+
+    it('does not flag notNull / isNull / inPeriodToDate filters', () => {
+        const warnings = findMalformedDashboardFilters(
+            dashboard([
+                filter({ operator: FilterOperator.NOT_NULL }),
+                filter({ operator: FilterOperator.NULL }),
+                filter({ operator: FilterOperator.IN_PERIOD_TO_DATE }),
+            ]),
+        );
+        expect(warnings).toEqual([]);
+    });
+
+    it('does not flag filters with values', () => {
+        const warnings = findMalformedDashboardFilters(
+            dashboard([filter({ values: ['SAVE10'] })]),
+        );
+        expect(warnings).toEqual([]);
+    });
+
+    it('returns an entry per malformed filter, preserving index', () => {
+        const warnings = findMalformedDashboardFilters(
+            dashboard([
+                filter({ values: ['SAVE10'] }), // ok
+                filter(), // malformed
+                filter({ disabled: true }), // ok
+                filter({ target: { fieldId: 'other', tableName: 'orders' } }), // malformed
+            ]),
+        );
+        expect(warnings).toHaveLength(2);
+        expect(warnings.map((w) => w.instancePath)).toEqual([
+            '/filters/dimensions/1',
+            '/filters/dimensions/3',
+        ]);
+    });
+
+    it('is a no-op for dashboards without filters', () => {
+        expect(
+            findMalformedDashboardFilters({ version: 1, tiles: [] }),
+        ).toEqual([]);
+    });
+
+    it('is a no-op for non-object input', () => {
+        expect(findMalformedDashboardFilters(null)).toEqual([]);
+        expect(findMalformedDashboardFilters(undefined)).toEqual([]);
+        expect(findMalformedDashboardFilters('not-a-dashboard')).toEqual([]);
+    });
+
+    it('also flags malformed metric and tableCalculation filters', () => {
+        const warnings = findMalformedDashboardFilters({
+            version: 1,
+            tiles: [],
+            filters: {
+                dimensions: [filter()],
+                metrics: [filter()],
+                tableCalculations: [filter()],
+            },
+        });
+        expect(warnings).toHaveLength(3);
+        expect(warnings.map((w) => w.instancePath)).toEqual([
+            '/filters/dimensions/0',
+            '/filters/metrics/0',
+            '/filters/tableCalculations/0',
+        ]);
+    });
+
+    it('treats YAML `values: ~` (null) as empty', () => {
+        const warnings = findMalformedDashboardFilters({
+            version: 1,
+            tiles: [],
+            filters: { dimensions: [filter({ values: null })] },
+        });
+        expect(warnings).toHaveLength(1);
+    });
+});

--- a/packages/cli/src/handlers/lint.ts
+++ b/packages/cli/src/handlers/lint.ts
@@ -1,7 +1,9 @@
 import {
     chartAsCodeSchema,
     dashboardAsCodeSchema,
+    FilterOperator,
     getErrorMessage,
+    isMalformedEmptyDashboardFilter,
     modelAsCodeSchema,
 } from '@lightdash/common';
 import type { ErrorObject } from 'ajv';
@@ -27,10 +29,76 @@ type FileValidationResult = {
     filePath: string;
     valid: boolean;
     errors?: ErrorObject[];
+    warnings?: ErrorObject[];
     fileContent?: string;
     locationMap?: LocationMap;
     type?: 'chart' | 'dashboard' | 'model';
 };
+
+/**
+ * Detect dashboard filters that look empty but still override chart-level
+ * filters at runtime — `disabled: false, values: []` with an operator that
+ * requires values. Returns ErrorObject-shaped entries so they flow through
+ * the existing SARIF pipeline as warnings.
+ *
+ * Walks all three filter buckets (dimensions, metrics, tableCalculations).
+ * See PROD-7445.
+ */
+export function findMalformedDashboardFilters(data: unknown): ErrorObject[] {
+    if (!data || typeof data !== 'object') return [];
+    const { filters } = data as {
+        filters?: {
+            dimensions?: unknown[];
+            metrics?: unknown[];
+            tableCalculations?: unknown[];
+        };
+    };
+    if (!filters) return [];
+
+    const warnings: ErrorObject[] = [];
+    const buckets: Array<'dimensions' | 'metrics' | 'tableCalculations'> = [
+        'dimensions',
+        'metrics',
+        'tableCalculations',
+    ];
+    for (const bucket of buckets) {
+        const rules = filters[bucket];
+        if (!Array.isArray(rules)) {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+        rules.forEach((filter, index) => {
+            if (!filter || typeof filter !== 'object') return;
+            const f = filter as {
+                operator?: FilterOperator;
+                values?: unknown[] | null;
+                disabled?: boolean;
+                label?: string;
+                target?: { fieldId?: string };
+            };
+            if (!f.operator) return;
+            if (
+                !isMalformedEmptyDashboardFilter({
+                    operator: f.operator,
+                    values: f.values,
+                    disabled: f.disabled,
+                })
+            ) {
+                return;
+            }
+            const fieldId = f.target?.fieldId ?? 'unknown';
+            const label = f.label ? `"${f.label}" ` : '';
+            warnings.push({
+                keyword: 'malformedEmptyDashboardFilter',
+                instancePath: `/filters/${bucket}/${index}`,
+                schemaPath: `#/properties/filters/properties/${bucket}`,
+                params: { fieldId, operator: f.operator, bucket },
+                message: `Dashboard filter ${label}on \`${fieldId}\` is empty (\`disabled: false, values: []\`) but uses an operator that requires values. This filter looks unset in the UI but still overrides chart-level filters. Set \`disabled: true\` or remove the filter.`,
+            });
+        });
+    }
+    return warnings;
+}
 
 const validateChartSchema = ajv.compile(chartAsCodeSchema);
 const validateDashboardSchema = ajv.compile(dashboardAsCodeSchema);
@@ -222,17 +290,26 @@ function validateFile(filePath: string): FileValidationResult {
         // Check if this is a dashboard (has version and tiles)
         if (dataObj.version === 1 && dataObj.tiles) {
             const valid = validateDashboardSchema(data);
+            const warnings = findMalformedDashboardFilters(data);
             if (!valid && validateDashboardSchema.errors) {
                 return {
                     filePath,
                     valid: false,
                     errors: validateDashboardSchema.errors,
+                    warnings: warnings.length > 0 ? warnings : undefined,
                     fileContent,
                     locationMap,
                     type: 'dashboard',
                 };
             }
-            return { filePath, valid: true, type: 'dashboard' };
+            return {
+                filePath,
+                valid: true,
+                warnings: warnings.length > 0 ? warnings : undefined,
+                fileContent,
+                locationMap,
+                type: 'dashboard',
+            };
         }
 
         // Not a lightdash code file
@@ -309,16 +386,20 @@ export async function lintHandler(options: LintOptions): Promise<void> {
                     );
                 }
             } else {
-                // Convert to SARIF format
-                const invalidResults = results.filter((r) => !r.valid);
-                const validCount = results.length - invalidResults.length;
-
-                // Build SARIF report from invalid results
-                const sarifResults = invalidResults
-                    .filter((r) => r.errors && r.fileContent && r.type)
+                // Build SARIF report from all results that produced findings
+                // (schema errors OR custom-check warnings).
+                const sarifResults = results
+                    .filter(
+                        (r) =>
+                            r.fileContent &&
+                            r.type &&
+                            ((r.errors && r.errors.length > 0) ||
+                                (r.warnings && r.warnings.length > 0)),
+                    )
                     .map((r) => ({
                         filePath: r.filePath,
-                        errors: r.errors!,
+                        errors: r.errors ?? [],
+                        warnings: r.warnings,
                         fileContent: r.fileContent!,
                         locationMap: r.locationMap,
                         schemaType: r.type as 'chart' | 'dashboard',
@@ -332,8 +413,10 @@ export async function lintHandler(options: LintOptions): Promise<void> {
                 } else {
                     // CLI format
                     const summary = getSarifSummary(sarifLog);
+                    const invalidCount = results.filter((r) => !r.valid).length;
+                    const validCount = results.length - invalidCount;
 
-                    if (!summary.hasErrors) {
+                    if (!summary.hasErrors && !summary.hasWarnings) {
                         console.log(
                             chalk.green(
                                 '\n✓ All Lightdash Code files are valid!\n',
@@ -347,16 +430,28 @@ export async function lintHandler(options: LintOptions): Promise<void> {
                             ),
                         );
                         console.log(chalk.green(`  ✓ ${validCount} valid`));
-                        console.log(
-                            chalk.red(`  ✗ ${summary.totalFiles} invalid`),
-                        );
+                        if (summary.hasErrors) {
+                            console.log(
+                                chalk.red(
+                                    `  ✗ ${invalidCount} invalid (${summary.totalErrors} error${summary.totalErrors === 1 ? '' : 's'})`,
+                                ),
+                            );
+                        }
+                        if (summary.hasWarnings) {
+                            console.log(
+                                chalk.yellow(
+                                    `  ⚠ ${summary.totalWarnings} warning${summary.totalWarnings === 1 ? '' : 's'}`,
+                                ),
+                            );
+                        }
 
-                        // Show formatted errors (starts with newline, so we don't need extra spacing)
+                        // Show formatted errors and warnings
                         console.log(formatSarifForCli(sarifLog, searchPath));
                     }
                 }
 
-                if (invalidResults.length > 0) {
+                // Warnings alone do not fail the lint — only schema errors do.
+                if (results.some((r) => !r.valid)) {
                     shouldExitWithError = true;
                 }
             }

--- a/packages/cli/src/handlers/lint/ajvToSarif.ts
+++ b/packages/cli/src/handlers/lint/ajvToSarif.ts
@@ -5,6 +5,7 @@ type LocationMap = Map<string, { line: number; column: number }>;
 type FileValidationResult = {
     filePath: string;
     errors: ErrorObject[];
+    warnings?: ErrorObject[];
     fileContent: string;
     locationMap?: LocationMap;
     schemaType: 'chart' | 'dashboard' | 'model';
@@ -216,84 +217,95 @@ export function createSarifReport(results: FileValidationResult[]): SarifLog {
     const sarifResults: SarifResult[] = [];
     const rules = new Map<string, SarifRule>();
 
-    for (const result of results) {
-        for (const error of result.errors) {
-            // For additionalProperties errors, append the property name to the path
-            // Handle root-level errors carefully to avoid double slashes (//propertyName)
-            let dataPath = error.instancePath || '/';
-            if (
-                error.keyword === 'additionalProperties' &&
-                error.params.additionalProperty
-            ) {
-                dataPath =
-                    dataPath === '/'
-                        ? `/${error.params.additionalProperty}`
-                        : `${dataPath}/${error.params.additionalProperty}`;
-            }
+    const pushResult = (
+        result: FileValidationResult,
+        error: ErrorObject,
+        level: 'error' | 'warning',
+    ) => {
+        // For additionalProperties errors, append the property name to the path
+        // Handle root-level errors carefully to avoid double slashes (//propertyName)
+        let dataPath = error.instancePath || '/';
+        if (
+            error.keyword === 'additionalProperties' &&
+            error.params.additionalProperty
+        ) {
+            dataPath =
+                dataPath === '/'
+                    ? `/${error.params.additionalProperty}`
+                    : `${dataPath}/${error.params.additionalProperty}`;
+        }
 
-            // Determine error location using a two-strategy approach:
-            // 1. PRIMARY: Use locationMap (built from YAML AST during parsing)
-            //    - Fast O(1) lookup for ~95% of cases
-            //    - Works for: additional properties, type errors, enum errors, nested errors, array items
-            //    - Works for: nested missing required fields (e.g., missing 'exploreName' in 'metricQuery')
-            //
-            // 2. FALLBACK: Use regex-based search when locationMap lookup fails
-            //    - Needed for: root-level missing required properties (e.g., missing 'name', 'version')
-            //      These have dataPath='/' which doesn't exist in locationMap since it stores actual YAML keys
-            //    - Also provides defensive error handling if AST traversal misses any edge cases
-            let location: { line: number; column: number } | null = null;
-            if (result.locationMap) {
-                location = result.locationMap.get(dataPath) || null;
-            }
-            if (!location) {
-                // Fallback to regex search - primarily for root-level missing required properties
-                location = findLocationForPath(result.fileContent, dataPath);
-            }
+        // Determine error location using a two-strategy approach:
+        // 1. PRIMARY: Use locationMap (built from YAML AST during parsing)
+        //    - Fast O(1) lookup for ~95% of cases
+        //    - Works for: additional properties, type errors, enum errors, nested errors, array items
+        //    - Works for: nested missing required fields (e.g., missing 'exploreName' in 'metricQuery')
+        //
+        // 2. FALLBACK: Use regex-based search when locationMap lookup fails
+        //    - Needed for: root-level missing required properties (e.g., missing 'name', 'version')
+        //      These have dataPath='/' which doesn't exist in locationMap since it stores actual YAML keys
+        //    - Also provides defensive error handling if AST traversal misses any edge cases
+        let location: { line: number; column: number } | null = null;
+        if (result.locationMap) {
+            location = result.locationMap.get(dataPath) || null;
+        }
+        if (!location) {
+            // Fallback to regex search - primarily for root-level missing required properties
+            location = findLocationForPath(result.fileContent, dataPath);
+        }
 
-            const message = getFriendlyMessage(error);
-            const ruleId = `${result.schemaType}/${error.keyword}`;
+        const message = getFriendlyMessage(error);
+        const ruleId = `${result.schemaType}/${error.keyword}`;
 
-            // Add rule if we haven't seen it before
-            if (!rules.has(ruleId)) {
-                rules.set(ruleId, {
-                    id: ruleId,
-                    shortDescription: {
-                        text: `${error.keyword} validation error`,
-                    },
-                });
-            }
-
-            const sarifResult: SarifResult = {
-                ruleId,
-                level: 'error',
-                message: {
-                    text: message,
+        // Add rule if we haven't seen it before
+        if (!rules.has(ruleId)) {
+            rules.set(ruleId, {
+                id: ruleId,
+                shortDescription: {
+                    text: `${error.keyword} validation ${level}`,
                 },
-                locations: [
-                    {
-                        physicalLocation: {
-                            artifactLocation: {
-                                uri: result.filePath,
-                            },
-                            region: {
-                                startLine: location?.line || 1,
-                                startColumn: location?.column || 1,
-                            },
+            });
+        }
+
+        const sarifResult: SarifResult = {
+            ruleId,
+            level,
+            message: {
+                text: message,
+            },
+            locations: [
+                {
+                    physicalLocation: {
+                        artifactLocation: {
+                            uri: result.filePath,
+                        },
+                        region: {
+                            startLine: location?.line || 1,
+                            startColumn: location?.column || 1,
                         },
                     },
-                ],
-            };
+                },
+            ],
+        };
 
-            // Add additional context
-            if (error.params) {
-                const properties: Record<string, unknown> = {};
-                Object.entries(error.params).forEach(([key, value]) => {
-                    properties[key] = value;
-                });
-                sarifResult.properties = { errorParams: properties };
-            }
+        // Add additional context
+        if (error.params) {
+            const properties: Record<string, unknown> = {};
+            Object.entries(error.params).forEach(([key, value]) => {
+                properties[key] = value;
+            });
+            sarifResult.properties = { errorParams: properties };
+        }
 
-            sarifResults.push(sarifResult);
+        sarifResults.push(sarifResult);
+    };
+
+    for (const result of results) {
+        for (const error of result.errors) {
+            pushResult(result, error, 'error');
+        }
+        for (const warning of result.warnings ?? []) {
+            pushResult(result, warning, 'warning');
         }
     }
 

--- a/packages/cli/src/handlers/lint/sarifFormatter.ts
+++ b/packages/cli/src/handlers/lint/sarifFormatter.ts
@@ -53,64 +53,83 @@ export function formatSarifForCli(
         return chalk.green('\n✓ All Lightdash Code files are valid!\n');
     }
 
-    // Group results by file
-    const resultsByFile = new Map<string, SarifResult[]>();
-    for (const result of results) {
-        const location = result.locations?.[0];
-        const uri = location?.physicalLocation?.artifactLocation?.uri;
-        if (uri) {
-            if (!resultsByFile.has(uri)) {
-                resultsByFile.set(uri, []);
+    const errorResults = results.filter((r) => r.level === 'error');
+    const warningResults = results.filter((r) => r.level === 'warning');
+
+    const renderSection = (
+        sectionResults: SarifResult[],
+        sectionLabel: string,
+        color: (text: string) => string,
+        boldColor: (text: string) => string,
+        marker: string,
+        closingLabel: (count: number) => string,
+    ) => {
+        if (sectionResults.length === 0) return;
+
+        // Group results by file
+        const byFile = new Map<string, SarifResult[]>();
+        for (const result of sectionResults) {
+            const uri =
+                result.locations?.[0]?.physicalLocation?.artifactLocation?.uri;
+            if (uri) {
+                if (!byFile.has(uri)) byFile.set(uri, []);
+                byFile.get(uri)!.push(result);
             }
-            resultsByFile.get(uri)!.push(result);
         }
-    }
 
-    // Count stats
-    const totalFiles = resultsByFile.size;
+        output.push(color(`\n${sectionLabel}\n`));
 
-    output.push(chalk.red('\nValidation Errors:\n'));
+        for (const [fileUri, fileResults] of byFile.entries()) {
+            const relativePath = path.relative(searchPath, fileUri);
+            output.push(boldColor(`\n${marker} ${relativePath}`));
 
-    // Format each file's errors
-    for (const [fileUri, fileResults] of resultsByFile.entries()) {
-        const relativePath = path.relative(searchPath, fileUri);
-        output.push(chalk.red.bold(`\n✗ ${relativePath}`));
+            for (const result of fileResults) {
+                const message = result.message.text;
+                const location = result.locations?.[0]?.physicalLocation;
+                const line = location?.region?.startLine;
+                const column = location?.region?.startColumn;
 
-        for (const result of fileResults) {
-            const message = result.message.text;
-            const location = result.locations?.[0]?.physicalLocation;
-            const line = location?.region?.startLine;
-            const column = location?.region?.startColumn;
+                output.push(
+                    color(`\n  ${message}${line ? ` (line ${line})` : ''}`),
+                );
 
-            output.push(
-                chalk.red(`\n  ${message}${line ? ` (line ${line})` : ''}`),
-            );
+                if (line) {
+                    // Encode the URI properly for file:// protocol to handle special characters (#, ?, &, spaces, etc.)
+                    const encodedPath = encodeURI(fileUri);
+                    const fileLink = `file://${encodedPath}:${line}${
+                        column ? `:${column}` : ''
+                    }`;
+                    output.push(chalk.dim(`  ${fileLink}`));
+                }
 
-            // Add clickable file link for IDEs
-            if (line) {
-                // Encode the URI properly for file:// protocol to handle special characters (#, ?, &, spaces, etc.)
-                const encodedPath = encodeURI(fileUri);
-                const fileLink = `file://${encodedPath}:${line}${
-                    column ? `:${column}` : ''
-                }`;
-                output.push(chalk.dim(`  ${fileLink}`));
-            }
-
-            if (line && fs.existsSync(fileUri)) {
-                const snippet = getCodeSnippet(fileUri, line);
-                if (snippet) {
-                    output.push(chalk.dim(`\n${snippet}\n`));
+                if (line && fs.existsSync(fileUri)) {
+                    const snippet = getCodeSnippet(fileUri, line);
+                    if (snippet) {
+                        output.push(chalk.dim(`\n${snippet}\n`));
+                    }
                 }
             }
         }
-    }
 
-    output.push(
-        chalk.red(
-            `\nValidation failed for ${totalFiles} file${
-                totalFiles > 1 ? 's' : ''
-            }`,
-        ),
+        output.push(color(`\n${closingLabel(byFile.size)}`));
+    };
+
+    renderSection(
+        errorResults,
+        'Validation Errors:',
+        chalk.red,
+        chalk.red.bold,
+        '✗',
+        (count) => `Validation failed for ${count} file${count > 1 ? 's' : ''}`,
+    );
+
+    renderSection(
+        warningResults,
+        'Validation Warnings:',
+        chalk.yellow,
+        chalk.yellow.bold,
+        '⚠',
+        (count) => `${count} file${count > 1 ? 's have' : ' has'} warnings`,
     );
 
     return output.join('\n');
@@ -122,27 +141,44 @@ export function formatSarifForCli(
 export function getSarifSummary(sarifLog: SarifLog): {
     totalFiles: number;
     totalErrors: number;
+    totalWarnings: number;
     hasErrors: boolean;
+    hasWarnings: boolean;
 } {
     if (!sarifLog.runs || sarifLog.runs.length === 0) {
-        return { totalFiles: 0, totalErrors: 0, hasErrors: false };
+        return {
+            totalFiles: 0,
+            totalErrors: 0,
+            totalWarnings: 0,
+            hasErrors: false,
+            hasWarnings: false,
+        };
     }
 
     const run = sarifLog.runs[0];
     const results = run.results || [];
 
     const uniqueFiles = new Set<string>();
+    let totalErrors = 0;
+    let totalWarnings = 0;
     for (const result of results) {
         const location = result.locations?.[0];
         const uri = location?.physicalLocation?.artifactLocation?.uri;
         if (uri) {
             uniqueFiles.add(uri);
         }
+        if (result.level === 'warning') {
+            totalWarnings += 1;
+        } else {
+            totalErrors += 1;
+        }
     }
 
     return {
         totalFiles: uniqueFiles.size,
-        totalErrors: results.length,
-        hasErrors: results.length > 0,
+        totalErrors,
+        totalWarnings,
+        hasErrors: totalErrors > 0,
+        hasWarnings: totalWarnings > 0,
     };
 }

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -19,6 +19,7 @@ import {
     createFilterRuleFromModelRequiredFilterRule,
     getDashboardFilterRulesForTileAndReferences,
     isFilterRuleInQuery,
+    isMalformedEmptyDashboardFilter,
     overrideChartFilter,
     reduceRequiredDimensionFiltersToFilterRules,
     resetRequiredFilterRules,
@@ -1527,5 +1528,87 @@ describe('stripOverridesForLockedFiltersOnTab', () => {
         );
         expect(result.filters.dimensions).toHaveLength(1);
         expect(result.droppedCount).toBe(0);
+    });
+});
+
+describe('isMalformedEmptyDashboardFilter', () => {
+    test('flags disabled:false + empty values + value-requiring operator', () => {
+        expect(
+            isMalformedEmptyDashboardFilter({
+                operator: FilterOperator.EQUALS,
+                disabled: false,
+                values: [],
+            }),
+        ).toBe(true);
+    });
+
+    test('flags missing values (treated as empty)', () => {
+        expect(
+            isMalformedEmptyDashboardFilter({
+                operator: FilterOperator.EQUALS,
+                disabled: false,
+            }),
+        ).toBe(true);
+    });
+
+    test('flags omitted disabled (defaults to active)', () => {
+        expect(
+            isMalformedEmptyDashboardFilter({
+                operator: FilterOperator.EQUALS,
+                values: [],
+            }),
+        ).toBe(true);
+    });
+
+    test('treats null values (YAML `values: ~`) as empty', () => {
+        expect(
+            isMalformedEmptyDashboardFilter({
+                operator: FilterOperator.EQUALS,
+                disabled: false,
+                values: null,
+            }),
+        ).toBe(true);
+    });
+
+    test('does NOT flag disabled filters', () => {
+        expect(
+            isMalformedEmptyDashboardFilter({
+                operator: FilterOperator.EQUALS,
+                disabled: true,
+                values: [],
+            }),
+        ).toBe(false);
+    });
+
+    test('does NOT flag operators that legitimately take no values', () => {
+        expect(
+            isMalformedEmptyDashboardFilter({
+                operator: FilterOperator.NULL,
+                disabled: false,
+                values: [],
+            }),
+        ).toBe(false);
+        expect(
+            isMalformedEmptyDashboardFilter({
+                operator: FilterOperator.NOT_NULL,
+                disabled: false,
+            }),
+        ).toBe(false);
+        expect(
+            isMalformedEmptyDashboardFilter({
+                operator: FilterOperator.IN_PERIOD_TO_DATE,
+                disabled: false,
+            }),
+        ).toBe(false);
+    });
+
+    test('does NOT flag filters with values', () => {
+        expect(
+            isMalformedEmptyDashboardFilter({
+                operator: FilterOperator.EQUALS,
+                disabled: false,
+                values: ['some-value'],
+            }),
+        ).toBe(false);
     });
 });

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -210,6 +210,24 @@ export const isWithValueFilter = (filterOperator: FilterOperator) =>
     filterOperator !== FilterOperator.NOT_NULL &&
     filterOperator !== FilterOperator.IN_PERIOD_TO_DATE;
 
+/**
+ * A dashboard filter is "malformed empty" when it is active (not disabled),
+ * uses an operator that requires values, and has no values. These filters
+ * look empty in the UI but still override chart-level filters at runtime,
+ * which is surprising. See PROD-7445.
+ *
+ * `values` is checked with Array.isArray to tolerate hand-authored YAML
+ * where `values:` or `values: ~` parses to JS `null` instead of `[]`.
+ */
+export const isMalformedEmptyDashboardFilter = (filter: {
+    operator: FilterOperator;
+    values?: unknown[] | null;
+    disabled?: boolean;
+}): boolean =>
+    filter.disabled !== true &&
+    isWithValueFilter(filter.operator) &&
+    (!Array.isArray(filter.values) || filter.values.length === 0);
+
 export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
     filterType: FilterType,
     field: FilterableField | undefined,


### PR DESCRIPTION
Closes: PROD-7445

### Description:

Introduces detection and handling of malformed empty dashboard filters — filters where `disabled: false`, `values: []`, and the operator requires values. These filters appear unset in the UI but silently override chart-level filters at runtime.

A new `isMalformedEmptyDashboardFilter` utility in `@lightdash/common` identifies this shape, tolerating `null` values from hand-authored YAML (`values: ~`). Operators that legitimately take no values (`NULL`, `NOT_NULL`, `IN_PERIOD_TO_DATE`) are excluded.

**Upload (`lightdash upload`):** A `sanitizeDashboardForUpload` function strips malformed filters from all three filter buckets (dimensions, metrics, tableCalculations) before sending the dashboard to the API. A warning is printed to the console for each dashboard where filters are dropped, advising users to run `lightdash lint` to locate them in their YAML.

**Lint (`lightdash lint`):** A `findMalformedDashboardFilters` function walks all filter buckets and emits `ErrorObject`-shaped warnings that flow through the existing SARIF pipeline. Warnings are surfaced in CLI output with yellow `⚠` markers and file links but do **not** cause the lint command to exit with an error — only schema validation failures do. The SARIF formatter and summary are updated to handle `warning`-level results separately from `error`-level results.