### PR TITLE
chore(ai): unify tool output contracts

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
@@ -162,8 +162,7 @@ type ToolArgs = {
  */
 export const getDiscoverFields = (args: ToolArgs, dependencies: Dependencies) =>
     tool({
-        description: discoverFieldsTool.description,
-        inputSchema: discoverFieldsTool.inputSchema,
+        ...discoverFieldsTool,
         async *execute(input, { toolCallId, abortSignal }) {
             try {
                 const { stream, flushPersistence } = runDiscoverFieldsAgent(

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -44,6 +44,37 @@ Parameters:
       "type": "object",
     },
     "name": "describeWarehouseTable",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "not_found",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: discoverFields
@@ -83,6 +114,268 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
       "type": "object",
     },
     "name": "discoverFields",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "metadata": {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "const": "streaming",
+                  "type": "string",
+                },
+                "streamingMessage": {},
+              },
+              "required": [
+                "status",
+              ],
+              "type": "object",
+            },
+            "result": {
+              "const": "",
+              "type": "string",
+            },
+          },
+          "required": [
+            "result",
+            "metadata",
+          ],
+          "type": "object",
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "metadata": {
+              "additionalProperties": false,
+              "properties": {
+                "discovery": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "explore": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "baseTable": {
+                              "type": "string",
+                            },
+                            "joinedTables": {
+                              "items": {
+                                "type": "string",
+                              },
+                              "type": "array",
+                            },
+                            "label": {
+                              "type": "string",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "label",
+                            "baseTable",
+                            "joinedTables",
+                          ],
+                          "type": "object",
+                        },
+                        "fields": {
+                          "description": "Filtered list of fields relevant to the user query — typically 5–20 entries. Not the full explore.",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "description": {
+                                "description": "Short description, only include when needed to distinguish similar fields.",
+                                "type": [
+                                  "string",
+                                  "null",
+                                ],
+                              },
+                              "fieldFilterType": {
+                                "type": "string",
+                              },
+                              "fieldId": {
+                                "description": "The fieldId to use in runQuery payloads.",
+                                "type": "string",
+                              },
+                              "fieldType": {
+                                "enum": [
+                                  "dimension",
+                                  "metric",
+                                ],
+                                "type": "string",
+                              },
+                              "fieldValueType": {
+                                "description": "The value type (e.g. number, string, date, timestamp, boolean).",
+                                "type": "string",
+                              },
+                              "isFromJoinedTable": {
+                                "type": "boolean",
+                              },
+                              "label": {
+                                "type": "string",
+                              },
+                              "name": {
+                                "type": "string",
+                              },
+                              "table": {
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "fieldId",
+                              "name",
+                              "label",
+                              "table",
+                              "fieldType",
+                              "fieldValueType",
+                              "fieldFilterType",
+                              "isFromJoinedTable",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                        "rationale": {
+                          "description": "Brief justification for the explore + field selection.",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
+                        "status": {
+                          "const": "resolved",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "explore",
+                        "fields",
+                        "rationale",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "candidates": {
+                          "description": "Plausible explores the parent should ask the user to disambiguate between.",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "exploreLabel": {
+                                "type": "string",
+                              },
+                              "exploreName": {
+                                "type": "string",
+                              },
+                              "reason": {
+                                "description": "Why this explore is a plausible candidate for the query.",
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "exploreName",
+                              "exploreLabel",
+                              "reason",
+                            ],
+                            "type": "object",
+                          },
+                          "minItems": 2,
+                          "type": "array",
+                        },
+                        "status": {
+                          "const": "ambiguous",
+                          "type": "string",
+                        },
+                        "suggestedQuestion": {
+                          "description": "A clarification question the parent can echo to the user (e.g. 'Did you mean revenue from the orders explore or the payments explore?').",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "candidates",
+                        "suggestedQuestion",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "reason": {
+                          "description": "Why no explore covers the user query — used by the parent to explain back to the user.",
+                          "type": "string",
+                        },
+                        "status": {
+                          "const": "no_match",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "reason",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+                "status": {
+                  "const": "success",
+                  "type": "string",
+                },
+                "streamingMessage": {},
+              },
+              "required": [
+                "status",
+                "discovery",
+              ],
+              "type": "object",
+            },
+            "result": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "result",
+            "metadata",
+          ],
+          "type": "object",
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "metadata": {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "const": "error",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+              ],
+              "type": "object",
+            },
+            "result": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "result",
+            "metadata",
+          ],
+          "type": "object",
+        },
+      ],
+    },
   },
   {
     "description": "Create a new dashboard or chart, consult the skills for the required fields. Returns the created content with the final persisted slug.",
@@ -291,6 +584,36 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
       "type": "object",
     },
     "name": "editContent",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: "findContent"
@@ -333,6 +656,36 @@ Usage tips:
       "type": "object",
     },
     "name": "findContent",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: findExplores
@@ -364,6 +717,131 @@ Output:
       "type": "object",
     },
     "name": "findExplores",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "ranking": {
+              "additionalProperties": false,
+              "properties": {
+                "exploreSearchResults": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "joinedTables": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                      "label": {
+                        "type": "string",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                      "searchRank": {
+                        "type": [
+                          "number",
+                          "null",
+                        ],
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "label",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "searchQuery": {
+                  "type": "string",
+                },
+                "topMatchingFields": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "chartUsage": {
+                        "type": [
+                          "number",
+                          "null",
+                        ],
+                      },
+                      "fieldType": {
+                        "type": "string",
+                      },
+                      "label": {
+                        "type": "string",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                      "searchRank": {
+                        "type": [
+                          "number",
+                          "null",
+                        ],
+                      },
+                      "tableName": {
+                        "type": "string",
+                      },
+                      "verifiedChartUsage": {
+                        "type": [
+                          "number",
+                          "null",
+                        ],
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "label",
+                      "tableName",
+                      "fieldType",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+              "required": [
+                "searchQuery",
+              ],
+              "type": "object",
+            },
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: "findFields"
@@ -424,6 +902,130 @@ Usage tips:
       "type": "object",
     },
     "name": "findFields",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "ranking": {
+              "additionalProperties": false,
+              "properties": {
+                "searchQueries": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "label": {
+                        "type": "string",
+                      },
+                      "pagination": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "page": {
+                            "type": "number",
+                          },
+                          "pageSize": {
+                            "type": "number",
+                          },
+                          "totalPageCount": {
+                            "type": "number",
+                          },
+                          "totalResults": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "page",
+                          "pageSize",
+                          "totalResults",
+                          "totalPageCount",
+                        ],
+                        "type": "object",
+                      },
+                      "results": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "chartUsage": {
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                            "fieldType": {
+                              "type": "string",
+                            },
+                            "label": {
+                              "type": "string",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                            "searchRank": {
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                            "tableName": {
+                              "type": "string",
+                            },
+                            "verifiedChartUsage": {
+                              "type": [
+                                "number",
+                                "null",
+                              ],
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "label",
+                            "tableName",
+                            "fieldType",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "required": [
+                      "label",
+                      "results",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+              "required": [
+                "searchQueries",
+              ],
+              "type": "object",
+            },
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "
@@ -2022,6 +2624,36 @@ Table calculations perform row-by-row calculations on query results without coll
       "type": "object",
     },
     "name": "generateDashboard",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Generate one or more UUIDs to use as stable identifiers when creating new objects.",
@@ -2042,6 +2674,36 @@ Table calculations perform row-by-row calculations on query results without coll
       "type": "object",
     },
     "name": "generateUuids",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: "getDashboardCharts"
@@ -2085,6 +2747,36 @@ Usage tips:
       "type": "object",
     },
     "name": "getDashboardCharts",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: get_knowledge_document_content
@@ -2119,6 +2811,58 @@ Parameters:
       "type": "object",
     },
     "name": "getKnowledgeDocumentContent",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "contentSizeBytes": {
+                  "type": "number",
+                },
+                "name": {
+                  "type": "string",
+                },
+                "status": {
+                  "const": "success",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+                "name",
+                "contentSizeBytes",
+              ],
+              "type": "object",
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "const": "error",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+              ],
+              "type": "object",
+            },
+          ],
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Get details about the Lightdash project you are currently working in and its underlying dbt project. Use this when the user asks what dbt project this is, which git repository/branch it connects to, what dbt version or warehouse it uses, or wants general context about the current project. This is read-only, applies to the project you are currently working in, and never returns credentials or secrets.",
@@ -2129,6 +2873,36 @@ Parameters:
       "type": "object",
     },
     "name": "getProjectInfo",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "
