### PR TITLE
test: cover DB feature-flag resolution priority and defaults (GLITCH-312)

### DIFF
--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -2,6 +2,13 @@ import { FeatureFlags } from '@lightdash/common';
 import { Knex } from 'knex';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { LightdashConfig } from '../../config/parseConfig';
+import {
+    DbFeatureFlag,
+    DbFeatureFlagOverride,
+    FeatureFlagOverridesTableName,
+    FeatureFlagsTableName,
+} from '../../database/entities/featureFlags';
+import Logger from '../../logging/logger';
 import { FeatureFlagModel } from './FeatureFlagModel';
 
 // Minimal stub — tests below don't exercise the database layer
@@ -24,6 +31,60 @@ const buildModel = (
             ...configOverrides,
         } as LightdashConfig,
     });
+
+// A valid v4-shaped UUID. The model only runs the user-override lookup when
+// userUuid matches its UUID_REGEX — anonymous embed accounts carry a
+// non-UUID externalId and must skip straight to the org lookup.
+const VALID_USER_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+const dbUser = {
+    userUuid: VALID_USER_UUID,
+    organizationUuid: 'org-uuid',
+    organizationName: 'Org',
+};
+
+type FakeRows = {
+    flag?: Partial<DbFeatureFlag>;
+    userOverride?: Partial<DbFeatureFlagOverride>;
+    orgOverride?: Partial<DbFeatureFlagOverride>;
+};
+
+// Fake Knex serving preconfigured rows by table + where-clause — enough to
+// exercise getFromDatabase()'s user-override > org-override > flag-default
+// precedence without a real DB. `.first()` is the only terminal the model
+// uses; the two override lookups are told apart by their filters (user
+// lookup → where('user_uuid'), org lookup → whereNull('user_uuid')).
+const buildFakeDatabase = (rows: FakeRows): Knex => {
+    const makeBuilder = (table: string) => {
+        const filters = new Set<string>();
+        const builder = {
+            where(column: string) {
+                filters.add(column);
+                return builder;
+            },
+            whereNull(column: string) {
+                filters.add(`${column}:null`);
+                return builder;
+            },
+            first() {
+                if (table === FeatureFlagsTableName) {
+                    return Promise.resolve(rows.flag);
+                }
+                if (table === FeatureFlagOverridesTableName) {
+                    if (filters.has('user_uuid')) {
+                        return Promise.resolve(rows.userOverride);
+                    }
+                    if (filters.has('user_uuid:null')) {
+                        return Promise.resolve(rows.orgOverride);
+                    }
+                }
+                return Promise.resolve(undefined);
+            },
+        };
+        return builder;
+    };
+    return ((table: string) => makeBuilder(table)) as unknown as Knex;
+};
 
 describe('FeatureFlagModel', () => {
     describe('env var override', () => {
@@ -150,11 +211,122 @@ describe('FeatureFlagModel', () => {
         });
     });
 
+    describe('database resolution', () => {
+        const DB_FLAG = 'db-only-flag';
+
+        it('prefers a user override over the org override', async () => {
+            // Default off and the org override off — only the user override
+            // (on) can yield `true`, which proves it takes priority.
+            const model = buildModel(
+                {},
+                buildFakeDatabase({
+                    flag: { default_enabled: false },
+                    userOverride: { enabled: true },
+                    orgOverride: { enabled: false },
+                }),
+            );
+
+            const result = await model.get({
+                featureFlagId: DB_FLAG,
+                user: dbUser,
+            });
+
+            expect(result).toEqual({ id: DB_FLAG, enabled: true });
+        });
+
+        it('uses the org override when the user has none', async () => {
+            const model = buildModel(
+                {},
+                buildFakeDatabase({
+                    flag: { default_enabled: false },
+                    userOverride: undefined,
+                    orgOverride: { enabled: true },
+                }),
+            );
+
+            const result = await model.get({
+                featureFlagId: DB_FLAG,
+                user: dbUser,
+            });
+
+            expect(result).toEqual({ id: DB_FLAG, enabled: true });
+        });
+
+        it('falls back to the flag default when no override matches', async () => {
+            const model = buildModel(
+                {},
+                buildFakeDatabase({ flag: { default_enabled: true } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: DB_FLAG,
+                user: dbUser,
+            });
+
+            expect(result).toEqual({ id: DB_FLAG, enabled: true });
+        });
+    });
+
+    describe('default_enabled honoured over env fallback', () => {
+        // ResultsCacheEnabled resolves to lightdashConfig.results.cacheEnabled
+        // only when the DB has no opinion. A concrete default_enabled in the
+        // DB wins, so `false` must beat an env fallback of `true`, while
+        // `null` (no default set) falls through to it.
+        const cacheEnabledConfig = {
+            results: { ...lightdashConfigMock.results, cacheEnabled: true },
+        };
+
+        it('default_enabled:false overrides an env fallback of true', async () => {
+            const model = buildModel(
+                cacheEnabledConfig,
+                buildFakeDatabase({ flag: { default_enabled: false } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.ResultsCacheEnabled,
+                user: dbUser,
+            });
+
+            expect(result).toEqual({
+                id: FeatureFlags.ResultsCacheEnabled,
+                enabled: false,
+            });
+        });
+
+        it('default_enabled:null falls through to the env fallback', async () => {
+            const model = buildModel(
+                cacheEnabledConfig,
+                buildFakeDatabase({ flag: { default_enabled: null } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.ResultsCacheEnabled,
+                user: dbUser,
+            });
+
+            expect(result).toEqual({
+                id: FeatureFlags.ResultsCacheEnabled,
+                enabled: true,
+            });
+        });
+    });
+
     describe('database error resilience', () => {
         // Reproduces the embed-account regression: a non-UUID userUuid
         // (e.g. `external::…`) makes Postgres throw 22P02 on the override
         // lookup. The model must swallow that and resolve to disabled
-        // rather than 500ing.
+        // rather than 500ing. Logger.warn is mocked so the expected warning
+        // stays out of the test output (and is asserted on instead).
+        let warnSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            warnSpy = jest.spyOn(Logger, 'warn').mockImplementation();
+        });
+
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
         it('does not throw when EnableTimezoneSupport DB lookup fails', async () => {
             const model = buildModel({}, throwingDatabase);
 
@@ -171,6 +343,7 @@ describe('FeatureFlagModel', () => {
                 id: FeatureFlags.EnableTimezoneSupport,
                 enabled: false,
             });
+            expect(warnSpy).toHaveBeenCalled();
         });
 
         it('does not throw when EnableDataApps DB lookup fails', async () => {
@@ -189,6 +362,7 @@ describe('FeatureFlagModel', () => {
                 id: FeatureFlags.EnableDataApps,
                 enabled: false,
             });
+            expect(warnSpy).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Closes:

### Description:

Expands the `FeatureFlagModel` test suite with a lightweight fake database layer that simulates the user-override → org-override → flag-default precedence chain without requiring a real database connection.

New test coverage includes:

- **Database resolution**: verifies that a user override takes priority over an org override, that the org override is used when no user override exists, and that the flag's `default_enabled` value is used as a final fallback.
- **`default_enabled` vs env fallback**: confirms that an explicit `default_enabled: false` in the database wins over a config-based fallback of `true`, while `default_enabled: null` correctly falls through to the config value.
- **Error resilience**: adds a `Logger.warn` spy to the existing DB-error tests so the expected warning is asserted on rather than silently swallowed, and keeps the test output clean.