### PR TITLE
fix(content-as-code): add view scope to split read from write (PROD-7379)

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -685,7 +685,7 @@ export class CoderService extends BaseService {
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
-                'manage',
+                'view',
                 subject('ContentAsCode', {
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
@@ -821,7 +821,7 @@ export class CoderService extends BaseService {
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
-                'manage',
+                'view',
                 subject('ContentAsCode', {
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
@@ -954,7 +954,7 @@ export class CoderService extends BaseService {
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
-                'manage',
+                'view',
                 subject('ContentAsCode', {
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -268,6 +268,11 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('view', 'OrganizationWarehouseCredentials', {
             organizationUuid: member.organizationUuid,
         });
+        // Editors can download content as code but not upload it. Upload
+        // stays gated behind `manage:ContentAsCode` (developer+).
+        can('view', 'ContentAsCode', {
+            organizationUuid: member.organizationUuid,
+        });
     },
     developer(member, { can }) {
         applyOrganizationMemberStaticAbilities.editor(member, { can });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -227,6 +227,11 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
             userUuid: member.userUuid,
         });
+        // Editors can download content as code but not upload it. Upload
+        // stays gated behind `manage:ContentAsCode` (developer+).
+        can('view', 'ContentAsCode', {
+            projectUuid: member.projectUuid,
+        });
     },
     developer(member, { can }) {
         projectMemberAbilities.editor(member, { can });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -94,6 +94,7 @@ const BASE_ROLE_SCOPES = {
         // Enterprise scopes
         'manage:MetricsTree',
         'manage:AiAgentThread@self', // User's own threads
+        'view:ContentAsCode', // Download (but not upload) content as code
     ],
 
     [ProjectMemberRole.DEVELOPER]: [
@@ -244,6 +245,7 @@ export const getNonEnterpriseScopesForRole = (
         'manage:AiAgent',
         'manage:AiAgentDocument',
         'manage:AiAgentThread',
+        'view:ContentAsCode',
         'manage:ContentAsCode',
         'view:DataApp',
         'manage:DataApp',

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -2251,4 +2251,60 @@ describe('scopeAbilityBuilder', () => {
             ).toBe(false);
         });
     });
+
+    describe('content as code permissions', () => {
+        const enterpriseContext = {
+            ...baseContext,
+            userUuid: 'user-456',
+            isEnterprise: true,
+        };
+
+        // Read endpoints (download) check `view`; write endpoints (upload)
+        // check `manage`. Splitting the scope lets a custom role grant
+        // download without upload (the PROD-7379 safeguard for production).
+        const contentAsCodeSubject = subject('ContentAsCode', {
+            organizationUuid: 'org-123',
+            projectUuid: 'project-123',
+        });
+
+        const buildAbility = (scopes: string[]) => {
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            buildAbilityFromScopes({ ...enterpriseContext, scopes }, builder);
+            return builder.build();
+        };
+
+        it('view:ContentAsCode allows download but not upload (PROD-7379)', () => {
+            const ability = buildAbility(['view:ContentAsCode']);
+
+            // Can download (view) content as code
+            expect(ability.can('view', contentAsCodeSubject)).toBe(true);
+
+            // Cannot upload (manage) — the safeguard this feature adds
+            expect(ability.can('manage', contentAsCodeSubject)).toBe(false);
+        });
+
+        it('manage:ContentAsCode allows download and upload', () => {
+            const ability = buildAbility(['manage:ContentAsCode']);
+
+            // `manage` implies `view`, so existing manage holders keep download
+            expect(ability.can('view', contentAsCodeSubject)).toBe(true);
+            expect(ability.can('manage', contentAsCodeSubject)).toBe(true);
+        });
+
+        it('content as code scopes are gated behind enterprise', () => {
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            buildAbilityFromScopes(
+                {
+                    ...baseContext,
+                    userUuid: 'user-456',
+                    isEnterprise: false,
+                    scopes: ['view:ContentAsCode', 'manage:ContentAsCode'],
+                },
+                builder,
+            );
+            const ability = builder.build();
+
+            expect(ability.rules.length).toBe(0);
+        });
+    });
 });

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -487,8 +487,15 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'view:ContentAsCode',
+        description: 'Download content as code',
+        isEnterprise: true,
+        group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:ContentAsCode',
-        description: 'Manage content as code features',
+        description: 'Download and upload content as code',
         isEnterprise: true,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
         getConditions: addDefaultUuidCondition,


### PR DESCRIPTION
## Summary

Closes [PROD-7379](https://linear.app/lightdash/issue/PROD-7379). Lets a custom role **download** production content-as-code without also being able to **upload** to it — closing the "a mis-targeted `lightdash upload` overwrites prod" gap.

Today `manage:ContentAsCode` bundles download (read) + upload (write) into one scope. Anyone who needs to pull production content for local dev also gets push rights to that project. This splits read from write so write access can be restricted via custom roles, while reads stay open.

## Approach

- **NEW `view:ContentAsCode`** — gates the three download endpoints (`getDashboards` / `getCharts` / `getSqlCharts`). CASL `manage` implies `view`, so developers / admins / service accounts keep working with **zero behavior change**.
- **`manage:ContentAsCode`** — continues to gate the upload (upsert) endpoints; unchanged power.
- **Editors** (project + org) gain `view:ContentAsCode` so non-developers can pull YAML for diffing/inspection without push rights.

A custom role can now grant `view:ContentAsCode` only on a production project: the holder can download/diff prod YAML but cannot push content-as-code back. Writes get gated to a controlled promotion path while reads stay open.

**No data migration required** — additive scope; `manage:ContentAsCode` is unchanged (not renamed/removed), so existing custom roles keep working.

> **Note on previews / `@self`:** the ticket also floated a `manage:ContentAsCode@self` scope so users could write content-as-code to their *own* previews. That was dropped from this PR: owning a preview requires `create:Project@preview` (Developer tier only), so `@self` would be a no-op for Editors and is redundant for Developers (who already hold broad `manage`). Left for a follow-up if we decide to extend preview ownership to editors.

## Changes
- `scopes.ts` — add `view:ContentAsCode`
- `roleToScopeMapping.ts` — editor gains `view:ContentAsCode` (also added to the enterprise set)
- `projectMemberAbility.ts` / `organizationMemberAbility.ts` — editor `view:ContentAsCode` rule
- `CoderService.ts` — the three download endpoints now check `view` instead of `manage`

## Tests
- Integration tests in `scopeAbilityBuilder.test.ts`: view-only (download yes / upload no), full manage (download + upload, `manage`⊇`view`), and enterprise gating.
- Verified: common authorization suites (503 pass incl. role↔scope parity + vocabulary coverage), CoderService (23 pass), common + backend typecheck, lint.
- **Verified live** on a local enterprise instance: a `member` user with a custom role holding only `view:ContentAsCode` could download charts/dashboards (200) but got **403** uploading; admin (`manage`) retained both.

## Regression risk
**LOW** — additive at the CASL layer (`manage` ⊇ `view`), no migration, no API shape change, no frontend gating (content-as-code is CLI-driven). The only behavior change is intended: editors can now download content-as-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)