@@ -2198,6 +2972,36 @@ Captures learnings from user corrections, clarifications, and guidance to improv
       "type": "object",
     },
     "name": "improveContext",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: "listContent"
@@ -2298,6 +3102,36 @@ Parameters:
       "type": "object",
     },
     "name": "listKnowledgeDocuments",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "List the Lightdash projects in this organization that the current user has access to. Use this when the user asks what projects exist, which projects they can access, or wants to know about other projects in their organization. This is read-only and only returns projects the user is allowed to view. It does not switch the project you are currently working in.",
@@ -2308,6 +3142,36 @@ Parameters:
       "type": "object",
     },
     "name": "listProjects",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: list_warehouse_tables
@@ -2354,6 +3218,36 @@ Parameters:
       "type": "object",
     },
     "name": "listWarehouseTables",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Load a built-in skill by name, One of it's sub-resources. Always start by loading the skill itself and then load resources on demand",
@@ -2386,6 +3280,36 @@ Parameters:
       "type": "object",
     },
     "name": "loadSkill",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "
@@ -3419,6 +4343,62 @@ Even if only the part is being changed, make sure to pass the entire value with 
       "type": "object",
     },
     "name": "proposeChange",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "changeUuid": {
+                  "type": "string",
+                },
+                "status": {
+                  "const": "success",
+                  "type": "string",
+                },
+                "userFeedback": {
+                  "default": "accepted",
+                  "enum": [
+                    "accepted",
+                    "rejected",
+                  ],
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+                "changeUuid",
+              ],
+              "type": "object",
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "const": "error",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+              ],
+              "type": "object",
+            },
+          ],
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Open a pull request that modifies the dbt project / Lightdash semantic layer for this project. Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata. Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent / proposeChange for those). The writeback agent runs in an isolated sandbox, edits the repo, runs \`lightdash compile\`, and opens a pull request. The call is synchronous and can take several minutes.",
@@ -3517,6 +4497,36 @@ Even if only the part is being changed, make sure to pass the entire value with 
       "type": "object",
     },
     "name": "readContent",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: runQuery
@@ -5104,6 +6114,36 @@ Table calculations perform row-by-row calculations on query results without coll
       "type": "object",
     },
     "name": "runQuery",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "
@@ -5135,6 +6175,36 @@ custom metrics are applied automatically.
       "type": "object",
     },
     "name": "runSavedChart",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: run_sql
@@ -5192,6 +6262,38 @@ Notes:
       "type": "object",
     },
     "name": "runSql",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+                "rejected",
+                "timeout",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
   {
     "description": "Tool: searchFieldValues
@@ -5890,6 +6992,36 @@ Usage Tips:
       "type": "object",
     },
     "name": "searchFieldValues",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
   },
 ]
 `;

--- a/packages/backend/src/ee/services/ai/tools/createContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/createContent.ts
@@ -1,7 +1,4 @@
-import {
-    createContentToolDefinition,
-    toolCreateContentOutputSchema,
-} from '@lightdash/common';
+import { createContentToolDefinition } from '@lightdash/common';
 import { tool } from 'ai';
 import type { CreateContentFn } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
