### PR TITLE
feat: separate system agent fallback from ai-writeback flag

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -342,10 +342,11 @@ const REFUSAL_RE =
 
 /**
  * The built-in "system" agent used as a fallback when an organization has no
- * configured agents (gated behind the AiWriteback feature flag). It answers
- * data questions with the normal query/find tools, and — because the run path
- * attaches the `proposeWriteback` tool whenever AiWriteback is enabled — it
- * routes dbt/semantic-layer change requests to the AI writeback flow.
+ * configured agents (gated behind the AiSlackSystemAgentFallback feature
+ * flag). It answers data questions with the normal query/find tools, and —
+ * because the run path attaches the `proposeWriteback` tool whenever
+ * AiWriteback is enabled — it routes dbt/semantic-layer change requests to
+ * the AI writeback flow.
  */
 const SYSTEM_AGENT_NAME = 'Lightdash Assistant';
 const SYSTEM_AGENT_INSTRUCTION = `You are Lightdash's built-in assistant. Help the user explore their data by using your query and find tools to answer questions about metrics, dimensions, charts, and dashboards.
@@ -7165,7 +7166,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
      */
     /**
      * Resolve the built-in system agent to use when no agents are configured.
-     * Gated behind the AiWriteback feature flag.
+     * Gated behind the AiSlackSystemAgentFallback feature flag.
      *
      * Returns:
      *  - an `AiAgentWithContext` to use as the fallback agent;
@@ -7203,7 +7204,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         const { enabled } = await this.featureFlagService.get({
             user,
-            featureFlagId: FeatureFlags.AiWriteback,
+            featureFlagId: FeatureFlags.AiSlackSystemAgentFallback,
         });
         if (!enabled) {
             return undefined;
@@ -7356,8 +7357,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         if (availableAgents.length === 0) {
             // No configured agents — fall back to the built-in system agent
-            // (gated behind AiWriteback). If the flag is off, keep the
-            // original "no agents" message.
+            // (gated behind AiSlackSystemAgentFallback). If the flag is off,
+            // keep the original "no agents" message.
             const fallback = await this.resolveSystemAgentForSlack({
                 organizationUuid,
                 userUuid,
@@ -8973,9 +8974,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         });
                 } catch (e) {
                     // No agent mapped to this channel — fall back to the
-                    // built-in system agent (gated behind AiWriteback). If the
-                    // flag is off, rethrow so the existing "no agent
-                    // configured" message is shown.
+                    // built-in system agent (gated behind
+                    // AiSlackSystemAgentFallback). If the flag is off, rethrow
+                    // so the existing "no agent configured" message is shown.
                     if (!(e instanceof AiAgentNotFoundError)) {
                         throw e;
                     }

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -221,6 +221,14 @@ export enum FeatureFlags {
      * built out.
      */
     AiWriteback = 'ai-writeback',
+
+    /**
+     * Enable the built-in system agent fallback in Slack. When enabled, if a
+     * Slack channel has no configured agent, the system will use the built-in
+     * system agent instead of showing an error. Independent of AiWriteback so
+     * the features can be toggled separately.
+     */
+    AiSlackSystemAgentFallback = 'ai-slack-system-agent-fallback',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
Move the Slack system agent fallback behind a new
`ai-slack-system-agent-fallback` feature flag, allowing it to be toggled independently from the `ai-writeback` flag.

https://claude.ai/code/session_01W94nYPLb4hR3bWDWGmshpH

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
