### PR TITLE
fix(ai-review): writeback hardening — progress-write race + resilience

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -561,6 +561,24 @@ describe('AiAgentReviewClassifierModel', () => {
         });
     });
 
+    describe('updateReviewItemWritebackProgress', () => {
+        it('guards against resurrecting a terminal row', async () => {
+            tracker.on.update(AiAgentReviewItemTableName).responseOnce(0);
+
+            await model.updateReviewItemWritebackProgress({
+                fingerprint: FINGERPRINT,
+                organizationUuid: ORGANIZATION_UUID,
+                message: 'Starting sandbox',
+            });
+
+            expect(tracker.history.update).toHaveLength(1);
+            const sql = tracker.history.update[0].sql.toLowerCase();
+            expect(sql).toContain('not in');
+            expect(tracker.history.update[0].bindings).toContain('completed');
+            expect(tracker.history.update[0].bindings).toContain('failed');
+        });
+    });
+
     describe('reconcileReviewItemPrState', () => {
         it('updates status and pr_state for a fingerprint in the org', async () => {
             tracker.on.update(AiAgentReviewItemTableName).responseOnce(1);

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1000,6 +1000,24 @@ export class AiAgentReviewClassifierModel {
             });
     }
 
+    async updateReviewItemWritebackProgress(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        message: string;
+    }): Promise<void> {
+        // Guarded so a late, fire-and-forget progress write can never resurrect
+        // a row that already reached a terminal (completed/failed) state.
+        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+            .where('fingerprint', args.fingerprint)
+            .where('organization_uuid', args.organizationUuid)
+            .whereNotIn('pr_writeback_status', ['completed', 'failed'])
+            .update({
+                pr_writeback_status: 'running',
+                pr_writeback_message: args.message,
+                updated_at: this.database.fn.now() as never,
+            });
+    }
+
     async reconcileReviewItemPrState(args: {
         fingerprint: string;
         organizationUuid: string;

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1018,6 +1018,22 @@ export class AiAgentReviewClassifierModel {
             });
     }
 
+    async failReviewItemWriteback(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        message: string;
+    }): Promise<void> {
+        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+            .where('fingerprint', args.fingerprint)
+            .where('organization_uuid', args.organizationUuid)
+            .whereIn('pr_writeback_status', ['queued', 'running'])
+            .update({
+                pr_writeback_status: 'failed',
+                pr_writeback_message: args.message,
+                updated_at: this.database.fn.now() as never,
+            });
+    }
+
     async reconcileReviewItemPrState(args: {
         fingerprint: string;
         organizationUuid: string;

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -206,6 +206,13 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     helpers.job,
                     AI_AGENT_REVIEW_WRITEBACK_TIMEOUT_MS,
                     async (job, e) => {
+                        await this.aiAgentAdminService.failReviewItemWritebackJob(
+                            {
+                                fingerprint: payload.fingerprint,
+                                organizationUuid: payload.organizationUuid,
+                                message: getErrorMessage(e),
+                            },
+                        );
                         await this.schedulerService.logSchedulerJob({
                             task: EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK,
                             jobId: job.id,

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -541,19 +541,14 @@ export class AiAgentAdminService extends BaseService {
         const { fingerprint, organizationUuid, projectUuid, userUuid } =
             payload;
 
-        const setStatus = (
-            status: 'running' | 'completed' | 'failed',
-            message: string | null,
-            agentUuid: string,
-        ) =>
-            this.aiAgentReviewClassifierModel.setReviewItemWritebackStatus({
-                fingerprint,
-                organizationUuid,
-                projectUuid,
-                agentUuid,
-                status,
-                message,
-            });
+        const setProgress = (message: string) =>
+            this.aiAgentReviewClassifierModel.updateReviewItemWritebackProgress(
+                {
+                    fingerprint,
+                    organizationUuid,
+                    message,
+                },
+            );
 
         const scope =
             await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
@@ -570,9 +565,22 @@ export class AiAgentAdminService extends BaseService {
         }
         const { agentUuid } = scope;
 
+        const setTerminal = (
+            status: 'completed' | 'failed',
+            message: string | null,
+        ) =>
+            this.aiAgentReviewClassifierModel.setReviewItemWritebackStatus({
+                fingerprint,
+                organizationUuid,
+                projectUuid,
+                agentUuid,
+                status,
+                message,
+            });
+
         try {
             const user = await this.userModel.findSessionUserByUUID(userUuid);
-            await setStatus('running', 'Starting writeback…', agentUuid);
+            await setProgress('Starting writeback…');
 
             const explores = await this.projectModel.findExploresFromCache(
                 projectUuid,
@@ -587,7 +595,7 @@ export class AiAgentAdminService extends BaseService {
                 projectUuid,
                 prompt: plan.promptText,
                 onProgress: (message) => {
-                    void setStatus('running', message, agentUuid);
+                    void setProgress(message);
                 },
             });
 
@@ -600,16 +608,15 @@ export class AiAgentAdminService extends BaseService {
                     linkedPrUrl: result.prUrl,
                     prState: 'open',
                 });
-                await setStatus('completed', 'Opened pull request', agentUuid);
+                await setTerminal('completed', 'Opened pull request');
             } else {
-                await setStatus(
+                await setTerminal(
                     'completed',
                     'Writeback ran — no changes were needed',
-                    agentUuid,
                 );
             }
         } catch (error) {
-            await setStatus('failed', getErrorMessage(error), agentUuid);
+            await setTerminal('failed', getErrorMessage(error));
             throw error;
         }
     }

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -14,6 +14,7 @@ import {
     getErrorMessage,
     KnexPaginateArgs,
     KnexPaginatedData,
+    MissingConfigError,
     NotFoundError,
     ParameterError,
     UpdateAiAgentReviewItemStatus,
@@ -60,6 +61,29 @@ const parsePullRequestUrl = (
     }
     return { owner: match[1], repo: match[2], pullNumber: Number(match[3]) };
 };
+
+// Longer than the worker's 30-min job timeout — past this, a queued/running writeback has lost its worker and is treated as failed so the UI recovers and retries.
+const WRITEBACK_STALE_MS = 35 * 60 * 1000;
+
+const isWritebackStale = (
+    item: AiAgentReviewItemSummary,
+    now: number,
+): boolean =>
+    (item.prWritebackStatus === 'queued' ||
+        item.prWritebackStatus === 'running') &&
+    now - new Date(item.updatedAt).getTime() > WRITEBACK_STALE_MS;
+
+const withStaleWritebackOverride = (
+    item: AiAgentReviewItemSummary,
+    now: number,
+): AiAgentReviewItemSummary =>
+    isWritebackStale(item, now)
+        ? {
+              ...item,
+              prWritebackStatus: 'failed',
+              prWritebackMessage: 'Writeback timed out',
+          }
+        : item;
 
 export class AiAgentAdminService extends BaseService {
     private readonly aiAgentModel: AiAgentModel;
@@ -199,6 +223,7 @@ export class AiAgentAdminService extends BaseService {
               )
             : new Set<string>();
 
+        const now = Date.now();
         const reconciled = items.map((item) => {
             const override = overrides.get(item.fingerprint);
             const writebackEligible =
@@ -206,7 +231,10 @@ export class AiAgentAdminService extends BaseService {
                 item.primaryRootCause === 'semantic_layer' &&
                 item.projectUuid !== null &&
                 githubProjects.has(item.projectUuid);
-            return { ...item, ...(override ?? {}), writebackEligible };
+            return withStaleWritebackOverride(
+                { ...item, ...(override ?? {}), writebackEligible },
+                now,
+            );
         });
 
         if (statuses) {
@@ -284,14 +312,22 @@ export class AiAgentAdminService extends BaseService {
             return overrides;
         }
 
-        const installationId =
-            await this.githubAppInstallationsModel.getInstallationId(
-                organizationUuid,
+        let token: string;
+        try {
+            const installationId =
+                await this.githubAppInstallationsModel.getInstallationId(
+                    organizationUuid,
+                );
+            if (!installationId) {
+                return overrides;
+            }
+            token = await getInstallationToken(installationId);
+        } catch (error) {
+            this.logger.warn(
+                `Skipping PR-state reconcile — could not resolve GitHub installation: ${error}`,
             );
-        if (!installationId) {
             return overrides;
         }
-        const token = await getInstallationToken(installationId);
 
         await Promise.all(
             open.map(async (item) => {
@@ -464,6 +500,18 @@ export class AiAgentAdminService extends BaseService {
             throw new ForbiddenError('AI writeback is not enabled');
         }
 
+        // Fail fast at the click rather than queue → run → fail on the worker.
+        if (!this.lightdashConfig.appRuntime.e2bApiKey) {
+            throw new MissingConfigError(
+                'E2B API key is not configured (E2B_API_KEY)',
+            );
+        }
+        if (!this.lightdashConfig.aiWriteback.anthropicApiKey) {
+            throw new MissingConfigError(
+                'Anthropic API key is not configured (AI_WRITEBACK_ANTHROPIC_API_KEY)',
+            );
+        }
+
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
                 organizationUuid,
@@ -482,10 +530,10 @@ export class AiAgentAdminService extends BaseService {
                 'A pull request is already open for this review item',
             );
         }
-        if (
+        const writebackInFlight =
             reviewItem.prWritebackStatus === 'queued' ||
-            reviewItem.prWritebackStatus === 'running'
-        ) {
+            reviewItem.prWritebackStatus === 'running';
+        if (writebackInFlight && !isWritebackStale(reviewItem, Date.now())) {
             throw new ParameterError(
                 'A writeback is already in progress for this review item',
             );
@@ -621,6 +669,14 @@ export class AiAgentAdminService extends BaseService {
         }
     }
 
+    async failReviewItemWritebackJob(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        message: string;
+    }): Promise<void> {
+        await this.aiAgentReviewClassifierModel.failReviewItemWriteback(args);
+    }
+
     async getReviewItem(
         user: SessionUser,
         fingerprint: string,
@@ -648,7 +704,10 @@ export class AiAgentAdminService extends BaseService {
             (await this.getGithubProjectUuids([reviewItem.projectUuid])).has(
                 reviewItem.projectUuid,
             );
-        return { ...reviewItem, writebackEligible };
+        return withStaleWritebackOverride(
+            { ...reviewItem, writebackEligible },
+            Date.now(),
+        );
     }
 
     /**


### PR DESCRIPTION
Part 8/8 (hardening). Two fixes to the worker writeback, squashed together:

**Progress-write race:** progress writes were fire-and-forget and could land after the terminal write, leaving a row stuck on `running`. Progress now uses a guarded UPDATE (`WHERE pr_writeback_status NOT IN ('completed','failed')`) so it can never resurrect a terminal row.

**Resilience:**
- Worker crash / 30-min timeout → row marked `failed` (timeout handler); on read, any queued/running older than 35 min is shown `failed` ("timed out").
- Stale in-flight runs are retryable (idempotency check).
- Missing `E2B_API_KEY` / Anthropic key → fail fast at the click.
- `getInstallationToken` failure no longer breaks the review-queue endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
