### PR TITLE
feat(scheduler): cap concurrent deliveries per org (PROD-7866)

### DIFF
--- a/packages/backend/src/clients/ClientRepository.ts
+++ b/packages/backend/src/clients/ClientRepository.ts
@@ -177,6 +177,8 @@ export class ClientRepository
                     lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics,
                     schedulerModel: this.models.getSchedulerModel(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
+                    organizationModel: this.models.getOrganizationModel(),
                 }),
         );
     }

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -613,6 +613,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig: context.lightdashConfig,
                     analytics: context.lightdashAnalytics,
                     schedulerModel: models.getSchedulerModel(),
+                    featureFlagModel: models.getFeatureFlagModel(),
+                    organizationModel: models.getOrganizationModel(),
                 }),
             slackClient: ({ context, models, repository }) =>
                 new CommercialSlackClient({

--- a/packages/backend/src/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.test.ts
@@ -1,0 +1,144 @@
+import {
+    FeatureFlags,
+    SchedulerAndTargets,
+    TraceTaskBase,
+} from '@lightdash/common';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
+import { type LightdashConfig } from '../config/parseConfig';
+import { FeatureFlagModel } from '../models/FeatureFlagModel/FeatureFlagModel';
+import { OrganizationModel } from '../models/OrganizationModel';
+import { SchedulerModel } from '../models/SchedulerModel';
+import { getOrgDeliveryQueueName, SchedulerClient } from './SchedulerClient';
+
+// The constructor eagerly calls makeWorkerUtils() to connect to graphile-worker;
+// stub it so we can construct the client without a database.
+jest.mock('graphile-worker', () => ({
+    makeWorkerUtils: jest
+        .fn()
+        .mockResolvedValue({ addJob: jest.fn(), withPgClient: jest.fn() }),
+}));
+
+const ORG_UUID = 'org-1';
+const ORG_NAME = 'Org One';
+
+const makeClient = (
+    allowMultiOrgs: boolean,
+    get: jest.Mock,
+    orgGet: jest.Mock = jest.fn().mockResolvedValue({ name: ORG_NAME }),
+) =>
+    new SchedulerClient({
+        lightdashConfig: {
+            allowMultiOrgs,
+            database: { connectionUri: 'postgres://noop' },
+        } as unknown as LightdashConfig,
+        analytics: { track: jest.fn() } as unknown as LightdashAnalytics,
+        schedulerModel: {
+            logSchedulerJob: jest.fn().mockResolvedValue(undefined),
+        } as unknown as SchedulerModel,
+        featureFlagModel: { get } as unknown as FeatureFlagModel,
+        organizationModel: { get: orgGet } as unknown as OrganizationModel,
+    });
+
+const scheduler = {
+    schedulerUuid: 'sched-1',
+    name: 'test',
+    cron: '0 * * * *', // hourly → 24 jobs for the test day
+    timezone: 'UTC',
+    enabled: true,
+    createdBy: 'user-1',
+    format: 'csv',
+    targets: [],
+} as unknown as SchedulerAndTargets;
+
+const traceProperties: TraceTaskBase = {
+    organizationUuid: ORG_UUID,
+    projectUuid: 'proj-1',
+    userUuid: 'user-1',
+};
+
+// A fixed start-of-day so getDailyDatesFromCron deterministically yields jobs.
+const startingDateTime = new Date(2023, 0, 1);
+
+describe('SchedulerClient per-org delivery queue', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('routes recurring deliveries into a per-org queue when multi-org + flag are on', async () => {
+        const get = jest.fn().mockResolvedValue({
+            id: FeatureFlags.ScheduledDeliveryPerOrgQueue,
+            enabled: true,
+        });
+        const client = makeClient(true, get);
+        const addJob = jest
+            .spyOn(client, 'addScheduledDeliveryJob')
+            .mockResolvedValue({ jobId: 'j1', date: new Date() });
+
+        await client.generateDailyJobsForScheduler(
+            scheduler,
+            traceProperties,
+            'UTC',
+            startingDateTime,
+        );
+
+        expect(addJob).toHaveBeenCalled();
+        expect(
+            addJob.mock.calls.every(
+                (call) => call[3] === getOrgDeliveryQueueName(ORG_UUID),
+            ),
+        ).toBe(true);
+        // Flag evaluated per-org with the resolved organization name.
+        expect(get).toHaveBeenCalledWith({
+            user: {
+                userUuid: 'user-1',
+                organizationUuid: ORG_UUID,
+                organizationName: ORG_NAME,
+            },
+            featureFlagId: FeatureFlags.ScheduledDeliveryPerOrgQueue,
+        });
+    });
+
+    it('does not set a queue when the flag is off', async () => {
+        const get = jest.fn().mockResolvedValue({
+            id: FeatureFlags.ScheduledDeliveryPerOrgQueue,
+            enabled: false,
+        });
+        const client = makeClient(true, get);
+        const addJob = jest
+            .spyOn(client, 'addScheduledDeliveryJob')
+            .mockResolvedValue({ jobId: 'j1', date: new Date() });
+
+        await client.generateDailyJobsForScheduler(
+            scheduler,
+            traceProperties,
+            'UTC',
+            startingDateTime,
+        );
+
+        expect(addJob).toHaveBeenCalled();
+        expect(addJob.mock.calls.every((call) => call[3] === undefined)).toBe(
+            true,
+        );
+    });
+
+    it('skips the org + flag lookups entirely on single-tenant instances', async () => {
+        const get = jest.fn();
+        const orgGet = jest.fn();
+        const client = makeClient(false, get, orgGet);
+        const addJob = jest
+            .spyOn(client, 'addScheduledDeliveryJob')
+            .mockResolvedValue({ jobId: 'j1', date: new Date() });
+
+        await client.generateDailyJobsForScheduler(
+            scheduler,
+            traceProperties,
+            'UTC',
+            startingDateTime,
+        );
+
+        expect(orgGet).not.toHaveBeenCalled();
+        expect(get).not.toHaveBeenCalled();
+        expect(addJob).toHaveBeenCalled();
+        expect(addJob.mock.calls.every((call) => call[3] === undefined)).toBe(
+            true,
+        );
+    });
+});

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -5,6 +5,7 @@ import {
     CreateSchedulerTarget,
     EmailBatchNotificationPayload,
     EmailNotificationPayload,
+    FeatureFlags,
     getSchedulerTargetUuid,
     getSchedulerUuid,
     GoogleChatBatchNotificationPayload,
@@ -62,15 +63,25 @@ import { nanoid } from 'nanoid';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../config/parseConfig';
 import Logger from '../logging/logger';
+import { FeatureFlagModel } from '../models/FeatureFlagModel/FeatureFlagModel';
+import { OrganizationModel } from '../models/OrganizationModel';
 import { SchedulerModel } from '../models/SchedulerModel';
 
 type SchedulerClientArguments = {
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
     schedulerModel: SchedulerModel;
+    featureFlagModel: FeatureFlagModel;
+    organizationModel: OrganizationModel;
 };
 
 const SCHEDULED_JOB_MAX_ATTEMPTS = 1;
+
+// Name of the per-org graphile named queue that serializes an organization's
+// recurring scheduled deliveries. One queue per org → at most one delivery
+// render runs at a time for that org, so it can't starve the worker pool.
+export const getOrgDeliveryQueueName = (organizationUuid: string): string =>
+    `delivery:${organizationUuid}`;
 
 type SchedulablePreAggregate = Omit<
     PreAggregateSchedulerDetails,
@@ -116,16 +127,24 @@ export class SchedulerClient {
 
     schedulerModel: SchedulerModel;
 
+    featureFlagModel: FeatureFlagModel;
+
+    organizationModel: OrganizationModel;
+
     private static STUCK_JOB_WINDOW = 1.5;
 
     constructor({
         lightdashConfig,
         analytics,
         schedulerModel,
+        featureFlagModel,
+        organizationModel,
     }: SchedulerClientArguments) {
         this.lightdashConfig = lightdashConfig;
         this.analytics = analytics;
         this.schedulerModel = schedulerModel;
+        this.featureFlagModel = featureFlagModel;
+        this.organizationModel = organizationModel;
         this.graphileUtils = makeWorkerUtils({
             connectionString: lightdashConfig.database.connectionUri,
         })
@@ -210,6 +229,7 @@ export class SchedulerClient {
         priority: JobPriority,
         maxAttempts: number = SCHEDULED_JOB_MAX_ATTEMPTS,
         explicitJobKey?: string,
+        queueName?: string,
     ) {
         const messageId = nanoid();
         const jobId = await Sentry.startSpan(
@@ -263,6 +283,9 @@ export class SchedulerClient {
                         // JobKeyMode is by default (replace) which means that if the job already exists it will be replaced if having the same key, which is what we want here - https://worker.graphile.org/docs/job-key
                         // Having this we can remove the duplicate jobs deletion logic
                         ...(jobKey && { jobKey }),
+                        // Named queue makes jobs run serially per queue (graphile-worker).
+                        // Used to cap concurrent deliveries per org.
+                        ...(queueName && { queueName }),
                     },
                 );
 
@@ -414,6 +437,7 @@ export class SchedulerClient {
         date: Date,
         scheduler: ScheduledDeliveryPayload,
         schedulerUuid: string | undefined, // This detects if a scheduled delivery is to be sent "now"
+        queueName?: string, // When set, jobs run serially in this named queue (per-org delivery cap)
     ) {
         const graphileClient = await this.graphileUtils;
 
@@ -446,6 +470,8 @@ export class SchedulerClient {
             date,
             JobPriority.LOW,
             maxAttempts,
+            undefined,
+            queueName,
         );
         await this.schedulerModel.logSchedulerJob({
             task: SCHEDULER_TASKS.HANDLE_SCHEDULED_DELIVERY,
@@ -855,6 +881,28 @@ export class SchedulerClient {
         };
     }
 
+    /**
+     * On multi-org (shared-tenant) instances with the per-org delivery queue flag
+     * enabled for the org, recurring deliveries are routed into a per-org graphile
+     * named queue so they run serially and can't occupy every worker. Returns the
+     * queue name, or undefined to keep the default (fully parallel) behavior.
+     * Gated cheaply by allowMultiOrgs first to avoid a flag lookup on single-tenant
+     * instances.
+     */
+    private async resolveDeliveryQueueName(
+        traceProperties: TraceTaskBase,
+    ): Promise<string | undefined> {
+        if (!this.lightdashConfig.allowMultiOrgs) return undefined;
+        const { organizationUuid, userUuid } = traceProperties;
+        const { name: organizationName } =
+            await this.organizationModel.get(organizationUuid);
+        const { enabled } = await this.featureFlagModel.get({
+            user: { userUuid, organizationUuid, organizationName },
+            featureFlagId: FeatureFlags.ScheduledDeliveryPerOrgQueue,
+        });
+        return enabled ? getOrgDeliveryQueueName(organizationUuid) : undefined;
+    }
+
     async generateDailyJobsForScheduler(
         scheduler: SchedulerAndTargets,
         traceProperties: TraceTaskBase,
@@ -874,6 +922,9 @@ export class SchedulerClient {
             startingDateTime,
         );
 
+        // Evaluate the per-org queue gate once; the org is constant across all dates.
+        const queueName = await this.resolveDeliveryQueueName(traceProperties);
+
         try {
             const promises = dates.map((date: Date) =>
                 this.addScheduledDeliveryJob(
@@ -883,6 +934,7 @@ export class SchedulerClient {
                         ...traceProperties,
                     },
                     scheduler.schedulerUuid,
+                    queueName,
                 ),
             );
 

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -58,6 +58,15 @@ export enum FeatureFlags {
     GoogleChatEnabled = 'google-chat-enabled',
 
     /**
+     * On multi-org (shared-tenant) instances, route an organization's recurring
+     * scheduled deliveries into a per-org graphile-worker named queue
+     * (`delivery:<organizationUuid>`) so they run serially and a single org can't
+     * occupy every worker / crash the headless browser pool. Default off; enable
+     * per-org for gradual rollout.
+     */
+    ScheduledDeliveryPerOrgQueue = 'scheduled-delivery-per-org-queue',
+
+    /**
      * Enable admin user impersonation. When disabled, impersonation
      * actions are blocked and active sessions are cleared.
      */


### PR DESCRIPTION
## What
On multi-org instances, route an org's recurring scheduled deliveries into a per-org graphile named queue (`delivery:<org>`) so they run **serially** — one customer can no longer occupy every worker and crash the headless browser pool.

## Why
A single org with ~1,366 PDF schedulers on one dashboard (all on the same cron) saturated every worker at the cron tick and took down deliveries for all tenants.

## How
- Gated by the `scheduled-delivery-per-org-queue` feature flag — **default off**, enable per-org for gradual rollout; only evaluated on multi-org instances.
- `queueName` threaded through `addJob` / `addScheduledDeliveryJob`, computed once in `generateDailyJobsForScheduler` (the chokepoint for all recurring schedules). Manual "Send now" is unaffected.

## Rollout
Default off (an unregistered flag resolves to disabled — no migration needed).
- **Instance-wide:** `LIGHTDASH_ENABLE_FEATURE_FLAGS=scheduled-delivery-per-org-queue`
- **Per-org (gradual):** insert a `feature_flags` row + a per-org `feature_flag_overrides` row.
- **Kill switch:** `LIGHTDASH_DISABLE_FEATURE_FLAGS=scheduled-delivery-per-org-queue`

## Test plan
- New `SchedulerClient.test.ts`: flag on → `delivery:<org>`; off → no queue; single-tenant → flag never evaluated.
- Backend typecheck + lint clean; full scheduler suite green.

Closes PROD-7866
https://linear.app/lightdash/issue/PROD-7866/limit-concurrent-deliveries-per-org