### PR TITLE
fix(ai-writeback): gate writeback on manage:SourceCode

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -650,8 +650,8 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
-     * Pre-flight: enforce the feature flag, the project view permission, and
-     * resolve everything from the request that doesn't require a sandbox.
+     * Pre-flight: enforce the feature flag, the `manage:SourceCode` permission,
+     * and resolve everything from the request that doesn't require a sandbox.
      */
     private async prepareTurn({
         user,
@@ -665,14 +665,18 @@ export class AiWritebackService extends BaseService {
         await this.assertEnabled(user);
 
         const project = await this.projectModel.get(projectUuid);
-        const canView = this.createAuditedAbility(user).can(
-            'view',
-            subject('Project', {
+        // Writeback opens a PR from a freshly created feature branch
+        // (`lightdash-ai-writeback/<uuid>`), so `isProtectedBranch: false`
+        // mirrors the gate on GitIntegrationService's PR-creating paths.
+        const canWriteback = this.createAuditedAbility(user).can(
+            'manage',
+            subject('SourceCode', {
                 organizationUuid: project.organizationUuid,
                 projectUuid,
+                isProtectedBranch: false,
             }),
         );
-        if (!canView) {
+        if (!canWriteback) {
             throw new ForbiddenError();
         }
 


### PR DESCRIPTION
Closes [PROD-7991](https://linear.app/lightdash/issue/PROD-7991/require-managesourcecode-permission-to-perform-writeback).

## What this fixes

`AiWritebackService.run()` is the single chokepoint for both writeback entry points (the `/api/v1/ee/projects/{projectUuid}/ai-writeback` HTTP route and the `proposeWriteback` AI-agent tool). Its pre-flight only checked `view:Project`, so any project viewer who could reach either surface could trigger an agent run that opens a PR against the project's dbt repo.

| Path | Today | After this PR |
| --- | --- | --- |
| `AiWritebackController.runAiWriteback` (HTTP) | Requires `view:Project` | Requires `manage:SourceCode` (non-protected branch) |
| `AiAgentService` → `proposeWriteback` tool | Requires `view:Project` | Requires `manage:SourceCode` (non-protected branch) |

## How

Single check swap in `AiWritebackService.prepareTurn` (`packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts`):

```
Before:  ability.can('view',   subject('Project',    { organizationUuid, projectUuid }))
After:   ability.can('manage', subject('SourceCode', { organizationUuid, projectUuid, isProtectedBranch: false }))
```

`isProtectedBranch: false` mirrors the gate on `GitIntegrationService.createPullRequestForChartFields` — writeback always branches off into a fresh `lightdash-ai-writeback/<uuid>` feature branch and opens a PR, so the protected-branch path is never taken.

## Who's affected

| User class | Holds `manage:SourceCode`? | Affected? |
| --- | --- | --- |
| Project admin | Yes | No |
| Developer system role | Yes | No |
| Editor / Interactive viewer / Viewer | No | **Yes** — calls now return 403. *This is the gap we are closing.* |
| Service accounts (ORG_ADMIN) | Yes | No |
| Custom role with `manage:SourceCode` | Yes | No |
| Custom role without `manage:SourceCode` | No | **Yes** — calls now return 403. Correct-by-spec. |

In practice writeback is invoked by data developers who already hold `manage:SourceCode`. The feature is also still behind the `ai-writeback` feature flag, off by default.

## Test plan

- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend lint` — clean
- [x] `pnpm -F backend test:dev:nowatch` — clean (only the MCP snapshot suite is in scope for the diff)
- [ ] Manual: as a developer, `POST /api/v1/ee/projects/:uuid/ai-writeback` still opens a PR
- [ ] Manual: as a viewer, the same call returns 403 (and the `proposeWriteback` tool surfaces the same ForbiddenError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)