### PR TITLE
feat(ai-agents): add paginated project-scoped thread list endpoint and sidebar infinite scroll

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1,4 +1,5 @@
 import {
+    AiAgentThreadFilters,
     AiArtifactTSOACompat,
     ApiAgentReadinessScoreResponse,
     ApiAgentSuggestionsResponse,
@@ -11,6 +12,7 @@ import {
     ApiAiAgentExploreAccessSummaryResponse,
     ApiAiAgentMcpServerToolListResponse,
     ApiAiAgentModelOptionsResponse,
+    ApiAiAgentProjectThreadSummaryListResponse,
     ApiAiAgentResponse,
     ApiAiAgentSqlApprovalRequest,
     ApiAiAgentSqlApprovalResponse,
@@ -313,6 +315,43 @@ export class AiAgentController extends BaseController {
         return {
             status: 'ok',
             results: undefined,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/threads')
+    @OperationId('listProjectThreads')
+    async listProjectThreads(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Query() page?: KnexPaginateArgs['page'],
+        @Query() pageSize?: KnexPaginateArgs['pageSize'],
+        @Query() agentUuid?: AiAgentThreadFilters['agentUuid'],
+        @Query() createdFrom?: AiAgentThreadFilters['createdFrom'],
+        @Query() search?: AiAgentThreadFilters['search'],
+    ): Promise<ApiAiAgentProjectThreadSummaryListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        const paginateArgs: KnexPaginateArgs | undefined =
+            page !== undefined && pageSize !== undefined
+                ? { page, pageSize }
+                : undefined;
+
+        const { data, pagination } =
+            await this.getAiAgentService().listProjectThreads(
+                toSessionUser(req.account),
+                projectUuid,
+                {
+                    filters: { agentUuid, createdFrom, search },
+                    paginateArgs,
+                },
+            );
+
+        return {
+            status: 'ok',
+            results: { data, pagination },
         };
     }
 

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -240,6 +240,23 @@ type DbAiAgentToolCallWithMcpServer = DbAiAgentToolCall & {
     mcp_server_icon_url: string | null;
 };
 
+type AiThreadSummaryRow = Pick<
+    DbAiThread,
+    | 'ai_thread_uuid'
+    | 'agent_uuid'
+    | 'created_at'
+    | 'created_from'
+    | 'title'
+    | 'title_generated_at'
+> &
+    Pick<DbAiPrompt, 'prompt' | 'ai_prompt_uuid'> & {
+        user_uuid: DbUser['user_uuid'] | null;
+    } & Pick<DbAiSlackThread, 'slack_user_id'> & {
+        user_name: string | null;
+        agent_name: string | null;
+        agent_image_url: string | null;
+    };
+
 export class AiAgentModel {
     private database: Knex;
 
@@ -2368,22 +2385,8 @@ export class AiAgentModel {
             .delete();
     }
 
-    async findThreads({
-        organizationUuid,
-        agentUuid,
-        threadUuid,
-        userUuid,
-        createdFrom,
-    }: {
-        organizationUuid: string;
-        agentUuid: string;
-        threadUuid?: string;
-        userUuid?: string;
-        createdFrom?: ('web_app' | 'slack' | 'evals')[];
-    }): Promise<
-        AiAgentThreadSummary<AiAgentUser & { slackUserId: string | null }>[]
-    > {
-        const query = this.database(AiThreadTableName)
+    private buildThreadSummaryQuery(organizationUuid: string) {
+        return this.database(AiThreadTableName)
             .join(
                 AiPromptTableName,
                 `${AiThreadTableName}.ai_thread_uuid`,
@@ -2399,6 +2402,11 @@ export class AiAgentModel {
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiSlackThreadTableName}.ai_thread_uuid`,
             )
+            .leftJoin(
+                AiAgentTableName,
+                `${AiThreadTableName}.agent_uuid`,
+                `${AiAgentTableName}.ai_agent_uuid`,
+            )
             .where(
                 `${AiPromptTableName}.created_at`,
                 this.database(AiPromptTableName)
@@ -2411,23 +2419,7 @@ export class AiAgentModel {
                 `${AiThreadTableName}.organization_uuid`,
                 organizationUuid,
             )
-            .andWhere(`${AiThreadTableName}.agent_uuid`, agentUuid)
-            .select<
-                (Pick<
-                    DbAiThread,
-                    | 'ai_thread_uuid'
-                    | 'agent_uuid'
-                    | 'created_at'
-                    | 'created_from'
-                    | 'title'
-                    | 'title_generated_at'
-                > &
-                    Pick<DbAiPrompt, 'prompt' | 'ai_prompt_uuid'> & {
-                        user_uuid: DbUser['user_uuid'] | null;
-                    } & Pick<DbAiSlackThread, 'slack_user_id'> & {
-                        user_name: string | null;
-                    })[]
-            >(
+            .select<AiThreadSummaryRow[]>(
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiThreadTableName}.agent_uuid`,
                 `${AiThreadTableName}.created_at`,
@@ -2441,8 +2433,57 @@ export class AiAgentModel {
                     `COALESCE(NULLIF(TRIM(CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name)), ''), 'Unknown user') as user_name`,
                 ),
                 `${AiSlackThreadTableName}.slack_user_id`,
+                `${AiAgentTableName}.name as agent_name`,
+                `${AiAgentTableName}.image_url as agent_image_url`,
             )
             .orderBy(`${AiThreadTableName}.created_at`, 'desc');
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private mapThreadSummaryRow(row: AiThreadSummaryRow): AiAgentThreadSummary<
+        AiAgentUser & { slackUserId: string | null }
+    > & {
+        threadUuid: string;
+    } {
+        return {
+            uuid: row.ai_thread_uuid,
+            threadUuid: row.ai_thread_uuid,
+            agentUuid: row.agent_uuid!,
+            createdAt: row.created_at as unknown as string,
+            createdFrom: row.created_from,
+            title: row.title,
+            titleGeneratedAt: row.title_generated_at?.toString() ?? null,
+            firstMessage: {
+                uuid: row.ai_prompt_uuid,
+                message: row.prompt,
+            },
+            user: {
+                uuid: row.user_uuid ?? '',
+                name: row.user_name || 'Unknown user',
+                slackUserId: row.slack_user_id,
+            },
+        };
+    }
+
+    async findThreads({
+        organizationUuid,
+        agentUuid,
+        threadUuid,
+        userUuid,
+        createdFrom,
+    }: {
+        organizationUuid: string;
+        agentUuid: string;
+        threadUuid?: string;
+        userUuid?: string;
+        createdFrom?: ('web_app' | 'slack' | 'evals')[];
+    }): Promise<
+        AiAgentThreadSummary<AiAgentUser & { slackUserId: string | null }>[]
+    > {
+        const query = this.buildThreadSummaryQuery(organizationUuid).andWhere(
+            `${AiThreadTableName}.agent_uuid`,
+            agentUuid,
+        );
 
         if (createdFrom) {
             void query.andWhere(
@@ -2465,24 +2506,69 @@ export class AiAgentModel {
 
         const rows = await query;
 
-        return rows.map((row) => ({
-            uuid: row.ai_thread_uuid,
-            threadUuid: row.ai_thread_uuid,
-            agentUuid: row.agent_uuid!,
-            createdAt: row.created_at as unknown as string,
-            createdFrom: row.created_from,
-            title: row.title,
-            titleGeneratedAt: row.title_generated_at?.toString() ?? null,
-            firstMessage: {
-                uuid: row.ai_prompt_uuid,
-                message: row.prompt,
-            },
-            user: {
-                uuid: row.user_uuid ?? '',
-                name: row.user_name || 'Unknown user',
-                slackUserId: row.slack_user_id,
-            },
-        }));
+        return rows.map((row) => this.mapThreadSummaryRow(row));
+    }
+
+    async findThreadsPaginated({
+        organizationUuid,
+        projectUuid,
+        userUuid,
+        agentUuids,
+        createdFrom,
+        search,
+        paginateArgs,
+    }: {
+        organizationUuid: string;
+        projectUuid: string;
+        userUuid: string;
+        agentUuids?: string[];
+        createdFrom?: ('web_app' | 'slack' | 'evals')[];
+        search?: string;
+        paginateArgs?: KnexPaginateArgs;
+    }): Promise<
+        KnexPaginatedData<
+            (AiAgentThreadSummary<
+                AiAgentUser & { slackUserId: string | null }
+            > & { agentName: string; agentImageUrl: string | null })[]
+        >
+    > {
+        const query = this.buildThreadSummaryQuery(organizationUuid)
+            .andWhere(`${AiThreadTableName}.project_uuid`, projectUuid)
+            .andWhere(`${UserTableName}.user_uuid`, userUuid);
+
+        if (agentUuids) {
+            void query.whereIn(`${AiThreadTableName}.agent_uuid`, agentUuids);
+        }
+
+        if (createdFrom) {
+            void query.andWhere(
+                `${AiThreadTableName}.created_from`,
+                'in',
+                createdFrom,
+            );
+        }
+
+        if (search) {
+            void query.andWhere(
+                `${AiThreadTableName}.title`,
+                'ILIKE',
+                `%${search}%`,
+            );
+        }
+
+        const { data, pagination } = await KnexPaginate.paginate(
+            query,
+            paginateArgs,
+        );
+
+        return {
+            data: data.map((row) => ({
+                ...this.mapThreadSummaryRow(row),
+                agentName: row.agent_name ?? '',
+                agentImageUrl: row.agent_image_url ?? null,
+            })),
+            pagination,
+        };
     }
 
     async findAdminThreadsPaginated({

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8,10 +8,13 @@ import {
     AiAgentEvaluationRun,
     AiAgentEvaluationSummary,
     AiAgentNotFoundError,
+    AiAgentProjectThreadSummary,
     AiAgentReviewClassifierEventType,
     AiAgentSummary,
     AiAgentThread,
+    AiAgentThreadFilters,
     AiAgentThreadSummary,
+    AiAgentUser,
     AiAgentUserPreferences,
     AiAgentWithContext,
     AiDuplicateSlackPromptError,
@@ -55,6 +58,7 @@ import {
     isSlackPrompt,
     isToolProposeChangeSuccessResult,
     KnexPaginateArgs,
+    KnexPaginatedData,
     LightdashUser,
     NotFoundError,
     NotImplementedError,
@@ -1541,6 +1545,107 @@ export class AiAgentService extends BaseService {
                 },
             };
         });
+    }
+
+    async listProjectThreads(
+        user: SessionUser,
+        projectUuid: string,
+        {
+            filters,
+            paginateArgs,
+        }: {
+            filters?: AiAgentThreadFilters;
+            paginateArgs?: KnexPaginateArgs;
+        },
+    ): Promise<
+        KnexPaginatedData<
+            AiAgentProjectThreadSummary<
+                AiAgentUser & { slackUserId: string | null }
+            >[]
+        >
+    > {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError();
+        }
+
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        if (!isCopilotEnabled) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const accessibleAgents = await this.listAgents(user, projectUuid);
+        const accessibleAgentUuids = accessibleAgents.map(
+            (agent) => agent.uuid,
+        );
+
+        if (
+            filters?.agentUuid &&
+            !accessibleAgentUuids.includes(filters.agentUuid)
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access this agent',
+            );
+        }
+
+        if (accessibleAgentUuids.length === 0) {
+            return {
+                data: [],
+                pagination: paginateArgs
+                    ? { ...paginateArgs, totalPageCount: 0, totalResults: 0 }
+                    : undefined,
+            };
+        }
+
+        const { data: threads, pagination } =
+            await this.aiAgentModel.findThreadsPaginated({
+                organizationUuid,
+                projectUuid,
+                userUuid: user.userUuid,
+                agentUuids: filters?.agentUuid
+                    ? [filters.agentUuid]
+                    : accessibleAgentUuids,
+                createdFrom: filters?.createdFrom
+                    ? [filters.createdFrom]
+                    : ['web_app', 'slack'],
+                search: filters?.search,
+                paginateArgs,
+            });
+
+        const slackUserIds = _.uniq(
+            threads
+                .filter((thread) => thread.createdFrom === 'slack')
+                .filter((thread) => thread.user.slackUserId !== null)
+                .map((thread) => thread.user.slackUserId),
+        );
+
+        const slackUsers = await Promise.all(
+            slackUserIds.map((userId) =>
+                this.slackClient.getUserInfo(organizationUuid, userId!),
+            ),
+        );
+
+        const data = threads.map((thread) => {
+            if (thread.createdFrom !== 'slack') {
+                return thread;
+            }
+
+            const slackUser = slackUsers.find(
+                ({ id }) =>
+                    thread.user.slackUserId !== null &&
+                    id === thread.user.slackUserId,
+            );
+
+            return {
+                ...thread,
+                user: {
+                    ...thread.user,
+                    name: slackUser?.name ?? thread.user.name,
+                },
+            };
+        });
+
+        return { data, pagination };
     }
 
     async getAgentThread(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10769,6 +10769,142 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentUser: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentThreadSummary_AiAgentUser_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                user: { ref: 'AiAgentUser', required: true },
+                firstMessage: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        message: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                titleGeneratedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdFrom: { dataType: 'string', required: true },
+                createdAt: { dataType: 'string', required: true },
+                agentUuid: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentProjectThreadSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'AiAgentThreadSummary_AiAgentUser_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        agentImageUrl: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        agentName: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'KnexPaginatedData_AiAgentProjectThreadSummary-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                pagination: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'KnexPaginateArgs' },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                totalResults: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                totalPageCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+                data: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentProjectThreadSummary',
+                    },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_KnexPaginatedData_AiAgentProjectThreadSummary-Array__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'KnexPaginatedData_AiAgentProjectThreadSummary-Array_',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentProjectThreadSummaryListResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_KnexPaginatedData_AiAgentProjectThreadSummary-Array__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_':
         {
             dataType: 'refAlias',
@@ -11616,18 +11752,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiAgentUser: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                name: { dataType: 'string', required: true },
-                uuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentThreadSummary: {
         dataType: 'refAlias',
         type: {
@@ -11681,45 +11805,6 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiAgentThreadSummary_AiAgentUser_: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                user: { ref: 'AiAgentUser', required: true },
-                firstMessage: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        message: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                    },
-                    required: true,
-                },
-                titleGeneratedAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                title: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                createdFrom: { dataType: 'string', required: true },
-                createdAt: { dataType: 'string', required: true },
-                agentUuid: { dataType: 'string', required: true },
-                uuid: { dataType: 'string', required: true },
             },
             validators: {},
         },
@@ -12148,11 +12233,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12167,11 +12252,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12186,11 +12271,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12205,11 +12290,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12315,17 +12400,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -12354,7 +12439,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12362,11 +12447,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12381,7 +12462,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12389,7 +12470,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12441,11 +12526,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12596,17 +12681,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -12638,11 +12723,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12657,11 +12742,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12704,11 +12789,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -12747,17 +12832,30 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 explore: {
                                                                     dataType:
                                                                         'nestedObjectLiteral',
                                                                     nestedProperties:
                                                                         {
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -12766,6 +12864,12 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -12807,45 +12911,6 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -12866,6 +12931,45 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -12873,25 +12977,6 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -12922,17 +13007,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -13000,11 +13085,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13019,11 +13104,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13038,11 +13123,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13057,11 +13142,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13076,11 +13161,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13126,11 +13211,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13145,11 +13230,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13164,11 +13249,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13181,6 +13266,10 @@ const models: TsoaRoute.Models = {
                                                 status: {
                                                     dataType: 'union',
                                                     subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
@@ -13188,10 +13277,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13210,11 +13295,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13229,11 +13314,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13248,11 +13333,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13267,11 +13352,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -26408,7 +26493,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -26418,7 +26503,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -26428,7 +26513,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -26441,7 +26526,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -42257,6 +42342,78 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'disconnectMcpOAuthConnection',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_listProjectThreads: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        page: { in: 'query', name: 'page', dataType: 'double' },
+        pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
+        agentUuid: { in: 'query', name: 'agentUuid', dataType: 'string' },
+        createdFrom: {
+            in: 'query',
+            name: 'createdFrom',
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['web_app'] },
+                { dataType: 'enum', enums: ['slack'] },
+            ],
+        },
+        search: { in: 'query', name: 'search', dataType: 'string' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/threads',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.listProjectThreads,
+        ),
+
+        async function AiAgentController_listProjectThreads(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_listProjectThreads,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listProjectThreads',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12338,6 +12338,138 @@
                 },
                 "type": "object"
             },
+            "AiAgentUser": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "uuid"],
+                "type": "object"
+            },
+            "AiAgentThreadSummary_AiAgentUser_": {
+                "properties": {
+                    "user": {
+                        "$ref": "#/components/schemas/AiAgentUser"
+                    },
+                    "firstMessage": {
+                        "properties": {
+                            "message": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["message", "uuid"],
+                        "type": "object"
+                    },
+                    "titleGeneratedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "createdFrom": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "agentUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "user",
+                    "firstMessage",
+                    "titleGeneratedAt",
+                    "title",
+                    "createdFrom",
+                    "createdAt",
+                    "agentUuid",
+                    "uuid"
+                ],
+                "type": "object"
+            },
+            "AiAgentProjectThreadSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AiAgentThreadSummary_AiAgentUser_"
+                    },
+                    {
+                        "properties": {
+                            "agentImageUrl": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "agentName": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["agentImageUrl", "agentName"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "KnexPaginatedData_AiAgentProjectThreadSummary-Array_": {
+                "properties": {
+                    "pagination": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/KnexPaginateArgs"
+                            },
+                            {
+                                "properties": {
+                                    "totalResults": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "totalPageCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    }
+                                },
+                                "required": ["totalResults", "totalPageCount"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "data": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentProjectThreadSummary"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["data"],
+                "type": "object"
+            },
+            "ApiSuccess_KnexPaginatedData_AiAgentProjectThreadSummary-Array__": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/KnexPaginatedData_AiAgentProjectThreadSummary-Array_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentProjectThreadSummaryListResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_KnexPaginatedData_AiAgentProjectThreadSummary-Array__"
+            },
             "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_": {
                 "properties": {
                     "description": {
@@ -13145,18 +13277,6 @@
                     }
                 ]
             },
-            "AiAgentUser": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    }
-                },
-                "required": ["name", "uuid"],
-                "type": "object"
-            },
             "AiAgentThreadSummary": {
                 "properties": {
                     "user": {
@@ -13222,56 +13342,6 @@
                     }
                 },
                 "required": ["results", "status"],
-                "type": "object"
-            },
-            "AiAgentThreadSummary_AiAgentUser_": {
-                "properties": {
-                    "user": {
-                        "$ref": "#/components/schemas/AiAgentUser"
-                    },
-                    "firstMessage": {
-                        "properties": {
-                            "message": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["message", "uuid"],
-                        "type": "object"
-                    },
-                    "titleGeneratedAt": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "title": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "createdFrom": {
-                        "type": "string"
-                    },
-                    "createdAt": {
-                        "type": "string"
-                    },
-                    "agentUuid": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "user",
-                    "firstMessage",
-                    "titleGeneratedAt",
-                    "title",
-                    "createdFrom",
-                    "createdAt",
-                    "agentUuid",
-                    "uuid"
-                ],
                 "type": "object"
             },
             "AiChartRuntimeOverrides": {
@@ -13699,8 +13769,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -13732,10 +13802,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -13744,8 +13814,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -13755,16 +13825,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -13794,8 +13864,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -13857,10 +13927,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -13869,8 +13939,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -13898,8 +13968,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -13933,8 +14003,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
+                                                            "success",
                                                             "not_found"
                                                         ]
                                                     }
@@ -13961,16 +14031,20 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "explore": {
                                                                         "properties": {
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -13980,8 +14054,8 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "baseTable",
                                                                             "joinedTables",
+                                                                            "baseTable",
                                                                             "label",
                                                                             "name"
                                                                         ],
@@ -13999,25 +14073,25 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
                                                                                 "fieldType": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
+                                                                                        "metric",
+                                                                                        "dimension"
                                                                                     ]
                                                                                 },
-                                                                                "label": {
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "table": {
+                                                                                "label": {
                                                                                     "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
                                                                                 },
                                                                                 "name": {
                                                                                     "type": "string"
@@ -14027,20 +14101,16 @@
                                                                                 "isFromJoinedTable",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "label",
-                                                                                "fieldId",
-                                                                                "table",
                                                                                 "description",
+                                                                                "fieldType",
+                                                                                "table",
+                                                                                "fieldId",
+                                                                                "label",
                                                                                 "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -14051,9 +14121,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "rationale",
                                                                     "explore",
                                                                     "fields",
-                                                                    "rationale",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14066,10 +14136,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -14077,8 +14147,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "reason",
                                                                                 "exploreLabel",
+                                                                                "reason",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -14153,9 +14223,9 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "error",
                                                             "success",
                                                             "rejected",
-                                                            "error",
                                                             "timeout"
                                                         ]
                                                     }
@@ -27422,22 +27492,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -36775,7 +36845,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3042.0",
+        "version": "0.3046.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -39003,6 +39073,87 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/threads": {
+            "get": {
+                "operationId": "listProjectThreads",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentProjectThreadSummaryListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "agentUuid",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "createdFrom",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["web_app", "slack"]
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "search",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}": {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -366,6 +366,23 @@ export type ApiAiAgentThreadSummaryListResponse = {
     results: AiAgentThreadSummary[];
 };
 
+export type AiAgentThreadFilters = {
+    agentUuid?: string;
+    createdFrom?: 'web_app' | 'slack';
+    search?: string;
+};
+
+export type AiAgentProjectThreadSummary<
+    TUser extends AiAgentUser = AiAgentUser,
+> = AiAgentThreadSummary<TUser> & {
+    agentName: string;
+    agentImageUrl: string | null;
+};
+
+export type ApiAiAgentProjectThreadSummaryListResponse = ApiSuccess<
+    KnexPaginatedData<AiAgentProjectThreadSummary[]>
+>;
+
 export type ApiAiAgentThreadResponse = {
     status: 'ok';
     results: AiAgentThread;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -10,6 +10,7 @@ import type {
     ApiAiAgentEvaluationRunResultsResponse,
     ApiAiAgentEvaluationRunSummaryListResponse,
     ApiAiAgentEvaluationSummaryListResponse,
+    ApiAiAgentProjectThreadSummaryListResponse,
     ApiAiAgentThreadCreateResponse,
     ApiAiAgentThreadGenerateTitleResponse,
     ApiAiAgentThreadMessageCreateResponse,
@@ -1051,6 +1052,7 @@ type ApiResults =
     | ApiAiAgentArtifactResponse['results']
     | ApiAiAgentThreadGenerateTitleResponse['results']
     | ApiAiAgentThreadSummaryListResponse['results']
+    | ApiAiAgentProjectThreadSummaryListResponse['results']
     | Account
     | ApiAiAgentAdminConversationsResponse['results']
     | ApiAiAgentEvaluationSummaryListResponse['results']

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -7,7 +7,6 @@ import {
     Badge,
     Box,
     Group,
-    Paper,
     Text,
     Tooltip,
     useMantineTheme,
@@ -40,7 +39,6 @@ import {
     type UIEvent,
 } from 'react';
 import { useNavigate } from 'react-router';
-import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import {
     ContentTable,
     useContentTable,
@@ -54,6 +52,7 @@ import { useIsTruncated } from '../../../../../hooks/useIsTruncated';
 import SlackSvg from '../../../../../svgs/slack.svg?react';
 import { useInfiniteAiAgentAdminThreads } from '../../hooks/useAiAgentAdmin';
 import { useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
+import { AgentNamePill } from '../AgentNamePill';
 import { AiAgentAdminTopToolbar } from './AiAgentAdminTopToolbar';
 
 type AiAgentAdminThreadsTableProps = {
@@ -232,24 +231,10 @@ const AiAgentAdminThreadsTable = ({
             Cell: ({ row }) => {
                 const thread = row.original;
                 return (
-                    <Paper px="xs" maw="100%">
-                        <Group gap="two" wrap="nowrap">
-                            <LightdashUserAvatar
-                                size={12}
-                                name={thread.agent.name}
-                                src={thread.agent.imageUrl}
-                            />
-                            <Text
-                                fz="sm"
-                                fw={500}
-                                c="ldGray.7"
-                                truncate
-                                maw={220}
-                            >
-                                {thread.agent.name}
-                            </Text>
-                        </Group>
-                    </Paper>
+                    <AgentNamePill
+                        name={thread.agent.name}
+                        imageUrl={thread.agent.imageUrl}
+                    />
                 );
             },
         },

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentNamePill.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentNamePill.tsx
@@ -1,0 +1,48 @@
+import { Group, Paper, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import { LightdashUserAvatar } from '../../../../components/Avatar';
+
+type AgentNamePillProps = {
+    name: string;
+    imageUrl: string | null;
+    // 'pill' for table cells (boxed, scanned once per column);
+    // 'inline' for lists (quiet secondary meta, repeated per row).
+    variant?: 'pill' | 'inline';
+};
+
+export const AgentNamePill: FC<AgentNamePillProps> = ({
+    name,
+    imageUrl,
+    variant = 'pill',
+}) => {
+    const isPill = variant === 'pill';
+
+    const content = (
+        <Group gap="two" wrap="nowrap">
+            <LightdashUserAvatar
+                size={isPill ? 12 : 14}
+                name={name}
+                src={imageUrl}
+            />
+            <Text
+                fz={isPill ? 'sm' : 'xs'}
+                fw={isPill ? 500 : 400}
+                c="ldGray.7"
+                truncate
+                maw={220}
+            >
+                {name}
+            </Text>
+        </Group>
+    );
+
+    if (!isPill) {
+        return content;
+    }
+
+    return (
+        <Paper px="xs" maw="100%" display="inline-block">
+            {content}
+        </Paper>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
@@ -1,4 +1,7 @@
-import { type AiAgent, type AiAgentThreadSummary } from '@lightdash/common';
+import {
+    type AiAgent,
+    type AiAgentProjectThreadSummary,
+} from '@lightdash/common';
 import {
     Alert,
     Box,
@@ -18,26 +21,27 @@ import {
     IconInfoCircle,
     IconSparkles,
 } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings';
-import { useAiAgentThreads } from '../../hooks/useProjectAiAgents';
+import { useInfiniteAiAgentThreads } from '../../hooks/useProjectAiAgents';
+import { AgentNamePill } from '../AgentNamePill';
+import classes from './agentSidebar.module.css';
 import { SidebarButton } from './SidebarButton';
 
-const INITIAL_MAX_THREADS = 10;
-const MAX_THREADS_INCREMENT = 10;
-
 type ThreadNavLinkProps = {
-    thread: AiAgentThreadSummary;
+    thread: AiAgentProjectThreadSummary;
     isActive: boolean;
     projectUuid: string;
+    showAgentName?: boolean;
 };
 
 const ThreadNavLink: FC<ThreadNavLinkProps> = ({
     thread,
     isActive,
     projectUuid,
+    showAgentName = false,
 }) => (
     <NavLink
         color="gray"
@@ -46,13 +50,20 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
         to={`/projects/${projectUuid}/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`}
         px="xs"
         py={rem(4)}
-        style={(theme) => ({
-            borderRadius: theme.radius.sm,
-        })}
+        className={classes.threadNavLink}
         label={
-            <Text truncate="end" size="sm" c="ldGray.9">
+            <Text truncate="end" size="sm" fw={500} c="ldGray.9">
                 {thread.title || thread.firstMessage.message}
             </Text>
+        }
+        description={
+            showAgentName ? (
+                <AgentNamePill
+                    name={thread.agentName}
+                    imageUrl={thread.agentImageUrl}
+                    variant="inline"
+                />
+            ) : undefined
         }
         active={isActive}
         rightSection={
@@ -65,6 +76,73 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
         viewTransition
     />
 );
+
+type ThreadListProps = {
+    projectUuid: string;
+    threadUuid?: string;
+    agentUuid?: string;
+    showAgentName?: boolean;
+};
+
+const ThreadList: FC<ThreadListProps> = ({
+    projectUuid,
+    threadUuid,
+    agentUuid,
+    showAgentName = false,
+}) => {
+    const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isSuccess } =
+        useInfiniteAiAgentThreads(projectUuid, { agentUuid });
+
+    const threads = data?.pages.flatMap((page) => page.data) ?? [];
+
+    if (!isSuccess) {
+        return null;
+    }
+
+    return (
+        <Stack gap="xs" style={{ flexGrow: 1, overflowY: 'auto' }}>
+            <Title order={6} c="dimmed" tt="uppercase" size="xs" ml="xs">
+                Recent
+            </Title>
+
+            <Stack gap={2}>
+                {threads.length === 0 && (
+                    <Paper variant="dotted" p="sm">
+                        <Text truncate="end" size="sm" c="ldGray.6" ta="center">
+                            No threads yet
+                        </Text>
+                    </Paper>
+                )}
+
+                <Box>
+                    {threads.map((thread) => (
+                        <ThreadNavLink
+                            key={thread.uuid}
+                            thread={thread}
+                            isActive={thread.uuid === threadUuid}
+                            projectUuid={projectUuid}
+                            showAgentName={showAgentName}
+                        />
+                    ))}
+                </Box>
+            </Stack>
+
+            <Box>
+                {hasNextPage && (
+                    <Button
+                        size="compact-xs"
+                        variant="subtle"
+                        loading={isFetchingNextPage}
+                        onClick={() => fetchNextPage()}
+                        leftSection={<MantineIcon icon={IconChevronDown} />}
+                    >
+                        View more
+                    </Button>
+                )}
+            </Box>
+        </Stack>
+    );
+};
 
 const TrialAlert = () => (
     <Alert
@@ -111,8 +189,6 @@ export const AgentSidebar: FC<AgentSidebarProps> = ({
     const isTrial =
         aiOrganizationSettingsQuery.isSuccess &&
         aiOrganizationSettingsQuery.data.isTrial;
-    const { data: threads } = useAiAgentThreads(projectUuid, agent.uuid);
-    const [showMaxItems, setShowMaxItems] = useState(INITIAL_MAX_THREADS);
 
     return (
         <Stack gap="md" style={{ flexGrow: 1, overflowY: 'auto' }}>
@@ -131,63 +207,12 @@ export const AgentSidebar: FC<AgentSidebarProps> = ({
                 </SidebarButton>
             </Box>
 
-            {projectUuid && threads && !isAgentSidebarCollapsed && (
-                <Stack gap="xs" style={{ flexGrow: 1, overflowY: 'auto' }}>
-                    <Title
-                        order={6}
-                        c="dimmed"
-                        tt="uppercase"
-                        size="xs"
-                        ml="xs"
-                    >
-                        Recent
-                    </Title>
-
-                    <Stack gap={2}>
-                        {threads.length === 0 && (
-                            <Paper variant="dotted" p="sm">
-                                <Text
-                                    truncate="end"
-                                    size="sm"
-                                    c="ldGray.6"
-                                    ta="center"
-                                >
-                                    No threads yet
-                                </Text>
-                            </Paper>
-                        )}
-
-                        <Box>
-                            {threads.slice(0, showMaxItems).map((thread) => (
-                                <ThreadNavLink
-                                    key={thread.uuid}
-                                    thread={thread}
-                                    isActive={thread.uuid === threadUuid}
-                                    projectUuid={projectUuid}
-                                />
-                            ))}
-                        </Box>
-                    </Stack>
-
-                    <Box>
-                        {threads.length >= showMaxItems && (
-                            <Button
-                                size="compact-xs"
-                                variant="subtle"
-                                onClick={() =>
-                                    setShowMaxItems(
-                                        (s) => s + MAX_THREADS_INCREMENT,
-                                    )
-                                }
-                                leftSection={
-                                    <MantineIcon icon={IconChevronDown} />
-                                }
-                            >
-                                View more
-                            </Button>
-                        )}
-                    </Box>
-                </Stack>
+            {projectUuid && !isAgentSidebarCollapsed && (
+                <ThreadList
+                    projectUuid={projectUuid}
+                    threadUuid={threadUuid}
+                    agentUuid={agent.uuid}
+                />
             )}
             {isTrial && <TrialAlert />}
         </Stack>
@@ -196,11 +221,13 @@ export const AgentSidebar: FC<AgentSidebarProps> = ({
 
 type AutoModeSidebarProps = {
     projectUuid: string;
+    threadUuid?: string;
     isAgentSidebarCollapsed: boolean;
 };
 
 export const AutoModeSidebar: FC<AutoModeSidebarProps> = ({
     projectUuid,
+    threadUuid,
     isAgentSidebarCollapsed,
 }) => {
     const aiOrganizationSettingsQuery = useAiOrganizationSettings();
@@ -224,6 +251,14 @@ export const AutoModeSidebar: FC<AutoModeSidebarProps> = ({
                     {isAgentSidebarCollapsed ? '' : 'New thread'}
                 </SidebarButton>
             </Box>
+
+            {projectUuid && !isAgentSidebarCollapsed && (
+                <ThreadList
+                    projectUuid={projectUuid}
+                    threadUuid={threadUuid}
+                    showAgentName
+                />
+            )}
 
             {isTrial && <TrialAlert />}
         </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/agentSidebar.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/agentSidebar.module.css
@@ -1,0 +1,14 @@
+.threadNavLink {
+    border-radius: var(--mantine-radius-sm);
+    transition: background-color 150ms ease;
+
+    /* Don't override Mantine's active background when also hovered. */
+    &:not([data-active]):hover {
+        @mixin light {
+            background-color: var(--mantine-color-ldGray-2);
+        }
+        @mixin dark {
+            background-color: var(--mantine-color-ldDark-3);
+        }
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -1,5 +1,7 @@
 import type {
     AiAgent,
+    AiAgentThreadFilters,
+    ApiAiAgentProjectThreadSummaryListResponse,
     ApiAiAgentResponse,
     ApiAiAgentSummaryResponse,
     ApiAiAgentThreadCreateRequest,
@@ -9,7 +11,6 @@ import type {
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQuery,
     ApiAiAgentThreadResponse,
-    ApiAiAgentThreadSummaryListResponse,
     ApiAiAgentVerifiedQuestionsResponse,
     ApiAppendInstructionRequest,
     ApiAppendInstructionResponse,
@@ -27,9 +28,12 @@ import type {
 } from '@lightdash/common';
 import { nanoid } from '@reduxjs/toolkit';
 import {
+    useInfiniteQuery,
     useMutation,
     useQuery,
     useQueryClient,
+    type InfiniteData,
+    type UseInfiniteQueryOptions,
     type UseQueryOptions,
 } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
@@ -317,28 +321,6 @@ export const useDeleteAiAgentMutation = (projectUuid: string) => {
 };
 
 // Thread-related functionality
-const listAgentThreads = async (
-    projectUuid: string,
-    agentUuid: string,
-    allUsers?: boolean,
-) => {
-    const searchParams = new URLSearchParams();
-    if (allUsers) {
-        searchParams.set('allUsers', 'true');
-    }
-
-    const queryString = searchParams.toString();
-    const url = `/projects/${projectUuid}/aiAgents/${agentUuid}/threads${
-        queryString ? `?${queryString}` : ''
-    }`;
-
-    return lightdashApi<ApiAiAgentThreadSummaryListResponse['results']>({
-        url,
-        method: 'GET',
-        body: undefined,
-    });
-};
-
 const getAgentThread = async (
     projectUuid: string,
     agentUuid: string,
@@ -350,38 +332,70 @@ const getAgentThread = async (
         body: undefined,
     });
 
-export const useAiAgentThreads = (
+const PROJECT_THREADS_KEY = 'project-threads';
+
+const listProjectThreads = async (
     projectUuid: string,
-    agentUuid: string,
-    allUsers?: boolean,
+    filters: AiAgentThreadFilters,
+    pagination: { page: number; pageSize: number },
+) => {
+    const searchParams = new URLSearchParams();
+    searchParams.set('page', String(pagination.page));
+    searchParams.set('pageSize', String(pagination.pageSize));
+    if (filters.agentUuid) searchParams.set('agentUuid', filters.agentUuid);
+    if (filters.createdFrom)
+        searchParams.set('createdFrom', filters.createdFrom);
+    if (filters.search) searchParams.set('search', filters.search);
+
+    return lightdashApi<ApiAiAgentProjectThreadSummaryListResponse['results']>({
+        url: `/projects/${projectUuid}/aiAgents/threads?${searchParams.toString()}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+const DEFAULT_THREADS_PAGE_SIZE = 20;
+
+export const useInfiniteAiAgentThreads = (
+    projectUuid: string,
+    filters: AiAgentThreadFilters = {},
+    options?: UseInfiniteQueryOptions<
+        ApiAiAgentProjectThreadSummaryListResponse['results'],
+        ApiError
+    >,
 ) => {
     const navigate = useNavigate();
     const { showToastApiError } = useToaster();
 
-    return useQuery<ApiAiAgentThreadSummaryListResponse['results'], ApiError>({
-        queryKey: [
-            AI_AGENTS_KEY,
-            projectUuid,
-            agentUuid,
-            'threads',
-            allUsers ? 'all' : 'user',
-        ],
-        queryFn: () => listAgentThreads(projectUuid, agentUuid, allUsers),
+    return useInfiniteQuery<
+        ApiAiAgentProjectThreadSummaryListResponse['results'],
+        ApiError
+    >({
+        queryKey: [AI_AGENTS_KEY, projectUuid, PROJECT_THREADS_KEY, filters],
+        queryFn: ({ pageParam }) =>
+            listProjectThreads(projectUuid, filters, {
+                page: (pageParam as number) ?? 1,
+                pageSize: DEFAULT_THREADS_PAGE_SIZE,
+            }),
+        getNextPageParam: (lastPage) => {
+            if (!lastPage.pagination) return undefined;
+            const { page, totalPageCount } = lastPage.pagination;
+            return page < totalPageCount ? page + 1 : undefined;
+        },
         onError: (error) => {
             if (error.error?.statusCode === 403) {
                 void navigate(
                     `/projects/${projectUuid}/ai-agents/not-authorized`,
                 );
-            }
-            // Don't show error toast for permission errors - let the UI handle it gracefully
-            if (error.error?.statusCode !== 403) {
+            } else {
                 showToastApiError({
                     title: 'Failed to fetch AI agent threads',
                     apiError: error.error,
                 });
             }
         },
-        enabled: !!agentUuid,
+        enabled: !!projectUuid,
+        ...options,
     });
 };
 
@@ -540,20 +554,27 @@ const useGenerateAgentThreadTitleMutation = (projectUuid: string) => {
     >({
         mutationFn: ({ agentUuid, threadUuid }) =>
             generateAgentThreadTitle(projectUuid, agentUuid, threadUuid),
-        onSuccess: (data, { agentUuid, threadUuid }) => {
-            queryClient.setQueryData(
-                [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', 'user'],
-                (
-                    currentData:
-                        | ApiAiAgentThreadSummaryListResponse['results']
-                        | undefined,
-                ) => {
+        onSuccess: (data, { threadUuid }) => {
+            queryClient.setQueriesData<
+                | InfiniteData<
+                      ApiAiAgentProjectThreadSummaryListResponse['results']
+                  >
+                | undefined
+            >(
+                { queryKey: [AI_AGENTS_KEY, projectUuid, PROJECT_THREADS_KEY] },
+                (currentData) => {
                     if (!currentData) return currentData;
-                    return currentData.map((thread) =>
-                        thread.uuid === threadUuid
-                            ? { ...thread, title: data.title }
-                            : thread,
-                    );
+                    return {
+                        ...currentData,
+                        pages: currentData.pages.map((page) => ({
+                            ...page,
+                            data: page.data.map((thread) =>
+                                thread.uuid === threadUuid
+                                    ? { ...thread, title: data.title }
+                                    : thread,
+                            ),
+                        })),
+                    };
                 },
             );
         },
@@ -614,6 +635,10 @@ export const useCreateAgentThreadMutation = (
             // Invalidate both user-specific and all-users thread queries
             await queryClient.invalidateQueries({
                 queryKey: [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads'],
+            });
+            // Invalidate the project-scoped paginated thread list (sidebar)
+            await queryClient.invalidateQueries({
+                queryKey: [AI_AGENTS_KEY, projectUuid, PROJECT_THREADS_KEY],
             });
 
             void generateThreadTitle({ agentUuid, threadUuid: thread.uuid });


### PR DESCRIPTION
### Description

Reworks the AI agent threads list to be paginated and project-scoped, and cleans up how the thread list reads in the sidebar.

**Backend: new project-scoped, paginated threads endpoint**

- Adds `GET /api/v1/projects/{projectUuid}/aiAgents/threads`, returning a `KnexPaginatedData` page of the requesting user's own threads across the project. Supports `page` / `pageSize` plus optional `agentUuid`, `createdFrom`, and `search` filters.
- Purely additive: the existing per-agent `GET /{agentUuid}/threads` route, the model `findThreads`, and the service `listAgentThreads` are left untouched, so the public API stays backwards compatible. The shared SELECT/JOIN query builder is extracted (`buildThreadSummaryQuery` / `mapThreadSummaryRow`) so the paginated and single-thread paths can't drift.
- Each thread now carries `agentName` and `agentImageUrl` so the UI can show which agent a thread belongs to when the list spans multiple agents.
- `generate-api` was run (regenerated `routes.ts` + `swagger.json`); the new route is registered before `/{agentUuid}` so it isn't captured as a path param.

**Frontend: infinite scroll + a calmer list**

- New `useInfiniteAiAgentThreads` hook (TanStack `useInfiniteQuery`), used by both the per-agent sidebar and the Ask AI router sidebar. Optimistic cache writers (create thread, generate title) updated for the paginated shape.
- The Ask AI router sidebar (`AutoModeSidebar`), previously empty, now lists all of the user's threads across the project, each labelled with its agent.
- Extracted a shared `AgentNamePill` with two variants: `pill` (boxed, used in the admin threads table where it sits in a column) and `inline` (quiet secondary meta, used per row in the sidebar), keeping the agent label consistent across surfaces.
- Tidied the list visuals: dropped the heavy per-row boxed pill, strengthened the thread title weight so titles lead and the agent recedes, bumped the agent label color to `ldGray.7` for AA contrast, and added a theme-aware hover state (CSS module, scoped so it doesn't override the active row).

### How to test

1. Open Ask AI (`/projects/{uuid}/ai-agents`): the sidebar now lists your recent threads across all agents in the project, each with its agent name.
2. Open a specific agent's page: the sidebar shows only that agent's threads.
3. Scroll / "View more" to confirm pagination loads further pages.
4. Hover a thread row to see the hover state; the active thread stays highlighted.

<!-- Screenshots / gif welcome here -->
