### PR TITLE
feat(ai-agents): add typed `onToolCall`/`onToolResult` stream callbacks with parsed tool definitions

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -653,6 +653,72 @@ export const runAiWritebackToolDefinition = defineTool({
     },
 });
 
+type AgentToolDefinitionsByName = {
+    findExplores: typeof findExploresToolDefinition;
+    findFields: typeof findFieldsToolDefinition;
+    findContent: typeof findContentToolDefinition;
+    searchFieldValues: typeof searchFieldValuesToolDefinition;
+    runQuery: typeof runQueryToolDefinition;
+    runSql: typeof runSqlToolDefinition;
+    discoverFields: typeof discoverFieldsToolDefinition;
+    generateDashboard: typeof generateDashboardToolDefinition;
+    generateUuids: typeof generateUuidsToolDefinition;
+    getDashboardCharts: typeof getDashboardChartsToolDefinition;
+    readContent: typeof readContentToolDefinition;
+    editContent: typeof editContentToolDefinition;
+    createContent: typeof createContentToolDefinition;
+    listContent: typeof listContentToolDefinition;
+    improveContext: typeof improveContextToolDefinition;
+    loadSkill: typeof loadSkillToolDefinition;
+    proposeChange: typeof proposeChangeToolDefinition;
+    proposeWriteback: typeof proposeWritebackToolDefinition;
+    runSavedChart: typeof runSavedChartToolDefinition;
+    listWarehouseTables: typeof listWarehouseTablesToolDefinition;
+    describeWarehouseTable: typeof describeWarehouseTableToolDefinition;
+    listKnowledgeDocuments: typeof listKnowledgeDocumentsToolDefinition;
+    getKnowledgeDocumentContent: typeof getKnowledgeDocumentContentToolDefinition;
+    findCharts: typeof findChartsToolDefinition;
+    findDashboards: typeof findDashboardsToolDefinition;
+    generateBarVizConfig: typeof generateBarVizConfigToolDefinition;
+    generateTableVizConfig: typeof generateTableVizConfigToolDefinition;
+    generateTimeSeriesVizConfig: typeof generateTimeSeriesVizConfigToolDefinition;
+    listProjects: typeof listProjectsToolDefinition;
+    getProjectInfo: typeof getProjectInfoToolDefinition;
+};
+
+export const agentToolDefinitionsByName: AgentToolDefinitionsByName = {
+    findExplores: findExploresToolDefinition,
+    findFields: findFieldsToolDefinition,
+    findContent: findContentToolDefinition,
+    searchFieldValues: searchFieldValuesToolDefinition,
+    runQuery: runQueryToolDefinition,
+    runSql: runSqlToolDefinition,
+    discoverFields: discoverFieldsToolDefinition,
+    generateDashboard: generateDashboardToolDefinition,
+    generateUuids: generateUuidsToolDefinition,
+    getDashboardCharts: getDashboardChartsToolDefinition,
+    readContent: readContentToolDefinition,
+    editContent: editContentToolDefinition,
+    createContent: createContentToolDefinition,
+    listContent: listContentToolDefinition,
+    improveContext: improveContextToolDefinition,
+    loadSkill: loadSkillToolDefinition,
+    proposeChange: proposeChangeToolDefinition,
+    proposeWriteback: proposeWritebackToolDefinition,
+    runSavedChart: runSavedChartToolDefinition,
+    listWarehouseTables: listWarehouseTablesToolDefinition,
+    describeWarehouseTable: describeWarehouseTableToolDefinition,
+    listKnowledgeDocuments: listKnowledgeDocumentsToolDefinition,
+    getKnowledgeDocumentContent: getKnowledgeDocumentContentToolDefinition,
+    findCharts: findChartsToolDefinition,
+    findDashboards: findDashboardsToolDefinition,
+    generateBarVizConfig: generateBarVizConfigToolDefinition,
+    generateTableVizConfig: generateTableVizConfigToolDefinition,
+    generateTimeSeriesVizConfig: generateTimeSeriesVizConfigToolDefinition,
+    listProjects: listProjectsToolDefinition,
+    getProjectInfo: getProjectInfoToolDefinition,
+};
+
 export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     findExploresToolDefinition,
     findFieldsToolDefinition,
