### PR TITLE
feat(settings): add collapsible sidebar support

### DIFF
--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -19,6 +19,7 @@ import {
     PAGE_CONTENT_WIDTH,
     PAGE_HEADER_HEIGHT,
     PAGE_MIN_CONTENT_WIDTH,
+    SIDEBAR_TOGGLE_RESERVE,
 } from './constants';
 import Sidebar from './Sidebar';
 import { SidebarPosition, type SidebarWidthProps } from './types';
@@ -44,6 +45,7 @@ type StyleProps = {
     noContentPadding?: boolean;
     noSidebarPadding?: boolean;
     isSidebarResizing?: boolean;
+    reserveSidebarToggle?: boolean;
     backgroundColor?: string;
     fullPageScroll?: boolean;
 };
@@ -164,6 +166,12 @@ const usePageStyles = createStyles<string, StyleProps>((theme, params) => {
                   }
                 : {}),
 
+            ...(params.reserveSidebarToggle
+                ? {
+                      paddingLeft: `calc(${theme.spacing.lg} + ${SIDEBAR_TOGGLE_RESERVE}px)`,
+                  }
+                : {}),
+
             ...(params.withXLargePaddedContent
                 ? {
                       padding: theme.spacing.xxl,
@@ -199,6 +207,9 @@ type Props = {
     title?: string;
     sidebar?: React.ReactNode;
     isSidebarOpen?: boolean;
+    isSidebarCollapsed?: boolean;
+    isSidebarCollapsible?: boolean;
+    collapsedSidebarContent?: React.ReactNode;
     rightSidebar?: React.ReactNode;
     isRightSidebarOpen?: boolean;
     rightSidebarWidthProps?: SidebarWidthProps;
@@ -210,6 +221,9 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
     header,
     sidebar,
     isSidebarOpen = true,
+    isSidebarCollapsed = false,
+    isSidebarCollapsible = false,
+    collapsedSidebarContent,
     rightSidebar,
     isRightSidebarOpen = false,
     rightSidebarWidthProps,
@@ -269,6 +283,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
             noContentPadding,
             flexContent,
             isSidebarResizing,
+            reserveSidebarToggle: isSidebarCollapsible && isSidebarCollapsed,
             backgroundColor,
             fullPageScroll,
         },
@@ -286,6 +301,9 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
                     <Sidebar
                         noSidebarPadding={noSidebarPadding}
                         isOpen={isSidebarOpen}
+                        isCollapsed={isSidebarCollapsed}
+                        collapsible={isSidebarCollapsible}
+                        collapsedContent={collapsedSidebarContent}
                         onResizeStart={startSidebarResizing}
                         onResizeEnd={stopSidebarResizing}
                     >

--- a/packages/frontend/src/components/common/Page/Sidebar.module.css
+++ b/packages/frontend/src/components/common/Page/Sidebar.module.css
@@ -1,0 +1,89 @@
+.floatContainer {
+    --sidebar-ease-reveal: cubic-bezier(0.22, 1, 0.36, 1);
+    --sidebar-ease-conceal: cubic-bezier(0.22, 1, 0.36, 1);
+    --sidebar-reveal-duration: 340ms;
+    --sidebar-conceal-duration: 300ms;
+
+    position: relative;
+    height: calc(100% - 1px);
+    max-height: 100%;
+    flex-shrink: 0;
+    z-index: var(--mantine-z-index-popover);
+    transition: width var(--sidebar-reveal-duration) var(--sidebar-ease-reveal);
+    top: 1px;
+}
+
+.floatingPanel {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: var(--mantine-z-index-popover);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 16px;
+    padding-bottom: 0;
+    /* Default = conceal: governs hide-on-leave and the unpin slide-out. */
+    transition: transform var(--sidebar-conceal-duration)
+        var(--sidebar-ease-conceal);
+}
+
+.floatingPanel[data-collapsed='false'] {
+    transform: translateX(0);
+    border-radius: 0;
+    transition: transform var(--sidebar-reveal-duration)
+        var(--sidebar-ease-reveal);
+}
+
+/* Off-screen at rest; the extra 24px clears the shadow and floating margin. */
+.floatingPanel[data-collapsed='true'] {
+    transform: translateX(calc(-100% - 24px));
+    margin: 8px;
+    border-radius: var(--mantine-radius-md);
+    will-change: transform;
+}
+
+.floatContainer:has(.edgeTrigger:hover) .floatingPanel[data-collapsed='true'],
+.floatContainer:has(.floatingPanel:hover)
+    .floatingPanel[data-collapsed='true'] {
+    transform: translateX(0);
+    /* Reveal: the panel glides in and decelerates into place. */
+    transition: transform var(--sidebar-reveal-duration)
+        var(--sidebar-ease-reveal);
+}
+
+/* Invisible full-height hover zone along the page's left edge — approaching it
+   reveals the sidebar. Its width matches the collapsed panel's 8px inset so the
+   zone meets the panel with no dead gap that would drop the hover mid-transit. */
+.edgeTrigger {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 8px;
+    z-index: 1;
+}
+
+.floatingPanelInner {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+/* Sits below the panel so the revealed panel covers it cleanly instead of
+   doubling up with the panel's own header controls. */
+.trigger {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .floatContainer,
+    .floatingPanel {
+        transition: none !important;
+    }
+}

--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -12,14 +12,19 @@ import useSidebarResize from '../../../hooks/useSidebarResize';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import {
+    SIDEBAR_ANIMATION_DURATION,
     SIDEBAR_DEFAULT_WIDTH,
     SIDEBAR_MIN_WIDTH,
     SIDEBAR_RESIZE_HANDLE_WIDTH,
 } from './constants';
+import classes from './Sidebar.module.css';
 import { SidebarPosition, type SidebarWidthProps } from './types';
 
 type Props = {
     isOpen?: boolean;
+    isCollapsed?: boolean;
+    collapsible?: boolean;
+    collapsedContent?: React.ReactNode;
     containerProps?: FlexProps;
     position?: SidebarPosition;
     widthProps?: SidebarWidthProps;
@@ -29,8 +34,53 @@ type Props = {
     onResizeEnd?: () => void;
 };
 
+const ResizeHandle: FC<{
+    position: SidebarPosition;
+    isResizing: boolean;
+    onMouseDown: (event: React.MouseEvent) => void;
+}> = ({ position, isResizing, onMouseDown }) => (
+    <Box
+        h="100%"
+        w={SIDEBAR_RESIZE_HANDLE_WIDTH}
+        pos="absolute"
+        top={0}
+        {...(position === SidebarPosition.LEFT
+            ? { right: -SIDEBAR_RESIZE_HANDLE_WIDTH }
+            : { left: -SIDEBAR_RESIZE_HANDLE_WIDTH })}
+        onMouseDown={onMouseDown}
+        sx={(theme) => ({
+            cursor: 'col-resize',
+            zIndex: getDefaultZIndex('app') + 1,
+            ...(isResizing
+                ? {
+                      background: theme.fn.linearGradient(
+                          90,
+                          theme.colorScheme === 'dark'
+                              ? theme.colors.blue[5]
+                              : theme.colors.blue[3],
+                          'transparent',
+                      ),
+                  }
+                : {
+                      ...theme.fn.hover({
+                          background: theme.fn.linearGradient(
+                              90,
+                              theme.colorScheme === 'dark'
+                                  ? theme.colors.blue[7]
+                                  : theme.colors.blue[1],
+                              'transparent',
+                          ),
+                      }),
+                  }),
+        })}
+    />
+);
+
 const Sidebar: FC<React.PropsWithChildren<Props>> = ({
     isOpen = true,
+    isCollapsed = false,
+    collapsible = false,
+    collapsedContent,
     containerProps,
     position = SidebarPosition.LEFT,
     widthProps = {},
@@ -54,6 +104,57 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
             onResizeEnd,
         });
 
+    // Collapsible sidebars drop out of the page flow when collapsed and
+    // reveal as a floating overlay when the edge trigger (or panel) is hovered.
+    if (collapsible) {
+        return (
+            <TrackSection name={SectionName.SIDEBAR}>
+                <Flex
+                    ref={sidebarRef}
+                    direction="column"
+                    className={classes.floatContainer}
+                    style={{ width: isCollapsed ? 0 : sidebarWidth }}
+                    {...containerProps}
+                >
+                    <Paper
+                        shadow="lg"
+                        radius={0}
+                        className={classes.floatingPanel}
+                        style={{ width: sidebarWidth }}
+                        data-collapsed={isCollapsed ? 'true' : 'false'}
+                        data-testid={
+                            isCollapsed
+                                ? 'common-sidebar-collapsed'
+                                : 'common-sidebar'
+                        }
+                    >
+                        <Box className={classes.floatingPanelInner}>
+                            {children}
+                        </Box>
+                    </Paper>
+
+                    {isCollapsed ? (
+                        <>
+                            <Box className={classes.edgeTrigger} />
+                            <Box className={classes.trigger}>
+                                {collapsedContent}
+                            </Box>
+                        </>
+                    ) : (
+                        <ResizeHandle
+                            position={position}
+                            isResizing={isResizing}
+                            onMouseDown={startResizing}
+                        />
+                    )}
+                </Flex>
+            </TrackSection>
+        );
+    }
+
+    const sidebarPadding = noSidebarPadding ? 0 : 16;
+    const contentWidth = sidebarWidth - sidebarPadding * 2;
+
     const transition: MantineTransition = {
         in: {
             opacity: 1,
@@ -67,8 +168,11 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                 ? { marginLeft: -sidebarWidth }
                 : { marginRight: -sidebarWidth }),
         },
-        transitionProperty: 'opacity, margin',
+        transitionProperty: isResizing
+            ? 'opacity, margin'
+            : 'opacity, margin, width',
     };
+
     return (
         <TrackSection name={SectionName.SIDEBAR}>
             <Flex
@@ -82,70 +186,45 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
             >
                 <Transition
                     mounted={isOpen}
-                    duration={500}
+                    duration={SIDEBAR_ANIMATION_DURATION}
                     transition={transition}
                 >
                     {(style) => (
                         <>
                             <Paper
                                 shadow="lg"
-                                p={noSidebarPadding ? undefined : 'lg'}
-                                pb={0}
-                                w={sidebarWidth}
-                                style={style}
+                                style={{
+                                    ...style,
+                                    width: sidebarWidth,
+                                    padding: sidebarPadding,
+                                    paddingBottom: 0,
+                                }}
                                 radius={0}
                                 sx={{
                                     display: 'flex',
                                     flexGrow: 1,
                                     flexDirection: 'column',
-                                    overflowY: 'auto',
+                                    overflow: 'hidden',
                                 }}
                                 data-testid="common-sidebar"
                             >
-                                {children}
+                                <Box
+                                    sx={{
+                                        flexGrow: 1,
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        width: contentWidth,
+                                        minHeight: 0,
+                                    }}
+                                >
+                                    {children}
+                                </Box>
                             </Paper>
 
-                            <Box
-                                h="100%"
-                                w={SIDEBAR_RESIZE_HANDLE_WIDTH}
-                                pos="absolute"
-                                top={0}
-                                {...(position === SidebarPosition.LEFT
-                                    ? { right: -SIDEBAR_RESIZE_HANDLE_WIDTH }
-                                    : { left: -SIDEBAR_RESIZE_HANDLE_WIDTH })}
+                            <ResizeHandle
+                                position={position}
+                                isResizing={isResizing}
                                 onMouseDown={startResizing}
-                                sx={(theme) => ({
-                                    cursor: 'col-resize',
-                                    zIndex: getDefaultZIndex('app') + 1,
-                                    ...(isResizing
-                                        ? {
-                                              background:
-                                                  theme.fn.linearGradient(
-                                                      90,
-                                                      theme.colorScheme ===
-                                                          'dark'
-                                                          ? theme.colors.blue[5]
-                                                          : theme.colors
-                                                                .blue[3],
-                                                      'transparent',
-                                                  ),
-                                          }
-                                        : {
-                                              ...theme.fn.hover({
-                                                  background:
-                                                      theme.fn.linearGradient(
-                                                          90,
-                                                          theme.colorScheme ===
-                                                              'dark'
-                                                              ? theme.colors
-                                                                    .blue[7]
-                                                              : theme.colors
-                                                                    .blue[1],
-                                                          'transparent',
-                                                      ),
-                                              }),
-                                          }),
-                                })}
                             />
                         </>
                     )}

--- a/packages/frontend/src/components/common/Page/constants.ts
+++ b/packages/frontend/src/components/common/Page/constants.ts
@@ -16,3 +16,9 @@ export const SIDEBAR_DEFAULT_WIDTH = 400;
 export const SIDEBAR_MIN_WIDTH = 320;
 
 export const SIDEBAR_RESIZE_HANDLE_WIDTH = 6;
+
+// Left gutter reserved on full-width content so the floating collapse toggle
+// (rendered at the top-left when the sidebar is collapsed) clears the page title.
+export const SIDEBAR_TOGGLE_RESERVE = 48;
+
+export const SIDEBAR_ANIMATION_DURATION = 150;

--- a/packages/frontend/src/pages/Settings.module.css
+++ b/packages/frontend/src/pages/Settings.module.css
@@ -1,4 +1,16 @@
 .sidebarStack {
     flex-grow: 1;
     overflow: hidden;
+    min-height: 0;
+}
+
+.sidebarHeader {
+    flex-wrap: nowrap;
+    gap: var(--mantine-spacing-xs);
+    flex-shrink: 0;
+}
+
+.sidebarScroll {
+    flex: 1 1 auto;
+    min-height: 0;
 }

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,6 +1,16 @@
 import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
-import { Anchor, Box, ScrollArea, Stack, Text, Title } from '@mantine-8/core';
+import {
+    Anchor,
+    ActionIcon,
+    Box,
+    Group,
+    ScrollArea,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+} from '@mantine-8/core';
 import {
     IconApps,
     IconAppWindow,
@@ -21,6 +31,8 @@ import {
     IconHistory,
     IconIdBadge2,
     IconKey,
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
     IconListCheck,
     IconLock,
     IconMessageCircle,
@@ -41,7 +53,7 @@ import {
     IconVariable,
     IconWorldCheck,
 } from '@tabler/icons-react';
-import { useMemo, type FC } from 'react';
+import { useState, useMemo, type FC } from 'react';
 import {
     matchPath,
     Navigate,
@@ -182,6 +194,8 @@ const Settings: FC = () => {
     );
     const isSsoOrganizationSettingsEnabled =
         ssoOrganizationSettingsFlag?.enabled ?? false;
+
+    const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
     const { track } = useTracking();
     const {
@@ -814,15 +828,69 @@ const Settings: FC = () => {
             withFixedContent={isFixedContent}
             withPaddedContent
             title="Settings"
+            isSidebarCollapsed={isSidebarCollapsed}
+            isSidebarCollapsible
+            collapsedSidebarContent={
+                <Tooltip label="Pin sidebar" position="right" variant="xs">
+                    <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        size="lg"
+                        onClick={() => setIsSidebarCollapsed(false)}
+                        aria-label="Pin sidebar"
+                    >
+                        <MantineIcon icon={IconLayoutSidebarLeftExpand} />
+                    </ActionIcon>
+                </Tooltip>
+            }
             sidebar={
                 <Stack className={classes.sidebarStack}>
-                    <PageBreadcrumbs
-                        items={[{ title: 'Settings', active: true }]}
-                    />
+                    <Group
+                        justify="space-between"
+                        align="center"
+                        className={classes.sidebarHeader}
+                    >
+                        <PageBreadcrumbs
+                            items={[{ title: 'Settings', active: true }]}
+                        />
+                        <Tooltip
+                            label={
+                                isSidebarCollapsed
+                                    ? 'Pin sidebar'
+                                    : 'Unpin sidebar'
+                            }
+                            variant="xs"
+                        >
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                size="lg"
+                                onClick={() =>
+                                    setIsSidebarCollapsed(
+                                        (collapsed) => !collapsed,
+                                    )
+                                }
+                                aria-label={
+                                    isSidebarCollapsed
+                                        ? 'Pin sidebar'
+                                        : 'Unpin sidebar'
+                                }
+                            >
+                                <MantineIcon
+                                    icon={
+                                        isSidebarCollapsed
+                                            ? IconLayoutSidebarLeftExpand
+                                            : IconLayoutSidebarLeftCollapse
+                                    }
+                                />
+                            </ActionIcon>
+                        </Tooltip>
+                    </Group>
                     <ScrollArea
                         variant="primary"
                         offsetScrollbars
                         scrollbarSize={8}
+                        className={classes.sidebarScroll}
                     >
                         <Stack gap="lg">
                             <Box>


### PR DESCRIPTION
### Description

Adds a collapsible sidebar to Settings.

- Pin / unpin the sidebar from the header toggle (or the floating toggle shown when it's unpinned).
- When unpinned, the sidebar drops out of the page flow so content uses the full width.
- Approaching the left edge of the window (or hovering the panel) reveals it as a floating overlay that slides in, and slides away when you move off.
- On full-width pages, a small left gutter is reserved so the toggle never overlaps the page title.
- Motion respects `prefers-reduced-motion`.

Scoped to Settings for now; other sidebars are unchanged.
