### PR TITLE
feat(ai-review): persist ai_agent_review_item (review-queue state)

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -368,6 +368,8 @@ import {
 import {
     AiAgentReviewClassifierRunTable,
     AiAgentReviewClassifierRunTableName,
+    AiAgentReviewItemTable,
+    AiAgentReviewItemTableName,
     AiAgentTurnSignalTable,
     AiAgentTurnSignalTableName,
 } from '../ee/database/entities/aiAgentReviewClassifier';
@@ -529,6 +531,7 @@ declare module 'knex/types/tables' {
         [AiAgentDocumentAccessTableName]: AiAgentDocumentAccessTable;
         [AiAgentReviewClassifierRunTableName]: AiAgentReviewClassifierRunTable;
         [AiAgentTurnSignalTableName]: AiAgentTurnSignalTable;
+        [AiAgentReviewItemTableName]: AiAgentReviewItemTable;
         [AiAgentGroupAccessTableName]: AiAgentGroupAccessTable;
         [AiAgentIntegrationTableName]: AiAgentIntegrationTable;
         [AiAgentSlackIntegrationTableName]: AiAgentSlackIntegrationTable;

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -9,7 +9,10 @@ import type {
     AiAgentReviewClassifierConfidence,
     AiAgentReviewClassifierRunScope,
     AiAgentReviewClassifierRunStatus,
+    AiAgentReviewItemDismissedReason,
     AiAgentReviewItemOwnerType,
+    AiAgentReviewItemPrState,
+    AiAgentReviewItemStatus,
     AiAgentRootCause,
     AiAgentRuntimeContextSnapshot,
     AiAgentTargetRef,
@@ -157,5 +160,52 @@ export type AiAgentTurnSignalTable = Knex.CompositeTableType<
         >,
     Partial<
         Pick<DbAiAgentTurnSignal, 'promoted_to_finding' | 'promotion_reason'>
+    >
+>;
+
+export const AiAgentReviewItemTableName = 'ai_agent_review_item';
+
+export type DbAiAgentReviewItem = {
+    ai_agent_review_item_uuid: string;
+    fingerprint: string;
+    organization_uuid: string;
+    project_uuid: string | null;
+    agent_uuid: string | null;
+    status: AiAgentReviewItemStatus;
+    dismissed_reason: AiAgentReviewItemDismissedReason | null;
+    assigned_to_user_uuid: string | null;
+    linked_issue_url: string | null;
+    linked_pr_url: string | null;
+    pr_writeback_thread_uuid: string | null;
+    pr_state: AiAgentReviewItemPrState | null;
+    status_updated_at: Date | null;
+    status_updated_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiAgentReviewItemTable = Knex.CompositeTableType<
+    DbAiAgentReviewItem,
+    Pick<
+        DbAiAgentReviewItem,
+        'fingerprint' | 'organization_uuid' | 'project_uuid' | 'agent_uuid'
+    > &
+        Partial<
+            Omit<
+                DbAiAgentReviewItem,
+                | 'ai_agent_review_item_uuid'
+                | 'created_at'
+                | 'updated_at'
+                | 'fingerprint'
+                | 'organization_uuid'
+                | 'project_uuid'
+                | 'agent_uuid'
+            >
+        >,
+    Partial<
+        Omit<
+            DbAiAgentReviewItem,
+            'ai_agent_review_item_uuid' | 'fingerprint' | 'created_at'
+        >
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260529120000_add_ai_agent_review_item.ts
+++ b/packages/backend/src/ee/database/migrations/20260529120000_add_ai_agent_review_item.ts
@@ -1,0 +1,93 @@
+import { Knex } from 'knex';
+
+const reviewItemTable = 'ai_agent_review_item';
+
+const organizationsTable = 'organizations';
+const projectsTable = 'projects';
+const aiAgentTable = 'ai_agent';
+const usersTable = 'users';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(reviewItemTable, (table) => {
+        table
+            .uuid('ai_agent_review_item_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        // Stable dedup key from getAiAgentReviewItemFingerprint (folds scope into the hash).
+        table.text('fingerprint').notNullable().unique();
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable(organizationsTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('project_uuid')
+            .nullable()
+            .references('project_uuid')
+            .inTable(projectsTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('agent_uuid')
+            .nullable()
+            .references('ai_agent_uuid')
+            .inTable(aiAgentTable)
+            .onDelete('CASCADE');
+        table
+            .text('status')
+            .notNullable()
+            .defaultTo('open')
+            .checkIn([
+                'open',
+                'in_progress',
+                'resolved',
+                'dismissed',
+                'duplicate',
+            ]);
+        table
+            .text('dismissed_reason')
+            .nullable()
+            .checkIn([
+                'not_actionable',
+                'expected_behavior',
+                'duplicate',
+                'low_confidence',
+                'other',
+            ]);
+        table
+            .uuid('assigned_to_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(usersTable)
+            .onDelete('SET NULL');
+        table.text('linked_issue_url').nullable();
+        table.text('linked_pr_url').nullable();
+        // Set when a writeback PR is opened (PR3); decoupled from the writeback schema, no FK.
+        table.uuid('pr_writeback_thread_uuid').nullable();
+        // Reconciled from GitHub on read (PR4).
+        table.text('pr_state').nullable().checkIn(['open', 'merged', 'closed']);
+        table.timestamp('status_updated_at', { useTz: false }).nullable();
+        table
+            .uuid('status_updated_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(usersTable)
+            .onDelete('SET NULL');
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['organization_uuid', 'status']);
+        table.index(['project_uuid']);
+        table.index(['agent_uuid']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(reviewItemTable);
+}

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -2,6 +2,7 @@ import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import {
     AiAgentReviewClassifierRunTableName,
+    AiAgentReviewItemTableName,
     AiAgentTurnSignalTableName,
 } from '../database/entities/aiAgentReviewClassifier';
 import { AiAgentReviewClassifierModel } from './AiAgentReviewClassifierModel';
@@ -287,6 +288,7 @@ describe('AiAgentReviewClassifierModel', () => {
                     created_at: new Date('2026-05-26T09:00:00.000Z'),
                 }),
             ]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
 
             const result = await model.listReviewItems({
                 organizationUuid: ORGANIZATION_UUID,
@@ -299,6 +301,8 @@ describe('AiAgentReviewClassifierModel', () => {
                     fingerprint: FINGERPRINT,
                     title: 'Review revenue metric',
                     status: 'open',
+                    linkedPrUrl: null,
+                    prState: null,
                     findingCount: 2,
                 }),
             );
@@ -315,6 +319,59 @@ describe('AiAgentReviewClassifierModel', () => {
                     ],
                 }),
             );
+        });
+
+        it('overlays persisted human state and PR linkage onto the projection', async () => {
+            tracker.on
+                .select(AiAgentTurnSignalTableName)
+                .responseOnce([makeTurnSignalRow()]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([
+                {
+                    ai_agent_review_item_uuid:
+                        '00000000-0000-0000-0000-000000000099',
+                    fingerprint: FINGERPRINT,
+                    organization_uuid: ORGANIZATION_UUID,
+                    project_uuid: PROJECT_UUID,
+                    agent_uuid: AGENT_UUID,
+                    status: 'resolved',
+                    dismissed_reason: null,
+                    assigned_to_user_uuid: null,
+                    linked_issue_url: null,
+                    linked_pr_url: 'https://github.com/acme/dbt/pull/42',
+                    pr_writeback_thread_uuid: null,
+                    pr_state: 'merged',
+                    status_updated_at: new Date('2026-05-28T10:00:00.000Z'),
+                    status_updated_by_user_uuid: null,
+                    created_at: SEEN_AT,
+                    updated_at: SEEN_AT,
+                },
+            ]);
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result[0]).toEqual(
+                expect.objectContaining({
+                    status: 'resolved',
+                    linkedPrUrl: 'https://github.com/acme/dbt/pull/42',
+                    prState: 'merged',
+                }),
+            );
+        });
+
+        it('filters by overlaid status', async () => {
+            tracker.on
+                .select(AiAgentTurnSignalTableName)
+                .responseOnce([makeTurnSignalRow()]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+                statuses: ['resolved'],
+            });
+
+            expect(result).toHaveLength(0);
         });
     });
 
@@ -369,6 +426,7 @@ describe('AiAgentReviewClassifierModel', () => {
                     ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID,
                 },
             ]);
+            tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
 
             const result = await model.createTurnSignal({
                 runUuid: RUN_UUID,
@@ -403,7 +461,29 @@ describe('AiAgentReviewClassifierModel', () => {
             });
 
             expect(result).toBe(TURN_SIGNAL_UUID);
+            expect(tracker.history.insert).toHaveLength(2);
+            expect(tracker.history.insert[1].sql).toContain(
+                AiAgentReviewItemTableName,
+            );
+        });
+
+        it('does not upsert a review item when the turn is not promoted', async () => {
+            tracker.on.insert(AiAgentTurnSignalTableName).responseOnce([
+                {
+                    ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID,
+                },
+            ]);
+
+            await model.createTurnSignal({
+                runUuid: RUN_UUID,
+                turnSignal: { ...turnSignal, promotedToFinding: false },
+                finding: null,
+            });
+
             expect(tracker.history.insert).toHaveLength(1);
+            expect(tracker.history.insert[0].sql).toContain(
+                AiAgentTurnSignalTableName,
+            );
         });
     });
 });

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -34,10 +34,13 @@ import {
 } from '../database/entities/ai';
 import {
     AiAgentReviewClassifierRunTableName,
+    AiAgentReviewItemTableName,
     AiAgentTurnSignalTableName,
     type AiAgentReviewClassifierRunTable,
+    type AiAgentReviewItemTable,
     type AiAgentTurnSignalTable,
     type DbAiAgentReviewClassifierRun,
+    type DbAiAgentReviewItem,
     type DbAiAgentTurnSignal,
 } from '../database/entities/aiAgentReviewClassifier';
 