@@ -700,15 +766,15 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
 
 export type BuiltInToolDefinition = ToolDefinitionInstance;
 
-export const agentToolDefinitions = builtInToolDefinitions.filter((tool) =>
-    tool.availability.includes('agent'),
-);
+export const agentToolDefinitions: readonly ToolDefinitionInstance[] =
+    builtInToolDefinitions.filter((tool) =>
+        tool.availability.includes('agent'),
+    );
 
 export type AgentToolDefinition = (typeof agentToolDefinitions)[number];
 
-export const mcpToolDefinitions = builtInToolDefinitions.filter((tool) =>
-    tool.availability.includes('mcp'),
-);
+export const mcpToolDefinitions: readonly ToolDefinitionInstance[] =
+    builtInToolDefinitions.filter((tool) => tool.availability.includes('mcp'));
 
 export type McpToolDefinition = (typeof mcpToolDefinitions)[number];
 
@@ -720,10 +786,6 @@ export const agentToolNames = agentToolDefinitions.map((tool) => tool.name) as [
 export const mcpToolNames = mcpToolDefinitions.map(
     (tool) => tool.for('mcp').name,
 ) as [string, ...string[]];
-
-export const agentToolDefinitionsByName = Object.fromEntries(
-    agentToolDefinitions.map((tool) => [tool.name, tool]),
-) as Record<string, AgentToolDefinition>;
 
 export const mcpToolDefinitionsByName = Object.fromEntries(
     mcpToolDefinitions.map((tool) => [tool.for('mcp').name, tool]),

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -46,6 +46,10 @@ import { type UserWithAbility } from '../../../../hooks/user/useUser';
 import useApp from '../../../../providers/App/useApp';
 import { useAiAgentThreadStreamMutation } from '../streaming/useAiAgentThreadStreamMutation';
 import {
+    type AiAgentToolCallHandler,
+    type AiAgentToolResultHandler,
+} from '../types';
+import {
     AGENT_AI_MCP_SERVERS_KEY,
     PROJECT_AI_MCP_SERVERS_KEY,
 } from './useProjectAiMcpServers';
@@ -600,6 +604,8 @@ export const useCreateAgentThreadMutation = (
     projectUuid: string,
     options?: {
         onCreated?: (thread: ApiAiAgentThreadCreateResponse['results']) => void;
+        onToolCall?: AiAgentToolCallHandler;
+        onToolResult?: AiAgentToolResultHandler;
         // Skip the default `navigate(...)` to the thread page. The launcher
         // uses this because it routes via its own panel/dock instead.
         skipNavigation?: boolean;
@@ -743,6 +749,8 @@ export const useCreateAgentThreadMutation = (
                             thread.uuid,
                         ],
                     }),
+                onToolCall: options?.onToolCall,
+                onToolResult: options?.onToolResult,
             });
 
             options?.onCreated?.(thread);
@@ -785,6 +793,10 @@ export const useCreateAgentThreadMessageMutation = (
     projectUuid: string,
     agentUuid: string | undefined,
     threadUuid: string | undefined,
+    options?: {
+        onToolCall?: AiAgentToolCallHandler;
+        onToolResult?: AiAgentToolResultHandler;
+    },
 ) => {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
@@ -934,6 +946,8 @@ export const useCreateAgentThreadMessageMutation = (
                             threadUuid,
                         ],
                     }),
