### PR TITLE
chore(ai): keep agent output schemas

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -2129,6 +2129,36 @@ Parameters:
       "type": "object",
     },
     "name": "getProjectInfo",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "
@@ -2308,6 +2338,36 @@ Parameters:
       "type": "object",
     },
     "name": "listProjects",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: list_warehouse_tables

--- a/packages/backend/src/ee/services/ai/tools/getProjectInfo.ts
+++ b/packages/backend/src/ee/services/ai/tools/getProjectInfo.ts
@@ -1,6 +1,7 @@
 import {
     DbtProjectTypeLabels,
     getProjectInfoToolDefinition,
+    toolGetProjectInfoOutputSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type { GetProjectInfoFn } from '../types/aiAgentDependencies';
@@ -16,6 +17,7 @@ export const getGetProjectInfo = ({ getProjectInfo }: Dependencies) =>
     tool({
         description: toolDefinition.description,
         inputSchema: toolDefinition.inputSchema,
+        outputSchema: toolGetProjectInfoOutputSchema,
         execute: async () => {
             try {
                 const info = await getProjectInfo();

--- a/packages/backend/src/ee/services/ai/tools/listProjects.ts
+++ b/packages/backend/src/ee/services/ai/tools/listProjects.ts
@@ -1,4 +1,7 @@
-import { listProjectsToolDefinition } from '@lightdash/common';
+import {
+    listProjectsToolDefinition,
+    toolListProjectsOutputSchema,
+} from '@lightdash/common';
 import { tool } from 'ai';
 import type { ListProjectsFn } from '../types/aiAgentDependencies';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
@@ -13,6 +16,7 @@ export const getListProjects = ({ listProjects }: Dependencies) =>
     tool({
         description: toolDefinition.description,
         inputSchema: toolDefinition.inputSchema,
+        outputSchema: toolListProjectsOutputSchema,
         execute: async () => {
             try {
                 const projects = await listProjects();


### PR DESCRIPTION
## Summary

- Restore explicit AI SDK `outputSchema` registration for `listProjects` and `getProjectInfo`.
- Keep these simple agent tools aligned with the preferred pattern: shared output schema in common, passed into `tool({...})` for SDK-level typing/contract coverage.
- Update the agent tool contract snapshot to include the output schemas again.

## Testing

- `pnpm -F backend format`
- `pnpm -F backend test:dev:nowatch -- agentToolContracts.snapshot.test.ts --runInBand`
