### PR TITLE
fix(ai-review): writeback resilience — fail fast, recover orphaned/timed-out runs, guard reconcile

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1018,6 +1018,22 @@ export class AiAgentReviewClassifierModel {
             });
     }
 
+    async failReviewItemWriteback(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        message: string;
+    }): Promise<void> {
+        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+            .where('fingerprint', args.fingerprint)
+            .where('organization_uuid', args.organizationUuid)
+            .whereIn('pr_writeback_status', ['queued', 'running'])
+            .update({
+                pr_writeback_status: 'failed',
+                pr_writeback_message: args.message,
+                updated_at: this.database.fn.now() as never,
+            });
+    }
+
     async reconcileReviewItemPrState(args: {
         fingerprint: string;
         organizationUuid: string;

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -206,6 +206,13 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     helpers.job,
                     AI_AGENT_REVIEW_WRITEBACK_TIMEOUT_MS,
                     async (job, e) => {
+                        await this.aiAgentAdminService.failReviewItemWritebackJob(
+                            {
+                                fingerprint: payload.fingerprint,
+                                organizationUuid: payload.organizationUuid,
+                                message: getErrorMessage(e),
+                            },
+                        );
                         await this.schedulerService.logSchedulerJob({
                             task: EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK,
                             jobId: job.id,

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -14,6 +14,7 @@ import {
     getErrorMessage,
     KnexPaginateArgs,
     KnexPaginatedData,
+    MissingConfigError,
     NotFoundError,
     ParameterError,
     UpdateAiAgentReviewItemStatus,
@@ -57,6 +58,29 @@ const parsePullRequestUrl = (
     }
     return { owner: match[1], repo: match[2], pullNumber: Number(match[3]) };
 };
+
+// Longer than the worker's 30-min job timeout — past this, a queued/running writeback has lost its worker and is treated as failed so the UI recovers and retries.
+const WRITEBACK_STALE_MS = 35 * 60 * 1000;
+
+const isWritebackStale = (
+    item: AiAgentReviewItemSummary,
+    now: number,
+): boolean =>
+    (item.prWritebackStatus === 'queued' ||
+        item.prWritebackStatus === 'running') &&
+    now - new Date(item.updatedAt).getTime() > WRITEBACK_STALE_MS;
+
+const withStaleWritebackOverride = (
+    item: AiAgentReviewItemSummary,
+    now: number,
+): AiAgentReviewItemSummary =>
+    isWritebackStale(item, now)
+        ? {
+              ...item,
+              prWritebackStatus: 'failed',
+              prWritebackMessage: 'Writeback timed out',
+          }
+        : item;
 
 export class AiAgentAdminService extends BaseService {
     private readonly aiAgentModel: AiAgentModel;
@@ -196,6 +220,7 @@ export class AiAgentAdminService extends BaseService {
               )
             : new Set<string>();
 
+        const now = Date.now();
         const reconciled = items.map((item) => {
             const override = overrides.get(item.fingerprint);
             const writebackEligible =
@@ -203,7 +228,10 @@ export class AiAgentAdminService extends BaseService {
                 item.primaryRootCause === 'semantic_layer' &&
                 item.projectUuid !== null &&
                 githubProjects.has(item.projectUuid);
-            return { ...item, ...(override ?? {}), writebackEligible };
+            return withStaleWritebackOverride(
+                { ...item, ...(override ?? {}), writebackEligible },
+                now,
+            );
         });
 
         if (statuses) {
@@ -281,14 +309,22 @@ export class AiAgentAdminService extends BaseService {
             return overrides;
         }
 
-        const installationId =
-            await this.githubAppInstallationsModel.getInstallationId(
-                organizationUuid,
+        let token: string;
+        try {
+            const installationId =
+                await this.githubAppInstallationsModel.getInstallationId(
+                    organizationUuid,
+                );
+            if (!installationId) {
+                return overrides;
+            }
+            token = await getInstallationToken(installationId);
+        } catch (error) {
+            this.logger.warn(
+                `Skipping PR-state reconcile — could not resolve GitHub installation: ${error}`,
             );
-        if (!installationId) {
             return overrides;
         }
-        const token = await getInstallationToken(installationId);
 
         await Promise.all(
             open.map(async (item) => {
@@ -461,6 +497,18 @@ export class AiAgentAdminService extends BaseService {
             throw new ForbiddenError('AI writeback is not enabled');
         }
 
+        // Fail fast at the click rather than queue → run → fail on the worker.
+        if (!this.lightdashConfig.appRuntime.e2bApiKey) {
+            throw new MissingConfigError(
+                'E2B API key is not configured (E2B_API_KEY)',
+            );
+        }
+        if (!this.lightdashConfig.aiWriteback.anthropicApiKey) {
+            throw new MissingConfigError(
+                'Anthropic API key is not configured (AI_WRITEBACK_ANTHROPIC_API_KEY)',
+            );
+        }
+
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
                 organizationUuid,
@@ -479,10 +527,10 @@ export class AiAgentAdminService extends BaseService {
                 'A pull request is already open for this review item',
             );
         }
-        if (
+        const writebackInFlight =
             reviewItem.prWritebackStatus === 'queued' ||
-            reviewItem.prWritebackStatus === 'running'
-        ) {
+            reviewItem.prWritebackStatus === 'running';
+        if (writebackInFlight && !isWritebackStale(reviewItem, Date.now())) {
             throw new ParameterError(
                 'A writeback is already in progress for this review item',
             );
@@ -611,6 +659,14 @@ export class AiAgentAdminService extends BaseService {
         }
     }
 
+    async failReviewItemWritebackJob(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        message: string;
+    }): Promise<void> {
+        await this.aiAgentReviewClassifierModel.failReviewItemWriteback(args);
+    }
+
     async getReviewItem(
         user: SessionUser,
         fingerprint: string,
@@ -638,7 +694,10 @@ export class AiAgentAdminService extends BaseService {
             (await this.getGithubProjectUuids([reviewItem.projectUuid])).has(
                 reviewItem.projectUuid,
             );
-        return { ...reviewItem, writebackEligible };
+        return withStaleWritebackOverride(
+            { ...reviewItem, writebackEligible },
+            Date.now(),
+        );
     }
 
     /**


### PR DESCRIPTION
Part 9/9 (fix). Hardens failure modes:

- Worker crash / 30-min timeout → row marked `failed` (timeout handler); on read, any queued/running older than 35 min is shown `failed` ("timed out").
- Stale in-flight runs are retryable (idempotency check).
- Missing `E2B_API_KEY` / Anthropic key → fail fast at the click instead of queue → run → fail.
- `getInstallationToken` failure no longer breaks the review-queue endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
