### PR TITLE
feat(ai-agents): project + root-cause filters and shared FilterFacet

### DIFF
--- a/packages/frontend/src/components/common/FilterFacet/FilterFacet.module.css
+++ b/packages/frontend/src/components/common/FilterFacet/FilterFacet.module.css
@@ -1,0 +1,38 @@
+.filterButton {
+    border: 1px dashed var(--mantine-color-ldGray-3);
+    background-color: transparent;
+    text-overflow: ellipsis;
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.filterButton:hover {
+    background-color: var(--mantine-color-ldGray-0);
+    transition: background-color var(--mantine-other-transitionDuration)
+        var(--mantine-other-transitionTimingFunction);
+}
+
+.filterButtonSelected {
+    border: 1px solid var(--mantine-color-indigo-2);
+    background-color: var(--mantine-color-indigo-0);
+    text-overflow: ellipsis;
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.filterButtonSelected:hover {
+    background-color: var(--mantine-color-ldGray-0);
+    transition: background-color var(--mantine-other-transitionDuration)
+        var(--mantine-other-transitionTimingFunction);
+}
+
+.option {
+    display: block;
+    width: 100%;
+    border-radius: 4px;
+}
+
+.option:hover {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-dark-6)
+    );
+}

--- a/packages/frontend/src/components/common/FilterFacet/FilterFacet.tsx
+++ b/packages/frontend/src/components/common/FilterFacet/FilterFacet.tsx
@@ -1,0 +1,185 @@
+import {
+    Badge,
+    Button,
+    Checkbox,
+    Group,
+    Popover,
+    ScrollArea,
+    Stack,
+    Text,
+    Tooltip,
+    UnstyledButton,
+} from '@mantine-8/core';
+import { IconChevronDown } from '@tabler/icons-react';
+import { type Icon as TablerIcon } from '@tabler/icons-react';
+import MantineIcon from '../MantineIcon';
+import classes from './FilterFacet.module.css';
+
+export type FilterFacetOption = {
+    value: string;
+    label: string;
+    count?: number;
+};
+
+export type FilterFacetProps = {
+    label: string;
+    options: FilterFacetOption[];
+    selected: string[];
+    onChange: (selected: string[]) => void;
+    icon?: TablerIcon;
+    emptyLabel?: string;
+    tooltipLabel?: string;
+    loading?: boolean;
+    maxDropdownHeight?: number;
+};
+
+const FilterFacet = ({
+    label,
+    options,
+    selected,
+    onChange,
+    icon,
+    emptyLabel = 'No options',
+    tooltipLabel,
+    loading,
+    maxDropdownHeight = 280,
+}: FilterFacetProps) => {
+    const selectedSet = new Set(selected);
+    const visibleOptions = options.filter(
+        (option) =>
+            option.count === undefined ||
+            option.count > 0 ||
+            selectedSet.has(option.value),
+    );
+
+    const toggle = (value: string) => {
+        if (selectedSet.has(value)) {
+            onChange(selected.filter((v) => v !== value));
+        } else {
+            onChange([...selected, value]);
+        }
+    };
+
+    const hasSelection = selected.length > 0;
+
+    const trigger = (
+        <Button
+            variant="default"
+            size="xs"
+            radius="md"
+            loading={loading}
+            className={
+                hasSelection
+                    ? classes.filterButtonSelected
+                    : classes.filterButton
+            }
+            leftSection={
+                icon ? (
+                    <MantineIcon
+                        icon={icon}
+                        size="md"
+                        color={hasSelection ? 'indigo.5' : 'ldGray.5'}
+                    />
+                ) : undefined
+            }
+            rightSection={
+                <MantineIcon
+                    icon={IconChevronDown}
+                    size="sm"
+                    color={hasSelection ? 'indigo.5' : 'ldGray.5'}
+                />
+            }
+        >
+            <Group gap={6} wrap="nowrap">
+                <Text
+                    fz="xs"
+                    fw={500}
+                    c={hasSelection ? 'indigo.7' : 'ldGray.7'}
+                >
+                    {label}
+                </Text>
+                {hasSelection && (
+                    <Badge size="xs" radius="xl" variant="light" color="indigo">
+                        {selected.length}
+                    </Badge>
+                )}
+            </Group>
+        </Button>
+    );
+
+    return (
+        <Popover position="bottom-start" withArrow shadow="md" radius="md">
+            <Popover.Target>
+                {tooltipLabel ? (
+                    <Tooltip withinPortal variant="xs" label={tooltipLabel}>
+                        {trigger}
+                    </Tooltip>
+                ) : (
+                    trigger
+                )}
+            </Popover.Target>
+            <Popover.Dropdown p={4} miw={220}>
+                {visibleOptions.length === 0 ? (
+                    <Text fz="xs" c="ldGray.6" p="xs">
+                        {emptyLabel}
+                    </Text>
+                ) : (
+                    <ScrollArea.Autosize
+                        mah={maxDropdownHeight}
+                        type="auto"
+                        scrollbars="y"
+                    >
+                        <Stack gap={0}>
+                            {visibleOptions.map((option) => {
+                                const isChecked = selectedSet.has(option.value);
+                                return (
+                                    <UnstyledButton
+                                        key={option.value}
+                                        onClick={() => toggle(option.value)}
+                                        px="xs"
+                                        py={6}
+                                        className={classes.option}
+                                    >
+                                        <Group
+                                            justify="space-between"
+                                            wrap="nowrap"
+                                            gap="md"
+                                        >
+                                            <Group gap="xs" wrap="nowrap">
+                                                <Checkbox
+                                                    size="xs"
+                                                    checked={isChecked}
+                                                    readOnly
+                                                    tabIndex={-1}
+                                                />
+                                                <Text
+                                                    fz="xs"
+                                                    c="ldGray.9"
+                                                    truncate
+                                                    maw={200}
+                                                >
+                                                    {option.label}
+                                                </Text>
+                                            </Group>
+                                            {option.count !== undefined && (
+                                                <Text
+                                                    fz="xs"
+                                                    c="ldGray.6"
+                                                    fw={500}
+                                                >
+                                                    {option.count}
+                                                </Text>
+                                            )}
+                                        </Group>
+                                    </UnstyledButton>
+                                );
+                            })}
+                        </Stack>
+                    </ScrollArea.Autosize>
+                )}
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+export default FilterFacet;

--- a/packages/frontend/src/components/common/FilterFacet/index.ts
+++ b/packages/frontend/src/components/common/FilterFacet/index.ts
@@ -1,0 +1,2 @@
+export { default } from './FilterFacet';
+export type { FilterFacetOption, FilterFacetProps } from './FilterFacet';

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.module.css
@@ -36,8 +36,8 @@
 
 .categoryTokenSecondaryText {
     color: light-dark(
-        var(--mantine-color-ldGray-6),
-        var(--mantine-color-dark-2)
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-dark-1)
     );
 }
 
@@ -86,4 +86,14 @@
     display: inline-flex;
     align-items: center;
     cursor: help;
+}
+
+.threadIcon {
+    opacity: 0;
+    transition: opacity 120ms ease-out;
+}
+
+.bodyRow:hover .threadIcon,
+.threadIcon:focus-visible {
+    opacity: 1;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -10,6 +10,7 @@ import {
 import {
     ActionIcon,
     Box,
+    Button,
     Divider,
     Group,
     Paper,
@@ -25,6 +26,7 @@ import {
     IconCircleCheck,
     IconCircleDashed,
     IconClock,
+    IconFilterX,
     IconHelpCircle,
     IconInfoCircle,
     IconListCheck,
@@ -33,13 +35,16 @@ import {
     IconTag,
     IconTriangle,
 } from '@tabler/icons-react';
-import { useDeferredValue, useMemo, useState } from 'react';
+import { useCallback, useDeferredValue, useMemo, useState } from 'react';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import {
     ContentTable,
     useContentTable,
     type MRT_ColumnDef,
 } from '../../../../../components/common/ContentTable';
+import FilterFacet, {
+    type FilterFacetOption,
+} from '../../../../../components/common/FilterFacet';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useProjects } from '../../../../../hooks/useProjects';
 import {
@@ -278,7 +283,7 @@ const CategoryToken = ({
     >
         <Text
             fz="xs"
-            fw={secondary ? 450 : 500}
+            fw={500}
             className={
                 secondary
                     ? styles.categoryTokenSecondaryText
@@ -337,7 +342,7 @@ const SuggestedStep = ({ children }: { children: string }) => (
                 size="xs"
                 className={styles.suggestedStepArrow}
             />
-            <Text fz="xs" c="ldGray.7" lineClamp={1}>
+            <Text fz="xs" fw={600} c="ldGray.8" lineClamp={1}>
                 {children}
             </Text>
         </Group>
@@ -365,6 +370,15 @@ const AiAgentAdminReviewItemsTable = ({
     const [search, setSearch] = useState<string | undefined>(undefined);
     const [reviewSurface, setReviewSurface] =
         useState<ReviewSurface>('findings');
+    const [selectedProjectUuids, setSelectedProjectUuids] = useState<string[]>(
+        [],
+    );
+    const [selectedRootCauses, setSelectedRootCauses] = useState<
+        AiAgentRootCause[]
+    >([]);
+    const [selectedSignals, setSelectedSignals] = useState<AiAgentTurnSignal[]>(
+        [],
+    );
     const deferredSearch = useDeferredValue(search);
 
     const { data: reviewItems = [], isLoading } = useAiAgentAdminReviewItems({
@@ -389,11 +403,11 @@ const AiAgentAdminReviewItemsTable = ({
         );
     }, [projects]);
 
-    const filteredReviewItems = useMemo(() => {
-        if (!deferredSearch) return reviewItems;
-
-        const searchLower = deferredSearch.toLowerCase();
-        return reviewItems.filter((reviewItem) => {
+    const matchesReviewItemSearch = useCallback(
+        (
+            reviewItem: AiAgentReviewItemSummary,
+            searchLower: string,
+        ): boolean => {
             const agentUuid =
                 reviewItem.latestFinding?.agentUuid ?? reviewItem.agentUuid;
             const projectUuid =
@@ -416,14 +430,12 @@ const AiAgentAdminReviewItemsTable = ({
             ]
                 .filter(Boolean)
                 .some((value) => value?.toLowerCase().includes(searchLower));
-        });
-    }, [agentsMap, deferredSearch, projectsMap, reviewItems]);
+        },
+        [agentsMap, projectsMap],
+    );
 
-    const filteredReviewSignals = useMemo(() => {
-        if (!deferredSearch) return reviewSignals;
-
-        const searchLower = deferredSearch.toLowerCase();
-        return reviewSignals.filter((signal) => {
+    const matchesSignalSearch = useCallback(
+        (signal: AiAgentReviewSignalSummary, searchLower: string): boolean => {
             const agent = agentsMap.get(signal.agentUuid);
             const project = projectsMap.get(signal.projectUuid);
             return [
@@ -439,8 +451,289 @@ const AiAgentAdminReviewItemsTable = ({
             ]
                 .filter(Boolean)
                 .some((value) => value?.toLowerCase().includes(searchLower));
+        },
+        [agentsMap, projectsMap],
+    );
+
+    const getReviewItemProjectUuid = (
+        reviewItem: AiAgentReviewItemSummary,
+    ): string | null =>
+        reviewItem.latestFinding?.projectUuid ?? reviewItem.projectUuid ?? null;
+
+    const searchFilteredReviewItems = useMemo(() => {
+        if (!deferredSearch) return reviewItems;
+        const searchLower = deferredSearch.toLowerCase();
+        return reviewItems.filter((item) =>
+            matchesReviewItemSearch(item, searchLower),
+        );
+    }, [deferredSearch, matchesReviewItemSearch, reviewItems]);
+
+    const searchFilteredReviewSignals = useMemo(() => {
+        if (!deferredSearch) return reviewSignals;
+        const searchLower = deferredSearch.toLowerCase();
+        return reviewSignals.filter((signal) =>
+            matchesSignalSearch(signal, searchLower),
+        );
+    }, [deferredSearch, matchesSignalSearch, reviewSignals]);
+
+    const projectFilteredReviewItems = useMemo(() => {
+        if (selectedProjectUuids.length === 0) {
+            return searchFilteredReviewItems;
+        }
+        const projectSet = new Set(selectedProjectUuids);
+        return searchFilteredReviewItems.filter((item) => {
+            const projectUuid = getReviewItemProjectUuid(item);
+            return projectUuid !== null && projectSet.has(projectUuid);
         });
-    }, [agentsMap, deferredSearch, projectsMap, reviewSignals]);
+    }, [searchFilteredReviewItems, selectedProjectUuids]);
+
+    const projectFilteredReviewSignals = useMemo(() => {
+        if (selectedProjectUuids.length === 0) {
+            return searchFilteredReviewSignals;
+        }
+        const projectSet = new Set(selectedProjectUuids);
+        return searchFilteredReviewSignals.filter((signal) =>
+            projectSet.has(signal.projectUuid),
+        );
+    }, [searchFilteredReviewSignals, selectedProjectUuids]);
+
+    const filteredReviewItems = useMemo(() => {
+        if (selectedRootCauses.length === 0) {
+            return projectFilteredReviewItems;
+        }
+        const rootCauseSet = new Set(selectedRootCauses);
+        return projectFilteredReviewItems.filter((item) =>
+            rootCauseSet.has(item.primaryRootCause),
+        );
+    }, [projectFilteredReviewItems, selectedRootCauses]);
+
+    const filteredReviewSignals = useMemo(() => {
+        if (selectedSignals.length === 0) {
+            return projectFilteredReviewSignals;
+        }
+        const signalSet = new Set(selectedSignals);
+        return projectFilteredReviewSignals.filter((signal) =>
+            signalSet.has(signal.signal),
+        );
+    }, [projectFilteredReviewSignals, selectedSignals]);
+
+    const projectFacetOptions = useMemo((): FilterFacetOption[] => {
+        const counts = new Map<string, number>();
+        const source =
+            reviewSurface === 'findings'
+                ? searchFilteredReviewItems
+                      .filter((item) => {
+                          if (selectedRootCauses.length === 0) return true;
+                          return selectedRootCauses.includes(
+                              item.primaryRootCause,
+                          );
+                      })
+                      .map(getReviewItemProjectUuid)
+                : searchFilteredReviewSignals
+                      .filter((signal) => {
+                          if (selectedSignals.length === 0) return true;
+                          return selectedSignals.includes(signal.signal);
+                      })
+                      .map((signal) => signal.projectUuid);
+
+        for (const projectUuid of source) {
+            if (!projectUuid) continue;
+            counts.set(projectUuid, (counts.get(projectUuid) ?? 0) + 1);
+        }
+
+        return Array.from(counts.entries())
+            .map(([projectUuid, count]) => ({
+                value: projectUuid,
+                label: projectsMap.get(projectUuid)?.name ?? 'Unknown project',
+                count,
+            }))
+            .sort(
+                (a, b) => b.count - a.count || a.label.localeCompare(b.label),
+            );
+    }, [
+        projectsMap,
+        reviewSurface,
+        searchFilteredReviewItems,
+        searchFilteredReviewSignals,
+        selectedRootCauses,
+        selectedSignals,
+    ]);
+
+    const rootCauseFacetOptions = useMemo((): FilterFacetOption[] => {
+        const counts = new Map<AiAgentRootCause, number>();
+        for (const item of projectFilteredReviewItems) {
+            counts.set(
+                item.primaryRootCause,
+                (counts.get(item.primaryRootCause) ?? 0) + 1,
+            );
+        }
+        return (Object.keys(rootCauseLabels) as AiAgentRootCause[])
+            .map((rootCause) => ({
+                value: rootCause,
+                label: rootCauseLabels[rootCause],
+                count: counts.get(rootCause) ?? 0,
+            }))
+            .sort(
+                (a, b) => b.count - a.count || a.label.localeCompare(b.label),
+            );
+    }, [projectFilteredReviewItems]);
+
+    const signalFacetOptions = useMemo((): FilterFacetOption[] => {
+        const counts = new Map<AiAgentTurnSignal, number>();
+        for (const signal of projectFilteredReviewSignals) {
+            counts.set(signal.signal, (counts.get(signal.signal) ?? 0) + 1);
+        }
+        return (Object.keys(signalLabels) as AiAgentTurnSignal[])
+            .map((turnSignal) => ({
+                value: turnSignal,
+                label: signalLabels[turnSignal],
+                count: counts.get(turnSignal) ?? 0,
+            }))
+            .sort(
+                (a, b) => b.count - a.count || a.label.localeCompare(b.label),
+            );
+    }, [projectFilteredReviewSignals]);
+
+    const hasActiveFilters =
+        selectedProjectUuids.length > 0 ||
+        selectedRootCauses.length > 0 ||
+        selectedSignals.length > 0;
+
+    const clearAllFilters = useCallback(() => {
+        setSelectedProjectUuids([]);
+        setSelectedRootCauses([]);
+        setSelectedSignals([]);
+    }, []);
+
+    const renderReviewsToolbar = ({
+        visibleCount,
+        totalCount,
+        noun,
+        isLoading: toolbarLoading,
+        surface,
+    }: {
+        visibleCount: number;
+        totalCount: number;
+        noun: 'item' | 'signal';
+        isLoading: boolean;
+        surface: ReviewSurface;
+    }) => {
+        const pluralised = visibleCount === 1 ? noun : `${noun}s`;
+        const countLabel = toolbarLoading
+            ? 'Loading...'
+            : hasActiveFilters && visibleCount !== totalCount
+              ? `${visibleCount} of ${totalCount} ${pluralised}`
+              : `${visibleCount} ${pluralised}`;
+
+        return (
+            <Box>
+                <Group
+                    p={`${theme.spacing.lg} ${theme.spacing.xl}`}
+                    justify="space-between"
+                >
+                    <Group gap="xs" wrap="wrap">
+                        <SearchFilter
+                            search={search}
+                            setSearch={setSearch}
+                            placeholder="Search reviews"
+                        />
+
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{
+                                alignSelf: 'center',
+                            }}
+                        />
+                        <SegmentedControl
+                            size="xs"
+                            radius="md"
+                            value={reviewSurface}
+                            onChange={(value) =>
+                                setReviewSurface(value as ReviewSurface)
+                            }
+                            data={[
+                                { value: 'findings', label: 'Findings' },
+                                { value: 'signals', label: 'Signals' },
+                            ]}
+                        />
+                        <ReviewConceptHelp />
+
+                        <FilterFacet
+                            label="Project"
+                            icon={IconBox}
+                            options={projectFacetOptions}
+                            selected={selectedProjectUuids}
+                            onChange={setSelectedProjectUuids}
+                            emptyLabel="No projects in current view"
+                            tooltipLabel="Filter by project"
+                        />
+                        {surface === 'findings' ? (
+                            <FilterFacet
+                                label="Root cause"
+                                icon={IconTag}
+                                options={rootCauseFacetOptions}
+                                selected={selectedRootCauses}
+                                onChange={(values) =>
+                                    setSelectedRootCauses(
+                                        values as AiAgentRootCause[],
+                                    )
+                                }
+                                emptyLabel="No root causes in current view"
+                                tooltipLabel="Filter by root cause"
+                            />
+                        ) : (
+                            <FilterFacet
+                                label="Signal"
+                                icon={IconTag}
+                                options={signalFacetOptions}
+                                selected={selectedSignals}
+                                onChange={(values) =>
+                                    setSelectedSignals(
+                                        values as AiAgentTurnSignal[],
+                                    )
+                                }
+                                emptyLabel="No signals in current view"
+                                tooltipLabel="Filter by signal type"
+                            />
+                        )}
+                        {hasActiveFilters && (
+                            <Button
+                                variant="subtle"
+                                color="gray"
+                                size="xs"
+                                radius="md"
+                                leftSection={
+                                    <MantineIcon icon={IconFilterX} size="xs" />
+                                }
+                                onClick={clearAllFilters}
+                            >
+                                Clear filters
+                            </Button>
+                        )}
+                    </Group>
+
+                    <Box
+                        bg="ldGray.1"
+                        c="ldGray.9"
+                        style={{
+                            borderRadius: 6,
+                            padding: `${theme.spacing.sm} ${theme.spacing.xs}`,
+                            height: 32,
+                            display: 'flex',
+                            alignItems: 'center',
+                        }}
+                    >
+                        <Text fz="sm" fw={500}>
+                            {countLabel}
+                        </Text>
+                    </Box>
+                </Group>
+                <Divider color="ldGray.2" />
+            </Box>
+        );
+    };
 
     const columns: MRT_ColumnDef<AiAgentReviewItemSummary>[] = useMemo(
         () => [
@@ -514,7 +807,7 @@ const AiAgentAdminReviewItemsTable = ({
                 accessorKey: 'agentUuid',
                 header: 'Agent',
                 enableSorting: false,
-                size: 180,
+                size: 140,
                 Header: ({ column }) => (
                     <Group gap="two">
                         <MantineIcon icon={IconRobotFace} color="ldGray.6" />
@@ -582,49 +875,50 @@ const AiAgentAdminReviewItemsTable = ({
                 accessorKey: 'lastSeenAt',
                 header: 'Last seen',
                 enableSorting: true,
-                size: 110,
+                size: 120,
                 Header: ({ column }) => (
                     <Group gap="two">
                         <MantineIcon icon={IconClock} color="ldGray.6" />
                         {column.columnDef.header}
                     </Group>
                 ),
-                Cell: ({ row }) => (
-                    <Text fz="xs" c="ldGray.7" fw={500}>
-                        {formatLastSeenDate(row.original.lastSeenAt)}
-                    </Text>
-                ),
-            },
-            {
-                id: 'threadPreview',
-                header: '',
-                enableSorting: false,
-                size: 56,
                 Cell: ({ row }) => {
                     const reviewItem = row.original;
                     const latestFinding = reviewItem.latestFinding;
-
-                    if (!latestFinding) return null;
-
                     return (
-                        <Tooltip label="Open AI thread preview" withArrow>
-                            <ActionIcon
-                                variant="subtle"
-                                color="gray"
-                                aria-label="Open AI thread preview"
-                                onClick={(event) => {
-                                    event.stopPropagation();
-                                    onReviewItemSelect?.({
-                                        projectUuid: latestFinding.projectUuid,
-                                        agentUuid: latestFinding.agentUuid,
-                                        threadUuid: latestFinding.threadUuid,
-                                        reviewItemUuid: reviewItem.uuid,
-                                    });
-                                }}
-                            >
-                                <MantineIcon icon={IconMessages} />
-                            </ActionIcon>
-                        </Tooltip>
+                        <Group gap="xs" wrap="nowrap" justify="space-between">
+                            <Text fz="xs" c="ldGray.7" fw={500}>
+                                {formatLastSeenDate(reviewItem.lastSeenAt)}
+                            </Text>
+                            {latestFinding && (
+                                <Tooltip
+                                    label="Open AI thread preview"
+                                    withArrow
+                                >
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="gray"
+                                        size="sm"
+                                        aria-label="Open AI thread preview"
+                                        className={styles.threadIcon}
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+                                            onReviewItemSelect?.({
+                                                projectUuid:
+                                                    latestFinding.projectUuid,
+                                                agentUuid:
+                                                    latestFinding.agentUuid,
+                                                threadUuid:
+                                                    latestFinding.threadUuid,
+                                                reviewItemUuid: reviewItem.uuid,
+                                            });
+                                        }}
+                                    >
+                                        <MantineIcon icon={IconMessages} />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                        </Group>
                     );
                 },
             },
@@ -737,7 +1031,7 @@ const AiAgentAdminReviewItemsTable = ({
                 accessorKey: 'agentUuid',
                 header: 'Agent',
                 enableSorting: false,
-                size: 180,
+                size: 140,
                 Header: ({ column }) => (
                     <Group gap="two">
                         <MantineIcon icon={IconRobotFace} color="ldGray.6" />
@@ -795,47 +1089,42 @@ const AiAgentAdminReviewItemsTable = ({
                 accessorKey: 'createdAt',
                 header: 'Reviewed',
                 enableSorting: true,
-                size: 110,
+                size: 120,
                 Header: ({ column }) => (
                     <Group gap="two">
                         <MantineIcon icon={IconClock} color="ldGray.6" />
                         {column.columnDef.header}
                     </Group>
                 ),
-                Cell: ({ row }) => (
-                    <Text fz="xs" c="ldGray.7" fw={500}>
-                        {formatLastSeenDate(row.original.createdAt)}
-                    </Text>
-                ),
-            },
-            {
-                id: 'threadPreview',
-                header: '',
-                enableSorting: false,
-                size: 56,
                 Cell: ({ row }) => {
                     const signal = row.original;
-
                     return (
-                        <Tooltip label="Open AI thread preview" withArrow>
-                            <ActionIcon
-                                variant="subtle"
-                                color="gray"
-                                aria-label="Open AI thread preview"
-                                onClick={(event) => {
-                                    event.stopPropagation();
-                                    onReviewItemSelect?.({
-                                        projectUuid: signal.projectUuid,
-                                        agentUuid: signal.agentUuid,
-                                        threadUuid: signal.threadUuid,
-                                        reviewItemUuid:
-                                            signal.finding?.reviewItemUuid,
-                                    });
-                                }}
-                            >
-                                <MantineIcon icon={IconMessages} />
-                            </ActionIcon>
-                        </Tooltip>
+                        <Group gap="xs" wrap="nowrap" justify="space-between">
+                            <Text fz="xs" c="ldGray.7" fw={500}>
+                                {formatLastSeenDate(signal.createdAt)}
+                            </Text>
+                            <Tooltip label="Open AI thread preview" withArrow>
+                                <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
+                                    size="sm"
+                                    aria-label="Open AI thread preview"
+                                    className={styles.threadIcon}
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+                                        onReviewItemSelect?.({
+                                            projectUuid: signal.projectUuid,
+                                            agentUuid: signal.agentUuid,
+                                            threadUuid: signal.threadUuid,
+                                            reviewItemUuid:
+                                                signal.finding?.reviewItemUuid,
+                                        });
+                                    }}
+                                >
+                                    <MantineIcon icon={IconMessages} />
+                                </ActionIcon>
+                            </Tooltip>
+                        </Group>
                     );
                 },
             },
@@ -897,6 +1186,7 @@ const AiAgentAdminReviewItemsTable = ({
             const isSelected = selectedReviewItemUuid === reviewItem.uuid;
 
             return {
+                className: styles.bodyRow,
                 style: {
                     backgroundColor: isSelected
                         ? theme.colors.ldGray[1]
@@ -904,67 +1194,14 @@ const AiAgentAdminReviewItemsTable = ({
                 },
             };
         },
-        renderTopToolbar: () => (
-            <Box>
-                <Group
-                    p={`${theme.spacing.lg} ${theme.spacing.xl}`}
-                    justify="space-between"
-                >
-                    <Group gap="xs">
-                        <SearchFilter
-                            search={search}
-                            setSearch={setSearch}
-                            placeholder="Search reviews"
-                        />
-
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
-                        />
-                        <SegmentedControl
-                            size="xs"
-                            radius="md"
-                            value={reviewSurface}
-                            onChange={(value) =>
-                                setReviewSurface(value as ReviewSurface)
-                            }
-                            data={[
-                                { value: 'findings', label: 'Findings' },
-                                { value: 'signals', label: 'Signals' },
-                            ]}
-                        />
-                        <ReviewConceptHelp />
-                    </Group>
-
-                    <Box
-                        bg="ldGray.1"
-                        c="ldGray.9"
-                        style={{
-                            borderRadius: 6,
-                            padding: `${theme.spacing.sm} ${theme.spacing.xs}`,
-                            height: 32,
-                            display: 'flex',
-                            alignItems: 'center',
-                        }}
-                    >
-                        <Text fz="sm" fw={500}>
-                            {isLoading
-                                ? 'Loading...'
-                                : `${filteredReviewItems.length} ${
-                                      filteredReviewItems.length === 1
-                                          ? 'item'
-                                          : 'items'
-                                  }`}
-                        </Text>
-                    </Box>
-                </Group>
-                <Divider color="ldGray.2" />
-            </Box>
-        ),
+        renderTopToolbar: () =>
+            renderReviewsToolbar({
+                visibleCount: filteredReviewItems.length,
+                totalCount: searchFilteredReviewItems.length,
+                noun: 'item',
+                isLoading,
+                surface: 'findings',
+            }),
         state: {
             showProgressBars: false,
             showSkeletons: isLoading,
@@ -1029,6 +1266,7 @@ const AiAgentAdminReviewItemsTable = ({
 
             const signal = row.original;
             return {
+                className: styles.bodyRow,
                 style: {
                     backgroundColor:
                         selectedReviewItemUuid &&
@@ -1039,67 +1277,14 @@ const AiAgentAdminReviewItemsTable = ({
                 },
             };
         },
-        renderTopToolbar: () => (
-            <Box>
-                <Group
-                    p={`${theme.spacing.lg} ${theme.spacing.xl}`}
-                    justify="space-between"
-                >
-                    <Group gap="xs">
-                        <SearchFilter
-                            search={search}
-                            setSearch={setSearch}
-                            placeholder="Search reviews"
-                        />
-
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
-                        />
-                        <SegmentedControl
-                            size="xs"
-                            radius="md"
-                            value={reviewSurface}
-                            onChange={(value) =>
-                                setReviewSurface(value as ReviewSurface)
-                            }
-                            data={[
-                                { value: 'findings', label: 'Findings' },
-                                { value: 'signals', label: 'Signals' },
-                            ]}
-                        />
-                        <ReviewConceptHelp />
-                    </Group>
-
-                    <Box
-                        bg="ldGray.1"
-                        c="ldGray.9"
-                        style={{
-                            borderRadius: 6,
-                            padding: `${theme.spacing.sm} ${theme.spacing.xs}`,
-                            height: 32,
-                            display: 'flex',
-                            alignItems: 'center',
-                        }}
-                    >
-                        <Text fz="sm" fw={500}>
-                            {isSignalsLoading
-                                ? 'Loading...'
-                                : `${filteredReviewSignals.length} ${
-                                      filteredReviewSignals.length === 1
-                                          ? 'signal'
-                                          : 'signals'
-                                  }`}
-                        </Text>
-                    </Box>
-                </Group>
-                <Divider color="ldGray.2" />
-            </Box>
-        ),
+        renderTopToolbar: () =>
+            renderReviewsToolbar({
+                visibleCount: filteredReviewSignals.length,
+                totalCount: searchFilteredReviewSignals.length,
+                noun: 'signal',
+                isLoading: isSignalsLoading,
+                surface: 'signals',
+            }),
         state: {
             showProgressBars: false,
             showSkeletons: isSignalsLoading,


### PR DESCRIPTION
## Why

Following the density polish in #23620, the admin reviews page still didn't feel like a real observability tool: no way to scope to a project, no way to filter by failure type, and the row hover was missing the "open thread" affordance everywhere else in the product uses.

Three jobs an admin needs to do on this page:
1. "Show me only X project's queue" — needs a project filter.
2. "Where are failures concentrated this week?" — needs distribution visible at a glance.
3. "Open the underlying conversation" — needs to feel like a row action, not a separate column.

This PR delivers all three.

## What changed

### New shared component: \`FilterFacet\`

\`packages/frontend/src/components/common/FilterFacet/\`. Button + popover + checkbox list with per-option counts, dashed border idle / indigo border selected (matching existing \`ProjectsFilter\` visual language), scrollable for long lists. Generic API — works with any table.

\`\`\`tsx
<FilterFacet
    label="Project"
    icon={IconBox}
    options={[{ value, label, count }, ...]}
    selected={selectedProjectUuids}
    onChange={setSelectedProjectUuids}
/>
\`\`\`

\`count\` is optional — when omitted the option just appears without a number. Counts can be cross-filtered or absolute depending on what the caller passes.

### Reviews page now has facets

Two filters in the toolbar above the table, both showing live counts:

- **Project** filter — multi-select across all projects that currently have review items / signals.
- **Root cause** filter (Findings tab) / **Signal** filter (Signals tab) — same UI, scoped to the relevant taxonomy.

Counts are **cross-filtered**: the Project facet shows counts after the root-cause / signal filter is applied, and vice versa. So you see "if I also pick Jaffle Shop, I'll have 6 items" before you click.

\`Clear filters\` button appears next to the filters when any selection is active. The header count badge updates to \`6 of 24 items\` when filtered.

### Date + thread icon merged

The thread-preview icon used to be its own narrow column with a permanent visible icon — wasting horizontal space and feeling like a separate concept from the row. Now it lives inside the \`Last seen\` / \`Reviewed\` cell, hidden by default and revealed on row hover (\`opacity 0 → 1\` over 120ms, also visible on keyboard focus). That bought back ~96px of column width per row.

Also tightened: Agent column 180 → 140, Last seen / Reviewed 110 → 120 (slightly wider to host the icon comfortably).

### Other typography nudges from review

- \`Suggested next step\` chip — bumped to \`fw=600 / ldGray.8\` so it reads as an action.
- Secondary category token (subcategory like \`domain abbreviation misinterpretation\`) — bumped from \`ldGray.6 / fw=450\` to \`ldGray.8 / fw=500\` so the supporting tag isn't visually inert.

## Regression analysis

- **No data fetching change.** Same hooks, same query keys. All filtering is client-side over already-loaded data. With ~hundreds-of-items pages this is fine; if review queues grow into thousands of rows we'd push filters server-side via the existing \`AiAgentAdminFilters\` shape (already supports \`projectUuids\`).
- **No URL persistence yet.** Filter state is local \`useState\`. Existing \`useAiAgentAdminFilters\` hook handles URL params for the Threads / Agents tabs; wiring the reviews filters into it (so the page is shareable) is a clean follow-up.
- **No behavior change for users without filters applied.** Default view is identical to pre-PR.
- **No props / API changes** to \`useAiAgentAdminReviewItems\` or \`useAiAgentAdminReviewSignals\`.
- **Accessibility:** the merged date/icon cell preserves keyboard access — the action icon stays focusable and becomes visible on \`:focus-visible\`. Tooltip remains for screen readers.
- **Visual consistency:** \`FilterFacet\` matches the dashed/indigo treatment of the existing \`ProjectsFilter\` / \`AgentsFilter\` components, so it doesn't introduce a new design language. Migrating those two to use the new shared component is a small follow-up and would surface counts there for free.

## Follow-ups (out of scope for this PR)

- Migrate \`ProjectsFilter\` / \`AgentsFilter\` in the Threads / Agents admin tabs to use the shared \`FilterFacet\` — they keep their public API, gain counts.
- Persist reviews filter state to URL via \`useAiAgentAdminFilters\` so admins can share filtered queue links.
- Server-side filtering when item counts grow past in-memory practicality.

## Test plan

- [x] Typecheck clean (\`pnpm -F frontend typecheck\`).
- [x] Visual verification at 1440×900: Findings and Signals tabs, filter open / closed states, indigo selected state, count badge, "Clear filters" button, hover-revealed thread icon.
- [ ] Verify dark mode for the new filter button and option hover state.
- [ ] Verify keyboard nav into a hidden thread icon focuses it and reveals it (focus-visible CSS).

Standalone PR — does not depend on #23618 (telemetry, still open).