### PR TITLE
feat(ai-agents): add scrollable container to agent picker candidates

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -110,6 +110,57 @@
     animation: pickerItemIn 360ms cubic-bezier(0.16, 1, 0.3, 1) 40ms both;
 }
 
+.pickerScroll {
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-xs);
+    max-height: min(420px, 55vh);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 4px;
+    padding-bottom: 10px;
+    margin: -4px;
+    scrollbar-width: thin;
+    scrollbar-color: light-dark(
+            var(--mantine-color-gray-3),
+            var(--mantine-color-dark-3)
+        )
+        transparent;
+    -webkit-mask-image: linear-gradient(
+        to bottom,
+        black calc(100% - 10px),
+        transparent 100%
+    );
+    mask-image: linear-gradient(
+        to bottom,
+        black calc(100% - 10px),
+        transparent 100%
+    );
+}
+
+.pickerScroll::-webkit-scrollbar {
+    width: 6px;
+}
+
+.pickerScroll::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.pickerScroll::-webkit-scrollbar-thumb {
+    background-color: light-dark(
+        var(--mantine-color-gray-3),
+        var(--mantine-color-dark-3)
+    );
+    border-radius: 999px;
+}
+
+.pickerScroll::-webkit-scrollbar-thumb:hover {
+    background-color: light-dark(
+        var(--mantine-color-gray-4),
+        var(--mantine-color-dark-2)
+    );
+}
+
 .candidateButton {
     display: block;
     width: 100%;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -6,6 +6,7 @@ import {
     ActionIcon,
     Avatar,
     Badge,
+    Box,
     Center,
     Group,
     Popover,
@@ -370,74 +371,82 @@ const AgentsRouterPage = () => {
                                 )}
                             </div>
 
-                            {sortedCandidates.map((c) => {
-                                const agent = agentsByUuid.get(c.agentUuid);
-                                const isRecommended =
-                                    c.agentUuid ===
-                                    phase.decision.decision.suggestedAgentUuid;
-                                return (
-                                    <UnstyledButton
-                                        key={c.agentUuid}
-                                        onClick={() => confirmPick(c.agentUuid)}
-                                        className={`${classes.candidateButton} ${
-                                            isRecommended
-                                                ? classes.recommended
-                                                : ''
-                                        }`}
-                                        aria-label={`Send to ${c.name}`}
-                                    >
-                                        <Group
-                                            gap="sm"
-                                            wrap="nowrap"
-                                            align="center"
+                            <Box className={classes.pickerScroll}>
+                                {sortedCandidates.map((c) => {
+                                    const agent = agentsByUuid.get(c.agentUuid);
+                                    const isRecommended =
+                                        c.agentUuid ===
+                                        phase.decision.decision
+                                            .suggestedAgentUuid;
+                                    return (
+                                        <UnstyledButton
+                                            key={c.agentUuid}
+                                            onClick={() =>
+                                                confirmPick(c.agentUuid)
+                                            }
+                                            className={`${classes.candidateButton} ${
+                                                isRecommended
+                                                    ? classes.recommended
+                                                    : ''
+                                            }`}
+                                            aria-label={`Send to ${c.name}`}
                                         >
-                                            <LightdashUserAvatar
-                                                size={32}
-                                                name={c.name}
-                                                src={agent?.imageUrl}
-                                            />
-                                            <Stack gap={2} miw={0} flex={1}>
-                                                <Group gap="xs" wrap="nowrap">
-                                                    <Text
-                                                        size="sm"
-                                                        fw={600}
-                                                        truncate="end"
+                                            <Group
+                                                gap="sm"
+                                                wrap="nowrap"
+                                                align="center"
+                                            >
+                                                <LightdashUserAvatar
+                                                    size={32}
+                                                    name={c.name}
+                                                    src={agent?.imageUrl}
+                                                />
+                                                <Stack gap={2} miw={0} flex={1}>
+                                                    <Group
+                                                        gap="xs"
+                                                        wrap="nowrap"
                                                     >
-                                                        {c.name}
-                                                    </Text>
-                                                    {isRecommended && (
-                                                        <Badge
-                                                            size="xs"
-                                                            color="violet"
-                                                            variant="light"
-                                                            radius="sm"
+                                                        <Text
+                                                            size="sm"
+                                                            fw={600}
+                                                            truncate="end"
                                                         >
-                                                            Recommended
-                                                        </Badge>
+                                                            {c.name}
+                                                        </Text>
+                                                        {isRecommended && (
+                                                            <Badge
+                                                                size="xs"
+                                                                color="violet"
+                                                                variant="light"
+                                                                radius="sm"
+                                                            >
+                                                                Recommended
+                                                            </Badge>
+                                                        )}
+                                                    </Group>
+                                                    {c.description && (
+                                                        <Text
+                                                            size="xs"
+                                                            c="dimmed"
+                                                            truncate="end"
+                                                            className={
+                                                                classes.candidateDescription
+                                                            }
+                                                        >
+                                                            {c.description}
+                                                        </Text>
                                                     )}
-                                                </Group>
-                                                {c.description && (
-                                                    <Text
-                                                        size="xs"
-                                                        c="dimmed"
-                                                        truncate="end"
-                                                        className={
-                                                            classes.candidateDescription
-                                                        }
-                                                    >
-                                                        {c.description}
-                                                    </Text>
-                                                )}
-                                            </Stack>
-                                            <MantineIcon
-                                                icon={IconChevronRight}
-                                                size={16}
-                                                className={classes.chevron}
-                                            />
-                                        </Group>
-                                    </UnstyledButton>
-                                );
-                            })}
+                                                </Stack>
+                                                <MantineIcon
+                                                    icon={IconChevronRight}
+                                                    size={16}
+                                                    className={classes.chevron}
+                                                />
+                                            </Group>
+                                        </UnstyledButton>
+                                    );
+                                })}
+                            </Box>
                         </Stack>
                     )}
                 </Stack>


### PR DESCRIPTION
### Description

When the AI Router picker surfaces many candidate agents, the list previously expanded past the viewport and got clipped by the outer `Center` with no way to scroll.

This wraps the candidates in a bounded scroll region inside `AgentsRouterPage`:

- `max-height: min(420px, 55vh)` so the list fits comfortably on most screens
- `overflow-y: auto` with `overscroll-behavior: contain` and a thin theme-aware scrollbar
- Bottom gradient mask (~10px) so the edge reads as "more below" instead of cropped
- Picker header (title + "Why these agents?" popover) stays pinned above the scroll region
- Existing stagger animations and `prefers-reduced-motion` rules continue to apply

### Test plan

- [ ] Open Ask AI with a prompt that surfaces >5 candidate agents — verify the list scrolls and the bottom fade renders in both light and dark themes
- [ ] Verify keyboard scrolling works inside the candidates region and doesn't escape to the page
- [ ] Verify with a small number of candidates (1–3) the layout is unchanged