### PR TITLE
fix: preserve service account auth in workers

### DIFF
--- a/packages/backend/src/auth/account/index.ts
+++ b/packages/backend/src/auth/account/index.ts
@@ -1,2 +1,7 @@
-export { fromJwt, fromSession, toSessionUser } from './account';
+export {
+    fromJwt,
+    fromServiceAccount,
+    fromSession,
+    toSessionUser,
+} from './account';
 export { requestContextFromExpress } from './requestContext';

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -860,8 +860,10 @@ export class UserModel {
         }
     }
 
-    private async findServiceAccountByUserUuid(userUuid: string): Promise<
+    async findServiceAccountByUserUuid(userUuid: string): Promise<
         | {
+              uuid: string;
+              description: string;
               scopes: ServiceAccountScope[];
               organizationUuid: string;
           }
@@ -871,15 +873,24 @@ export class UserModel {
             .where('service_account_user_uuid', userUuid)
             .select<
                 {
+                    service_account_uuid: string;
+                    description: string;
                     scopes: string[];
                     organization_uuid: string;
                 }[]
-            >('scopes', 'organization_uuid')
+            >(
+                'service_account_uuid',
+                'description',
+                'scopes',
+                'organization_uuid',
+            )
             .first();
         if (!row) {
             return undefined;
         }
         return {
+            uuid: row.service_account_uuid,
+            description: row.description,
             scopes: row.scopes as ServiceAccountScope[],
             organizationUuid: row.organization_uuid,
         };

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -122,7 +122,6 @@ import {
     LightdashAnalytics,
     parseAnalyticsLimit,
 } from '../analytics/LightdashAnalytics';
-import * as Account from '../auth/account';
 import EmailClient from '../clients/EmailClient/EmailClient';
 import { type FileStorageClient } from '../clients/FileStorage/FileStorageClient';
 import { GoogleDriveClient } from '../clients/Google/GoogleDriveClient';
@@ -614,9 +613,8 @@ export default class SchedulerTask {
                 throw new Error("Don't fetch csv for gsheets");
             case SchedulerFormat.CSV:
             case SchedulerFormat.XLSX:
-                const sessionUser =
-                    await this.userService.getSessionByUserUuid(userUuid);
-                const account = Account.fromSession(sessionUser);
+                const account =
+                    await this.userService.getAccountByUserUuid(userUuid);
                 const csvOptions = isSchedulerCsvOptions(options)
                     ? options
                     : undefined;
@@ -1917,10 +1915,9 @@ export default class SchedulerTask {
             };
 
         try {
-            const sessionUser = await this.userService.getSessionByUserUuid(
+            const account = await this.userService.getAccountByUserUuid(
                 payload.userUuid,
             );
-            const account = Account.fromSession(sessionUser);
 
             await this.schedulerService.logSchedulerJob({
                 ...baseLog,
@@ -2274,10 +2271,9 @@ export default class SchedulerTask {
                 status: SchedulerJobStatus.STARTED,
             });
 
-            const sessionUser = await this.userService.getSessionByUserUuid(
+            const account = await this.userService.getAccountByUserUuid(
                 payload.userUuid,
             );
-            const account = Account.fromSession(sessionUser);
             this.analytics.trackAccount(account, {
                 event: 'download_results.started',
                 userId: payload.userUuid,
@@ -2942,7 +2938,9 @@ export default class SchedulerTask {
             sessionUser = await this.userService.getSessionByUserUuid(
                 scheduler.createdBy,
             );
-            account = Account.fromSession(sessionUser);
+            account = await this.userService.getAccountByUserUuid(
+                scheduler.createdBy,
+            );
 
             const schedulerUuidParam = setUuidParam(
                 'scheduler_uuid',
@@ -3547,7 +3545,7 @@ export default class SchedulerTask {
 
         const sessionUser =
             await this.userService.getSessionByUserUuid(userUuid);
-        const account = Account.fromSession(sessionUser);
+        const account = await this.userService.getAccountByUserUuid(userUuid);
 
         // If the scheduler is not a gsheets and has no targets, we skip the delivery
         if (
@@ -4201,9 +4199,8 @@ export default class SchedulerTask {
                     projectUuid,
                 } = payload;
 
-                const sessionUser =
-                    await this.userService.getSessionByUserUuid(userUuid);
-                const account = Account.fromSession(sessionUser);
+                const account =
+                    await this.userService.getAccountByUserUuid(userUuid);
                 const dashboard =
                     await this.schedulerService.dashboardModel.getByIdOrSlug(
                         dashboardUuid,
@@ -4690,10 +4687,9 @@ export default class SchedulerTask {
                 },
             },
             async () => {
-                const sessionUser = await this.userService.getSessionByUserUuid(
+                const account = await this.userService.getAccountByUserUuid(
                     payload.userUuid,
                 );
-                const account = Account.fromSession(sessionUser);
                 return this.asyncQueryService.download({
                     account,
                     ...payload,

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -58,6 +58,7 @@ const userModel = {
     findUserByEmail: jest.fn(async () => undefined),
     createPendingUser: jest.fn(async () => newUser),
     findSessionUserByPrimaryEmail: jest.fn(async () => sessionUser),
+    findServiceAccountByUserUuid: jest.fn(async () => undefined),
     joinOrg: jest.fn(async () => sessionUser),
     hasUsers: jest.fn(async () => false),
 };
@@ -156,6 +157,43 @@ describe('UserService', () => {
     afterEach(() => {
         jest.clearAllMocks();
     });
+
+    describe('getAccountByUserUuid', () => {
+        test('should return a session account for normal users', async () => {
+            const account = await userService.getAccountByUserUuid('userUuid');
+
+            expect(userModel.findSessionUserByUUID).toHaveBeenCalledWith(
+                'userUuid',
+            );
+            expect(userModel.findServiceAccountByUserUuid).toHaveBeenCalledWith(
+                'userUuid',
+            );
+            expect(account.isSessionUser()).toBe(true);
+            expect(account.isServiceAccount()).toBe(false);
+        });
+
+        test('should return a service account when the user backs a service account', async () => {
+            (
+                userModel.findServiceAccountByUserUuid as jest.Mock
+            ).mockResolvedValueOnce({
+                uuid: 'service-account-uuid',
+                description: 'CI preview',
+                scopes: ['system:developer'],
+                organizationUuid: sessionUser.organizationUuid,
+            });
+
+            const account = await userService.getAccountByUserUuid('userUuid');
+
+            expect(account.isServiceAccount()).toBe(true);
+            expect(account.authentication).toMatchObject({
+                type: 'service-account',
+                serviceAccountUuid: 'service-account-uuid',
+                serviceAccountDescription: 'CI preview',
+            });
+            expect(account.user.id).toBe('userUuid');
+        });
+    });
+
     test('should return email and no sso (default case)', async () => {
         expect(await userService.getLoginOptions('test@lightdash.com')).toEqual(
             {

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -52,12 +52,14 @@ import {
     validateOrganizationEmailDomains,
     validateOrganizationNameOrThrow,
     WarehouseTypes,
+    type RegisteredAccount,
 } from '@lightdash/common';
 import { randomInt } from 'crypto';
 import { uniq } from 'lodash';
 import { nanoid } from 'nanoid';
 import refresh from 'passport-oauth2-refresh';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
+import * as AccountFactory from '../auth/account';
 import EmailClient from '../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../config/parseConfig';
 import {
@@ -1674,6 +1676,27 @@ export class UserService extends BaseService {
 
     async getSessionByUserUuid(userUuid: string): Promise<SessionUser> {
         return this.userModel.findSessionUserByUUID(userUuid);
+    }
+
+    async getAccountByUserUuid(userUuid: string): Promise<RegisteredAccount> {
+        const sessionUser = await this.getSessionByUserUuid(userUuid);
+        const serviceAccount =
+            await this.userModel.findServiceAccountByUserUuid(userUuid);
+
+        if (serviceAccount) {
+            return AccountFactory.fromServiceAccount(
+                {
+                    ...sessionUser,
+                    serviceAccount: {
+                        uuid: serviceAccount.uuid,
+                        description: serviceAccount.description,
+                    },
+                },
+                '',
+            );
+        }
+
+        return AccountFactory.fromSession(sessionUser);
     }
 
     private otpExpirationDate(createdAt: Date) {


### PR DESCRIPTION
## Summary
- preserve service-account authentication when scheduler workers rehydrate an account from `userUuid`
- route scheduler account construction through `UserService.getAccountByUserUuid`
- cover normal user vs service-account backing user behavior in `UserService` tests

## Problem
Scheduler jobs store `userUuid` and later rehydrate it as a normal session account. For service-account-created jobs, that backing user intentionally has no primary email row. Rehydrating as a session user causes downstream user-attribute resolution to look up primary email status and fail with `Cannot find matching verification status for user's email`.

## Testing
- `pnpm -F backend typecheck`
- `pnpm -F backend test -- UserService.test.ts -t getAccountByUserUuid --runInBand`
- manual scheduled CSV repro with a service-account token now completes
- manual scheduled CSV check with normal PAT still completes as a session user

Closes: https://github.com/lightdash/lightdash/issues/23648