@@ -780,10 +783,6 @@ export class AiAgentReviewClassifierModel {
     async listReviewItems(
         args: ListReviewItemsArgs,
     ): Promise<AiAgentReviewItemSummary[]> {
-        if (args.statuses && !args.statuses.includes('open')) {
-            return [];
-        }
-
         const rows: DbAiAgentTurnSignal[] =
             await this.database<AiAgentTurnSignalTable>(
                 AiAgentTurnSignalTableName,
@@ -810,12 +809,16 @@ export class AiAgentReviewClassifierModel {
             byFingerprint.set(row.fingerprint, group);
         });
 
+        const fingerprints = Array.from(byFingerprint.keys());
+        const persisted = await this.getReviewItemsByFingerprint(fingerprints);
+
         return Array.from(byFingerprint.entries())
             .map(([fingerprint, group]) => {
                 const latest = group[0];
                 const createdAts = group.map((row) => row.created_at.getTime());
                 const firstSeenAt = new Date(Math.min(...createdAts));
                 const lastSeenAt = new Date(Math.max(...createdAts));
+                const item = persisted.get(fingerprint) ?? null;
                 return {
                     uuid: fingerprint,
                     fingerprint,
@@ -825,19 +828,21 @@ export class AiAgentReviewClassifierModel {
                     title: latest.review_item_title ?? 'Review AI agent issue',
                     description: latest.review_item_description ?? '',
                     primaryRootCause: latest.primary_root_cause ?? 'ambiguous',
-                    status: 'open' as const,
-                    dismissedReason: null,
+                    status: item?.status ?? 'open',
+                    dismissedReason: item?.dismissed_reason ?? null,
                     ownerType: latest.owner_type ?? 'unknown',
-                    assignedToUserUuid: null,
+                    assignedToUserUuid: item?.assigned_to_user_uuid ?? null,
                     firstSeenAt,
                     lastSeenAt,
                     findingCount: group.length,
-                    statusUpdatedAt: lastSeenAt,
-                    statusUpdatedByUserUuid: null,
-                    linkedIssueUrl: null,
-                    linkedPrUrl: null,
-                    createdAt: firstSeenAt,
-                    updatedAt: lastSeenAt,
+                    statusUpdatedAt: item?.status_updated_at ?? lastSeenAt,
+                    statusUpdatedByUserUuid:
+                        item?.status_updated_by_user_uuid ?? null,
+                    linkedIssueUrl: item?.linked_issue_url ?? null,
+                    linkedPrUrl: item?.linked_pr_url ?? null,
+                    prState: item?.pr_state ?? null,
+                    createdAt: item?.created_at ?? firstSeenAt,
+                    updatedAt: item?.updated_at ?? lastSeenAt,
                     latestFinding: {
                         uuid: latest.ai_agent_review_turn_signal_uuid,
                         promptUuid: latest.ai_prompt_uuid,
@@ -853,7 +858,23 @@ export class AiAgentReviewClassifierModel {
                     },
                 };
             })
+            .filter(
+                (reviewItem) =>
+                    !args.statuses || args.statuses.includes(reviewItem.status),
+            )
             .slice(0, Math.min(args.limit ?? 100, 500));
+    }
+
+    async getReviewItemsByFingerprint(
+        fingerprints: string[],
+    ): Promise<Map<string, DbAiAgentReviewItem>> {
+        if (fingerprints.length === 0) {
+            return new Map();
+        }
+        const items = await this.database<AiAgentReviewItemTable>(
+            AiAgentReviewItemTableName,
+        ).whereIn('fingerprint', fingerprints);
+        return new Map(items.map((item) => [item.fingerprint, item]));
     }
 
     async listReviewSignals(
@@ -967,6 +988,32 @@ export class AiAgentReviewClassifierModel {
             })
             .returning('ai_agent_review_turn_signal_uuid');
 
+        if (turnSignal.promotedToFinding && finding) {
+            await this.ensureReviewItem({
+                fingerprint: finding.reviewItem.fingerprint,
+                organizationUuid: turnSignal.subject.organizationUuid,
+                projectUuid: turnSignal.subject.projectUuid,
+                agentUuid: turnSignal.subject.agentUuid,
+            });
+        }
+
         return row.ai_agent_review_turn_signal_uuid;
+    }
+
+    private async ensureReviewItem(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+    }): Promise<void> {
+        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+            .insert({
+                fingerprint: args.fingerprint,
+                organization_uuid: args.organizationUuid,
+                project_uuid: args.projectUuid,
+                agent_uuid: args.agentUuid,
+            })
+            .onConflict('fingerprint')
+            .merge({ updated_at: this.database.fn.now() });
     }
 }

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -317,6 +317,8 @@ export type AiAgentReviewItemOwnerType =
     | 'support'
     | 'unknown';
 