@@ -15,9 +12,7 @@ const toolDefinition = createContentToolDefinition.for('agent');
 
 export const getCreateContent = ({ createContent }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
-        outputSchema: toolCreateContentOutputSchema,
+        ...toolDefinition,
         execute: async ({ type, content }) => {
             try {
                 const result = await createContent({

--- a/packages/backend/src/ee/services/ai/tools/describeWarehouseTable.ts
+++ b/packages/backend/src/ee/services/ai/tools/describeWarehouseTable.ts
@@ -13,8 +13,7 @@ export const getDescribeWarehouseTable = ({
     describeWarehouseTable,
 }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async ({ table, schema }) => {
             try {
                 const { columns, resolvedSchema } =

--- a/packages/backend/src/ee/services/ai/tools/editContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/editContent.ts
@@ -12,8 +12,7 @@ const toolDefinition = editContentToolDefinition.for('agent');
 
 export const getEditContent = ({ editContent }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async ({ slug, type, patch }) => {
             try {
                 const result = await editContent({ slug, type, patch });

--- a/packages/backend/src/ee/services/ai/tools/findContent.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findContent.tsx
@@ -186,8 +186,7 @@ export const getFindContent = ({
     trackCoverage,
 }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async (args) => {
             try {
                 const searchQueryResults = await Promise.all(

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -107,8 +107,7 @@ export const getFindExplores = ({
     fieldSearchSize,
 }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async (args) => {
             try {
                 await updateProgress(

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -115,8 +115,7 @@ export const getFindFields = ({
     pageSize,
 }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async (args) => {
             try {
                 const searchLabels = args.fieldSearchQueries

--- a/packages/backend/src/ee/services/ai/tools/generateDashboardV2.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDashboardV2.ts
@@ -25,8 +25,7 @@ export const getGenerateDashboardV2 = ({
     createOrUpdateArtifact,
 }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async (toolArgs, { experimental_context: context }) => {
             try {
                 const ctx = AgentContext.from(context);

--- a/packages/backend/src/ee/services/ai/tools/generateUuids.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateUuids.ts
@@ -7,8 +7,7 @@ const toolDefinition = generateUuidsToolDefinition.for('agent');
 
 export const getGenerateUuids = () =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async ({ count }) => {
             try {
                 return {

--- a/packages/backend/src/ee/services/ai/tools/getDashboardCharts.tsx
+++ b/packages/backend/src/ee/services/ai/tools/getDashboardCharts.tsx
@@ -40,8 +40,7 @@ export const getGetDashboardCharts = ({
     pageSize,
 }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async (args) => {
             try {
                 const page = args.page ?? 1;

--- a/packages/backend/src/ee/services/ai/tools/getKnowledgeDocumentContent.tsx
+++ b/packages/backend/src/ee/services/ai/tools/getKnowledgeDocumentContent.tsx
@@ -14,8 +14,7 @@ export const getGetKnowledgeDocumentContent = ({
     getKnowledgeDocumentContent,
 }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async ({ documentUuid }) => {
             try {
                 const document = await getKnowledgeDocumentContent({

--- a/packages/backend/src/ee/services/ai/tools/getProjectInfo.ts
+++ b/packages/backend/src/ee/services/ai/tools/getProjectInfo.ts
@@ -14,8 +14,7 @@ const toolDefinition = getProjectInfoToolDefinition.for('agent');
 
 export const getGetProjectInfo = ({ getProjectInfo }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async () => {
             try {
                 const info = await getProjectInfo();

--- a/packages/backend/src/ee/services/ai/tools/improveContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/improveContext.ts
@@ -8,8 +8,7 @@ const toolDefinition = improveContextToolDefinition.for('agent');
 
 export const getImproveContext = () =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async (toolArgs) => {
             try {
                 Logger.debug(`[AI Agent] Attempting to improve context:

--- a/packages/backend/src/ee/services/ai/tools/listContent.tsx
+++ b/packages/backend/src/ee/services/ai/tools/listContent.tsx
@@ -1,8 +1,4 @@
-import {
-    ContentType,
-    listContentToolDefinition,
-    toolListContentOutputSchema,
-} from '@lightdash/common';
+import { ContentType, listContentToolDefinition } from '@lightdash/common';
 import { tool } from 'ai';
 import type { ListContentFn } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
@@ -48,9 +44,7 @@ const renderContent = (content: Awaited<ReturnType<ListContentFn>>) => (
 
 export const getListContent = ({ listContent }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
-        outputSchema: toolListContentOutputSchema,
+        ...toolDefinition,
         execute: async (args) => {
             try {
                 return {

--- a/packages/backend/src/ee/services/ai/tools/listKnowledgeDocuments.tsx
+++ b/packages/backend/src/ee/services/ai/tools/listKnowledgeDocuments.tsx
@@ -24,8 +24,7 @@ export const getListKnowledgeDocuments = ({
     listKnowledgeDocuments,
 }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async () => {
             try {
                 const documents = await listKnowledgeDocuments();

--- a/packages/backend/src/ee/services/ai/tools/listProjects.ts
+++ b/packages/backend/src/ee/services/ai/tools/listProjects.ts
@@ -11,8 +11,7 @@ const toolDefinition = listProjectsToolDefinition.for('agent');
 
 export const getListProjects = ({ listProjects }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async () => {
             try {
                 const projects = await listProjects();

--- a/packages/backend/src/ee/services/ai/tools/listWarehouseTables.ts
+++ b/packages/backend/src/ee/services/ai/tools/listWarehouseTables.ts
@@ -11,8 +11,7 @@ const toolDefinition = listWarehouseTablesToolDefinition.for('agent');
 
 export const getListWarehouseTables = ({ listWarehouseTables }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async ({ schema, search, limit }) => {
             try {
                 const all = await listWarehouseTables();

--- a/packages/backend/src/ee/services/ai/tools/loadSkill.ts
+++ b/packages/backend/src/ee/services/ai/tools/loadSkill.ts
@@ -17,8 +17,7 @@ const toolDefinition = loadSkillToolDefinition.for('agent');
 
 export const getLoadSkill = ({ loadSkill }: { loadSkill: LoadAgentSkillFn }) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async ({ name, resourceName }) => {
             try {
                 const skill = await loadSkill(name);

--- a/packages/backend/src/ee/services/ai/tools/proposeChange.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeChange.ts
@@ -118,8 +118,7 @@ export const getProposeChange = ({
     getExploreCompiler,
 }: GetProposeChangeArgs) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async (toolArgs, { experimental_context: context }) => {
             try {
                 const ctx = AgentContext.from(context);

--- a/packages/backend/src/ee/services/ai/tools/proposeWriteback.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeWriteback.ts
@@ -1,7 +1,4 @@
-import {
-    proposeWritebackToolDefinition,
-    toolProposeWritebackOutputSchema,
-} from '@lightdash/common';
+import { proposeWritebackToolDefinition } from '@lightdash/common';
 import { tool } from 'ai';
 import type { ProposeWritebackFn } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
@@ -15,9 +12,7 @@ const toolDefinition = proposeWritebackToolDefinition.for('agent');
 
 export const getProposeWriteback = ({ proposeWriteback }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
-        outputSchema: toolProposeWritebackOutputSchema,
+        ...toolDefinition,
         execute: async ({ prompt }) => {
             try {
                 const { prUrl, output, projectName, repository } =

--- a/packages/backend/src/ee/services/ai/tools/readContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/readContent.ts
@@ -12,8 +12,7 @@ const toolDefinition = readContentToolDefinition.for('agent');
 
 export const getReadContent = ({ readContent }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async ({ slug, type }) => {
             try {
                 const result = await readContent({ slug, type });

--- a/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
@@ -89,8 +89,7 @@ export const getRunMetricQuery = ({
     };
 
     return tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async (toolArgs, { experimental_context: context }) => {
             try {
                 const ctx = AgentContext.from(context);

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -176,8 +176,7 @@ export const getRunQuery = ({
     enableSelfImprovement,
 }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async (toolArgs, { experimental_context: context }) => {
             try {
                 await updateProgress('Running your query...');

--- a/packages/backend/src/ee/services/ai/tools/runSavedChart.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSavedChart.ts
@@ -95,8 +95,7 @@ export const getRunSavedChart = ({
     enableDataAccess,
 }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async ({ chartUuid }) => {
             try {
                 await updateProgress('Running saved chart...');

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -93,6 +93,8 @@ export const getRunSql = ({
     return tool({
         description: buildRunSqlDescription(500, maxQueryLimit),
         inputSchema,
+        outputSchema: toolDefinition.outputSchema,
+        toModelOutput: toolDefinition.toModelOutput,
         execute: async ({ sql, limit }, { toolCallId }) => {
             if (sqlApprovalTimedOut) {
                 return {

--- a/packages/backend/src/ee/services/ai/tools/searchFieldValues.ts
+++ b/packages/backend/src/ee/services/ai/tools/searchFieldValues.ts
@@ -16,8 +16,7 @@ const toolDefinition = searchFieldValuesToolDefinition.for('agent');
 
 export const getSearchFieldValues = ({ searchFieldValues }: Dependencies) =>
     tool({
-        description: toolDefinition.description,
-        inputSchema: toolDefinition.inputSchema,
+        ...toolDefinition,
         execute: async (toolArgs) => {
             try {
                 const args =

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -18,6 +18,65 @@ describe('defineTool', () => {
         expect(mcpView.outputSchema).toBeDefined();
     });
 
+    it('builds spreadable agent views with output schemas', () => {
+        const outputSchema = z.object({
+            result: z.string(),
+            metadata: z.object({ status: z.enum(['success', 'error']) }),
+        });
+        const tool = defineTool({
+            name: 'sampleAgentTool',
+            title: 'Sample agent tool',
+            description: 'Sample',
+            availability: ['agent'],
+            inputSchema: z.object({}),
+            agent: { outputSchema },
+        });
+
+        const agentView = tool.for('agent');
+        expect(agentView.outputSchema).toBe(outputSchema);
+        expect(
+            agentView.toModelOutput({
+                output: {
+                    result: 'Nope',
+                    metadata: { status: 'error' },
+                },
+            }),
+        ).toEqual({ type: 'error-text', value: 'Nope' });
+    });
+
+    it('builds MCP result helpers', () => {
+        const outputSchema = z.object({ count: z.number() });
+        const tool = defineTool({
+            name: 'sampleMcpTool',
+            title: 'Sample MCP tool',
+            description: 'Sample',
+            availability: ['mcp'],
+            inputSchema: z.object({}),
+            mcp: {
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                },
+                structuredContentSchema: outputSchema,
+            },
+        });
+
+        const mcpView = tool.for('mcp');
+        expect(mcpView.outputSchema).toBe(outputSchema);
+        expect(mcpView.result.text('Done')).toEqual({
+            content: [{ type: 'text', text: 'Done' }],
+        });
+        expect(mcpView.result.error('Bad')).toEqual({
+            isError: true,
+            content: [{ type: 'text', text: 'Bad' }],
+        });
+        expect(mcpView.result.structured('Counted', { count: 1 })).toEqual({
+            content: [{ type: 'text', text: 'Counted' }],
+            structuredContent: { count: 1 },
+        });
+    });
+
     it('resolves descriptions with the runtime-specific name', () => {
         const tool = defineTool({
             name: 'sampleTool',

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.ts
@@ -14,7 +14,52 @@ export type McpToolAnnotations = {
     idempotentHint: boolean;
 };
 
-type McpOutputSchema = z.ZodObject<z.ZodRawShape>;
+export type AgentModelOutput =
+    | { type: 'text'; value: string }
+    | { type: 'error-text'; value: string };
+
+export type AgentToModelOutput<TOutput = unknown> = (args: {
+    output: TOutput;
+}) => AgentModelOutput;
+
+export type StandardAgentToolOutput = {
+    result: string;
+    metadata: { status: string };
+};
+
+export type AgentOutputSchema = z.ZodTypeAny;
+
+export type AgentToolConfig<
+    TOutputSchema extends AgentOutputSchema | undefined = undefined,
+> = {
+    outputSchema?: TOutputSchema;
+    toModelOutput?: AgentToModelOutput<StandardAgentToolOutput>;
+};
+
+export type McpOutputSchema = z.ZodObject<z.ZodRawShape>;
+
+export type McpTextContent = { type: 'text'; text: string };
+
+export type McpTextResult = { content: [McpTextContent] };
+
+export type McpErrorResult = {
+    isError: true;
+    content: [McpTextContent];
+};
+
+export type McpStructuredResult<TStructuredContent> = {
+    content: [McpTextContent];
+    structuredContent: TStructuredContent;
+};
+
+export type McpToolResultBuilders<TStructuredContent = unknown> = {
+    text(text: string): McpTextResult;
+    error(text: string): McpErrorResult;
+    structured(
+        text: string,
+        structuredContent: TStructuredContent,
+    ): McpStructuredResult<TStructuredContent>;
+};
 
 type McpToolConfigBase = {
     name?: string;
@@ -23,19 +68,19 @@ type McpToolConfigBase = {
 };
 
 export type McpToolConfigWithoutOutput = McpToolConfigBase & {
-    outputSchema?: undefined;
+    structuredContentSchema?: undefined;
 };
 
 export type McpToolConfigWithOutput<TOutputSchema extends McpOutputSchema> =
     McpToolConfigBase & {
-        outputSchema: TOutputSchema;
+        structuredContentSchema: TOutputSchema;
     };
 
 export type McpToolConfig =
     | McpToolConfigWithoutOutput
     | McpToolConfigWithOutput<McpOutputSchema>;
 
-export type AgentToolView<
+type AgentToolViewBase<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
 > = {
@@ -43,6 +88,15 @@ export type AgentToolView<
     title: string;
     description: string;
     inputSchema: TInput;
+};
+
+export type AgentToolView<
+    TName extends string,
+    TInput extends z.ZodObject<z.ZodRawShape>,
+    TAgentOutputSchema extends AgentOutputSchema | undefined = undefined,
+> = AgentToolViewBase<TName, TInput> & {
+    outputSchema?: TAgentOutputSchema;
+    toModelOutput: AgentToModelOutput<StandardAgentToolOutput>;
 };
 
 type McpToolViewBase<
@@ -56,18 +110,22 @@ type McpToolViewBase<
     inputSchema: TInput;
     annotations: McpToolAnnotations;
     meta: Record<string, unknown> | undefined;
+    result: McpToolResultBuilders;
 };
 
 export type McpToolViewWithoutOutput<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
-> = McpToolViewBase<TName, TInput>;
+> = McpToolViewBase<TName, TInput> & {
+    outputSchema?: undefined;
+};
 
 export type McpToolViewWithOutput<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TOutputSchema extends McpOutputSchema,
-> = McpToolViewBase<TName, TInput> & {
+> = Omit<McpToolViewBase<TName, TInput>, 'result'> & {
+    result: McpToolResultBuilders<z.infer<TOutputSchema>>;
     outputSchema: TOutputSchema;
 };
 
@@ -75,6 +133,7 @@ export type ToolDefinitionWithoutMcpOutput<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TInputTransformed extends z.ZodTypeAny,
+    TAgentOutputSchema extends AgentOutputSchema | undefined,
 > = {
     readonly name: TName;
     readonly title: string;
@@ -82,7 +141,7 @@ export type ToolDefinitionWithoutMcpOutput<
     readonly inputSchema: TInput;
     readonly inputSchemaTransformed: TInputTransformed;
     readonly description: string;
-    for(runtime: 'agent'): AgentToolView<TName, TInput>;
+    for(runtime: 'agent'): AgentToolView<TName, TInput, TAgentOutputSchema>;
     for(runtime: 'mcp'): McpToolViewWithoutOutput<TName, TInput>;
 };
 
@@ -90,6 +149,7 @@ export type ToolDefinitionWithMcpOutput<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TInputTransformed extends z.ZodTypeAny,
+    TAgentOutputSchema extends AgentOutputSchema | undefined,
     TOutputSchema extends McpOutputSchema,
 > = {
     readonly name: TName;
@@ -98,7 +158,7 @@ export type ToolDefinitionWithMcpOutput<
     readonly inputSchema: TInput;
     readonly inputSchemaTransformed: TInputTransformed;
     readonly description: string;
-    for(runtime: 'agent'): AgentToolView<TName, TInput>;
+    for(runtime: 'agent'): AgentToolView<TName, TInput, TAgentOutputSchema>;
     for(runtime: 'mcp'): McpToolViewWithOutput<TName, TInput, TOutputSchema>;
 };
 
@@ -106,19 +166,27 @@ export type ToolDefinition<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TInputTransformed extends z.ZodTypeAny = TInput,
+    TAgentOutputSchema extends AgentOutputSchema | undefined = undefined,
 > =
-    | ToolDefinitionWithoutMcpOutput<TName, TInput, TInputTransformed>
+    | ToolDefinitionWithoutMcpOutput<
+          TName,
+          TInput,
+          TInputTransformed,
+          TAgentOutputSchema
+      >
     | ToolDefinitionWithMcpOutput<
           TName,
           TInput,
           TInputTransformed,
+          TAgentOutputSchema,
           McpOutputSchema
       >;
 
 export type ToolDefinitionInstance = ToolDefinition<
     string,
     z.ZodObject<z.ZodRawShape>,
-    z.ZodTypeAny
+    z.ZodTypeAny,
+    AgentOutputSchema | undefined
 >;
 
 export type ToolInput<T extends ToolDefinitionInstance> = z.infer<
@@ -133,6 +201,7 @@ type ToolDefinitionArgsBase<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TInputTransformed extends z.ZodTypeAny,
+    TAgentOutputSchema extends AgentOutputSchema | undefined,
 > = {
     name: TName;
     title: string;
@@ -140,13 +209,20 @@ type ToolDefinitionArgsBase<
     availability: readonly ToolRuntime[];
     inputSchema: TInput;
     inputSchemaTransformed?: TInputTransformed;
+    agent?: AgentToolConfig<TAgentOutputSchema>;
 };
 
 type ToolDefinitionArgsWithoutMcpOutput<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TInputTransformed extends z.ZodTypeAny,
-> = ToolDefinitionArgsBase<TName, TInput, TInputTransformed> & {
+    TAgentOutputSchema extends AgentOutputSchema | undefined,
+> = ToolDefinitionArgsBase<
+    TName,
+    TInput,
+    TInputTransformed,
+    TAgentOutputSchema
+> & {
     mcp?: McpToolConfigWithoutOutput;
 };
 
@@ -154,8 +230,14 @@ type ToolDefinitionArgsWithMcpOutput<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TInputTransformed extends z.ZodTypeAny,
+    TAgentOutputSchema extends AgentOutputSchema | undefined,
     TOutputSchema extends McpOutputSchema,
-> = ToolDefinitionArgsBase<TName, TInput, TInputTransformed> & {
+> = ToolDefinitionArgsBase<
+    TName,
+    TInput,
+    TInputTransformed,
+    TAgentOutputSchema
+> & {
     mcp: McpToolConfigWithOutput<TOutputSchema>;
 };
 
@@ -177,44 +259,80 @@ const validateToolDefinition = (args: {
     }
 };
 
+const hasMcpStructuredContentSchema = (
+    mcpConfig: McpToolConfig | undefined,
+): mcpConfig is McpToolConfigWithOutput<McpOutputSchema> =>
+    mcpConfig?.structuredContentSchema !== undefined;
+
 export function defineTool<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TInputTransformed extends z.ZodTypeAny = TInput,
+    TAgentOutputSchema extends AgentOutputSchema | undefined = undefined,
     TOutputSchema extends McpOutputSchema = McpOutputSchema,
 >(
     def: ToolDefinitionArgsWithMcpOutput<
         TName,
         TInput,
         TInputTransformed,
+        TAgentOutputSchema,
         TOutputSchema
     >,
-): ToolDefinitionWithMcpOutput<TName, TInput, TInputTransformed, TOutputSchema>;
+): ToolDefinitionWithMcpOutput<
+    TName,
+    TInput,
+    TInputTransformed,
+    TAgentOutputSchema,
+    TOutputSchema
+>;
 export function defineTool<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TInputTransformed extends z.ZodTypeAny = TInput,
+    TAgentOutputSchema extends AgentOutputSchema | undefined = undefined,
 >(
-    def: ToolDefinitionArgsWithoutMcpOutput<TName, TInput, TInputTransformed>,
-): ToolDefinitionWithoutMcpOutput<TName, TInput, TInputTransformed>;
+    def: ToolDefinitionArgsWithoutMcpOutput<
+        TName,
+        TInput,
+        TInputTransformed,
+        TAgentOutputSchema
+    >,
+): ToolDefinitionWithoutMcpOutput<
+    TName,
+    TInput,
+    TInputTransformed,
+    TAgentOutputSchema
+>;
 export function defineTool<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
 >(
     def:
-        | ToolDefinitionArgsWithoutMcpOutput<TName, TInput, z.ZodTypeAny>
+        | ToolDefinitionArgsWithoutMcpOutput<
+              TName,
+              TInput,
+              z.ZodTypeAny,
+              AgentOutputSchema | undefined
+          >
         | ToolDefinitionArgsWithMcpOutput<
               TName,
               TInput,
               z.ZodTypeAny,
+              AgentOutputSchema | undefined,
               McpOutputSchema
           >,
 ):
-    | ToolDefinitionWithoutMcpOutput<TName, TInput, z.ZodTypeAny>
+    | ToolDefinitionWithoutMcpOutput<
+          TName,
+          TInput,
+          z.ZodTypeAny,
+          AgentOutputSchema | undefined
+      >
     | ToolDefinitionWithMcpOutput<
           TName,
           TInput,
           z.ZodTypeAny,
+          AgentOutputSchema | undefined,
           McpOutputSchema
       > {
     validateToolDefinition(def);
@@ -222,7 +340,9 @@ export function defineTool<
     const inputSchemaTransformed =
         def.inputSchemaTransformed ?? def.inputSchema;
 
-    if (def.mcp?.outputSchema) {
+    const mcpConfig: McpToolConfig | undefined = def.mcp;
+
+    if (hasMcpStructuredContentSchema(mcpConfig)) {
         return new ToolDefinitionWithMcpOutputImpl({
             name: def.name,
             title: def.title,
@@ -230,7 +350,8 @@ export function defineTool<
             availability: def.availability,
             inputSchema: def.inputSchema,
             inputSchemaTransformed,
-            mcpConfig: def.mcp,
+            agentConfig: def.agent ?? null,
+            mcpConfig,
         });
     }
 
@@ -241,6 +362,7 @@ export function defineTool<
         availability: def.availability,
         inputSchema: def.inputSchema,
         inputSchemaTransformed,
-        mcpConfig: def.mcp ?? null,
+        agentConfig: def.agent ?? null,
+        mcpConfig: mcpConfig ?? null,
     });
 }

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionUtils.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionUtils.ts
@@ -1,4 +1,13 @@
-import { type ToolDescription, type ToolRuntime } from './defineTool';
+import {
+    type AgentToModelOutput,
+    type McpErrorResult,
+    type McpStructuredResult,
+    type McpTextResult,
+    type McpToolResultBuilders,
+    type StandardAgentToolOutput,
+    type ToolDescription,
+    type ToolRuntime,
+} from './defineTool';
 
 export const resolveDescription = (
     description: ToolDescription,
@@ -17,3 +26,35 @@ export const assertAvailable = (
         );
     }
 };
+
+export const defaultAgentToModelOutput: AgentToModelOutput<
+    StandardAgentToolOutput
+> = ({ output }) =>
+    output.metadata.status === 'error'
+        ? { type: 'error-text', value: output.result }
+        : { type: 'text', value: output.result };
+
+const text = (textContent: string): McpTextResult => ({
+    content: [{ type: 'text', text: textContent }],
+});
+
+const error = (textContent: string): McpErrorResult => ({
+    isError: true,
+    content: [{ type: 'text', text: textContent }],
+});
+
+const structured = <TStructuredContent>(
+    textContent: string,
+    structuredContent: TStructuredContent,
+): McpStructuredResult<TStructuredContent> => ({
+    content: [{ type: 'text', text: textContent }],
+    structuredContent,
+});
+
+export const createMcpToolResultBuilders = <
+    TStructuredContent = unknown,
+>(): McpToolResultBuilders<TStructuredContent> => ({
+    text,
+    error,
+    structured,
+});

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithMcpOutput.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithMcpOutput.ts
@@ -1,19 +1,27 @@
 import snakeCase from 'lodash/snakeCase';
 import { type z } from 'zod';
 import {
+    type AgentToolConfig,
     type AgentToolView,
+    type McpOutputSchema,
     type McpToolConfigWithOutput,
     type McpToolViewWithOutput,
     type ToolDescription,
     type ToolRuntime,
 } from './defineTool';
-import { assertAvailable, resolveDescription } from './toolDefinitionUtils';
+import {
+    assertAvailable,
+    createMcpToolResultBuilders,
+    defaultAgentToModelOutput,
+    resolveDescription,
+} from './toolDefinitionUtils';
 
 export class ToolDefinitionWithMcpOutputImpl<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TInputTransformed extends z.ZodTypeAny,
-    TOutputSchema extends z.ZodObject<z.ZodRawShape>,
+    TAgentOutputSchema extends z.ZodTypeAny | undefined,
+    TOutputSchema extends McpOutputSchema,
 > {
     readonly name: TName;
 
@@ -27,6 +35,8 @@ export class ToolDefinitionWithMcpOutputImpl<
 
     private readonly descriptionConfig: ToolDescription;
 
+    private readonly agentConfig: AgentToolConfig<TAgentOutputSchema> | null;
+
     private readonly mcpConfig: McpToolConfigWithOutput<TOutputSchema>;
 
     constructor(args: {
@@ -36,6 +46,7 @@ export class ToolDefinitionWithMcpOutputImpl<
         availability: readonly ToolRuntime[];
         inputSchema: TInput;
         inputSchemaTransformed: TInputTransformed;
+        agentConfig: AgentToolConfig<TAgentOutputSchema> | null;
         mcpConfig: McpToolConfigWithOutput<TOutputSchema>;
     }) {
         this.name = args.name;
@@ -44,6 +55,7 @@ export class ToolDefinitionWithMcpOutputImpl<
         this.availability = args.availability;
         this.inputSchema = args.inputSchema;
         this.inputSchemaTransformed = args.inputSchemaTransformed;
+        this.agentConfig = args.agentConfig;
         this.mcpConfig = args.mcpConfig;
     }
 
@@ -51,22 +63,41 @@ export class ToolDefinitionWithMcpOutputImpl<
         return resolveDescription(this.descriptionConfig, this.name);
     }
 
-    for(runtime: 'agent'): AgentToolView<TName, TInput>;
+    private buildAgentView(): AgentToolView<TName, TInput, TAgentOutputSchema> {
+        const base = {
+            name: this.name,
+            title: this.title,
+            description: this.description,
+            inputSchema: this.inputSchema,
+            toModelOutput:
+                this.agentConfig?.toModelOutput ?? defaultAgentToModelOutput,
+        };
+
+        if (this.agentConfig?.outputSchema) {
+            return {
+                ...base,
+                outputSchema: this.agentConfig.outputSchema,
+            };
+        }
+
+        return base;
+    }
+
+    private get outputSchema(): TOutputSchema {
+        return this.mcpConfig.structuredContentSchema;
+    }
+
+    for(runtime: 'agent'): AgentToolView<TName, TInput, TAgentOutputSchema>;
     for(runtime: 'mcp'): McpToolViewWithOutput<TName, TInput, TOutputSchema>;
     for(
         runtime: ToolRuntime,
     ):
-        | AgentToolView<TName, TInput>
+        | AgentToolView<TName, TInput, TAgentOutputSchema>
         | McpToolViewWithOutput<TName, TInput, TOutputSchema> {
         assertAvailable(this.name, this.availability, runtime);
 
         if (runtime === 'agent') {
-            return {
-                name: this.name,
-                title: this.title,
-                description: this.description,
-                inputSchema: this.inputSchema,
-            };
+            return this.buildAgentView();
         }
 
         const mcpName = this.mcpConfig.name ?? snakeCase(this.name);
@@ -77,8 +108,9 @@ export class ToolDefinitionWithMcpOutputImpl<
             description: resolveDescription(this.descriptionConfig, mcpName),
             inputSchema: this.inputSchema,
             annotations: this.mcpConfig.annotations,
-            outputSchema: this.mcpConfig.outputSchema,
+            outputSchema: this.outputSchema,
             meta: this.mcpConfig.meta,
+            result: createMcpToolResultBuilders<z.infer<TOutputSchema>>(),
         };
     }
 }

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithoutMcpOutput.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithoutMcpOutput.ts
@@ -1,18 +1,25 @@
 import snakeCase from 'lodash/snakeCase';
 import { type z } from 'zod';
 import {
+    type AgentToolConfig,
     type AgentToolView,
     type McpToolConfigWithoutOutput,
     type McpToolViewWithoutOutput,
     type ToolDescription,
     type ToolRuntime,
 } from './defineTool';
-import { assertAvailable, resolveDescription } from './toolDefinitionUtils';
+import {
+    assertAvailable,
+    createMcpToolResultBuilders,
+    defaultAgentToModelOutput,
+    resolveDescription,
+} from './toolDefinitionUtils';
 
 export class ToolDefinitionWithoutMcpOutputImpl<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
     TInputTransformed extends z.ZodTypeAny,
+    TAgentOutputSchema extends z.ZodTypeAny | undefined,
 > {
     readonly name: TName;
 
@@ -26,6 +33,8 @@ export class ToolDefinitionWithoutMcpOutputImpl<
 
     private readonly descriptionConfig: ToolDescription;
 
+    private readonly agentConfig: AgentToolConfig<TAgentOutputSchema> | null;
+
     private readonly mcpConfig: McpToolConfigWithoutOutput | null;
 
     constructor(args: {
@@ -35,6 +44,7 @@ export class ToolDefinitionWithoutMcpOutputImpl<
         availability: readonly ToolRuntime[];
         inputSchema: TInput;
         inputSchemaTransformed: TInputTransformed;
+        agentConfig: AgentToolConfig<TAgentOutputSchema> | null;
         mcpConfig: McpToolConfigWithoutOutput | null;
     }) {
         this.name = args.name;
@@ -43,6 +53,7 @@ export class ToolDefinitionWithoutMcpOutputImpl<
         this.availability = args.availability;
         this.inputSchema = args.inputSchema;
         this.inputSchemaTransformed = args.inputSchemaTransformed;
+        this.agentConfig = args.agentConfig;
         this.mcpConfig = args.mcpConfig;
     }
 
@@ -50,20 +61,37 @@ export class ToolDefinitionWithoutMcpOutputImpl<
         return resolveDescription(this.descriptionConfig, this.name);
     }
 
-    for(runtime: 'agent'): AgentToolView<TName, TInput>;
+    private buildAgentView(): AgentToolView<TName, TInput, TAgentOutputSchema> {
+        const base = {
+            name: this.name,
+            title: this.title,
+            description: this.description,
+            inputSchema: this.inputSchema,
+            toModelOutput:
+                this.agentConfig?.toModelOutput ?? defaultAgentToModelOutput,
+        };
+
+        if (this.agentConfig?.outputSchema) {
+            return {
+                ...base,
+                outputSchema: this.agentConfig.outputSchema,
+            };
+        }
+
+        return base;
+    }
+
+    for(runtime: 'agent'): AgentToolView<TName, TInput, TAgentOutputSchema>;
     for(runtime: 'mcp'): McpToolViewWithoutOutput<TName, TInput>;
     for(
         runtime: ToolRuntime,
-    ): AgentToolView<TName, TInput> | McpToolViewWithoutOutput<TName, TInput> {
+    ):
+        | AgentToolView<TName, TInput, TAgentOutputSchema>
+        | McpToolViewWithoutOutput<TName, TInput> {
         assertAvailable(this.name, this.availability, runtime);
 
         if (runtime === 'agent') {
-            return {
-                name: this.name,
-                title: this.title,
-                description: this.description,
-                inputSchema: this.inputSchema,
-            };
+            return this.buildAgentView();
         }
 
         if (this.mcpConfig === null) {
@@ -79,6 +107,7 @@ export class ToolDefinitionWithoutMcpOutputImpl<
             inputSchema: this.inputSchema,
             annotations: this.mcpConfig.annotations,
             meta: this.mcpConfig.meta,
+            result: createMcpToolResultBuilders(),
         };
     }
 }

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -17,112 +17,139 @@ import {
 import {
     TOOL_CREATE_CONTENT_DESCRIPTION,
     toolCreateContentArgsSchema,
+    toolCreateContentOutputSchema,
 } from './toolCreateContentArgs';
 import {
     TOOL_DASHBOARD_DESCRIPTION,
     toolDashboardArgsSchema,
+    toolDashboardOutputSchema,
 } from './toolDashboardArgs';
 import {
     TOOL_DASHBOARD_V2_DESCRIPTION,
     toolDashboardV2ArgsSchema,
+    toolDashboardV2OutputSchema,
 } from './toolDashboardV2Args';
 import {
     TOOL_DESCRIBE_WAREHOUSE_TABLE_DESCRIPTION,
     toolDescribeWarehouseTableArgsSchema,
+    toolDescribeWarehouseTableOutputSchema,
 } from './toolDescribeWarehouseTableArgs';
 import {
     DISCOVER_FIELDS_DESCRIPTION,
     discoverFieldsInputSchema,
+    toolDiscoverFieldsOutputSchema,
 } from './toolDiscoverFieldsArgs';
 import {
     TOOL_EDIT_CONTENT_DESCRIPTION,
     toolEditContentArgsSchema,
+    toolEditContentOutputSchema,
 } from './toolEditContentArgs';
 import {
     TOOL_FIND_CHARTS_DESCRIPTION,
     toolFindChartsArgsSchema,
+    toolFindChartsOutputSchema,
 } from './toolFindChartsArgs';
 import {
     TOOL_FIND_CONTENT_DESCRIPTION,
     toolFindContentArgsSchema,
+    toolFindContentOutputSchema,
 } from './toolFindContentArgs';
 import {
     TOOL_FIND_DASHBOARDS_DESCRIPTION,
     toolFindDashboardsArgsSchema,
+    toolFindDashboardsOutputSchema,
 } from './toolFindDashboardsArgs';
 import {
     TOOL_FIND_EXPLORES_DESCRIPTION,
     toolFindExploresArgsSchemaV3,
+    toolFindExploresOutputSchema,
 } from './toolFindExploresArgs';
 import {
     TOOL_FIND_FIELDS_DESCRIPTION,
     toolFindFieldsArgsSchema,
+    toolFindFieldsOutputSchema,
 } from './toolFindFieldsArgs';
 import {
     TOOL_GENERATE_UUIDS_DESCRIPTION,
     toolGenerateUuidsArgsSchema,
+    toolGenerateUuidsOutputSchema,
 } from './toolGenerateUuidsArgs';
 import {
     TOOL_GET_DASHBOARD_CHARTS_DESCRIPTION,
     toolGetDashboardChartsArgsSchema,
+    toolGetDashboardChartsOutputSchema,
 } from './toolGetDashboardChartsArgs';
 import {
     TOOL_GET_KNOWLEDGE_DOCUMENT_CONTENT_DESCRIPTION,
     toolGetKnowledgeDocumentContentArgsSchema,
+    toolGetKnowledgeDocumentContentOutputSchema,
 } from './toolGetKnowledgeDocumentContentArgs';
 import {
     TOOL_GET_PROJECT_INFO_DESCRIPTION,
     toolGetProjectInfoArgsSchema,
+    toolGetProjectInfoOutputSchema,
 } from './toolGetProjectInfoArgs';
 import {
     TOOL_IMPROVE_CONTEXT_DESCRIPTION,
     toolImproveContextArgsSchema,
+    toolImproveContextOutputSchema,
 } from './toolImproveContextArgs';
 import {
     TOOL_LIST_CONTENT_DESCRIPTION,
     toolListContentArgsSchema,
+    toolListContentOutputSchema,
 } from './toolListContentArgs';
 import {
     TOOL_LIST_KNOWLEDGE_DOCUMENTS_DESCRIPTION,
     toolListKnowledgeDocumentsArgsSchema,
+    toolListKnowledgeDocumentsOutputSchema,
 } from './toolListKnowledgeDocumentsArgs';
 import {
     TOOL_LIST_PROJECTS_DESCRIPTION,
     toolListProjectsArgsSchema,
+    toolListProjectsOutputSchema,
 } from './toolListProjectsArgs';
 import {
     TOOL_LIST_WAREHOUSE_TABLES_DESCRIPTION,
     toolListWarehouseTablesArgsSchema,
+    toolListWarehouseTablesOutputSchema,
 } from './toolListWarehouseTablesArgs';
 import {
     TOOL_LOAD_SKILL_DESCRIPTION,
     toolLoadSkillArgsSchema,
+    toolLoadSkillOutputSchema,
 } from './toolLoadSkillArgs';
 import {
     TOOL_PROPOSE_CHANGE_DESCRIPTION,
     toolProposeChangeArgsSchema,
+    toolProposeChangeOutputSchema,
 } from './toolProposeChangeArgs';
 import {
     TOOL_PROPOSE_WRITEBACK_DESCRIPTION,
     toolProposeWritebackArgsSchema,
+    toolProposeWritebackOutputSchema,
 } from './toolProposeWritebackArgs';
 import {
     TOOL_READ_CONTENT_DESCRIPTION,
     toolReadContentArgsSchema,
+    toolReadContentOutputSchema,
 } from './toolReadContentArgs';
 import {
     TOOL_RUN_METRIC_QUERY_DESCRIPTION,
     toolRunMetricQueryArgsSchema,
+    toolRunMetricQueryOutputSchema,
 } from './toolRunMetricQueryArgs';
 import {
     mcpRunMetricQueryStructuredOutputSchema,
     TOOL_RUN_QUERY_DESCRIPTION,
     toolRunQueryArgsSchema,
     toolRunQueryArgsSchemaTransformed,
+    toolRunQueryOutputSchema,
 } from './toolRunQueryArgs';
 import {
     TOOL_RUN_SAVED_CHART_DESCRIPTION,
     toolRunSavedChartArgsSchema,
+    toolRunSavedChartOutputSchema,
 } from './toolRunSavedChartArgs';
 import {
     buildRunSqlDescription,
@@ -130,25 +157,30 @@ import {
     DEFAULT_RUN_SQL_MAX_LIMIT,
     mcpRunSqlStructuredOutputSchema,
     toolRunSqlArgsSchema,
+    toolRunSqlOutputSchema,
 } from './toolRunSqlArgs';
 import {
     TOOL_SEARCH_FIELD_VALUES_DESCRIPTION,
     toolSearchFieldValuesArgsSchema,
+    toolSearchFieldValuesOutputSchema,
 } from './toolSearchFieldValuesArgs';
 import {
     TOOL_TABLE_VIZ_DESCRIPTION,
     toolTableVizArgsSchema,
     toolTableVizArgsSchemaTransformed,
+    toolTableVizOutputSchema,
 } from './toolTableVizArgs';
 import {
     TOOL_TIME_SERIES_VIZ_DESCRIPTION,
     toolTimeSeriesArgsSchema,
     toolTimeSeriesArgsSchemaTransformed,
+    toolTimeSeriesOutputSchema,
 } from './toolTimeSeriesArgs';
 import {
     TOOL_VERTICAL_BAR_VIZ_DESCRIPTION,
     toolVerticalBarArgsSchema,
     toolVerticalBarArgsSchemaTransformed,
+    toolVerticalBarOutputSchema,
 } from './toolVerticalBarArgs';
 
 const readOnlyAnnotations: McpToolAnnotations = {
@@ -171,6 +203,7 @@ export const findExploresToolDefinition = defineTool({
     description: TOOL_FIND_EXPLORES_DESCRIPTION,
     availability: ['agent', 'mcp'],
     inputSchema: toolFindExploresArgsSchemaV3,
+    agent: { outputSchema: toolFindExploresOutputSchema },
     mcp: { annotations: readOnlyAnnotations },
 });
 
@@ -180,6 +213,7 @@ export const findFieldsToolDefinition = defineTool({
     description: TOOL_FIND_FIELDS_DESCRIPTION,
     availability: ['agent', 'mcp'],
     inputSchema: toolFindFieldsArgsSchema,
+    agent: { outputSchema: toolFindFieldsOutputSchema },
     mcp: { annotations: readOnlyAnnotations },
 });
 
@@ -189,6 +223,7 @@ export const findContentToolDefinition = defineTool({
     description: TOOL_FIND_CONTENT_DESCRIPTION,
     availability: ['agent', 'mcp'],
     inputSchema: toolFindContentArgsSchema,
+    agent: { outputSchema: toolFindContentOutputSchema },
     mcp: { annotations: readOnlyAnnotations },
 });
 
@@ -198,6 +233,7 @@ export const searchFieldValuesToolDefinition = defineTool({
     description: TOOL_SEARCH_FIELD_VALUES_DESCRIPTION,
     availability: ['agent', 'mcp'],
     inputSchema: toolSearchFieldValuesArgsSchema,
+    agent: { outputSchema: toolSearchFieldValuesOutputSchema },
     mcp: { annotations: readOnlyAnnotations },
 });
 
@@ -208,10 +244,11 @@ export const runQueryToolDefinition = defineTool({
     availability: ['agent', 'mcp'],
     inputSchema: toolRunQueryArgsSchema,
     inputSchemaTransformed: toolRunQueryArgsSchemaTransformed,
+    agent: { outputSchema: toolRunQueryOutputSchema },
     mcp: {
         name: 'run_metric_query',
         annotations: readOnlyAnnotations,
-        outputSchema: mcpRunMetricQueryStructuredOutputSchema,
+        structuredContentSchema: mcpRunMetricQueryStructuredOutputSchema,
     },
 });
 
@@ -224,9 +261,10 @@ export const runSqlToolDefinition = defineTool({
     ),
     availability: ['agent', 'mcp'],
     inputSchema: toolRunSqlArgsSchema,
+    agent: { outputSchema: toolRunSqlOutputSchema },
     mcp: {
         annotations: readOnlyAnnotations,
-        outputSchema: mcpRunSqlStructuredOutputSchema,
+        structuredContentSchema: mcpRunSqlStructuredOutputSchema,
     },
 });
 
@@ -237,6 +275,7 @@ export const runMetricQueryToolDefinition = defineTool({
     description: TOOL_RUN_METRIC_QUERY_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolRunMetricQueryArgsSchema,
+    agent: { outputSchema: toolRunMetricQueryOutputSchema },
 });
 
 export const discoverFieldsToolDefinition = defineTool({
@@ -245,6 +284,7 @@ export const discoverFieldsToolDefinition = defineTool({
     description: DISCOVER_FIELDS_DESCRIPTION,
     availability: ['agent'],
     inputSchema: discoverFieldsInputSchema,
+    agent: { outputSchema: toolDiscoverFieldsOutputSchema },
 });
 
 export const generateDashboardToolDefinition = defineTool({
@@ -253,18 +293,22 @@ export const generateDashboardToolDefinition = defineTool({
     description: TOOL_DASHBOARD_V2_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolDashboardV2ArgsSchema,
+    agent: { outputSchema: toolDashboardV2OutputSchema },
 });
 
 /** @deprecated Legacy v1 dashboard tool schema kept for historical tool calls and artifacts. */
 export const generateDashboardV1ToolDefinition: ToolDefinition<
     'generateDashboard',
-    typeof toolDashboardArgsSchema
+    typeof toolDashboardArgsSchema,
+    typeof toolDashboardArgsSchema,
+    typeof toolDashboardOutputSchema
 > = defineTool({
     name: 'generateDashboard',
     title: 'Generate dashboard',
     description: TOOL_DASHBOARD_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolDashboardArgsSchema,
+    agent: { outputSchema: toolDashboardOutputSchema },
 });
 
 export const generateUuidsToolDefinition = defineTool({
@@ -273,6 +317,7 @@ export const generateUuidsToolDefinition = defineTool({
     description: TOOL_GENERATE_UUIDS_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolGenerateUuidsArgsSchema,
+    agent: { outputSchema: toolGenerateUuidsOutputSchema },
 });
 
 export const getDashboardChartsToolDefinition = defineTool({
@@ -281,6 +326,7 @@ export const getDashboardChartsToolDefinition = defineTool({
     description: TOOL_GET_DASHBOARD_CHARTS_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolGetDashboardChartsArgsSchema,
+    agent: { outputSchema: toolGetDashboardChartsOutputSchema },
 });
 
 export const readContentToolDefinition = defineTool({
@@ -289,6 +335,7 @@ export const readContentToolDefinition = defineTool({
     description: TOOL_READ_CONTENT_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolReadContentArgsSchema,
+    agent: { outputSchema: toolReadContentOutputSchema },
 });
 
 export const editContentToolDefinition = defineTool({
@@ -297,6 +344,7 @@ export const editContentToolDefinition = defineTool({
     description: TOOL_EDIT_CONTENT_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolEditContentArgsSchema,
+    agent: { outputSchema: toolEditContentOutputSchema },
 });
 
 export const createContentToolDefinition = defineTool({
@@ -305,6 +353,7 @@ export const createContentToolDefinition = defineTool({
     description: TOOL_CREATE_CONTENT_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolCreateContentArgsSchema,
+    agent: { outputSchema: toolCreateContentOutputSchema },
 });
 
 export const listContentToolDefinition = defineTool({
@@ -313,6 +362,7 @@ export const listContentToolDefinition = defineTool({
     description: TOOL_LIST_CONTENT_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolListContentArgsSchema,
+    agent: { outputSchema: toolListContentOutputSchema },
 });
 
 export const improveContextToolDefinition = defineTool({
@@ -321,6 +371,7 @@ export const improveContextToolDefinition = defineTool({
     description: TOOL_IMPROVE_CONTEXT_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolImproveContextArgsSchema,
+    agent: { outputSchema: toolImproveContextOutputSchema },
 });
 
 export const listProjectsToolDefinition = defineTool({
@@ -329,6 +380,7 @@ export const listProjectsToolDefinition = defineTool({
     description: TOOL_LIST_PROJECTS_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolListProjectsArgsSchema,
+    agent: { outputSchema: toolListProjectsOutputSchema },
 });
 
 export const getProjectInfoToolDefinition = defineTool({
@@ -337,6 +389,7 @@ export const getProjectInfoToolDefinition = defineTool({
     description: TOOL_GET_PROJECT_INFO_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolGetProjectInfoArgsSchema,
+    agent: { outputSchema: toolGetProjectInfoOutputSchema },
 });
 
 export const loadSkillToolDefinition = defineTool({
@@ -345,6 +398,7 @@ export const loadSkillToolDefinition = defineTool({
     description: TOOL_LOAD_SKILL_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolLoadSkillArgsSchema,
+    agent: { outputSchema: toolLoadSkillOutputSchema },
 });
 
 export const proposeChangeToolDefinition = defineTool({
@@ -353,6 +407,7 @@ export const proposeChangeToolDefinition = defineTool({
     description: TOOL_PROPOSE_CHANGE_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolProposeChangeArgsSchema,
+    agent: { outputSchema: toolProposeChangeOutputSchema },
 });
 
 export const proposeWritebackToolDefinition = defineTool({
@@ -361,6 +416,7 @@ export const proposeWritebackToolDefinition = defineTool({
     description: TOOL_PROPOSE_WRITEBACK_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolProposeWritebackArgsSchema,
+    agent: { outputSchema: toolProposeWritebackOutputSchema },
 });
 
 export const runSavedChartToolDefinition = defineTool({
@@ -369,6 +425,7 @@ export const runSavedChartToolDefinition = defineTool({
     description: TOOL_RUN_SAVED_CHART_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolRunSavedChartArgsSchema,
+    agent: { outputSchema: toolRunSavedChartOutputSchema },
 });
 
 export const listWarehouseTablesToolDefinition = defineTool({
@@ -377,6 +434,7 @@ export const listWarehouseTablesToolDefinition = defineTool({
     description: TOOL_LIST_WAREHOUSE_TABLES_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolListWarehouseTablesArgsSchema,
+    agent: { outputSchema: toolListWarehouseTablesOutputSchema },
 });
 
 export const describeWarehouseTableToolDefinition = defineTool({
@@ -385,6 +443,7 @@ export const describeWarehouseTableToolDefinition = defineTool({
     description: TOOL_DESCRIBE_WAREHOUSE_TABLE_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolDescribeWarehouseTableArgsSchema,
+    agent: { outputSchema: toolDescribeWarehouseTableOutputSchema },
 });
 
 export const listKnowledgeDocumentsToolDefinition = defineTool({
@@ -393,6 +452,7 @@ export const listKnowledgeDocumentsToolDefinition = defineTool({
     description: TOOL_LIST_KNOWLEDGE_DOCUMENTS_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolListKnowledgeDocumentsArgsSchema,
+    agent: { outputSchema: toolListKnowledgeDocumentsOutputSchema },
 });
 
 export const getKnowledgeDocumentContentToolDefinition = defineTool({
@@ -401,6 +461,7 @@ export const getKnowledgeDocumentContentToolDefinition = defineTool({
     description: TOOL_GET_KNOWLEDGE_DOCUMENT_CONTENT_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolGetKnowledgeDocumentContentArgsSchema,
+    agent: { outputSchema: toolGetKnowledgeDocumentContentOutputSchema },
 });
 
 /** @deprecated Legacy agent tool kept for historical tool calls. */
@@ -410,6 +471,7 @@ export const findChartsToolDefinition = defineTool({
     description: TOOL_FIND_CHARTS_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolFindChartsArgsSchema,
+    agent: { outputSchema: toolFindChartsOutputSchema },
 });
 
 /** @deprecated Legacy agent tool kept for historical tool calls. */
@@ -419,6 +481,7 @@ export const findDashboardsToolDefinition = defineTool({
     description: TOOL_FIND_DASHBOARDS_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolFindDashboardsArgsSchema,
+    agent: { outputSchema: toolFindDashboardsOutputSchema },
 });
 
 /** @deprecated Legacy agent tool kept for historical tool calls. */
@@ -429,6 +492,7 @@ export const generateBarVizConfigToolDefinition = defineTool({
     availability: ['agent'],
     inputSchema: toolVerticalBarArgsSchema,
     inputSchemaTransformed: toolVerticalBarArgsSchemaTransformed,
+    agent: { outputSchema: toolVerticalBarOutputSchema },
 });
 
 /** @deprecated Legacy agent tool kept for historical tool calls. */
@@ -439,6 +503,7 @@ export const generateTableVizConfigToolDefinition = defineTool({
     availability: ['agent'],
     inputSchema: toolTableVizArgsSchema,
     inputSchemaTransformed: toolTableVizArgsSchemaTransformed,
+    agent: { outputSchema: toolTableVizOutputSchema },
 });
 
 /** @deprecated Legacy agent tool kept for historical tool calls. */
@@ -449,6 +514,7 @@ export const generateTimeSeriesVizConfigToolDefinition = defineTool({
     availability: ['agent'],
     inputSchema: toolTimeSeriesArgsSchema,
     inputSchemaTransformed: toolTimeSeriesArgsSchemaTransformed,
+    agent: { outputSchema: toolTimeSeriesOutputSchema },
 });
 
 export const getLightdashVersionToolDefinition = defineTool({
@@ -564,7 +630,7 @@ export const runAiWritebackToolDefinition = defineTool({
     inputSchema: mcpRunAiWritebackArgsSchema,
     mcp: {
         annotations: writeAnnotations,
-        outputSchema: mcpRunAiWritebackStructuredOutputSchema,
+        structuredContentSchema: mcpRunAiWritebackStructuredOutputSchema,
     },
 });
 


### PR DESCRIPTION
## Summary

- Extend shared tool definitions so `for('agent')` returns spreadable AI SDK tool config, including default `toModelOutput` and `outputSchema`.
- Add output schemas to all shared agent tool definitions and update agent tool registrations to spread the shared agent view, so output contracts are type-visible and captured in the agent snapshot.
- Add MCP `structuredContentSchema` as the `defineTool` config prop, while `for('mcp')` exposes MCP SDK-compatible `outputSchema` for `registerTool`.
- Add MCP result builders on the MCP runtime view for text, error, and structured-content responses.

## Notes

- MCP tools are not required to define structured content schemas.
- Agent output schemas and MCP structured content schemas remain separate concepts.
- `structuredContentSchema` is only the Lightdash definition-time name; the MCP runtime view exposes `outputSchema` because that is what MCP `registerTool` accepts.
- No unsafe type assertions or duck-typed output checks were added.
- This intentionally changes model-facing output for tools that previously had no `toModelOutput`: `describeWarehouseTable`, `getProjectInfo`, `listProjects`, `listWarehouseTables`, `listKnowledgeDocuments`, and `getKnowledgeDocumentContent` now send only `result` as text/error-text to the model instead of the raw `{ result, metadata }` object.
- Confirmed against AI SDK v6 source: server-executed tool results are not validated against `outputSchema` in the execute path; validation is in UI message / external tool-result paths.

## Testing

- `pnpm -F common format`
- `pnpm -F backend format`
- `pnpm -F common test -- defineTool.test.ts --runInBand`
- `pnpm -F common typecheck`
- `pnpm -F common build`
- `pnpm -F backend test:dev:nowatch -- agentToolContracts.snapshot.test.ts mcpToolContracts.snapshot.test.ts --runInBand`