+                onToolCall: options?.onToolCall,
+                onToolResult: options?.onToolResult,
             });
         },
         onError: ({ error }) => {

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
@@ -1,0 +1,92 @@
+import { agentToolDefinitionsByName, type ToolName } from '@lightdash/common';
+import { type z } from 'zod';
+
+type ParsedToolName = ToolName;
+type ToolArgs<TName extends ParsedToolName> = z.infer<
+    (typeof agentToolDefinitionsByName)[TName]['inputSchema']
+>;
+type ToolResult<TName extends ParsedToolName> = z.infer<
+    NonNullable<
+        ReturnType<
+            (typeof agentToolDefinitionsByName)[TName]['for']
+        >['outputSchema']
+    >
+>;
+
+export type AiAgentToolCall = {
+    [K in ParsedToolName]: {
+        toolName: K;
+        toolArgs: ToolArgs<K>;
+        isPreliminary?: boolean;
+    };
+}[ParsedToolName];
+
+export type AiAgentToolResult = {
+    [K in ParsedToolName]: {
+        toolName: K;
+        toolArgs: ToolArgs<K>;
+        toolResult: ToolResult<K>;
+        isPreliminary?: boolean;
+    };
+}[ParsedToolName];
+
+export type AiAgentToolCallHandler = (toolCall: AiAgentToolCall) => void;
+export type AiAgentToolResultHandler = (toolResult: AiAgentToolResult) => void;
+
+export type StreamRawToolCall = {
+    toolName: string;
+    toolArgs: unknown;
+    isPreliminary?: boolean;
+};
+
+export type StreamRawToolResult = StreamRawToolCall & {
+    toolOutput: unknown;
+};
+
+const isParsedToolName = (toolName: string): toolName is ParsedToolName =>
+    toolName in agentToolDefinitionsByName;
+
+const parseToolArgs = (toolName: ParsedToolName, toolArgs: unknown) =>
+    agentToolDefinitionsByName[toolName].inputSchema.safeParse(toolArgs);
+
+const parseToolOutput = (toolName: ParsedToolName, toolOutput: unknown) => {
+    const outputSchema =
+        agentToolDefinitionsByName[toolName].for('agent').outputSchema;
+
+    return outputSchema?.safeParse(toolOutput) ?? null;
+};
+
+export const parseStreamRawToolCall = (
+    toolCall: StreamRawToolCall,
+): AiAgentToolCall | null => {
+    if (!isParsedToolName(toolCall.toolName)) return null;
+
+    const toolArgs = parseToolArgs(toolCall.toolName, toolCall.toolArgs);
+    if (!toolArgs.success) return null;
+
+    return {
+        toolName: toolCall.toolName,
+        toolArgs: toolArgs.data,
+        isPreliminary: toolCall.isPreliminary,
+    } as AiAgentToolCall;
+};
+
+export const parseStreamRawToolResult = (
+    toolResult: StreamRawToolResult,
+): AiAgentToolResult | null => {
+    if (!isParsedToolName(toolResult.toolName)) return null;
+
+    const toolArgs = parseToolArgs(toolResult.toolName, toolResult.toolArgs);
+    const parsedToolResult = parseToolOutput(
+        toolResult.toolName,
+        toolResult.toolOutput,
+    );
+    if (!toolArgs.success || !parsedToolResult?.success) return null;
+
+    return {
+        toolName: toolResult.toolName,
+        toolArgs: toolArgs.data,
+        toolResult: parsedToolResult.data,
+        isPreliminary: toolResult.isPreliminary,
+    } as AiAgentToolResult;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -28,7 +28,12 @@ import {
     type StreamPart,
 } from '../store/aiAgentThreadStreamSlice';
 import { useAiAgentStoreDispatch } from '../store/hooks';
+import { type AiAgentToolCall, type AiAgentToolResult } from '../types';
 import { useAiAgentThreadStreamAbortController } from './AiAgentThreadStreamAbortControllerContext';
+import {
+    parseStreamRawToolCall,
+    parseStreamRawToolResult,
+} from './parseStreamRawToolResult';
 
 export interface AiAgentThreadStreamOptions {
     projectUuid: string;
@@ -39,8 +44,22 @@ export interface AiAgentThreadStreamOptions {
     toolHints?: string[];
     onFinish?: () => void;
     onError?: (error: string) => void;
+    onToolCall?: (toolCall: AiAgentToolCall) => void;
+    onToolResult?: (toolResult: AiAgentToolResult) => void;
     refetchThread?: () => void;
 }
+
+type StreamToolCallPart = Extract<StreamPart, { type: 'toolCall' }>;
+
+type StreamToolPart = {
+    type: string;
+    toolName?: string;
+    toolCallId: string;
+    input?: unknown;
+    output?: unknown;
+    preliminary?: boolean;
+    state: string;
+};
 
 type McpUnavailableNoticeChunk = UIMessageChunk & {
     type: 'data-mcp-unavailable';
@@ -112,6 +131,49 @@ const getReasoningFromPart = (part: ReasoningUIPart) => {
     }
 };
 
+const getStreamToolPart = (
+    part: UIMessage['parts'][number],
+): StreamToolPart | null => {
+    if (!part.type.startsWith('tool-') && part.type !== 'dynamic-tool') {
+        return null;
+    }
+
+    const toolPart = part as StreamToolPart;
+    return {
+        ...toolPart,
+        toolName:
+            toolPart.type === 'dynamic-tool'
+                ? toolPart.toolName
+                : toolPart.type.slice(5),
+    };
+};
+
+const getStreamToolCallPart = (
+    part: UIMessage['parts'][number],
+): StreamToolCallPart | null => {
+    const toolPart = getStreamToolPart(part);
+    if (
+        !toolPart ||
+        !toolPart.toolName ||
+        !isAiAgentToolName(toolPart.toolName) ||
+        (toolPart.state !== 'input-available' &&
+            toolPart.state !== 'output-available' &&
+            toolPart.state !== 'output-error')
+    ) {
+        return null;
+    }
+
+    const hasOutput = toolPart.state === 'output-available';
+    return {
+        type: 'toolCall',
+        toolCallId: toolPart.toolCallId,
+        toolName: toolPart.toolName,
+        toolArgs: toolPart.input,
+        toolOutput: hasOutput ? toolPart.output : undefined,
+        isPreliminary: hasOutput ? (toolPart.preliminary ?? false) : undefined,
+    };
+};
+
 export const getMcpUnavailableNoticeFromChunk = (
     chunk: UIMessageChunk,
 ): McpUnavailableNoticeChunk['data'] | null => {
@@ -172,6 +234,8 @@ export function useAiAgentThreadStreamMutation() {
             toolHints = [],
             onFinish,
             onError,
+            onToolCall,
+            onToolResult,
             refetchThread,
         }: AiAgentThreadStreamOptions) => {
             const abortController = new AbortController();
@@ -203,6 +267,8 @@ export function useAiAgentThreadStreamMutation() {
                 const handledToolInputIds = new Set<string>();
                 const handledToolDecisionIds = new Set<string>();
                 const handledToolOutputIds = new Set<string>();
+                const notifiedToolCallIds = new Set<string>();
+                const notifiedToolOutputIds = new Set<string>();
 
                 const consumeRawChunks = (async () => {
                     while (true) {
@@ -263,45 +329,10 @@ export function useAiAgentThreadStreamMutation() {
                                 type: 'text',
                                 text: part.text,
                             });
-                        } else if (
-                            part.type.startsWith('tool-') ||
-                            part.type === 'dynamic-tool'
-                        ) {
-                            const toolPart = part as {
-                                type: string;
-                                toolName?: string;
-                                toolCallId: string;
-                                input?: unknown;
-                                output?: unknown;
-                                preliminary?: boolean;
-                                state: string;
-                            };
-                            if (
-                                toolPart.state === 'input-available' ||
-                                toolPart.state === 'output-available' ||
-                                toolPart.state === 'output-error'
-                            ) {
-                                const toolName =
-                                    toolPart.type === 'dynamic-tool'
-                                        ? toolPart.toolName
-                                        : toolPart.type.slice(5);
-
-                                if (toolName && isAiAgentToolName(toolName)) {
-                                    const hasOutput =
-                                        toolPart.state === 'output-available';
-                                    orderedParts.push({
-                                        type: 'toolCall',
-                                        toolCallId: toolPart.toolCallId,
-                                        toolName,
-                                        toolArgs: toolPart.input,
-                                        toolOutput: hasOutput
-                                            ? toolPart.output
-                                            : undefined,
-                                        isPreliminary: hasOutput
-                                            ? (toolPart.preliminary ?? false)
-                                            : undefined,
-                                    });
-                                }
+                        } else {
+                            const toolCallPart = getStreamToolCallPart(part);
+                            if (toolCallPart) {
+                                orderedParts.push(toolCallPart);
                             }
                         }
                     }
@@ -310,6 +341,46 @@ export function useAiAgentThreadStreamMutation() {
                     // Process tool calls from the complete message
                     for (const part of uiMessage.parts) {
                         if (abortController.signal.aborted) return;
+
+                        const toolPart = getStreamToolPart(part);
+                        const toolCallPart = getStreamToolCallPart(part);
+
+                        if (
+                            toolPart?.toolName &&
+                            toolPart.state === 'input-available' &&
+                            !notifiedToolCallIds.has(toolPart.toolCallId)
+                        ) {
+                            notifiedToolCallIds.add(toolPart.toolCallId);
+                            const toolCall = parseStreamRawToolCall({
+                                toolName: toolPart.toolName,
+                                toolArgs: toolPart.input,
+                            });
+                            if (toolCall) {
+                                onToolCall?.(toolCall);
+                            }
+                        }
+
+                        if (
+                            toolCallPart?.toolOutput !== undefined &&
+                            toolCallPart.isPreliminary !== undefined
+                        ) {
+                            const outputKey = `${toolCallPart.toolCallId}:${String(
+                                toolCallPart.isPreliminary,
+                            )}`;
+                            if (!notifiedToolOutputIds.has(outputKey)) {
+                                notifiedToolOutputIds.add(outputKey);
+                                const toolResult = parseStreamRawToolResult({
+                                    toolName: toolCallPart.toolName,
+                                    toolArgs: toolCallPart.toolArgs,
+                                    toolOutput: toolCallPart.toolOutput,
+                                    isPreliminary: toolCallPart.isPreliminary,
+                                });
+                                if (toolResult) {
+                                    onToolResult?.(toolResult);
+                                }
+                            }
+                        }
+
                         switch (part.type) {
                             // TODO: this is a temporary solution
                             // there should be a way of leveraging ToolUIPart based on the tools available

--- a/packages/frontend/src/ee/features/aiCopilot/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/types.ts
@@ -1,0 +1,6 @@
+export type {
+    AiAgentToolCall,
+    AiAgentToolCallHandler,
+    AiAgentToolResult,
+    AiAgentToolResultHandler,
+} from './streaming/parseStreamRawToolResult';


### PR DESCRIPTION
Closes:

### Description:

Adds typed tool call and tool result callbacks to the AI agent streaming pipeline, enabling consumers to react to individual tool invocations with fully parsed and type-safe arguments and outputs.

A new `agentToolDefinitionsByName` lookup is introduced that maps each tool name to its strongly-typed definition, replacing the previous `Object.fromEntries` approach that lost type information. This allows input schemas to be accessed per-tool by name with full inference.

A new `parseStreamRawToolResult.ts` module validates raw tool call and result payloads from the stream against both the tool's input schema and a corresponding output schema map, returning typed `AiAgentToolCall` and `AiAgentToolResult` discriminated union values, or `null` if parsing fails.

The streaming mutation now accepts `onToolCall` and `onToolResult` callbacks. During stream processing, each tool part is checked once (tracked via deduplication sets) and the parsed, validated call or result is forwarded to the appropriate callback. These callbacks are threaded through `useCreateAgentThreadMutation` and `useCreateAgentThreadMessageMutation` so callers can subscribe to tool activity at the hook level.