### PR TITLE
fix(ai-agents): replace violet color with ldGray in AgentSelector and AgentsRouterPage

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -102,11 +102,11 @@ export const AgentSelector = ({
                 >
                     <Group gap={6} wrap="nowrap" align="center" w="100%">
                         {isAuto ? (
-                            <Avatar size={22} color="violet" radius="xl">
+                            <Avatar size={22} color="ldGray" radius="xl">
                                 <MantineIcon
                                     icon={IconSparkles}
                                     size="sm"
-                                    color="violet.6"
+                                    color="ldGray.6"
                                 />
                             </Avatar>
                         ) : (
@@ -133,26 +133,26 @@ export const AgentSelector = ({
                     <Combobox.Header p={4} pr={6}>
                         <Combobox.Option value={AUTO_VALUE} p={2}>
                             <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
-                                <Avatar size={22} color="violet" radius="xl">
+                                <Avatar size={22} color="ldGray" radius="xl">
                                     <MantineIcon
                                         icon={IconSparkles}
                                         size="sm"
-                                        color="violet.6"
+                                        color="ldGray.6"
                                     />
                                 </Avatar>
                                 <Stack gap={0} flex={1} miw={0}>
-                                    <Text size="xs" fw={600} c="violet.7">
+                                    <Text size="xs" fw={600}>
                                         Auto
                                     </Text>
                                     <Text size="xs" c="dimmed" truncate="end">
-                                        We'll route to the besy-fit agent
+                                        We'll route to the best-fit agent
                                     </Text>
                                 </Stack>
                                 {isAuto && (
                                     <MantineIcon
                                         icon={IconCheck}
                                         size="sm"
-                                        color="violet"
+                                        color="ldGray.7"
                                     />
                                 )}
                             </Group>
@@ -183,7 +183,7 @@ export const AgentSelector = ({
                                         <MantineIcon
                                             icon={IconCheck}
                                             size="sm"
-                                            color="violet"
+                                            color="ldGray.7"
                                         />
                                     )}
                             </Group>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -8,7 +8,8 @@
     position: absolute;
     inset: -6px;
     border-radius: 50%;
-    border: 1px solid var(--mantine-color-violet-4);
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-4), var(--mantine-color-ldGray-5));
     opacity: 0;
     pointer-events: none;
 }
@@ -62,7 +63,10 @@
     width: 4px;
     height: 4px;
     border-radius: 50%;
-    background-color: var(--mantine-color-violet-5);
+    background-color: light-dark(
+        var(--mantine-color-ldGray-5),
+        var(--mantine-color-ldGray-4)
+    );
     animation: routingDotBlink 1100ms cubic-bezier(0.45, 0, 0.55, 1) infinite;
 }
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -271,7 +271,7 @@ const AgentsRouterPage = () => {
                     <Stack align="center" gap="xxs">
                         <Avatar
                             size="lg"
-                            color="violet"
+                            color="ldGray"
                             radius="xl"
                             className={`${classes.heroAvatar} ${
                                 isWorking ? classes.heroAvatarWorking : ''
@@ -280,7 +280,7 @@ const AgentsRouterPage = () => {
                             <MantineIcon
                                 icon={IconSparkles}
                                 size="xl"
-                                color="violet.6"
+                                color="ldGray.6"
                                 className={classes.heroSparkles}
                             />
                         </Avatar>


### PR DESCRIPTION
### Description

Tones down the purple accents on the "Ask AI" router page so the generic entry point reads calm, while keeping violet where it carries real meaning.

The page is the generic "Ask AI" landing state, so the violet accents were pulling too much attention and gave the "Auto" mode (a non-choice) the visual weight of a primary action. Neutralizing those accents fits the page better.

#### Decision: neutral by default, violet only as a selection signal

The violet was doing two different jobs that got conflated. As decoration on the landing state it was over-weighted, but inside the picker it is a genuine selection signal, the one place an accent color earns its keep. So the split is:

**Neutralized to `ldGray`:**
- Hero avatar + sparkles icon
- "Thinking" routing dots
- Auto mode chip, label, and sparkles in the shared `AgentSelector`
- Dropdown selection checkmarks

**Kept violet (intentionally):**
- The "Recommended" candidate in the agent picker: border, hover fill, description tint, chevron, settle glow, and the "Recommended" badge

Violet stays on the recommended candidate because it is a real selection signal, and because it reads better in dark mode: violet's light variant has enough chroma to lift off the dark surface where flat gray collapses into the background.

#### Other
- Fixed a typo in the Auto dropdown copy: "besy-fit" to "best-fit"
