### PR TITLE
fix: stop org members list 500 when a group has a custom role

### DIFF
--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -1,4 +1,10 @@
-import { LightdashInstallType } from '@lightdash/common';
+import { Ability } from '@casl/ability';
+import {
+    LightdashInstallType,
+    OrganizationMemberRole,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { buildAccount } from '../../auth/account/account.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
@@ -15,9 +21,13 @@ import { organization, user } from './OrganizationService.mock';
 
 const projectModel = {
     hasProjects: jest.fn(async () => true),
+    getProjectGroupAccesses: jest.fn(),
 };
 const organizationModel = {
     get: jest.fn(async () => organization),
+};
+const organizationMemberProfileModel = {
+    getOrganizationMembersAndGroups: jest.fn(),
 };
 
 describe('organization service', () => {
@@ -27,7 +37,8 @@ describe('organization service', () => {
         organizationModel: organizationModel as unknown as OrganizationModel,
         projectModel: projectModel as unknown as ProjectModel,
         onboardingModel: {} as OnboardingModel,
-        organizationMemberProfileModel: {} as OrganizationMemberProfileModel,
+        organizationMemberProfileModel:
+            organizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
         userModel: {} as UserModel,
         organizationAllowedEmailDomainsModel:
             {} as OrganizationAllowedEmailDomainsModel,
@@ -61,5 +72,49 @@ describe('organization service', () => {
             ...organization,
             needsProject: true,
         });
+    });
+
+    it('getUsers falls back to the member org role when their group has a custom role', async () => {
+        // Group access carries a custom-role UUID (coalesced from role_uuid),
+        // which is not a system ProjectMemberRole and must not throw.
+        const customRoleUuid = 'ac5ac86a-b8a6-47fa-9679-40520dcb6136';
+        const projectUuid = 'project-1';
+        const groupUuid = 'group-1';
+        const adminUser: SessionUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'OrganizationMemberProfile', action: 'manage' },
+            ]),
+        };
+        const member = {
+            userUuid: 'member-1',
+            email: 'member@lightdash.com',
+            firstName: 'Member',
+            lastName: 'One',
+            organizationUuid: organization.organizationUuid,
+            role: OrganizationMemberRole.MEMBER,
+            isActive: true,
+            isInviteExpired: false,
+            groups: [{ uuid: groupUuid, name: 'Custom group' }],
+        };
+        organizationMemberProfileModel.getOrganizationMembersAndGroups.mockResolvedValueOnce(
+            { pagination: undefined, data: [member] },
+        );
+        projectModel.getProjectGroupAccesses.mockResolvedValueOnce([
+            { projectUuid, groupUuid, role: customRoleUuid },
+        ]);
+
+        const result = await organizationService.getUsers(
+            adminUser,
+            10,
+            undefined,
+            undefined,
+            projectUuid,
+        );
+
+        // Assert the behavioural outcome: a custom-role group must not throw and
+        // the member keeps their own org role (no system-role conversion).
+        expect(result.data).toHaveLength(1);
+        expect(result.data[0].role).toBe(OrganizationMemberRole.MEMBER);
     });
 });

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -11,6 +11,7 @@ import {
     ForbiddenError,
     Group,
     GroupWithMembers,
+    isSystemRole,
     isUserWithOrg,
     KnexPaginateArgs,
     KnexPaginatedData,
@@ -288,9 +289,15 @@ export class OrganizationService extends BaseService {
                 );
                 return {
                     ...member,
-                    role: groupAccess?.role
-                        ? convertProjectRoleToOrganizationRole(groupAccess.role)
-                        : member.role,
+                    // A group can carry a custom-role UUID instead of a system
+                    // role. Those aren't convertible to an org role, so fall back
+                    // to the member's own org role rather than throwing.
+                    role:
+                        groupAccess?.role && isSystemRole(groupAccess.role)
+                            ? convertProjectRoleToOrganizationRole(
+                                  groupAccess.role,
+                              )
+                            : member.role,
                 };
             });
         }


### PR DESCRIPTION
Closes: PROD-8012
Closes #23681

Stacked on #23647.

## Problem

`GET /api/v1/org/users` with **both** `projectUuid` and `includeGroups` 500s when a group in the project is assigned a **custom role**. The **Share Space modal** (restricted-access space → member/group picker) hits this on open, as do the scheduler/agent recipient pickers.

```
Error: Project role ac5ac86a-… does not match Organization roles
  at convertProjectRoleToOrganizationRole (projectMemberRole.ts)
  at OrganizationService.ts:292  (getUsers)
```

This is the **backend twin** of the AI-agent white-screen fixed in #23647 — same root cause (`getProjectGroupAccesses` coalesces `role_uuid` into `role`), different surface.

## Fix

Guard the conversion in `OrganizationService.getUsers` with `isProjectMemberRole` (added in #23647) and fall back to the member's own org role when the group carries a custom-role UUID — mirroring the frontend fix. The converter itself stays strict/throwing (the contract); the call site handles the legacy coalesced value.

Adds a regression test (`getUsers` no longer throws and returns the member's org role for a custom-role group).

## Verified
- `pnpm -F common -F backend build` ✅
- `pnpm -F backend lint` ✅
- `pnpm -F backend test OrganizationService` ✅ (3/3)
- Reproduced the 500 live (Share Space modal) before the fix.

Relates to PROD-7999.

