### PR TITLE
feat: make S3 storage required, drop Snowflake-without-S3 fallback

### DIFF
--- a/packages/backend/src/clients/ResultsFileStorageClients/CLAUDE.md
+++ b/packages/backend/src/clients/ResultsFileStorageClients/CLAUDE.md
@@ -58,7 +58,7 @@ const downloadUrl = await resultsClient.uploadFile(
 - File extension auto-appended via `sanitizeFileExtension` if missing
 - Pre-signed URLs expire based on `lightdashConfig.s3.expirationTime`
 - Throws `MissingConfigError` if methods called when S3 not configured
-- Without S3 configured, async queries fall back to re-querying warehouse (Snowflake only)
+- S3-compatible storage is required at boot, so `isEnabled` is always true in a running instance
 </importantToKnow>
 
 <links>

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -153,13 +153,11 @@ test('Should use explicit apps S3 config when set', () => {
     });
 });
 
-test('Should return null apps S3 config when base S3 is not configured', () => {
+test('Should fail fast when base S3 is not configured', () => {
     delete process.env.S3_ENDPOINT;
     delete process.env.S3_BUCKET;
     delete process.env.S3_REGION;
-    process.env.APPS_S3_BUCKET = 'apps_bucket';
-    const config = parseConfig();
-    expect(config.appRuntime.s3).toBeNull();
+    expect(() => parseConfig()).toThrow('S3-compatible storage is required');
 });
 
 test('Should parse rudder config from env', () => {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -669,7 +669,10 @@ export const parseBaseS3Config = (): LightdashConfig['s3'] => {
         .filter((v) => v.length > 0);
 
     if (!endpoint || !bucket || !region) {
-        return undefined;
+        throw new ParseError(
+            'S3-compatible storage is required. Set S3_ENDPOINT, S3_BUCKET and S3_REGION (AWS S3, GCS, MinIO, etc.) - https://docs.lightdash.com/self-host/customize-deployment/environment-variables#s3',
+            {},
+        );
     }
 
     return {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1619,7 +1619,7 @@ describe('AsyncQueryService', () => {
             serviceWithCache.queryHistoryModel.get = jest
                 .fn()
                 .mockResolvedValue(mockQueryHistory);
-            serviceWithCache.getResultsPageFromWarehouse = jest
+            serviceWithCache.getResultsPageFromS3 = jest
                 .fn()
                 .mockResolvedValue({
                     rows: [expectedFormattedRow],

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -587,39 +587,6 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
-    async getResultsPageFromWarehouse(
-        account: Account,
-        queryHistory: QueryHistory,
-        page: number,
-        pageSize: number,
-        formatter: (row: Record<string, unknown>) => ResultRow,
-    ) {
-        if (!queryHistory.projectUuid) {
-            throw new Error('Project UUID is required');
-        }
-
-        const warehouseConnection = await this._getWarehouseClient(
-            queryHistory.projectUuid,
-            await this.getWarehouseCredentials({
-                projectUuid: queryHistory.projectUuid,
-                userId: account.user.id,
-                isRegisteredUser: account.isRegisteredUser(),
-                isServiceAccount: account.isServiceAccount(),
-            }),
-        );
-
-        return warehouseConnection.warehouseClient.getAsyncQueryResults(
-            {
-                sql: queryHistory.compiledSql,
-                queryId: queryHistory.warehouseQueryId,
-                queryMetadata: queryHistory.warehouseQueryMetadata,
-                page,
-                pageSize,
-            },
-            formatter,
-        );
-    }
-
     async cancelAsyncQuery({
         account,
         projectUuid,
@@ -846,35 +813,19 @@ export class AsyncQueryService extends ProjectService {
                 displayTimezone ?? undefined,
             );
 
-        const resultsCacheEnabled =
-            (await this.cacheService?.isResultsCacheEnabled({
-                userUuid: account.user.id,
-                organizationUuid: account.organization.organizationUuid,
-                organizationName: account.organization.name,
-            })) ?? false;
-
         const {
             result: { rows },
             durationMs,
         } = await measureTime(
             () =>
-                this.getResultsStorageClientForContext(queryHistory.context)
-                    .isEnabled || resultsCacheEnabled
-                    ? this.getResultsPageFromS3(
-                          queryUuid,
-                          resultsFileName,
-                          queryHistory.context,
-                          page,
-                          defaultedPageSize,
-                          formatter,
-                      )
-                    : this.getResultsPageFromWarehouse(
-                          account,
-                          queryHistory,
-                          page,
-                          defaultedPageSize,
-                          formatter,
-                      ),
+                this.getResultsPageFromS3(
+                    queryUuid,
+                    resultsFileName,
+                    queryHistory.context,
+                    page,
+                    defaultedPageSize,
+                    formatter,
+                ),
             'getCachedResultsPage',
             this.logger,
             context,
@@ -5855,34 +5806,6 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             queryUuid,
         });
-
-        const queryHistory = await this.queryHistoryModel.get(
-            queryUuid,
-            projectUuid,
-            account,
-        );
-
-        if (!queryHistory.resultsFileName) {
-            // Some self-hosted installs disable results-file storage, so the
-            // async query still completes but there is no file to download.
-            const { rows } = await this.getResultsPageFromWarehouse(
-                account,
-                queryHistory,
-                1,
-                Math.max(queryHistory.totalRowCount ?? 0, 1),
-                (row) => row as ResultRow,
-            );
-
-            return {
-                rows,
-                cacheMetadata,
-                fields,
-                pivotDetails:
-                    AsyncQueryService.getPivotDetailsFromQueryHistory(
-                        queryHistory,
-                    ),
-            };
-        }
 
         return this.getReadyQueryResults({
             account,

--- a/packages/backend/src/services/AsyncQueryService/CLAUDE.md
+++ b/packages/backend/src/services/AsyncQueryService/CLAUDE.md
@@ -111,10 +111,7 @@ For queries returning millions of rows, this blocks the event loop during proces
 `PENDING`, `RUNNING`, `READY`, `ERROR`, or `CANCELLED`
 
 **Polling Results Source:**
-When `getAsyncQueryResults` is called, results are fetched from different sources depending on configuration:
-
-- **S3 enabled** (`resultsStorageClient.isEnabled`): Reads paginated results from S3 JSONL file
-- **S3 disabled**: Falls back to `getResultsPageFromWarehouse()`, which re-queries the warehouse using stored `warehouseQueryId`. Currently only **Snowflake** supports this via `warehouseClient.getAsyncQueryResults()`. Other warehouses throw `NotImplementedError` and require S3 to be configured.
+When `getAsyncQueryResults` is called, results are always read from the S3 JSONL file via `resultsStorageClient`. S3-compatible storage is required at boot (see `parseBaseS3Config`), so every warehouse uses this path uniformly — there is no warehouse re-query fallback.
 
 **Pagination:**
 Results are paginated (default 500 rows, max 5000). Use `page` and `pageSize` parameters.

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -39,15 +39,6 @@ export const warehouseClientMock: WarehouseClient = {
             },
         },
     }),
-    getAsyncQueryResults: async () => ({
-        queryId: null,
-        queryMetadata: null,
-        totalRows: 0,
-        durationMs: 0,
-        fields: {},
-        pageCount: 0,
-        rows: [],
-    }),
     streamQuery(query, streamCallback) {
         void streamCallback({
             fields: {},
@@ -155,15 +146,6 @@ export const bigqueryClientMock: WarehouseClient = {
                 },
             },
         },
-    }),
-    getAsyncQueryResults: async () => ({
-        queryId: null,
-        queryMetadata: null,
-        totalRows: 0,
-        durationMs: 0,
-        fields: {},
-        pageCount: 0,
-        rows: [],
     }),
     streamQuery(query, streamCallback) {
         void streamCallback({

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -33,15 +33,6 @@ export const warehouseClientMock: WarehouseClient = {
             },
         },
     }),
-    getAsyncQueryResults: async () => ({
-        queryId: null,
-        queryMetadata: null,
-        totalRows: 0,
-        durationMs: 0,
-        fields: {},
-        pageCount: 0,
-        rows: [],
-    }),
     streamQuery: async (_query, streamCallback) => {
         await streamCallback({
             fields: {},

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -52,11 +52,6 @@ export type WarehouseResults = {
     rows: Record<string, AnyType>[];
 };
 
-export type WarehousePaginationArgs = {
-    page: number;
-    pageSize: number;
-};
-
 export type WarehouseExecuteAsyncQueryArgs = {
     tags: Record<string, string>;
     timezone?: string;
@@ -70,22 +65,6 @@ export type WarehouseExecuteAsyncQuery = {
     queryMetadata: WarehouseQueryMetadata | null;
     totalRows: number;
     durationMs: number;
-};
-
-export type WarehouseGetAsyncQueryResultsArgs = WarehousePaginationArgs & {
-    sql: string;
-    queryId: string | null;
-    queryMetadata: WarehouseQueryMetadata | null;
-};
-
-export type WarehouseGetAsyncQueryResults<
-    TFormattedRow extends Record<string, unknown>,
-> = {
-    queryId: string | null;
-    fields: Record<string, { type: DimensionType }>;
-    pageCount: number;
-    totalRows: number;
-    rows: TFormattedRow[];
 };
 
 export enum TimeIntervalUnit {
@@ -131,11 +110,6 @@ export interface WarehouseClient extends WarehouseSqlBuilder {
             table: string;
         }[],
     ) => Promise<WarehouseCatalog>;
-
-    getAsyncQueryResults<TFormattedRow extends Record<string, unknown>>(
-        args: WarehouseGetAsyncQueryResultsArgs,
-        rowFormatter?: (row: Record<string, unknown>) => TFormattedRow,
-    ): Promise<WarehouseGetAsyncQueryResults<TFormattedRow>>;
 
     streamQuery(
         query: string,

--- a/packages/common/src/utils/convertCustomDimensionsToYaml.ts
+++ b/packages/common/src/utils/convertCustomDimensionsToYaml.ts
@@ -88,9 +88,6 @@ const warehouseClientMock: WarehouseClient = {
     getCatalog() {
         throw new NotImplementedError('getCatalog not implemented');
     },
-    getAsyncQueryResults() {
-        throw new NotImplementedError('getAsyncQueryResults not implemented');
-    },
     getAdapterType() {
         throw new NotImplementedError('getCatalog not implemented');
     },

--- a/packages/common/src/utils/virtualView.test.ts
+++ b/packages/common/src/utils/virtualView.test.ts
@@ -23,15 +23,6 @@ const fakeWarehouseClient: WarehouseClient = {
         sshTunnelUser: '',
     },
     getCatalog: async () => ({}),
-    getAsyncQueryResults: async () => ({
-        queryId: null,
-        queryMetadata: null,
-        totalRows: 0,
-        durationMs: 0,
-        fields: {},
-        pageCount: 0,
-        rows: [],
-    }),
     streamQuery: async () => {},
     executeAsyncQuery: async () => ({
         queryId: null,

--- a/packages/common/src/utils/virtualView.ts
+++ b/packages/common/src/utils/virtualView.ts
@@ -101,15 +101,6 @@ export const createTemporaryVirtualView = (
             maximumBytesBilled: 0,
         },
         getCatalog: async () => ({}),
-        getAsyncQueryResults: async () => ({
-            queryId: null,
-            queryMetadata: null,
-            totalRows: 0,
-            durationMs: 0,
-            fields: {},
-            pageCount: 0,
-            rows: [],
-        }),
         streamQuery: async () => {},
         executeAsyncQuery: async () => ({
             queryId: null,

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -16,8 +16,6 @@ import {
     WarehouseTypes,
     type WarehouseExecuteAsyncQuery,
     type WarehouseExecuteAsyncQueryArgs,
-    type WarehouseGetAsyncQueryResults,
-    type WarehouseGetAsyncQueryResultsArgs,
 } from '@lightdash/common';
 import * as crypto from 'crypto';
 import {
@@ -574,55 +572,6 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             : {};
     }
 
-    private async getAsyncStatementResults<
-        TFormattedRow extends Record<string, unknown>,
-    >(
-        connection: Connection,
-        queryId: string,
-        start: number,
-        end: number,
-        rowFormatter?: (row: Record<string, unknown>) => TFormattedRow,
-    ): Promise<{
-        rows: TFormattedRow[];
-        fields: Record<string, { type: DimensionType }>;
-        numRows: number;
-    }> {
-        const statement = await connection.getResultsFromQueryId({
-            sqlText: '', // ! This shouldn't be needed but is required by the snowflake sdk, https://github.com/snowflakedb/snowflake-connector-nodejs/issues/978
-            queryId,
-        });
-
-        const rows: TFormattedRow[] = [];
-
-        await new Promise<void>((resolve, reject) => {
-            statement
-                .streamRows({
-                    start,
-                    end,
-                })
-                .on('error', (err) => {
-                    reject(err);
-                })
-                .on('data', (row) => {
-                    const parsedRow = parseRow(row);
-                    const formattedRow = rowFormatter
-                        ? rowFormatter(parsedRow)
-                        : (parsedRow as TFormattedRow);
-
-                    rows.push(formattedRow);
-                })
-                .on('end', () => {
-                    resolve();
-                });
-        });
-
-        return {
-            rows,
-            fields: this.getFieldsFromStatement(statement),
-            numRows: statement.getNumRows(),
-        };
-    }
-
     private async destroyConnection(
         connection: Connection,
         authenticator: string | undefined,
@@ -643,46 +592,6 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                 resolve(conn);
             });
         });
-    }
-
-    async getAsyncQueryResults<TFormattedRow extends Record<string, unknown>>(
-        { sql, page, pageSize, queryId }: WarehouseGetAsyncQueryResultsArgs,
-        rowFormatter?: (row: Record<string, unknown>) => TFormattedRow,
-    ): Promise<WarehouseGetAsyncQueryResults<TFormattedRow>> {
-        if (queryId === null) {
-            throw new WarehouseQueryError('Query ID is required');
-        }
-
-        const connection = await this.getConnection();
-
-        try {
-            const start = (page - 1) * pageSize;
-            const end = start + pageSize - 1;
-
-            const results = await this.getAsyncStatementResults(
-                connection,
-                queryId,
-                start,
-                end,
-                rowFormatter,
-            );
-
-            return {
-                fields: results.fields,
-                rows: results.rows,
-                queryId,
-                pageCount: Math.ceil(results.numRows / pageSize),
-                totalRows: results.numRows,
-            };
-        } catch (e) {
-            const error = e as SnowflakeError;
-            throw this.parseError(error, sql);
-        } finally {
-            await this.destroyConnection(
-                connection,
-                this.connectionOptions.authenticator,
-            );
-        }
     }
 
     async executeAsyncQuery(

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
@@ -3,7 +3,6 @@ import {
     CreateWarehouseCredentials,
     DimensionType,
     Metric,
-    NotImplementedError,
     PartitionColumn,
     SupportedDbtAdapter,
     TimeIntervalUnit,
@@ -13,8 +12,6 @@ import {
     WeekDay,
     type WarehouseExecuteAsyncQuery,
     type WarehouseExecuteAsyncQueryArgs,
-    type WarehouseGetAsyncQueryResults,
-    type WarehouseGetAsyncQueryResultsArgs,
 } from '@lightdash/common';
 import { type WarehouseClient } from '../types';
 
@@ -65,15 +62,6 @@ export default abstract class WarehouseBaseClient<
     abstract getCatalog(
         config: { database: string; schema: string; table: string }[],
     ): Promise<WarehouseCatalog>;
-
-    async getAsyncQueryResults<TFormattedRow extends Record<string, unknown>>(
-        _args: WarehouseGetAsyncQueryResultsArgs,
-        _rowFormatter?: (row: Record<string, unknown>) => TFormattedRow,
-    ): Promise<WarehouseGetAsyncQueryResults<TFormattedRow>> {
-        throw new NotImplementedError(
-            `Native pagination not supported. Please configure S3 Storage to use ${this.getAdapterType()} - https://docs.lightdash.com/self-host/customize-deployment/environment-variables#s3`,
-        );
-    }
 
     abstract streamQuery(
         query: string,


### PR DESCRIPTION
Closes: GLITCH-476

### Description:
Makes S3-compatible storage required at boot — `parseBaseS3Config` now throws a clear error when `S3_ENDPOINT`/`S3_BUCKET`/`S3_REGION` are missing, instead of silently running without it. Removes the no-S3 results path in `AsyncQueryService` and the warehouse-client native pagination (`getAsyncQueryResults`) that only Snowflake implemented, so every warehouse now fetches async-query results from S3 uniformly. Also drops the now-unused warehouse types/interface method and stale docs, and updates the config test to assert the fail-fast behaviour. Dev/preview docker-compose already provisions MinIO, so local boots are unaffected.