### PR TITLE
feat(ee): name the selected project in the Slack picker confirmation

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8163,10 +8163,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
                 try {
                     // The action value is user-controlled (it round-trips
-                    // through Slack), so validate its shape before trusting it.
+                    // through Slack), so validate its shape before trusting
+                    // it. `projectName` round-trips so the confirmation
+                    // message can name the project without an extra lookup.
                     const projectSelectionSchema = z.object({
                         projectUuid: z.string().uuid(),
                         channelId: z.string().min(1),
+                        projectName: z.string().min(1),
                     });
                     const parseResult = projectSelectionSchema.safeParse(
                         JSON.parse(rawValue),
@@ -8178,7 +8181,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         });
                         return;
                     }
-                    const { projectUuid, channelId } = parseResult.data;
+                    const { projectUuid, channelId, projectName } =
+                        parseResult.data;
 
                     const organizationUuid =
                         await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
@@ -8281,19 +8285,21 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             instruction: SYSTEM_AGENT_INSTRUCTION,
                         });
 
-                    // Replace the picker with a confirmation.
+                    // Replace the picker with a confirmation that names the
+                    // selected project, so the user has a record of which
+                    // project this conversation is bound to.
                     if (body.message?.ts) {
                         try {
                             await client.chat.update({
                                 channel: channelId,
                                 ts: body.message.ts,
-                                text: '✅ Project selected',
+                                text: `✅ Project selected: ${projectName}`,
                                 blocks: [
                                     {
                                         type: 'section',
                                         text: {
                                             type: 'mrkdwn',
-                                            text: ':white_check_mark: Working in the project you selected.',
+                                            text: `:white_check_mark: Working in *${projectName}*.`,
                                         },
                                     },
                                 ],

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -655,6 +655,20 @@ export function getProjectSelectionBlocks(
         },
     };
 
+    // The project name is round-tripped through the action value so the
+    // handler can name the project in its confirmation message without an
+    // extra DB lookup. Truncated to match the visible label, and well within
+    // Slack's ~2000-char limit for `value`.
+    const buildSelectionValue = (project: {
+        projectUuid: string;
+        name: string;
+    }): string =>
+        JSON.stringify({
+            projectUuid: project.projectUuid,
+            channelId,
+            projectName: truncateText(project.name, 75),
+        });
+
     // Few projects: one button each for a single tap.
     if (projects.length <= PROJECT_SELECTION_BUTTON_THRESHOLD) {
         return [
@@ -671,10 +685,7 @@ export function getProjectSelectionBlocks(
                         type: 'plain_text',
                         text: truncateText(project.name, 75),
                     },
-                    value: JSON.stringify({
-                        projectUuid: project.projectUuid,
-                        channelId,
-                    }),
+                    value: buildSelectionValue(project),
                 })),
             },
         ];
@@ -700,10 +711,7 @@ export function getProjectSelectionBlocks(
                             type: 'plain_text',
                             text: truncateText(project.name, 75),
                         },
-                        value: JSON.stringify({
-                            projectUuid: project.projectUuid,
-                            channelId,
-                        }),
+                        value: buildSelectionValue(project),
                     })),
                 },
             ],


### PR DESCRIPTION
## What

When a user picks a project from the Slack project picker, the bot now confirms which one was chosen by name.

**Before:**
```
✅ Working in the project you selected.
```

**After:**
```
✅ Working in *Jaffle Shop EU*.
```

(or whichever project the user picked).

## Why

A picker with three identical-looking buttons → a generic confirmation gives the user no way to spot a misclick before kicking off a writeback or query against the wrong project. Echoing the name is cheap and removes that footgun.

## How

To keep the click handler simple — and avoid a DB round-trip just to look up a project name we already had at picker-render time — the project name is round-tripped through the existing JSON `value` field on each picker option, alongside the `projectUuid` and `channelId` already being round-tripped. Truncated to 75 chars to match the visible label (so the value can't be larger than the option that produced it) and well under Slack's ~2000-char `value` limit.

Three small touches:

1. **`getSlackBlocks.ts`** — extract a `buildSelectionValue` helper so the button-variant (≤3 projects) and dropdown-variant (>3 projects) of the picker can't drift apart on the value shape.
2. **`AiAgentService.ts` Zod schema** — add a required `projectName: z.string().min(1)` field. Greenfield: we never released this picker with the old value shape externally, so no back-compat path is needed.
3. **`AiAgentService.ts` confirmation** — interpolate the name into both the message `text` (used in notifications / fallbacks) and the `mrkdwn` block.

## Verified locally

Typecheck + lint clean. Live picker triggering hit a tooling snag — the test channel has an agent configured, so the system-agent picker fallback only fires in a channel with *no* configured agent + multiple projects, which isn't a state I can flip on the fly. The change is small (+27/-13 lines, behaviour-narrow) and the failure modes are caught by the Zod schema, so it's safe to verify in beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)