### PR TITLE
fix(ai-agent): disable Slack writeback when aiRequireOAuth is off

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5700,19 +5700,28 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         const enableSqlMode = options.enableSqlMode ?? false;
 
-        let canRunSql = enableSqlMode;
-        // Without OAuth, Slack messages run as a workspace-default user — the CASL check below would evaluate against that default, letting anyone in the workspace trigger SQL under another person's identity. Fail-closed.
-        if (canRunSql && isSlackPrompt(prompt) && user.organizationUuid) {
+        // Whether this prompt's caller identity can be trusted as the real
+        // sender. For Slack prompts that's only true when the org has
+        // `aiRequireOAuth` on; otherwise every message runs as the
+        // workspace installer and downstream CASL checks would evaluate
+        // against the installer's ability. Non-Slack callers are always
+        // the real sender, so default to true.
+        let aiRequireOAuth = true;
+        if (isSlackPrompt(prompt) && user.organizationUuid) {
             const slackSettings =
                 await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
                     user.organizationUuid,
                 );
-            if (!slackSettings?.aiRequireOAuth) {
-                this.logger.info(
-                    `Disabling runSql for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
-                );
-                canRunSql = false;
-            }
+            aiRequireOAuth = !!slackSettings?.aiRequireOAuth;
+        }
+
+        let canRunSql = enableSqlMode;
+        // Fail-closed: CASL would evaluate against the installer, not the sender.
+        if (canRunSql && !aiRequireOAuth) {
+            this.logger.info(
+                `Disabling runSql for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
+            );
+            canRunSql = false;
         }
 
         // Require the same CASL ability the SQL Runner page uses. The check
@@ -5783,11 +5792,18 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 user,
                 featureFlagId: FeatureFlags.AiAgentRevamp,
             });
-        const { enabled: aiWritebackEnabled } =
-            await this.featureFlagService.get({
+        let { enabled: aiWritebackEnabled } = await this.featureFlagService.get(
+            {
                 user,
                 featureFlagId: FeatureFlags.AiWriteback,
-            });
+            },
+        );
+        if (aiWritebackEnabled && !aiRequireOAuth) {
+            this.logger.info(
+                `Disabling proposeWriteback for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
+            );
+            aiWritebackEnabled = false;
+        }
         const availableSkills = agentRevampEnabled
             ? await BuiltInSkills.getAiAgentSkills()
             : [];


### PR DESCRIPTION
Closes [PROD-8009](https://linear.app/lightdash/issue/PROD-8009/require-oauth-for-writeback). Follow-up to #23659.

## What this fixes

When the Slack `aiRequireOAuth` setting is off (the default), every Slack prompt runs as the workspace installer's Lightdash identity — `SlackAuthenticationModel.getUserUuid(teamId)` returns the installer's `user_uuid` regardless of who actually sent the message. The `manage:SourceCode` gate added in #23659 evaluates against the installer's CASL ability, so any workspace member who can @-mention the bot can trigger a writeback PR as the installer.

Fail-closed by not registering the `proposeWriteback` tool with the agent when this risk exists. Mirrors the existing `runSql` guard at `AiAgentService.ts:5705`.

| Path | Today (with `manage:SourceCode` from #23659) | After this PR |
| --- | --- | --- |
| HTTP `POST /ai-writeback` | Gated by `manage:SourceCode` on the real session user | Unchanged |
| Web-app agent stream → `proposeWriteback` | Gated by `manage:SourceCode` on the real session user | Unchanged |
| Slack agent → `proposeWriteback`, `aiRequireOAuth` on | Gated by `manage:SourceCode` on the real Slack sender | Unchanged |
| Slack agent → `proposeWriteback`, `aiRequireOAuth` off | Gated by `manage:SourceCode` on the **installer** — bypass | Tool not registered with the agent at all |

## How

In `AiAgentService.generateOrStreamAgentResponse`, lift the Slack-settings lookup into a single `aiRequireOAuth` boolean computed once per prompt. Defaults to `true` so non-Slack callers are unaffected. Both `runSql` and `proposeWriteback` consume the same signal:

```
                              ┌─── isSlackPrompt? ──────────┐
                              │                             │
                            no│                          yes│
                              │                             ▼
                              │              slackSettings.aiRequireOAuth
                              │                             │
                              ▼                             ▼
                       aiRequireOAuth = true       aiRequireOAuth = !!setting

                                          │
                       ┌──────────────────┴───────────────────┐
                       ▼                                      ▼
        if (canRunSql && !aiRequireOAuth)      if (aiWritebackEnabled && !aiRequireOAuth)
           → disable runSql                        → disable proposeWriteback
```

Gating at tool-registration (rather than throwing inside `AiWritebackService.run`) means the agent's toolset never contains a tool it cannot use, so the model cannot be coerced into calling it and the user never sees a mid-turn ForbiddenError.

## Who's affected

| User class | Slack `aiRequireOAuth` | Affected? |
| --- | --- | --- |
| HTTP / web-app caller | n/a | No — real session user, gated by `manage:SourceCode` |
| Slack sender, OAuth on, has `manage:SourceCode` | on | No — sender is the real user, gate passes |
| Slack sender, OAuth on, no `manage:SourceCode` | on | No — gate denies via `ForbiddenError` |
| Slack sender, OAuth off, installer has `manage:SourceCode` | off | **Yes** — could previously trigger writeback as installer. *This is the bypass we are closing.* Tool no longer registered. |
| Slack sender, OAuth off, installer lacks `manage:SourceCode` | off | No — gate denied anyway |

The `ai-writeback` feature flag is off by default, so this only matters for orgs that have explicitly enabled writeback **and** kept Slack `aiRequireOAuth` off. The fix is to either enable OAuth (recommended) or accept that writeback won't be offered on Slack.

## Test plan

- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend lint` — clean
- [ ] Manual: org with `aiRequireOAuth = off` and `ai-writeback = on` — Slack @mention asking for a writeback gets a response that does not include a writeback PR (agent never calls the tool)
- [ ] Manual: same org with `aiRequireOAuth = on` and the sender linked via OAuth and holding `manage:SourceCode` — writeback PR opens as before
- [ ] Manual: HTTP `POST /api/v1/ee/projects/:uuid/ai-writeback` continues to work for a user with `manage:SourceCode` regardless of Slack settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)