### PR TITLE
feat(ai-review): run writeback on worker with live progress (PR6)

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -163,6 +163,29 @@ export class AiAgentAdminController extends BaseController {
      * @summary List AI agent review signals
      */
     /**
+     * Get a single AI agent review item (lightweight, for polling progress)
+     * @summary Get AI agent review item
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/review-items/{fingerprint}')
+    @OperationId('getAiAgentReviewItem')
+    async getReviewItem(
+        @Request() req: express.Request,
+        @Path() fingerprint: string,
+    ): Promise<ApiAiAgentReviewItemResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().getReviewItem(
+                toSessionUser(req.account),
+                fingerprint,
+            ),
+        };
+    }
+
+    /**
      * Update the status of an AI agent review item (e.g. dismiss it)
      * @summary Update AI agent review item status
      */

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -13,6 +13,7 @@ import type {
     AiAgentReviewItemOwnerType,
     AiAgentReviewItemPrState,
     AiAgentReviewItemStatus,
+    AiAgentReviewItemWritebackStatus,
     AiAgentRootCause,
     AiAgentRuntimeContextSnapshot,
     AiAgentTargetRef,
@@ -178,6 +179,8 @@ export type DbAiAgentReviewItem = {
     linked_pr_url: string | null;
     pr_writeback_thread_uuid: string | null;
     pr_state: AiAgentReviewItemPrState | null;
+    pr_writeback_status: AiAgentReviewItemWritebackStatus | null;
+    pr_writeback_message: string | null;
     status_updated_at: Date | null;
     status_updated_by_user_uuid: string | null;
     created_at: Date;

--- a/packages/backend/src/ee/database/migrations/20260529160000_add_ai_agent_review_item_writeback_status.ts
+++ b/packages/backend/src/ee/database/migrations/20260529160000_add_ai_agent_review_item_writeback_status.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+const reviewItemTable = 'ai_agent_review_item';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(reviewItemTable, (table) => {
+        table
+            .text('pr_writeback_status')
+            .nullable()
+            .checkIn(['queued', 'running', 'completed', 'failed']);
+        table.text('pr_writeback_message').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(reviewItemTable, (table) => {
+        table.dropColumn('pr_writeback_status');
+        table.dropColumn('pr_writeback_message');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -193,7 +193,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getAiWritebackService<AiWritebackService>(),
                     prometheusMetrics,
                 }),
-            aiAgentAdminService: ({ models, repository, context }) =>
+            aiAgentAdminService: ({ models, repository, context, clients }) =>
                 new AiAgentAdminService({
                     aiAgentModel: models.getAiAgentModel(),
                     aiAgentReviewClassifierModel:
@@ -204,6 +204,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getAiWritebackService<AiWritebackService>(),
                     githubAppInstallationsModel:
                         models.getGithubAppInstallationsModel(),
+                    schedulerClient:
+                        clients.getSchedulerClient() as CommercialSchedulerClient,
+                    userModel: models.getUserModel(),
                     lightdashConfig: context.lightdashConfig,
                 }),
             aiRouterService: ({ models, repository, context }) =>
@@ -606,6 +609,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 workerHealth: context.workerHealth,
                 aiAgentReviewClassifierService:
                     context.serviceRepository.getAiAgentReviewClassifierService(),
+                aiAgentAdminService:
+                    context.serviceRepository.getAiAgentAdminService<AiAgentAdminService>(),
             }),
         clientProviders: {
             schedulerClient: ({ context, models }) =>

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -540,6 +540,27 @@ describe('AiAgentReviewClassifierModel', () => {
         });
     });
 
+    describe('setReviewItemWritebackStatus', () => {
+        it('upserts writeback status and message by fingerprint', async () => {
+            tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
+
+            await model.setReviewItemWritebackStatus({
+                fingerprint: FINGERPRINT,
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+                agentUuid: AGENT_UUID,
+                status: 'running',
+                message: 'Discovering models',
+            });
+
+            expect(tracker.history.insert).toHaveLength(1);
+            expect(tracker.history.insert[0].sql).toContain('on conflict');
+            expect(tracker.history.insert[0].bindings).toContain(
+                'Discovering models',
+            );
+        });
+    });
+
     describe('reconcileReviewItemPrState', () => {
         it('updates status and pr_state for a fingerprint in the org', async () => {
             tracker.on.update(AiAgentReviewItemTableName).responseOnce(1);

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -19,6 +19,7 @@ import type {
     AiAgentReviewItemPrState,
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
+    AiAgentReviewItemWritebackStatus,
     AiAgentReviewSignalSummary,
     AiAgentRootCause,
     AiAgentTargetRef,
@@ -857,6 +858,8 @@ export class AiAgentReviewClassifierModel {
                     linkedIssueUrl: item?.linked_issue_url ?? null,
                     linkedPrUrl: item?.linked_pr_url ?? null,
                     prState: item?.pr_state ?? null,
+                    prWritebackStatus: item?.pr_writeback_status ?? null,
+                    prWritebackMessage: item?.pr_writeback_message ?? null,
                     createdAt: item?.created_at ?? firstSeenAt,
                     updatedAt: item?.updated_at ?? lastSeenAt,
                     latestFinding: {
@@ -967,6 +970,31 @@ export class AiAgentReviewClassifierModel {
             .merge({
                 linked_pr_url: args.linkedPrUrl,
                 pr_state: args.prState,
+                updated_at: this.database.fn.now(),
+            });
+    }
+
+    async setReviewItemWritebackStatus(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+        status: AiAgentReviewItemWritebackStatus;
+        message: string | null;
+    }): Promise<void> {
+        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+            .insert({
+                fingerprint: args.fingerprint,
+                organization_uuid: args.organizationUuid,
+                project_uuid: args.projectUuid,
+                agent_uuid: args.agentUuid,
+                pr_writeback_status: args.status,
+                pr_writeback_message: args.message,
+            })
+            .onConflict('fingerprint')
+            .merge({
+                pr_writeback_status: args.status,
+                pr_writeback_message: args.message,
                 updated_at: this.database.fn.now(),
             });
     }

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -1,6 +1,7 @@
 import {
     AiAgentEvalRunJobPayload,
     AiAgentReviewClassifierJobPayload,
+    AiAgentReviewWritebackJobPayload,
     AppGeneratePipelineJobPayload,
     EE_SCHEDULER_TASKS,
     EmbedArtifactVersionJobPayload,
@@ -48,6 +49,20 @@ export class CommercialSchedulerClient extends SchedulerClient {
                 runAt: now,
                 maxAttempts: 1,
                 jobKey: `ai-agent-review:${payload.eventType}:${payload.promptUuid}`,
+            },
+        );
+        return { jobId };
+    }
+
+    async aiAgentReviewWriteback(payload: AiAgentReviewWritebackJobPayload) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK,
+            payload,
+            {
+                runAt: new Date(),
+                maxAttempts: 1,
+                jobKey: `ai-agent-review-writeback:${payload.fingerprint}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -14,6 +14,7 @@ import {
     SchedulerWorkerArguments,
 } from '../../scheduler/SchedulerWorker';
 import { TypedEETaskList } from '../../scheduler/types';
+import { AiAgentAdminService } from '../services/AiAgentAdminService';
 import { AiAgentReviewClassifierService } from '../services/AiAgentReviewClassifierService';
 import { AiAgentService } from '../services/AiAgentService/AiAgentService';
 import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
@@ -22,11 +23,13 @@ import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgen
 
 const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
+const AI_AGENT_REVIEW_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 
 type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     aiAgentService: AiAgentService;
     aiAgentReviewClassifierService: AiAgentReviewClassifierService;
+    aiAgentAdminService: AiAgentAdminService;
     embedService: EmbedService;
     managedAgentService: ManagedAgentService;
     appGenerateService: AppGenerateService;
@@ -36,6 +39,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
     protected readonly aiAgentService: AiAgentService;
 
     protected readonly aiAgentReviewClassifierService: AiAgentReviewClassifierService;
+
+    protected readonly aiAgentAdminService: AiAgentAdminService;
 
     protected readonly embedService: EmbedService;
 
@@ -48,6 +53,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.aiAgentService = args.aiAgentService;
         this.aiAgentReviewClassifierService =
             args.aiAgentReviewClassifierService;
+        this.aiAgentAdminService = args.aiAgentAdminService;
         this.embedService = args.embedService;
         this.managedAgentService = args.managedAgentService;
         this.appGenerateService = args.appGenerateService;
@@ -176,6 +182,40 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                                 threadUuid: payload.threadUuid,
                                 promptUuid: payload.promptUuid,
                                 eventType: payload.eventType,
+                            },
+                        });
+                    },
+                );
+            },
+            [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.aiAgentAdminService.runReviewItemWritebackJob(
+                                payload,
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    AI_AGENT_REVIEW_WRITEBACK_TIMEOUT_MS,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                error: getErrorMessage(e),
+                                organizationUuid: payload.organizationUuid,
+                                projectUuid: payload.projectUuid,
+                                fingerprint: payload.fingerprint,
                             },
                         });
                     },

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -6,10 +6,12 @@ import {
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
     AiAgentReviewSignalSummary,
+    AiAgentReviewWritebackJobPayload,
     AiAgentSummary,
     DbtProjectType,
     FeatureFlags,
     ForbiddenError,
+    getErrorMessage,
     KnexPaginateArgs,
     KnexPaginatedData,
     NotFoundError,
@@ -25,11 +27,16 @@ import {
 import { type LightdashConfig } from '../../config/parseConfig';
 import { type GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { type UserModel } from '../../models/UserModel';
 import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { AiAgentModel } from '../models/AiAgentModel';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
-import { planReviewWriteback } from './ai/reviewWriteback/buildReviewWritebackPrompt';
+import { type CommercialSchedulerClient } from '../scheduler/SchedulerClient';
+import {
+    buildYmlPathByModel,
+    planReviewWriteback,
+} from './ai/reviewWriteback/buildReviewWritebackPrompt';
 import { type AiWritebackService } from './AiWritebackService/AiWritebackService';
 
 type AiAgentAdminServiceDependencies = {
@@ -39,6 +46,8 @@ type AiAgentAdminServiceDependencies = {
     projectModel: ProjectModel;
     aiWritebackService: AiWritebackService;
     githubAppInstallationsModel: GithubAppInstallationsModel;
+    schedulerClient: CommercialSchedulerClient;
+    userModel: UserModel;
     lightdashConfig: LightdashConfig;
 };
 
@@ -67,6 +76,10 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly githubAppInstallationsModel: GithubAppInstallationsModel;
 
+    private readonly schedulerClient: CommercialSchedulerClient;
+
+    private readonly userModel: UserModel;
+
     constructor(dependencies: AiAgentAdminServiceDependencies) {
         super();
         this.aiAgentModel = dependencies.aiAgentModel;
@@ -77,6 +90,8 @@ export class AiAgentAdminService extends BaseService {
         this.aiWritebackService = dependencies.aiWritebackService;
         this.githubAppInstallationsModel =
             dependencies.githubAppInstallationsModel;
+        this.schedulerClient = dependencies.schedulerClient;
+        this.userModel = dependencies.userModel;
         this.lightdashConfig = dependencies.lightdashConfig;
     }
 
@@ -392,6 +407,14 @@ export class AiAgentAdminService extends BaseService {
                 'A pull request is already open for this review item',
             );
         }
+        if (
+            reviewItem.prWritebackStatus === 'queued' ||
+            reviewItem.prWritebackStatus === 'running'
+        ) {
+            throw new ParameterError(
+                'A writeback is already in progress for this review item',
+            );
+        }
 
         const scope =
             await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
@@ -409,30 +432,132 @@ export class AiAgentAdminService extends BaseService {
             );
         }
 
-        const plan = planReviewWriteback(reviewItem);
-
-        const result = await this.aiWritebackService.run({
-            user,
+        await this.aiAgentReviewClassifierModel.setReviewItemWritebackStatus({
+            fingerprint,
+            organizationUuid,
             projectUuid: scope.projectUuid,
-            prompt: plan.promptText,
+            agentUuid: scope.agentUuid,
+            status: 'queued',
+            message: 'Queued',
         });
 
-        if (result.prUrl) {
-            await this.aiAgentReviewClassifierModel.setReviewItemPrLink({
-                fingerprint,
-                organizationUuid,
-                projectUuid: scope.projectUuid,
-                agentUuid: scope.agentUuid,
-                linkedPrUrl: result.prUrl,
-                prState: 'open',
-            });
-        }
+        await this.schedulerClient.aiAgentReviewWriteback({
+            fingerprint,
+            organizationUuid,
+            projectUuid: scope.projectUuid,
+            userUuid: user.userUuid,
+        });
 
         const updated = await this.aiAgentReviewClassifierModel.getReviewItem(
             organizationUuid,
             fingerprint,
         );
         return updated ?? reviewItem;
+    }
+
+    /**
+     * Runs on the scheduler worker. Performs the writeback synchronously inside
+     * the job, streaming phase messages onto the review item so the admin UI
+     * can poll for progress.
+     */
+    async runReviewItemWritebackJob(
+        payload: AiAgentReviewWritebackJobPayload,
+    ): Promise<void> {
+        const { fingerprint, organizationUuid, projectUuid, userUuid } =
+            payload;
+
+        const setStatus = (
+            status: 'running' | 'completed' | 'failed',
+            message: string | null,
+            agentUuid: string,
+        ) =>
+            this.aiAgentReviewClassifierModel.setReviewItemWritebackStatus({
+                fingerprint,
+                organizationUuid,
+                projectUuid,
+                agentUuid,
+                status,
+                message,
+            });
+
+        const scope =
+            await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
+                organizationUuid,
+                fingerprint,
+            );
+        const reviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
+        if (!scope || !reviewItem) {
+            return;
+        }
+        const { agentUuid } = scope;
+
+        try {
+            const user = await this.userModel.findSessionUserByUUID(userUuid);
+            await setStatus('running', 'Starting writeback…', agentUuid);
+
+            const explores = await this.projectModel.findExploresFromCache(
+                projectUuid,
+                'name',
+            );
+            const plan = planReviewWriteback(
+                reviewItem,
+                buildYmlPathByModel(Object.values(explores)),
+            );
+            const result = await this.aiWritebackService.run({
+                user,
+                projectUuid,
+                prompt: plan.promptText,
+                onProgress: (message) => {
+                    void setStatus('running', message, agentUuid);
+                },
+            });
+
+            if (result.prUrl) {
+                await this.aiAgentReviewClassifierModel.setReviewItemPrLink({
+                    fingerprint,
+                    organizationUuid,
+                    projectUuid,
+                    agentUuid,
+                    linkedPrUrl: result.prUrl,
+                    prState: 'open',
+                });
+                await setStatus('completed', 'Opened pull request', agentUuid);
+            } else {
+                await setStatus(
+                    'completed',
+                    'Writeback ran — no changes were needed',
+                    agentUuid,
+                );
+            }
+        } catch (error) {
+            await setStatus('failed', getErrorMessage(error), agentUuid);
+            throw error;
+        }
+    }
+
+    async getReviewItem(
+        user: SessionUser,
+        fingerprint: string,
+    ): Promise<AiAgentReviewItemSummary> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const reviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
+        if (!reviewItem) {
+            throw new NotFoundError('Review item not found');
+        }
+        return reviewItem;
     }
 
     /**

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -24,6 +24,8 @@ const baseItem = (
     linkedIssueUrl: null,
     linkedPrUrl: null,
     prState: null,
+    prWritebackStatus: null,
+    prWritebackMessage: null,
     createdAt: new Date('2026-05-26T00:00:00.000Z'),
     updatedAt: new Date('2026-05-26T00:00:00.000Z'),
     latestFinding: {
@@ -61,7 +63,10 @@ const baseItem = (
 
 describe('planReviewWriteback', () => {
     it('builds a deterministic one-shot prompt for semantic_layer items', () => {
-        const plan = planReviewWriteback(baseItem());
+        const plan = planReviewWriteback(
+            baseItem(),
+            new Map([['orders', 'models/orders.yml']]),
+        );
 
         expect(plan.aggregationKey).toBeNull();
         expect(plan.promptText).toContain(
@@ -70,10 +75,19 @@ describe('planReviewWriteback', () => {
         expect(plan.promptText).toContain(
             'Add an ai_hint to average_order_size',
         );
-        expect(plan.promptText).toContain('metric "orders.average_order_size"');
+        expect(plan.promptText).toContain(
+            'metric "orders.average_order_size" (yaml: models/orders.yml)',
+        );
         expect(plan.promptText).toContain(
             'use average_order_size, not total_order_amount',
         );
+    });
+
+    it('omits the yaml path when the model is not in the resolved map', () => {
+        const plan = planReviewWriteback(baseItem());
+
+        expect(plan.promptText).toContain('metric "orders.average_order_size"');
+        expect(plan.promptText).not.toContain('(yaml:');
     });
 
     it('throws for unsupported root causes', () => {

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -1,8 +1,11 @@
 import {
     assertUnreachable,
+    isExploreError,
     type AiAgentReviewItemSummary,
     type AiAgentSemanticTargetRef,
     type AiAgentTargetRef,
+    type Explore,
+    type ExploreError,
 } from '@lightdash/common';
 
 /**
@@ -15,24 +18,47 @@ export type ReviewWritebackPlan = {
     aggregationKey: string | null;
 };
 
-const formatSemanticTargetRef = (ref: AiAgentSemanticTargetRef): string => {
+// Resolves each model's dbt YAML path from compiled explores so the writeback agent edits the right file (the judge only gives names).
+export const buildYmlPathByModel = (
+    explores: (Explore | ExploreError)[],
+): Map<string, string> => {
+    const map = new Map<string, string>();
+    explores.forEach((explore) => {
+        if (isExploreError(explore)) {
+            return;
+        }
+        Object.entries(explore.tables).forEach(([tableName, table]) => {
+            if (table.ymlPath) {
+                map.set(tableName, table.ymlPath);
+            }
+        });
+    });
+    return map;
+};
+
+const formatSemanticTargetRef = (
+    ref: AiAgentSemanticTargetRef,
+    ymlPathByModel: Map<string, string>,
+): string => {
+    const ymlPath = ymlPathByModel.get(ref.modelName);
+    const yaml = ymlPath ? ` (yaml: ${ymlPath})` : '';
     switch (ref.type) {
         case 'model':
-            return `model "${ref.modelName}"`;
+            return `model "${ref.modelName}"${yaml}`;
         case 'explore':
-            return `explore "${ref.exploreName}" on model "${ref.modelName}"`;
+            return `explore "${ref.exploreName}" on model "${ref.modelName}"${yaml}`;
         case 'join':
-            return `join "${ref.joinName}" on model "${ref.modelName}"`;
+            return `join "${ref.joinName}" on model "${ref.modelName}"${yaml}`;
         case 'dimension':
-            return `dimension "${ref.modelName}.${ref.dimensionName}"`;
+            return `dimension "${ref.modelName}.${ref.dimensionName}"${yaml}`;
         case 'metric':
-            return `metric "${ref.modelName}.${ref.metricName}"`;
+            return `metric "${ref.modelName}.${ref.metricName}"${yaml}`;
         case 'additional_dimension':
-            return `additional dimension "${ref.modelName}.${ref.parentDimensionName}.${ref.dimensionName}"`;
+            return `additional dimension "${ref.modelName}.${ref.parentDimensionName}.${ref.dimensionName}"${yaml}`;
         case 'required_filter':
-            return `required filter on "${ref.modelName}.${ref.fieldName}" in explore "${ref.exploreName}"`;
+            return `required filter on "${ref.modelName}.${ref.fieldName}" in explore "${ref.exploreName}"${yaml}`;
         case 'ai_hint':
-            return `ai_hint on ${ref.targetType} "${ref.modelName}.${ref.targetName}"`;
+            return `ai_hint on ${ref.targetType} "${ref.modelName}.${ref.targetName}"${yaml}`;
         default:
             return assertUnreachable(ref, 'Unknown semantic target ref type');
     }
@@ -48,11 +74,12 @@ const isSemanticTargetRef = (
 
 const buildSemanticLayerWritebackPrompt = (
     item: AiAgentReviewItemSummary,
+    ymlPathByModel: Map<string, string>,
 ): ReviewWritebackPlan => {
     const finding = item.latestFinding;
     const targetLines = (finding?.targetRefs ?? [])
         .filter(isSemanticTargetRef)
-        .map((ref) => `- ${formatSemanticTargetRef(ref)}`);
+        .map((ref) => `- ${formatSemanticTargetRef(ref, ymlPathByModel)}`);
     const evidenceLines = (finding?.evidenceExcerpts ?? []).map(
         (excerpt) => `- (${excerpt.source}) "${excerpt.text}"`,
     );
@@ -87,9 +114,10 @@ const buildSemanticLayerWritebackPrompt = (
  */
 export const planReviewWriteback = (
     item: AiAgentReviewItemSummary,
+    ymlPathByModel: Map<string, string> = new Map(),
 ): ReviewWritebackPlan => {
     if (item.primaryRootCause === 'semantic_layer') {
-        return buildSemanticLayerWritebackPrompt(item);
+        return buildSemanticLayerWritebackPrompt(item, ymlPathByModel);
     }
     throw new Error(
         `Writeback is not supported for root cause "${item.primaryRootCause}"`,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -18800,6 +18800,20 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemWritebackStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['queued'] },
+                { dataType: 'enum', enums: ['running'] },
+                { dataType: 'enum', enums: ['completed'] },
+                { dataType: 'enum', enums: ['failed'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentReviewItem: {
         dataType: 'refAlias',
         type: {
@@ -18807,6 +18821,22 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 updatedAt: { dataType: 'datetime', required: true },
                 createdAt: { dataType: 'datetime', required: true },
+                prWritebackMessage: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                prWritebackStatus: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiAgentReviewItemWritebackStatus' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 prState: {
                     dataType: 'union',
                     subSchemas: [
@@ -23819,6 +23849,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['slackAiPrompt'] },
                 { dataType: 'enum', enums: ['aiAgentEvalResult'] },
                 { dataType: 'enum', enums: ['aiAgentReviewClassifier'] },
+                { dataType: 'enum', enums: ['aiAgentReviewWriteback'] },
                 { dataType: 'enum', enums: ['embedArtifactVersion'] },
                 { dataType: 'enum', enums: ['generateArtifactQuestion'] },
                 { dataType: 'enum', enums: ['appGeneratePipeline'] },
@@ -26551,7 +26582,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -26561,7 +26592,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -26571,7 +26602,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -26584,7 +26615,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -27239,7 +27270,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27249,7 +27280,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27259,7 +27290,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -27272,7 +27303,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -47945,6 +47976,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getReviewItems',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getReviewItem: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        fingerprint: {
+            in: 'path',
+            name: 'fingerprint',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/review-items/:fingerprint',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getReviewItem,
+        ),
+
+        async function AiAgentAdminController_getReviewItem(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getReviewItem,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getReviewItem',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -19450,6 +19450,10 @@
                 "type": "string",
                 "enum": ["open", "merged", "closed"]
             },
+            "AiAgentReviewItemWritebackStatus": {
+                "type": "string",
+                "enum": ["queued", "running", "completed", "failed"]
+            },
             "AiAgentReviewItem": {
                 "properties": {
                     "updatedAt": {
@@ -19459,6 +19463,18 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "prWritebackMessage": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "prWritebackStatus": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiAgentReviewItemWritebackStatus"
+                            }
+                        ],
+                        "nullable": true
                     },
                     "prState": {
                         "allOf": [
@@ -19544,6 +19560,8 @@
                 "required": [
                     "updatedAt",
                     "createdAt",
+                    "prWritebackMessage",
+                    "prWritebackStatus",
                     "prState",
                     "linkedPrUrl",
                     "linkedIssueUrl",
@@ -24595,6 +24613,7 @@
                     "slackAiPrompt",
                     "aiAgentEvalResult",
                     "aiAgentReviewClassifier",
+                    "aiAgentReviewWriteback",
                     "embedArtifactVersion",
                     "generateArtifactQuestion",
                     "appGeneratePipeline",
@@ -27523,22 +27542,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -28098,22 +28117,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -36909,7 +36928,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3052.2",
+        "version": "0.3054.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -43396,8 +43415,8 @@
             }
         },
         "/api/v1/aiAgents/admin/review-items/{fingerprint}": {
-            "patch": {
-                "operationId": "updateAiAgentReviewItemStatus",
+            "get": {
+                "operationId": "getAiAgentReviewItem",
                 "responses": {
                     "200": {
                         "description": "Success",
@@ -43422,6 +43441,44 @@
                 },
                 "description": "Get AI agent classifier review signals for admin debugging",
                 "summary": "List AI agent review signals",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "fingerprint",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "updateAiAgentReviewItemStatus",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update the status of an AI agent review item (e.g. dismiss it)",
+                "summary": "Update AI agent review item status",
                 "security": [],
                 "parameters": [
                     {

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -165,6 +165,12 @@ const getTagsForTask: {
         'ai_agent_review.event_type': payload.eventType,
     }),
 
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid,
+    }),
+
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -313,6 +313,12 @@ export type AiAgentReviewItemOwnerType =
 
 export type AiAgentReviewItemPrState = 'open' | 'merged' | 'closed';
 
+export type AiAgentReviewItemWritebackStatus =
+    | 'queued'
+    | 'running'
+    | 'completed'
+    | 'failed';
+
 const aiAgentConfigurationSettingSchema = z.enum([
     'instructions',
     'knowledge_documents',
@@ -490,6 +496,8 @@ export type AiAgentReviewItem = {
     linkedIssueUrl: string | null;
     linkedPrUrl: string | null;
     prState: AiAgentReviewItemPrState | null;
+    prWritebackStatus: AiAgentReviewItemWritebackStatus | null;
+    prWritebackMessage: string | null;
     createdAt: Date;
     updatedAt: Date;
 };

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -181,6 +181,12 @@ export type AiAgentReviewClassifierJobPayload = TraceTaskBase & {
     promptUuid: string;
 };
 
+export type AiAgentReviewWritebackJobPayload = TraceTaskBase & {
+    fingerprint: string;
+    organizationUuid: string;
+    projectUuid: string;
+};
+
 export type EmbedArtifactVersionJobPayload = TraceTaskBase & {
     artifactVersionUuid: string;
     title: string | null;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -2,6 +2,7 @@ import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
     type AiAgentReviewClassifierJobPayload,
+    type AiAgentReviewWritebackJobPayload,
     type ChartReference,
     type DataAppClaudeModel,
     type DataAppTemplate,
@@ -62,6 +63,7 @@ export const EE_SCHEDULER_TASKS = {
     SLACK_AI_PROMPT: 'slackAiPrompt',
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
     AI_AGENT_REVIEW_CLASSIFIER: 'aiAgentReviewClassifier',
+    AI_AGENT_REVIEW_WRITEBACK: 'aiAgentReviewWriteback',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
@@ -146,6 +148,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
@@ -156,6 +159,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
+    [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -15,6 +15,7 @@ import {
     Button,
     Divider,
     Group,
+    Loader,
     Paper,
     SegmentedControl,
     Stack,
@@ -54,6 +55,7 @@ import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useProjects } from '../../../../../hooks/useProjects';
 import {
     useAiAgentAdminAgents,
+    useAiAgentAdminReviewItem,
     useAiAgentAdminReviewItems,
     useAiAgentAdminReviewSignals,
     useCreateAiAgentReviewItemWriteback,
@@ -385,12 +387,38 @@ const ReviewItemActionsCell = ({
     const updateStatus = useUpdateAiAgentReviewItemStatus();
     const createWriteback = useCreateAiAgentReviewItemWriteback();
 
+    const propInFlight =
+        reviewItem.prWritebackStatus === 'queued' ||
+        reviewItem.prWritebackStatus === 'running';
+    // While a writeback runs on the worker, poll the single item so the live
+    // phase messages ("Starting sandbox", "Discovering models"…) surface here.
+    const { data: polled } = useAiAgentAdminReviewItem(reviewItem.fingerprint, {
+        enabled: propInFlight,
+        refetchInterval: propInFlight ? 2500 : false,
+    });
+    const current = polled ?? reviewItem;
+
+    const isWritebackInFlight =
+        current.prWritebackStatus === 'queued' ||
+        current.prWritebackStatus === 'running';
     const isTerminal =
-        reviewItem.status === 'resolved' || reviewItem.status === 'dismissed';
+        current.status === 'resolved' || current.status === 'dismissed';
     const canCreatePr =
-        reviewItem.primaryRootCause === 'semantic_layer' &&
-        !reviewItem.linkedPrUrl &&
-        !isTerminal;
+        current.primaryRootCause === 'semantic_layer' &&
+        !current.linkedPrUrl &&
+        !isTerminal &&
+        !isWritebackInFlight;
+
+    if (isWritebackInFlight) {
+        return (
+            <Group gap="xs" wrap="nowrap" justify="flex-end">
+                <Loader size="xs" color="violet" />
+                <Text fz="xs" c="ldGray.7" lineClamp={1} maw={170}>
+                    {current.prWritebackMessage ?? 'Working…'}
+                </Text>
+            </Group>
+        );
+    }
 
     return (
         <Group gap="xs" wrap="nowrap" justify="flex-end">
@@ -398,14 +426,14 @@ const ReviewItemActionsCell = ({
                 size="sm"
                 radius="sm"
                 variant="light"
-                color={statusColors[reviewItem.status]}
+                color={statusColors[current.status]}
             >
-                {reviewItem.status.replaceAll('_', ' ')}
+                {current.status.replaceAll('_', ' ')}
             </Badge>
 
-            {reviewItem.linkedPrUrl && (
+            {current.linkedPrUrl && (
                 <Anchor
-                    href={reviewItem.linkedPrUrl}
+                    href={current.linkedPrUrl}
                     target="_blank"
                     onClick={(event) => event.stopPropagation()}
                 >
@@ -420,7 +448,7 @@ const ReviewItemActionsCell = ({
 
             {canCreatePr && (
                 <Tooltip
-                    label="Open a pull request against the dbt project (may take a few minutes)"
+                    label="Open a pull request against the dbt project (runs in the background, may take a few minutes)"
                     withArrow
                     multiline
                     maw={260}
@@ -435,7 +463,7 @@ const ReviewItemActionsCell = ({
                         }
                         onClick={(event) => {
                             event.stopPropagation();
-                            createWriteback.mutate(reviewItem.fingerprint);
+                            createWriteback.mutate(current.fingerprint);
                         }}
                     >
                         Create PR
@@ -454,7 +482,7 @@ const ReviewItemActionsCell = ({
                         onClick={(event) => {
                             event.stopPropagation();
                             updateStatus.mutate({
-                                fingerprint: reviewItem.fingerprint,
+                                fingerprint: current.fingerprint,
                                 body: {
                                     status: 'dismissed',
                                     dismissedReason: 'not_actionable',

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -142,6 +142,27 @@ export const useAiAgentAdminReviewItems = (
     });
 };
 
+const getAiAgentAdminReviewItem = async (fingerprint: string) => {
+    return lightdashApi<ApiAiAgentReviewItemResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items/${encodeURIComponent(fingerprint)}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useAiAgentAdminReviewItem = (
+    fingerprint: string,
+    options?: { enabled?: boolean; refetchInterval?: number | false },
+) => {
+    return useQuery<ApiAiAgentReviewItemResponse['results'], ApiError>({
+        queryKey: ['ai-agent-admin-review-item', fingerprint],
+        queryFn: () => getAiAgentAdminReviewItem(fingerprint),
+        enabled: options?.enabled ?? true,
+        refetchInterval: options?.refetchInterval,
+    });
+};
+
 const updateAiAgentReviewItemStatus = async (args: {
     fingerprint: string;
     body: UpdateAiAgentReviewItemStatus;


### PR DESCRIPTION
Part 6/9. Moves the (multi-minute) writeback off the API request onto the Graphile worker, with live progress.

- New `aiAgentReviewWriteback` EE scheduler task; `POST .../writeback` now enqueues + sets `queued` and returns immediately.
- Worker runs the engine with `onProgress` streaming phase messages onto the item; lightweight `GET .../review-items/{fingerprint}` for cheap polling.
- Migration adds `pr_writeback_status` / `pr_writeback_message`.

**Regression analysis:** changes the writeback trigger from sync → async. Only affects the new, flag-gated review-writeback path; the chat `proposeWriteback` tool is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