+export type AiAgentReviewItemPrState = 'open' | 'merged' | 'closed';
+
 const aiAgentConfigurationSettingSchema = z.enum([
     'instructions',
     'knowledge_documents',
@@ -493,6 +495,7 @@ export type AiAgentReviewItem = {
     statusUpdatedByUserUuid: string | null;
     linkedIssueUrl: string | null;
     linkedPrUrl: string | null;
+    prState: AiAgentReviewItemPrState | null;
     createdAt: Date;
     updatedAt: Date;
 };


### PR DESCRIPTION
Part 1/8 of the **AI review-findings → writeback PRs** stack.

Persists review items so they can hold human decisions + PR links — previously derived on the fly with hardcoded `status:'open'` / `linkedPrUrl:null`.

- New `ai_agent_review_item` table keyed by `fingerprint` (status, dismissed_reason, owner, assigned_to, linked_pr_url, pr_state, …).
- Upserts a row when a signal is promoted to a finding.
- `listReviewItems` LEFT JOINs and overlays the real persisted state.

No new feature flag: the review-writeback feature is gated by the existing `ai-agent-review-classifier` (review pipeline) + `ai-writeback` (PR engine) flags.

**Regression analysis:** behavior-preserving. With no persisted row, `listReviewItems` returns exactly what it did before (status `open`, null PR fields). EE + flag-gated admin queue only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
