### PR TITLE
chore(ai): cover agent tool registry in snapshots

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -6957,3 +6957,25 @@ Response shape (MCP CallToolResult):
   ],
 }
 `;
+
+exports[`MCP tool contracts matches the shared MCP tool definition names snapshot 1`] = `
+[
+  "find_explores",
+  "find_fields",
+  "find_content",
+  "search_field_values",
+  "run_metric_query",
+  "run_sql",
+  "get_lightdash_version",
+  "list_explores",
+  "list_projects",
+  "set_project",
+  "get_current_project",
+  "list_agents",
+  "set_agent",
+  "clear_agent",
+  "get_current_agent",
+  "list_verified_content",
+  "run_ai_writeback",
+]
+`;

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -1,3 +1,4 @@
+import { mcpToolDefinitions } from '@lightdash/common';
 import type { ZodRawShape, ZodTypeAny } from 'zod';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
@@ -101,10 +102,18 @@ const makeMcpService = (): McpService =>
         userAttributesModel: {},
     } as ConstructorParameters<typeof McpService>[0]);
 
+const sharedMcpToolDefinitionNames = mcpToolDefinitions.map(
+    (toolDefinition) => toolDefinition.for('mcp').name,
+);
+
 describe('MCP tool contracts', () => {
     beforeEach(() => {
         mockRegisteredMcpTools.length = 0;
         mockRegisteredMcpPrompts.length = 0;
+    });
+
+    it('matches the shared MCP tool definition names snapshot', () => {
+        expect(sharedMcpToolDefinitionNames).toMatchSnapshot();
     });
 
     it('matches the current MCP tool and prompt contract snapshot', () => {

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -2121,6 +2121,16 @@ Parameters:
     "name": "getKnowledgeDocumentContent",
   },
   {
+    "description": "Get details about the Lightdash project you are currently working in and its underlying dbt project. Use this when the user asks what dbt project this is, which git repository/branch it connects to, what dbt version or warehouse it uses, or wants general context about the current project. This is read-only, applies to the project you are currently working in, and never returns credentials or secrets.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object",
+    },
+    "name": "getProjectInfo",
+  },
+  {
     "description": "
 Captures learnings from user corrections, clarifications, and guidance to improve future responses.
 
@@ -2288,6 +2298,16 @@ Parameters:
       "type": "object",
     },
     "name": "listKnowledgeDocuments",
+  },
+  {
+    "description": "List the Lightdash projects in this organization that the current user has access to. Use this when the user asks what projects exist, which projects they can access, or wants to know about other projects in their organization. This is read-only and only returns projects the user is allowed to view. It does not switch the project you are currently working in.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object",
+    },
+    "name": "listProjects",
   },
   {
     "description": "Tool: list_warehouse_tables
@@ -5871,5 +5891,40 @@ Usage Tips:
     },
     "name": "searchFieldValues",
   },
+]
+`;
+
+exports[`AI agent tool contracts matches the shared agent tool definition names snapshot 1`] = `
+[
+  "findExplores",
+  "findFields",
+  "findContent",
+  "searchFieldValues",
+  "runQuery",
+  "runSql",
+  "discoverFields",
+  "generateDashboard",
+  "generateUuids",
+  "getDashboardCharts",
+  "readContent",
+  "editContent",
+  "createContent",
+  "listContent",
+  "improveContext",
+  "loadSkill",
+  "proposeChange",
+  "proposeWriteback",
+  "runSavedChart",
+  "listWarehouseTables",
+  "describeWarehouseTable",
+  "listKnowledgeDocuments",
+  "getKnowledgeDocumentContent",
+  "findCharts",
+  "findDashboards",
+  "generateBarVizConfig",
+  "generateTableVizConfig",
+  "generateTimeSeriesVizConfig",
+  "listProjects",
+  "getProjectInfo",
 ]
 `;

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -1,3 +1,4 @@
+import { agentToolDefinitions } from '@lightdash/common';
 import type { ZodTypeAny } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { getDiscoverFields } from '../agents/discoverFields/tool';
@@ -11,9 +12,11 @@ import { getGenerateDashboardV2 } from './generateDashboardV2';
 import { getGenerateUuids } from './generateUuids';
 import { getGetDashboardCharts } from './getDashboardCharts';
 import { getGetKnowledgeDocumentContent } from './getKnowledgeDocumentContent';
