### PR TITLE
chore(ai-agents): log implicit signals on review judgments

### DIFF
--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -68,7 +68,7 @@ const makeRun = (overrides: Record<string, unknown> = {}) => ({
     organizationUuid: ORGANIZATION_UUID,
     status: 'running' as const,
     reviewAgentVersion: 'llm-judge-v1',
-    judgePromptHash: 'ai-agent-review-judge-v1',
+    judgePromptHash: 'ai-agent-review-judge-v2',
     agentConfigSnapshotHash: null,
     agentConfigSnapshot: null,
     agentConfigSnapshotAgentUpdatedAt: null,

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -35,7 +35,7 @@ import { defaultAgentOptions } from './ai/agents/agentV2';
 import { getModel } from './ai/models';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
-const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v1';
+const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v2';
 
 type AiAgentReviewClassifierJudge = (
     candidate: AiAgentReviewClassifierTurnCandidate,
@@ -871,7 +871,7 @@ export class AiAgentReviewClassifierService extends BaseService {
 
 Classify whether the assistant turn contains an actionable issue. Use only the supplied evidence packet. Do not invent project fields or facts.
 
-Definitions:
+Root cause definitions:
 - semantic_layer: dbt/Lightdash YAML model, dimension, metric, join, filter, or AI hint should change.
 - project_context: available explores, project context, or knowledge about which explore to use is missing/wrong.
 - agent_configuration: Lightdash agent settings should change, e.g. instructions, knowledge docs, data access, SQL mode, MCP, access.
@@ -882,9 +882,46 @@ Definitions:
 - not_a_failure: normal refinement, new request, acceptance, formatting-only change, or harmless follow-up.
 - ambiguous: likely issue, but insufficient evidence to choose one root cause.
 
-Return promotedToFinding=false for normal refinement, acceptance/continuation, unrelated new questions, or formatting-only changes.
-Successful queries can still be findings when the user asked broad business language and the semantic/catalog context does not clearly support the selected field, explore, or metric. Promote those as semantic_layer or project_context when a model definition, AI hint, or project context rule would prevent future ambiguity.
-Use agentConfig to catch Lightdash-layer fixes: missing instructions, disabled data access, missing knowledge docs, access restrictions, or capability settings. Promote those as agent_configuration when the answer quality depends on agent setup.
+Implicit signal definitions — set these whenever the evidence supports them:
+- assistant_no_answer: the assistant did not answer the user's actual question. This includes giving only a workaround for missing data ("we don't have X, so here's Y instead"), explicitly saying the data is not available, or producing an empty / non-substantive response.
+- next_user_correction: the next user prompt corrects or pushes back on the previous answer's field, metric, explore, scope, business definition, or data availability ("actually I meant…", "but what about…", "you can't connect them?"). Do not use this for ordinary drill-downs or additive follow-up questions.
+- next_user_dispute: the next user prompt explicitly says the previous answer was wrong.
+- next_user_retry: the next user prompt asks the same unresolved question again or asks to try a different approach after a failed, empty, non-substantive, or off-target answer. Do not use this for normal iterative exploration after a useful answer.
+- output_shape_correction: the next user prompt asks for a different chart / format / grouping with no semantic change.
+- tool_error: a tool call errored, timed out, or returned an empty / error result the assistant did not recover from.
+- product_capability_request: the user asked for something Lightdash cannot currently express.
+- human_intervention: an admin or engineer had to step in.
+
+Decision rules — apply in order:
+
+1. First, populate implicitSignalSources by inspecting the evidence packet. Do not skip this step.
+
+2. Treat implicitSignalSources as strong evidence of unresolved user intent, not as decoration. Promote when the implicit signal points to likely assistant failure:
+   - Always promote assistant_no_answer, next_user_dispute, tool_error, product_capability_request, and human_intervention.
+   - Promote next_user_correction when the correction is about field choice, metric choice, explore/source selection, scoping, business definition, missing data, or whether the assistant can connect the requested data.
+   - Promote next_user_retry only when the previous answer was failed, empty, non-substantive, off-target, or only offered a workaround instead of answering the user's actual question.
+   - Do not promote output_shape_correction alone, routine drill-downs, normal follow-up questions, or chart/format-only changes when the assistant answered the user's actual question.
+
+When promoting, pick primaryRootCause by mapping the dominant signal:
+   - assistant_no_answer where the assistant names a missing join, missing column, missing relationship, or missing field → semantic_layer.
+   - assistant_no_answer where the assistant picked a wrong / unrelated explore or field → project_context.
+   - assistant_no_answer due to disabled SQL or data access, missing instructions, or missing knowledge docs → agent_configuration.
+   - assistant_no_answer because the warehouse genuinely lacks the data → data_gap.
+   - assistant_no_answer because Lightdash cannot express the question (missing chart type, unsupported pivot, etc.) → product_capability.
+   - next_user_correction or next_user_dispute about field choice, scoping, or definition → semantic_layer or project_context.
+   - next_user_retry after a failed or empty answer → runtime_reliability or agent_configuration depending on cause.
+   - tool_error → runtime_reliability.
+   - product_capability_request → product_capability.
+   - human_intervention → agent_configuration unless evidence clearly points elsewhere.
+
+3. Only set promotedToFinding=false when there is no promotable implicit signal AND the assistant answered the user's actual question. In that case use signal=acceptance_or_continuation, new_question, output_shape_correction, or normal_refinement and primaryRootCause=not_a_failure.
+
+4. Successful queries can still be findings even without implicit signals when the user asked broad business language and the semantic / catalog context does not clearly support the selected field, explore, or metric. Promote those as semantic_layer or project_context when a model definition, AI hint, or project context rule would prevent future ambiguity.
+
+5. Use agentConfig to catch Lightdash-layer fixes: missing instructions, disabled data access, missing knowledge docs, access restrictions, or capability settings. Promote those as agent_configuration when the answer quality depends on agent setup.
+
+6. If you would promote but cannot pick one primaryRootCause confidently, set primaryRootCause=ambiguous with confidence=low or medium and still promote.
+
 When promotedToFinding=true, provide concise evidence excerpts copied or summarized from the packet and a practical recommendation.
 Use one primaryRootCause. Secondary causes are optional.
 For targetRefs, return compact refs:

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -506,6 +506,10 @@ export class AiAgentReviewClassifierService extends BaseService {
             },
             modelMetadata: candidate.modelMetadata,
         };
+        const promotableImplicitSignalSources =
+            judgeOutput.implicitSignalSources.filter(
+                (source) => source !== 'output_shape_correction',
+            );
 
         Logger.info('AI agent review agent judged turn', {
             runPromptUuid: candidate.subject.assistantPromptUuid,
@@ -516,6 +520,14 @@ export class AiAgentReviewClassifierService extends BaseService {
             primaryRootCause: judgeOutput.primaryRootCause,
             promotedToFinding: judgeOutput.promotedToFinding,
             confidence: judgeOutput.confidence,
+            judgePromptHash: JUDGE_PROMPT_HASH,
+            implicitSignalSources: judgeOutput.implicitSignalSources,
+            hasImplicitSignal: judgeOutput.implicitSignalSources.length > 0,
+            hasPromotableImplicitSignal:
+                promotableImplicitSignalSources.length > 0,
+            droppedImplicitSignal:
+                promotableImplicitSignalSources.length > 0 &&
+                !judgeOutput.promotedToFinding,
         });
         this.debugLog('TurnJudged', {
             promptUuid: candidate.subject.assistantPromptUuid,


### PR DESCRIPTION
## Why

When v1 of the judge prompt was silently dropping every implicit signal (root cause in #23617), the always-on \`Logger.info('AI agent review agent judged turn', ...)\` line was the only signal available in GCP — and it did not include \`implicitSignalSources\`. The bug was invisible from logs; you had to query the DB to see that the judge had extracted failure signals and then ignored them.

This adds enough fields to that existing log line so the same regression can be spotted in a single GCP query next time, without flipping \`AI_COPILOT_DEBUG_LOGGING_ENABLED=true\` in prod.

## What

Extends the existing judged-turn info log with:

- \`implicitSignalSources\` — array of signals the judge extracted.
- \`hasImplicitSignal\` — boolean, easy GCP filter.
- \`droppedImplicitSignal\` — boolean. True iff the judge identified signals AND did not promote. This is the canary: should be ~0% in healthy operation; spikes to ~100% in the failure mode the parent PR fixes.
- \`judgePromptHash\` — so v1 vs v2 rollouts can be split in GCP without a DB join.

## Regression analysis

- **No new log volume** — extends an existing line that already fires once per classified turn.
- **No PII/PHI risk** — added fields are enum values (\`assistant_no_answer\`, \`next_user_correction\`, etc.) and the prompt-version string. No user prompt content, no project content.
- **No behavior change** — purely additive telemetry; classification logic is unchanged.

## Test plan

- [x] Existing \`AiAgentReviewClassifier\` unit tests still pass (12/12).
- [ ] After rollout, GCP query \`jsonPayload.droppedImplicitSignal=true\` should return ~0 results once #23617 is enabled.

Stacked on #23617.