### PR TITLE
feat: add option to place legend outside of chart

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4665,11 +4665,25 @@ const models: TsoaRoute.Models = {
         type: { ref: 'Partial_CompleteCartesianChartLayout_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    LegendPlacement: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['custom'] },
+                { dataType: 'enum', enums: ['outsideRight'] },
+                { dataType: 'enum', enums: ['outsideLeft'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     EchartsLegend: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                placement: { ref: 'LegendPlacement' },
                 icon: {
                     dataType: 'union',
                     subSchemas: [
@@ -8138,10 +8152,10 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'union',
             subSchemas: [
+                { dataType: 'enum', enums: ['custom'] },
                 { dataType: 'enum', enums: ['dashboard'] },
                 { dataType: 'enum', enums: ['slideshow'] },
                 { dataType: 'enum', enums: ['pdf'] },
-                { dataType: 'enum', enums: ['custom'] },
             ],
             validators: {},
         },
@@ -12295,17 +12309,6 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                tableName:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
-                                                                                                name: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 fieldType:
                                                                                                     {
                                                                                                         dataType:
@@ -12313,6 +12316,17 @@ const models: TsoaRoute.Models = {
                                                                                                         required: true,
                                                                                                     },
                                                                                                 label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                                tableName:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -12390,12 +12404,12 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -12576,17 +12590,6 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    tableName:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
-                                                                                                        },
-                                                                                                    name: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     fieldType:
                                                                                                         {
                                                                                                             dataType:
@@ -12594,6 +12597,17 @@ const models: TsoaRoute.Models = {
                                                                                                             required: true,
                                                                                                         },
                                                                                                     label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
+                                                                                                    tableName:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
+                                                                                                    name: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
@@ -12661,13 +12675,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -12754,36 +12768,17 @@ const models: TsoaRoute.Models = {
                                                                                     },
                                                                                     required: true,
                                                                                 },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
                                                                             label: {
                                                                                 dataType:
                                                                                     'string',
                                                                                 required: true,
                                                                             },
-                                                                        },
-                                                                    required: true,
-                                                                },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
+                                                                            name: {
                                                                                 dataType:
                                                                                     'string',
+                                                                                required: true,
                                                                             },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
+                                                                        },
                                                                     required: true,
                                                                 },
                                                                 fields: {
@@ -12806,31 +12801,6 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 fieldFilterType:
                                                                                     {
                                                                                         dataType:
@@ -12860,24 +12830,68 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 fieldId:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                table: {
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -13173,11 +13187,11 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -26394,7 +26408,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -26404,7 +26418,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -26414,7 +26428,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -26427,7 +26441,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -27082,7 +27096,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27092,7 +27106,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27102,7 +27116,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -27115,7 +27129,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5305,8 +5305,17 @@
             "CartesianChartLayout": {
                 "$ref": "#/components/schemas/Partial_CompleteCartesianChartLayout_"
             },
+            "LegendPlacement": {
+                "type": "string",
+                "enum": ["custom", "outsideRight", "outsideLeft"],
+                "description": "High-level legend placement preset. Set to 'outsideRight' or 'outsideLeft' to\nrender the legend beside the plot with reserved grid space. Undefined behaves\nlike 'custom' (no override of the existing legend position fields)."
+            },
             "EchartsLegend": {
                 "properties": {
+                    "placement": {
+                        "$ref": "#/components/schemas/LegendPlacement",
+                        "description": "High-level placement preset. Overrides orient/top/right/bottom/left\nwhen set to an outside value."
+                    },
                     "icon": {
                         "type": "string",
                         "enum": [
@@ -9523,7 +9532,7 @@
             },
             "DataAppTemplate": {
                 "type": "string",
-                "enum": ["dashboard", "slideshow", "pdf", "custom"]
+                "enum": ["custom", "dashboard", "slideshow", "pdf"]
             },
             "AppChartReference": {
                 "properties": {
@@ -13720,24 +13729,24 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "tableName": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "name": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
                                                                             "type": "string"
+                                                                        },
+                                                                        "tableName": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "tableName",
-                                                                        "name",
                                                                         "fieldType",
-                                                                        "label"
+                                                                        "label",
+                                                                        "tableName",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -13758,16 +13767,16 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "name",
-                                                                        "label"
+                                                                        "label",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -13845,24 +13854,24 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "name": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "label": {
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "name": {
+                                                                                        "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "tableName",
-                                                                                    "name",
                                                                                     "fieldType",
-                                                                                    "label"
+                                                                                    "label",
+                                                                                    "tableName",
+                                                                                    "name"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -13903,19 +13912,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -13963,24 +13972,20 @@
                                                                                 },
                                                                                 "type": "array"
                                                                             },
-                                                                            "name": {
+                                                                            "label": {
                                                                                 "type": "string"
                                                                             },
-                                                                            "label": {
+                                                                            "name": {
                                                                                 "type": "string"
                                                                             }
                                                                         },
                                                                         "required": [
                                                                             "baseTable",
                                                                             "joinedTables",
-                                                                            "name",
-                                                                            "label"
+                                                                            "label",
+                                                                            "name"
                                                                         ],
                                                                         "type": "object"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "fields": {
                                                                         "items": {
@@ -13989,13 +13994,6 @@
                                                                                     "type": "boolean"
                                                                                 },
                                                                                 "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "name": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldFilterType": {
@@ -14008,30 +14006,41 @@
                                                                                         "metric"
                                                                                     ]
                                                                                 },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "label": {
                                                                                     "type": "string"
                                                                                 },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
                                                                                 "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "name": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
                                                                                 "isFromJoinedTable",
                                                                                 "fieldValueType",
-                                                                                "description",
-                                                                                "name",
                                                                                 "fieldFilterType",
                                                                                 "fieldType",
-                                                                                "fieldId",
                                                                                 "label",
-                                                                                "table"
+                                                                                "fieldId",
+                                                                                "table",
+                                                                                "description",
+                                                                                "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
+                                                                    },
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -14043,8 +14052,8 @@
                                                                 },
                                                                 "required": [
                                                                     "explore",
-                                                                    "rationale",
                                                                     "fields",
+                                                                    "rationale",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14145,8 +14154,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "success",
-                                                            "error",
                                                             "rejected",
+                                                            "error",
                                                             "timeout"
                                                         ]
                                                     }
@@ -27413,22 +27422,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -27988,22 +27997,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -36766,7 +36775,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3038.0",
+        "version": "0.3042.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -1091,6 +1091,10 @@
                     "enum": ["horizontal", "vertical"],
                     "type": "string"
                 },
+                "placement": {
+                    "$ref": "#/$defs/LegendPlacement",
+                    "description": "High-level placement preset. Overrides orient/top/right/bottom/left\nwhen set to an outside value."
+                },
                 "right": {
                     "description": "Right position",
                     "type": "string"
@@ -1545,6 +1549,11 @@
             },
             "required": ["value", "matchType"],
             "type": "object"
+        },
+        "LegendPlacement": {
+            "description": "High-level legend placement preset. Set to 'outsideRight' or 'outsideLeft' to\nrender the legend beside the plot with reserved grid space. Undefined behaves\nlike 'custom' (no override of the existing legend position fields).",
+            "enum": ["custom", "outsideRight", "outsideLeft"],
+            "type": "string"
         },
         "MapChart": {
             "properties": {

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -572,6 +572,11 @@ export type Series = {
     isFilteredOut?: boolean;
 };
 
+/** High-level legend placement preset. Set to 'outsideRight' or 'outsideLeft' to
+ * render the legend beside the plot with reserved grid space. Undefined behaves
+ * like 'custom' (no override of the existing legend position fields). */
+export type LegendPlacement = 'custom' | 'outsideRight' | 'outsideLeft';
+
 export type EchartsLegend = {
     /** Show the legend */
     show?: boolean;
@@ -603,6 +608,9 @@ export type EchartsLegend = {
         | 'pin'
         | 'arrow'
         | 'none';
+    /** High-level placement preset. Overrides orient/top/right/bottom/left
+     * when set to an outside value. */
+    placement?: LegendPlacement;
 };
 
 export type EchartsGrid = {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -6,6 +6,7 @@ import {
     type CustomDimension,
     type EchartsLegend,
     type Field,
+    type LegendPlacement,
     type Series,
     type TableCalculation,
 } from '@lightdash/common';
@@ -17,9 +18,11 @@ import {
     Stack,
     Switch,
 } from '@mantine/core';
-import { lazy, Suspense, useMemo, type FC } from 'react';
+import { useDebouncedCallback } from '@mantine-8/hooks';
+import { lazy, Suspense, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useToggle } from 'react-use';
+import UnitInput from '../../../common/UnitInput';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../../common/Config';
@@ -44,6 +47,37 @@ enum Positions {
 type MarginConfigurationProps = {
     legendConfig: EchartsLegend;
     handleChange: (prop: string, newValue: string | undefined) => void;
+};
+
+type LegendAreaWidthInputProps = {
+    /** Initial value from the chart's grid config. */
+    initialValue: string;
+    /** Called with the debounced value so the chart re-renders less often. */
+    onCommit: (value: string) => void;
+};
+
+const LegendAreaWidthInput: FC<LegendAreaWidthInputProps> = ({
+    initialValue,
+    onCommit,
+}) => {
+    const [value, setValue] = useState(initialValue);
+    const debouncedOnCommit = useDebouncedCallback(onCommit, 300);
+
+    return (
+        <UnitInput
+            size="xs"
+            w={80}
+            name="legendAreaWidth"
+            units={['%', 'px']}
+            value={value}
+            defaultValue={initialValue}
+            onChange={(next) => {
+                const v = next ?? '';
+                setValue(v);
+                if (v) debouncedOnCommit(v);
+            }}
+        />
+    );
 };
 
 const PositionConfiguration: FC<MarginConfigurationProps> = ({
@@ -153,7 +187,8 @@ export const Legend: FC<Props> = ({ items }) => {
     }, [visualizationConfig, items]);
     if (!isCartesianVisualizationConfig(visualizationConfig)) return null;
 
-    const { dirtyEchartsConfig, setLegend } = visualizationConfig.chartConfig;
+    const { dirtyEchartsConfig, setLegend, setGrid } =
+        visualizationConfig.chartConfig;
 
     const legendConfig = dirtyEchartsConfig?.legend ?? {};
 
@@ -184,45 +219,119 @@ export const Legend: FC<Props> = ({ items }) => {
                     <Collapse in={legendConfig.show ?? showDefault}>
                         <Stack spacing="xs">
                             <Group spacing="xs">
-                                <Config.Label>Scroll behavior</Config.Label>
+                                <Config.Label>Placement</Config.Label>
                                 <SegmentedControl
-                                    value={
-                                        dirtyEchartsConfig?.legend?.type ??
-                                        'scroll'
-                                    }
-                                    data={[
-                                        { label: 'Scroll', value: 'scroll' },
-                                        { label: 'Wrap', value: 'plain' },
-                                    ]}
-                                    onChange={(value) =>
-                                        handleChange('type', value)
-                                    }
-                                />
-                            </Group>
-                            <Group spacing="xs">
-                                <Config.Label>Orientation</Config.Label>
-                                <SegmentedControl
-                                    name="orient"
-                                    value={legendConfig.orient ?? 'horizontal'}
+                                    name="placement"
+                                    value={legendConfig.placement ?? 'custom'}
                                     onChange={(val) =>
-                                        handleChange('orient', val)
+                                        handleChange(
+                                            'placement',
+                                            val as LegendPlacement,
+                                        )
                                     }
                                     data={[
                                         {
-                                            label: 'Horizontal',
-                                            value: 'horizontal',
+                                            label: 'Chart area',
+                                            value: 'custom',
                                         },
                                         {
-                                            label: 'Vertical',
-                                            value: 'vertical',
+                                            label: 'Outside right',
+                                            value: 'outsideRight',
+                                        },
+                                        {
+                                            label: 'Outside left',
+                                            value: 'outsideLeft',
                                         },
                                     ]}
                                 />
                             </Group>
-                            <PositionConfiguration
-                                legendConfig={legendConfig}
-                                handleChange={handleChange}
-                            />
+                            {(legendConfig.placement ?? 'custom') ===
+                                'custom' && (
+                                <>
+                                    <Group spacing="xs">
+                                        <Config.Label>
+                                            Scroll behavior
+                                        </Config.Label>
+                                        <SegmentedControl
+                                            value={
+                                                dirtyEchartsConfig?.legend
+                                                    ?.type ?? 'scroll'
+                                            }
+                                            data={[
+                                                {
+                                                    label: 'Scroll',
+                                                    value: 'scroll',
+                                                },
+                                                {
+                                                    label: 'Wrap',
+                                                    value: 'plain',
+                                                },
+                                            ]}
+                                            onChange={(value) =>
+                                                handleChange('type', value)
+                                            }
+                                        />
+                                    </Group>
+                                    <Group spacing="xs">
+                                        <Config.Label>Orientation</Config.Label>
+                                        <SegmentedControl
+                                            name="orient"
+                                            value={
+                                                legendConfig.orient ??
+                                                'horizontal'
+                                            }
+                                            onChange={(val) =>
+                                                handleChange('orient', val)
+                                            }
+                                            data={[
+                                                {
+                                                    label: 'Horizontal',
+                                                    value: 'horizontal',
+                                                },
+                                                {
+                                                    label: 'Vertical',
+                                                    value: 'vertical',
+                                                },
+                                            ]}
+                                        />
+                                    </Group>
+                                    <PositionConfiguration
+                                        legendConfig={legendConfig}
+                                        handleChange={handleChange}
+                                    />
+                                </>
+                            )}
+                            {(legendConfig.placement === 'outsideRight' ||
+                                legendConfig.placement === 'outsideLeft') && (
+                                <Group spacing="xs">
+                                    <Config.Label>
+                                        Legend area width
+                                    </Config.Label>
+                                    <LegendAreaWidthInput
+                                        key={legendConfig.placement}
+                                        initialValue={
+                                            (legendConfig.placement ===
+                                            'outsideRight'
+                                                ? dirtyEchartsConfig?.grid
+                                                      ?.right
+                                                : dirtyEchartsConfig?.grid
+                                                      ?.left) || '25%'
+                                        }
+                                        onCommit={(value) => {
+                                            const gridSide =
+                                                legendConfig.placement ===
+                                                'outsideRight'
+                                                    ? 'right'
+                                                    : 'left';
+                                            setGrid({
+                                                ...(dirtyEchartsConfig?.grid ??
+                                                    {}),
+                                                [gridSide]: value,
+                                            });
+                                        }}
+                                    />
+                                </Group>
+                            )}
                         </Stack>
                     </Collapse>
                 </Config.Section>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -10,6 +10,7 @@ import {
     type Series,
     type TableCalculation,
 } from '@lightdash/common';
+import { useDebouncedCallback } from '@mantine-8/hooks';
 import {
     Collapse,
     Group,
@@ -18,7 +19,6 @@ import {
     Stack,
     Switch,
 } from '@mantine/core';
-import { useDebouncedCallback } from '@mantine-8/hooks';
 import { lazy, Suspense, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useToggle } from 'react-use';

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -14,12 +14,14 @@ import timezonePlugin from 'dayjs/plugin/timezone';
 import utcPlugin from 'dayjs/plugin/utc';
 import { describe, expect, test, vi } from 'vitest';
 import {
+    applyLegendPlacementToGrid,
     filterSeriesWithNoData,
     getAxisDefaultMaxValue,
     getAxisDefaultMinValue,
     getCategoryDateAxisConfig,
     getMinAndMaxValues,
     getStackTotalSeries,
+    mergeLegendSettings,
     padDatasetForContinuousAxis,
     selectContinuousDateRange,
 } from './useEchartsCartesianConfig';
@@ -1290,5 +1292,187 @@ describe('getStackTotalSeries', () => {
             baseArgs.isStack100,
         );
         expect(result).toHaveLength(0);
+    });
+});
+
+describe('mergeLegendSettings', () => {
+    const series = [{ name: 'A' }, { name: 'B' }] as any;
+    const selected = { A: true, B: true };
+
+    test('returns defaults when config is undefined', () => {
+        const result = mergeLegendSettings(undefined, selected, series);
+        expect(result).toMatchObject({
+            show: true,
+            type: 'scroll',
+            orient: 'horizontal',
+            top: 0,
+            selected,
+        });
+    });
+
+    test('passes through user orient/position when placement is unset', () => {
+        const result = mergeLegendSettings(
+            { orient: 'vertical', right: '10', top: '20' },
+            selected,
+            series,
+        );
+        expect(result).toMatchObject({
+            orient: 'vertical',
+            right: '10',
+            top: '20',
+            selected,
+        });
+        expect(result).not.toHaveProperty('placement');
+    });
+
+    test('outsideRight overrides orient/position, forces scroll, and truncates labels', () => {
+        const result = mergeLegendSettings(
+            {
+                placement: 'outsideRight',
+                type: 'plain', // should be overridden to 'scroll'
+                orient: 'horizontal', // should be overridden
+                left: '50', // should be wiped
+            },
+            selected,
+            series,
+        );
+        expect(result).toMatchObject({
+            type: 'scroll',
+            orient: 'vertical',
+            right: '2%',
+            top: 'middle',
+            height: '80%',
+            textStyle: { overflow: 'truncate', width: 150 },
+            tooltip: { show: true },
+            selected,
+        });
+        expect(result.left).toBeUndefined();
+        expect(result.bottom).toBeUndefined();
+        expect(result).not.toHaveProperty('placement');
+    });
+
+    test('outsideLeft mirrors outsideRight and forces scroll', () => {
+        const result = mergeLegendSettings(
+            { placement: 'outsideLeft', type: 'plain' },
+            selected,
+            series,
+        );
+        expect(result).toMatchObject({
+            type: 'scroll',
+            orient: 'vertical',
+            left: '2%',
+            top: 'middle',
+            height: '80%',
+            textStyle: { overflow: 'truncate', width: 150 },
+            tooltip: { show: true },
+            selected,
+        });
+        expect(result.right).toBeUndefined();
+        expect(result.bottom).toBeUndefined();
+        expect(result).not.toHaveProperty('placement');
+    });
+
+    test('outside placement margins always use defaults, ignoring stale user values', () => {
+        const result = mergeLegendSettings(
+            {
+                placement: 'outsideRight',
+                // User has stale positional values from a prior Chart Area
+                // session; outside placement should ignore them and apply
+                // the canonical defaults.
+                top: '20%',
+                bottom: '5%',
+                right: '8%',
+            },
+            selected,
+            series,
+        );
+        expect(result).toMatchObject({
+            type: 'scroll',
+            orient: 'vertical',
+            top: 'middle',
+            height: '80%',
+            right: '2%',
+            selected,
+        });
+        expect(result.left).toBeUndefined();
+        expect(result.bottom).toBeUndefined();
+    });
+
+    test("placement 'custom' is treated as no override", () => {
+        const result = mergeLegendSettings(
+            { placement: 'custom', orient: 'vertical', right: '5' },
+            selected,
+            series,
+        );
+        expect(result).toMatchObject({
+            orient: 'vertical',
+            right: '5',
+            selected,
+        });
+        expect(result).not.toHaveProperty('placement');
+    });
+});
+
+describe('applyLegendPlacementToGrid', () => {
+    const baseGrid = {
+        containLabel: true,
+        left: '10px',
+        right: '10px',
+        top: '10px',
+        bottom: '10px',
+    };
+
+    test('returns the grid unchanged when legend is not shown', () => {
+        const result = applyLegendPlacementToGrid(
+            baseGrid,
+            { placement: 'outsideRight' },
+            false,
+        );
+        expect(result).toEqual(baseGrid);
+    });
+
+    test('returns the grid unchanged when placement is custom/unset', () => {
+        expect(applyLegendPlacementToGrid(baseGrid, undefined, true)).toEqual(
+            baseGrid,
+        );
+        expect(
+            applyLegendPlacementToGrid(baseGrid, { placement: 'custom' }, true),
+        ).toEqual(baseGrid);
+    });
+
+    test('reserves 25% on the right when placement is outsideRight', () => {
+        const result = applyLegendPlacementToGrid(
+            baseGrid,
+            { placement: 'outsideRight' },
+            true,
+        );
+        expect(result).toEqual({ ...baseGrid, right: '25%' });
+    });
+
+    test('reserves 25% on the left when placement is outsideLeft', () => {
+        const result = applyLegendPlacementToGrid(
+            baseGrid,
+            { placement: 'outsideLeft' },
+            true,
+        );
+        expect(result).toEqual({ ...baseGrid, left: '25%' });
+    });
+
+    test('user-set grid values override the default 25% reservation', () => {
+        const outsideRight = applyLegendPlacementToGrid(
+            baseGrid,
+            { placement: 'outsideRight' },
+            true,
+            { right: '40%' },
+        );
+        expect(outsideRight).toEqual({ ...baseGrid, right: '40%' });
+
+        const outsideLeft = applyLegendPlacementToGrid(
+            baseGrid,
+            { placement: 'outsideLeft' },
+            true,
+            { left: '15%' },
+        );
+        expect(outsideLeft).toEqual({ ...baseGrid, left: '15%' });
     });
 });

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -57,6 +57,7 @@ import {
     type CartesianChart,
     type CustomDimension,
     type EChartsSeries,
+    type EchartsLegend,
     type Field,
     type Item,
     type ItemsMap,
@@ -356,22 +357,28 @@ const convertPivotValuesColumnsIntoMap = (
     );
 };
 
-const removeEmptyProperties = <T = Record<any, any>>(obj: T | undefined) => {
+const removeEmptyProperties = <
+    T extends Record<string, any> = Record<any, any>,
+>(
+    obj: T | undefined,
+): Partial<T> | undefined => {
     if (!obj) return undefined;
-    return Object.entries(obj).reduce(
+    return Object.entries(obj).reduce<Partial<T>>(
         (sum, [key, value]) =>
             value !== undefined && value !== ''
-                ? { ...sum, [key]: value }
+                ? { ...sum, [key as keyof T]: value }
                 : sum,
         {},
     );
 };
 
-const mergeLegendSettings = <T = Record<any, any>>(
+export const mergeLegendSettings = <
+    T extends Record<string, any> = Record<any, any>,
+>(
     legendConfig: T | undefined,
     legendsSelected: LegendValues,
     series: EChartsSeries[],
-) => {
+): Record<string, unknown> => {
     const normalizedConfig = removeEmptyProperties(legendConfig);
     if (!normalizedConfig) {
         return {
@@ -382,15 +389,88 @@ const mergeLegendSettings = <T = Record<any, any>>(
             selected: legendsSelected,
         };
     }
+
+    const { placement, ...rest } = normalizedConfig;
+
+    // Truncate long series labels so they don't bleed into the plot area
+    // when the legend column is narrower than the label width. Hover shows
+    // the full label via the legend's built-in tooltip.
+    const outsideLegendOverflow = {
+        textStyle: {
+            overflow: 'truncate',
+            width: 150,
+        },
+        tooltip: { show: true },
+    };
+
+    if (placement === 'outsideRight') {
+        return {
+            ...rest,
+            // Force scroll: 'plain' wraps items into a grid that overruns the
+            // reserved grid.right margin when there are many series or long labels.
+            type: 'scroll',
+            orient: 'vertical',
+            // Center vertically: top 'middle' aligns the legend's centre with
+            // the canvas middle; height caps the bounding box so scroll
+            // pagination still works for legends with many series.
+            top: 'middle',
+            height: '80%',
+            right: '2%',
+            left: undefined,
+            bottom: undefined,
+            ...outsideLegendOverflow,
+            selected: legendsSelected,
+        };
+    }
+
+    if (placement === 'outsideLeft') {
+        return {
+            ...rest,
+            type: 'scroll',
+            orient: 'vertical',
+            top: 'middle',
+            height: '80%',
+            left: '2%',
+            right: undefined,
+            bottom: undefined,
+            ...outsideLegendOverflow,
+            selected: legendsSelected,
+        };
+    }
+
     return {
         orient: 'horizontal',
         // After echarts v6, the new default legend is positioned at bottom. We need to keep old behavior in placeholders
         // so we only define top 0 if there is no 'bottom' configuration.
-        // spreading `normalizedConfig` will overwrite top value if needed
-        top: 'bottom' in normalizedConfig ? undefined : 0,
-        ...normalizedConfig,
+        // spreading `rest` will overwrite top value if needed
+        top: 'bottom' in rest ? undefined : 0,
+        ...rest,
         selected: legendsSelected,
     };
+};
+
+type GridLike = {
+    containLabel: boolean;
+    left: string;
+    right: string;
+    top: string;
+    bottom: string;
+};
+
+export const applyLegendPlacementToGrid = (
+    grid: GridLike,
+    legendConfig: Pick<EchartsLegend, 'placement'> | undefined,
+    isLegendShown: boolean,
+    userGrid?: { left?: string; right?: string },
+): GridLike => {
+    if (!isLegendShown) return grid;
+    if (legendConfig?.placement === 'outsideRight') {
+        return { ...grid, right: userGrid?.right ?? '25%' };
+    }
+    if (legendConfig?.placement === 'outsideLeft') {
+        return { ...grid, left: userGrid?.left ?? '25%' };
+    }
+    return grid;
 };
 
 const minDate = (a: number | string, b: string) => {
@@ -3327,6 +3407,15 @@ const useEchartsCartesianConfig = (
         if (isLegendShown && !hasExplicitTop && isPxValue(grid.top)) {
             grid.top = addPx(grid.top, legendTopSpacing);
         }
+
+        const gridWithPlacement = applyLegendPlacementToGrid(
+            grid,
+            legendConfig,
+            isLegendShown,
+            validCartesianConfig?.eChartsConfig.grid,
+        );
+        grid.left = gridWithPlacement.left;
+        grid.right = gridWithPlacement.right;
 
         const gridLeft = grid.left;
         const gridRight = grid.right;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19913 

### Description:

Gives an option to position the legend outside of the chart. 

<img width="1017" height="472" alt="Screenshot 2026-05-28 at 20 16 01" src="https://github.com/user-attachments/assets/e260fc20-0a2f-461b-8d1c-a5cb8a7dd975" />

Not the default for now to avoid breaking changes. It could be the default for new charts if people like it. 