+import { getGetProjectInfo } from './getProjectInfo';
 import { getImproveContext } from './improveContext';
 import { getListContent } from './listContent';
 import { getListKnowledgeDocuments } from './listKnowledgeDocuments';
+import { getListProjects } from './listProjects';
 import { getListWarehouseTables } from './listWarehouseTables';
 import { getLoadSkill } from './loadSkill';
 import { getProposeChange } from './proposeChange';
@@ -48,6 +51,10 @@ const agentToolSnapshot = (name: string, toolDefinition: SnapshotTool) => ({
         ? { outputSchema: schemaToJson(toolDefinition.outputSchema) }
         : {}),
 });
+
+const sharedAgentToolDefinitionNames = agentToolDefinitions.map(
+    (toolDefinition) => toolDefinition.for('agent').name,
+);
 
 const makeAgentTools = () => {
     const noop = jest.fn();
@@ -117,11 +124,13 @@ const makeAgentTools = () => {
         getKnowledgeDocumentContent: getGetKnowledgeDocumentContent({
             getKnowledgeDocumentContent: noop,
         }),
+        getProjectInfo: getGetProjectInfo({ getProjectInfo: noop }),
         improveContext: getImproveContext(),
         listContent: getListContent({ listContent: noop }),
         listKnowledgeDocuments: getListKnowledgeDocuments({
             listKnowledgeDocuments: noop,
         }),
+        listProjects: getListProjects({ listProjects: noop }),
         listWarehouseTables: getListWarehouseTables({
             listWarehouseTables: noop,
         }),
@@ -169,6 +178,10 @@ const makeAgentTools = () => {
 };
 
 describe('AI agent tool contracts', () => {
+    it('matches the shared agent tool definition names snapshot', () => {
+        expect(sharedAgentToolDefinitionNames).toMatchSnapshot();
+    });
+
     it('matches the current agent tool contract snapshot', () => {
         const agentTools = makeAgentTools();
 

--- a/packages/backend/src/ee/services/ai/tools/getProjectInfo.ts
+++ b/packages/backend/src/ee/services/ai/tools/getProjectInfo.ts
@@ -1,7 +1,6 @@
 import {
     DbtProjectTypeLabels,
     getProjectInfoToolDefinition,
-    toolGetProjectInfoOutputSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type { GetProjectInfoFn } from '../types/aiAgentDependencies';
@@ -17,7 +16,6 @@ export const getGetProjectInfo = ({ getProjectInfo }: Dependencies) =>
     tool({
         description: toolDefinition.description,
         inputSchema: toolDefinition.inputSchema,
-        outputSchema: toolGetProjectInfoOutputSchema,
         execute: async () => {
             try {
                 const info = await getProjectInfo();

--- a/packages/backend/src/ee/services/ai/tools/listProjects.ts
+++ b/packages/backend/src/ee/services/ai/tools/listProjects.ts
@@ -1,7 +1,4 @@
-import {
-    listProjectsToolDefinition,
-    toolListProjectsOutputSchema,
-} from '@lightdash/common';
+import { listProjectsToolDefinition } from '@lightdash/common';
 import { tool } from 'ai';
 import type { ListProjectsFn } from '../types/aiAgentDependencies';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
@@ -16,7 +13,6 @@ export const getListProjects = ({ listProjects }: Dependencies) =>
     tool({
         description: toolDefinition.description,
         inputSchema: toolDefinition.inputSchema,
-        outputSchema: toolListProjectsOutputSchema,
         execute: async () => {
             try {
                 const projects = await listProjects();


### PR DESCRIPTION
## Summary

- Add `listProjects` and `getProjectInfo` to the agent tool contract snapshot setup so the test covers the tools wired into the live agent runtime.
- Add registry-driven snapshots of `agentToolDefinitions` and `mcpToolDefinitions` names so new shared tool definitions are surfaced by snapshot tests without relying only on per-tool imports.
- Drop redundant agent-side `outputSchema` registration from `listProjects` and `getProjectInfo`; these outputs have no app-side structured consumer and only return the standard `{ result, metadata.status }` shape.

## Testing

- `pnpm -F backend test:dev:nowatch -- agentToolContracts.snapshot.test.ts mcpToolContracts.snapshot.test.ts --runInBand`
