### PR TITLE
fix: use advisory lock to deduplicate concurrent forced-slug creates (PROD-7883)

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -80,7 +80,10 @@ import { SpaceTableName } from '../../database/entities/spaces';
 import { UserTable, UserTableName } from '../../database/entities/users';
 import { DbValidationTable } from '../../database/entities/validation';
 import Logger from '../../logging/logger';
-import { generateUniqueSlug } from '../../utils/SlugUtils';
+import {
+    acquireProjectSlugLock,
+    generateUniqueSlug,
+} from '../../utils/SlugUtils';
 import { ContentVerificationModel } from '../ContentVerificationModel';
 import { SpaceModel } from '../SpaceModel';
 import Transaction = Knex.Transaction;
@@ -1285,6 +1288,33 @@ export class DashboardModel {
         projectUuid: string,
     ): Promise<DashboardDAO> {
         const dashboardId = await this.database.transaction(async (trx) => {
+            if (dashboard.forceSlug) {
+                // Forced slugs (content-as-code / promotion) skip unique-slug
+                // generation, and there is no DB unique constraint on the slug.
+                // Serialize concurrent creates of the same (project, slug) and
+                // dedupe against a row a racing upsert already created, so we
+                // never insert a duplicate slug (PROD-7883).
+                await acquireProjectSlugLock(trx, projectUuid, dashboard.slug);
+                const [existing] = await trx(DashboardsTableName)
+                    .innerJoin(
+                        SpaceTableName,
+                        `${SpaceTableName}.space_id`,
+                        `${DashboardsTableName}.space_id`,
+                    )
+                    .innerJoin(
+                        ProjectTableName,
+                        `${SpaceTableName}.project_id`,
+                        `${ProjectTableName}.project_id`,
+                    )
+                    .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                    .where(`${DashboardsTableName}.slug`, dashboard.slug)
+                    .whereNull(`${DashboardsTableName}.deleted_at`)
+                    .select(`${DashboardsTableName}.dashboard_uuid`);
+                if (existing) {
+                    return existing.dashboard_uuid;
+                }
+            }
+
             const [space] = await trx(SpaceTableName)
                 .where('space_uuid', spaceUuid)
                 .select(`${SpaceTableName}.*`)

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -84,7 +84,7 @@ import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
 import { wrapSentryTransaction } from '../utils';
-import { generateUniqueSlug } from '../utils/SlugUtils';
+import { acquireProjectSlugLock, generateUniqueSlug } from '../utils/SlugUtils';
 import { ContentVerificationModel } from './ContentVerificationModel';
 import { SpaceModel } from './SpaceModel';
 
@@ -411,6 +411,45 @@ export const createSavedChart = async (
     },
 ): Promise<string> =>
     db.transaction(async (trx) => {
+        if (forceSlug) {
+            // Forced slugs (content-as-code / promotion) skip unique-slug
+            // generation, and there is no DB unique constraint on the slug.
+            // Serialize concurrent creates of the same (project, slug) and
+            // dedupe against a row a racing upsert already created, so we never
+            // insert a duplicate slug (PROD-7883). Resolves the chart's project
+            // through either its space or its parent dashboard's space.
+            await acquireProjectSlugLock(trx, projectUuid, slug);
+            const [existing] = await trx(SavedChartsTableName)
+                .leftJoin(
+                    DashboardsTableName,
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                )
+                .innerJoin(SpaceTableName, function spaceJoin() {
+                    this.on(
+                        `${SpaceTableName}.space_id`,
+                        '=',
+                        `${DashboardsTableName}.space_id`,
+                    ).orOn(
+                        `${SpaceTableName}.space_id`,
+                        '=',
+                        `${SavedChartsTableName}.space_id`,
+                    );
+                })
+                .innerJoin(
+                    ProjectTableName,
+                    `${SpaceTableName}.project_id`,
+                    `${ProjectTableName}.project_id`,
+                )
+                .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                .where(`${SavedChartsTableName}.slug`, slug)
+                .whereNull(`${SavedChartsTableName}.deleted_at`)
+                .select(`${SavedChartsTableName}.saved_query_uuid`);
+            if (existing) {
+                return existing.saved_query_uuid;
+            }
+        }
+
         let chart: InsertChart;
         const baseChart = {
             name,

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -13,6 +13,36 @@ type SlugTables =
     | typeof DashboardsTableName
     | typeof SpaceTableName;
 
+// Advisory-lock namespace for content-as-code / promotion slug creation.
+// Namespace 1 is already used by cached explores (ProjectModel), so use 2 here
+// to avoid clashing with that lock space.
+const CONTENT_AS_CODE_SLUG_LOCK_NAMESPACE = 2;
+
+/**
+ * Take a transaction-scoped Postgres advisory lock keyed on (projectUuid, slug).
+ *
+ * Content-as-code (and promotion) force the exact slug from the YAML/source when
+ * creating charts and dashboards, bypassing the unique-slug generation. The
+ * create-vs-update decision in CoderService is a non-atomic find-then-create, so
+ * two concurrent uploads of the same slug could both decide to create and insert
+ * duplicate slugs (PROD-7883) — there is no DB unique constraint to catch it.
+ *
+ * Holding this lock around the find-then-create makes that decision atomic: a
+ * second caller with the same key blocks until the first transaction commits, by
+ * which point the first row is visible and the second can dedupe instead of
+ * inserting a duplicate. The lock is released automatically when `trx` ends.
+ */
+export const acquireProjectSlugLock = async (
+    trx: Knex,
+    projectUuid: string,
+    slug: string,
+): Promise<void> => {
+    await trx.raw('SELECT pg_advisory_xact_lock(?, hashtext(?))', [
+        CONTENT_AS_CODE_SLUG_LOCK_NAMESPACE,
+        `${projectUuid}:${slug}`,
+    ]);
+};
+
 export const generateUniqueSlug = async (
     trx: Knex,
     tableName: SlugTables,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7883/investigate-duplicate-slugs-on-prod

Complete:
  - ✅ Root cause confirmed (concurrent content-as-code upsert race + no DB constraint)
  - ✅ Fix implemented (advisory lock + dedupe in DashboardModel.create, createSavedChart, SlugUtils.ts)
  - ✅ Verified live: 2 and 6 concurrent same-slug upserts now produce 1 row (was 2 before); sequential upsert still updates correctly
  - ✅ Typecheck passes, lint clean, 30 existing tests pass, test data cleaned up
  - 
### Description:

When content-as-code or promotion flows create charts and dashboards, they force a specific slug from the YAML/source rather than generating a unique one. Because the create-vs-update decision is a non-atomic find-then-create, two concurrent uploads of the same slug could both decide to insert, resulting in duplicate slugs with no DB unique constraint to prevent it.

This fix introduces a transaction-scoped Postgres advisory lock (`acquireProjectSlugLock`) keyed on `(projectUuid, slug)`. When a forced slug is used during chart or dashboard creation, the lock is acquired before the existence check. A second concurrent caller with the same key will block until the first transaction commits, at which point the newly created row is visible and the second caller can return the existing record instead of inserting a duplicate. The lock is automatically released when the transaction ends.