### PR TITLE
refactor(ai-agents): consolidate `toolOutput` into typed `toolResult` on stream tool call parts

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -135,7 +135,7 @@ const segmentStreamParts = (
             toolCallId: part.toolCallId,
             toolName: part.toolName,
             toolArgs: part.toolArgs,
-            toolOutput: part.toolOutput,
+            toolOutput: part.toolResult ?? undefined,
             isPreliminary: part.isPreliminary,
         };
         const last = segments[segments.length - 1];
@@ -251,7 +251,7 @@ const getLatestSuccessfulRunSqlLinkState = ({
                 part.type !== 'toolCall' ||
                 part.toolName !== 'runSql' ||
                 part.isPreliminary === true ||
-                getToolOutputStatus(part.toolOutput) !== 'success'
+                getToolOutputStatus(part.toolResult) !== 'success'
             ) {
                 continue;
             }
@@ -433,7 +433,7 @@ const AssistantBubbleContent: FC<{
     //     isToolProposeWritebackResult type predicate.
     //   - Live streaming: pull it from streamingState.parts. The streaming
     //     slice mirrors AI SDK output-available chunks into each part's
-    //     toolOutput, which is the full tool return shape {result,metadata}.
+    //     toolResult, which is the full tool return shape {result,metadata}.
     //     We re-shape to the structured `metadata` the card expects.
     const proposeWritebackMetadata:
         | ToolProposeWritebackOutput['metadata']
@@ -447,10 +447,10 @@ const AssistantBubbleContent: FC<{
             (p): p is Extract<StreamPart, { type: 'toolCall' }> =>
                 p.type === 'toolCall' &&
                 p.toolName === 'proposeWriteback' &&
-                p.toolOutput !== undefined &&
+                p.toolResult !== null &&
                 p.isPreliminary !== true,
         );
-        const liveOutput = livePart?.toolOutput as
+        const liveOutput = livePart?.toolResult as
             | ToolProposeWritebackOutput
             | undefined;
         return liveOutput?.metadata ?? null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -389,11 +389,12 @@ type DiscoverFieldsOutputMetadata = {
     trace?: TraceEntry[];
 };
 
-const extractTraceFromMessage = (
+const extractDiscoverFieldsTraceFromStreamingMessage = (
     message: StreamingMessage | undefined,
 ): TraceEntry[] | null => {
     if (!message) return null;
     const entries: TraceEntry[] = [];
+    const seenToolCallIds = new Set<string>();
     for (const part of message.parts) {
         if (
             part.type !== 'tool-findExplores' &&
@@ -402,6 +403,8 @@ const extractTraceFromMessage = (
             continue;
         }
         if (!part.toolCallId) continue;
+        if (seenToolCallIds.has(part.toolCallId)) continue;
+        seenToolCallIds.add(part.toolCallId);
         entries.push({
             toolCallId: part.toolCallId,
             toolName:
@@ -445,7 +448,9 @@ const getDiscoverFieldsTrace = (
     const metadata = toolResult.metadata as
         | DiscoverFieldsOutputMetadata
         | undefined;
-    const fromMessage = extractTraceFromMessage(metadata?.streamingMessage);
+    const fromMessage = extractDiscoverFieldsTraceFromStreamingMessage(
+        metadata?.streamingMessage,
+    );
     if (fromMessage) return fromMessage;
     const legacy = metadata?.trace;
     return Array.isArray(legacy) && legacy.length > 0 ? legacy : null;
@@ -464,7 +469,9 @@ const getDiscoverFieldsTraceFromCall = (
     const output = call.toolOutput as
         | { metadata?: DiscoverFieldsOutputMetadata }
         | undefined;
-    return extractTraceFromMessage(output?.metadata?.streamingMessage);
+    return extractDiscoverFieldsTraceFromStreamingMessage(
+        output?.metadata?.streamingMessage,
+    );
 };
 
 /**

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.test.ts
@@ -77,7 +77,8 @@ describe('aiAgentThreadStreamSlice', () => {
                 threadUuid: 'thread-1',
                 toolCallId: 'tool-1',
                 toolName: 'findExplores',
-                toolArgs: {},
+                toolArgs: { searchQuery: 'orders' },
+                toolResult: null,
             }).meta,
         ).toEqual(expectedMeta);
         expect(
@@ -248,6 +249,61 @@ describe('aiAgentThreadStreamSlice', () => {
         );
         expect(afterText['thread-1']?.stepProgressMessages).toEqual([
             { message: 'Committing changes', toolName: 'proposeWriteback' },
+        ]);
+    });
+
+    it('dedupes stream tool parts by toolCallId when setting parts', () => {
+        const startedState = aiAgentThreadStreamSlice.reducer(
+            undefined,
+            startStreaming({
+                threadUuid: 'thread-1',
+                messageUuid: 'message-1',
+            }),
+        );
+
+        const state = aiAgentThreadStreamSlice.reducer(
+            startedState,
+            setParts({
+                threadUuid: 'thread-1',
+                parts: [
+                    { type: 'text', text: 'before' },
+                    {
+                        type: 'toolCall',
+                        toolCallId: 'tool-1',
+                        toolName: 'findExplores',
+                        toolArgs: { searchQuery: 'orders' },
+                        toolResult: null,
+                    },
+                    {
+                        type: 'toolCall',
+                        toolCallId: 'tool-1',
+                        toolName: 'findExplores',
+                        toolArgs: { searchQuery: 'orders' },
+                        toolResult: {
+                            result: '<searchResults />',
+                            metadata: { status: 'success' },
+                        },
+                        isPreliminary: false,
+                    },
+                    { type: 'text', text: 'after' },
+                ],
+            }),
+        );
+
+        expect(state['thread-1']?.parts).toEqual([
+            { type: 'text', text: 'before' },
+            {
+                type: 'toolCall',
+                toolCallId: 'tool-1',
+                toolName: 'findExplores',
+                toolArgs: { searchQuery: 'orders' },
+                toolResult: {
+                    result: '<searchResults />',
+                    metadata: { status: 'success' },
+                },
+                isPreliminary: false,
+            },
+            { type: 'text', text: 'after' },
         ]);
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
@@ -1,17 +1,14 @@
-import {
-    type AiAgentToolName,
-    type AiMcpServerConnectionStatus,
-} from '@lightdash/common';
+import { type AiMcpServerConnectionStatus } from '@lightdash/common';
 import {
     createSlice,
     prepareAutoBatched,
     type PayloadAction,
 } from '@reduxjs/toolkit';
+import { type AiAgentToolCall, type AiAgentToolOutput } from '../types';
 
-type ToolCall = {
+type ToolCall = AiAgentToolCall & {
     toolCallId: string;
-    toolName: AiAgentToolName;
-    toolArgs: unknown;
+    toolResult: AiAgentToolOutput | null;
 };
 
 type Reasoning = {
@@ -35,26 +32,32 @@ export type StepProgressMessage = {
 
 export type StreamPart =
     | { type: 'text'; text: string }
-    | {
-          type: 'toolCall';
-          toolCallId: string;
-          toolName: AiAgentToolName;
-          toolArgs: unknown;
-          /**
-           * The tool's output once the call resolves. Populated for live
-           * preliminary updates (tools whose execute is an async generator
-           * like `discoverFields`) and for the final non-preliminary result.
-           * `undefined` while the tool is still streaming its input or before
-           * the first preliminary chunk lands.
-           */
-          toolOutput?: unknown;
-          /**
-           * `true` for AI-SDK preliminary tool-result chunks (each yield from
-           * an async-generator execute). `false` for the final non-preliminary
-           * tool result. `undefined` when toolOutput is absent.
-           */
-          isPreliminary?: boolean;
-      };
+    | (ToolCall & { type: 'toolCall' });
+
+const dedupeStreamParts = (parts: StreamPart[]): StreamPart[] => {
+    const dedupedParts: StreamPart[] = [];
+    const toolCallIndexById = new Map<string, number>();
+
+    for (const part of parts) {
+        if (part.type !== 'toolCall') {
+            dedupedParts.push(part);
+            continue;
+        }
+
+        const existingIndex = toolCallIndexById.get(part.toolCallId);
+        if (existingIndex === undefined) {
+            toolCallIndexById.set(part.toolCallId, dedupedParts.length);
+            dedupedParts.push(part);
+        } else {
+            dedupedParts[existingIndex] = {
+                ...dedupedParts[existingIndex],
+                ...part,
+            } as StreamPart;
+        }
+    }
+
+    return dedupedParts;
+};
 
 export interface AiAgentThreadStreamingState {
     threadUuid: string;
@@ -155,7 +158,7 @@ export const aiAgentThreadStreamSlice = createSlice({
                 const { threadUuid, parts } = action.payload;
                 const streamingThread = state[threadUuid];
                 if (streamingThread) {
-                    streamingThread.parts = parts;
+                    streamingThread.parts = dedupeStreamParts(parts);
                 }
             },
             prepare: prepareAutoBatched<{
@@ -201,25 +204,19 @@ export const aiAgentThreadStreamSlice = createSlice({
                 state,
                 action: PayloadAction<ToolCall & { threadUuid: string }>,
             ) => {
-                const { threadUuid, toolCallId, toolName, toolArgs } =
-                    action.payload;
+                const { threadUuid, ...toolCall } = action.payload;
                 const streamingThread = state[threadUuid];
                 if (streamingThread) {
                     const existingIndex = streamingThread.toolCalls.findIndex(
-                        (tc: ToolCall) => tc.toolCallId === toolCallId,
+                        (tc: ToolCall) => tc.toolCallId === toolCall.toolCallId,
                     );
                     if (existingIndex !== -1) {
                         streamingThread.toolCalls[existingIndex] = {
                             ...streamingThread.toolCalls[existingIndex],
-                            toolName,
-                            toolArgs,
-                        };
+                            ...toolCall,
+                        } as ToolCall;
                     } else {
-                        streamingThread.toolCalls.push({
-                            toolCallId,
-                            toolName,
-                            toolArgs,
-                        });
+                        streamingThread.toolCalls.push(toolCall);
                     }
                 }
             },

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
@@ -1,22 +1,36 @@
-import { agentToolDefinitionsByName, type ToolName } from '@lightdash/common';
+import {
+    agentToolDefinitionsByName,
+    type ToolDefinition,
+    type ToolName,
+} from '@lightdash/common';
 import { type z } from 'zod';
 
 type ParsedToolName = ToolName;
 type ToolArgs<TName extends ParsedToolName> = z.infer<
     (typeof agentToolDefinitionsByName)[TName]['inputSchema']
 >;
-type ToolResult<TName extends ParsedToolName> = z.infer<
-    NonNullable<
-        ReturnType<
-            (typeof agentToolDefinitionsByName)[TName]['for']
-        >['outputSchema']
+type ToolOutputSchema<TName extends ParsedToolName> =
+    (typeof agentToolDefinitionsByName)[TName] extends ToolDefinition<
+        string,
+        z.ZodObject<z.ZodRawShape>,
+        z.ZodTypeAny,
+        infer TOutputSchema
     >
+        ? TOutputSchema
+        : never;
+type ToolResult<TName extends ParsedToolName> = z.infer<
+    NonNullable<ToolOutputSchema<TName>>
 >;
+
+export type AiAgentToolOutput = {
+    [K in ParsedToolName]: ToolResult<K>;
+}[ParsedToolName];
 
 export type AiAgentToolCall = {
     [K in ParsedToolName]: {
         toolName: K;
         toolArgs: ToolArgs<K>;
+        toolResult?: ToolResult<K> | null;
         isPreliminary?: boolean;
     };
 }[ParsedToolName];

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -164,14 +164,44 @@ const getStreamToolCallPart = (
     }
 
     const hasOutput = toolPart.state === 'output-available';
+
+    // Output chunks include both the original args and the tool result. Parse
+    // once through the result schema so toolName, toolArgs, and toolResult stay
+    // correlated in the returned typed stream part.
+    if (hasOutput && toolPart.output !== undefined) {
+        const toolResult = parseStreamRawToolResult({
+            toolName: toolPart.toolName,
+            toolArgs: toolPart.input,
+            toolOutput: toolPart.output,
+            isPreliminary: toolPart.preliminary ?? false,
+        });
+        if (!toolResult) return null;
+
+        return {
+            type: 'toolCall',
+            toolCallId: toolPart.toolCallId,
+            toolName: toolResult.toolName,
+            toolArgs: toolResult.toolArgs,
+            toolResult: toolResult.toolResult,
+            isPreliminary: toolResult.isPreliminary,
+        } as StreamToolCallPart;
+    }
+
+    // Input-only chunks are emitted before any result exists. They still need
+    // typed args for live rendering, while toolResult remains null until an
+    // output chunk for the same toolCallId arrives.
+    const toolCall = parseStreamRawToolCall({
+        toolName: toolPart.toolName,
+        toolArgs: toolPart.input,
+    });
+    if (!toolCall) return null;
+
     return {
         type: 'toolCall',
         toolCallId: toolPart.toolCallId,
-        toolName: toolPart.toolName,
-        toolArgs: toolPart.input,
-        toolOutput: hasOutput ? toolPart.output : undefined,
-        isPreliminary: hasOutput ? (toolPart.preliminary ?? false) : undefined,
-    };
+        ...toolCall,
+        toolResult: null,
+    } as StreamToolCallPart;
 };
 
 export const getMcpUnavailableNoticeFromChunk = (
@@ -345,23 +375,24 @@ export function useAiAgentThreadStreamMutation() {
                         const toolPart = getStreamToolPart(part);
                         const toolCallPart = getStreamToolCallPart(part);
 
+                        if (toolCallPart) {
+                            const { type: _type, ...toolCall } = toolCallPart;
+                            dispatch(addToolCall({ threadUuid, ...toolCall }));
+                        }
+
                         if (
+                            toolCallPart &&
                             toolPart?.toolName &&
                             toolPart.state === 'input-available' &&
                             !notifiedToolCallIds.has(toolPart.toolCallId)
                         ) {
                             notifiedToolCallIds.add(toolPart.toolCallId);
-                            const toolCall = parseStreamRawToolCall({
-                                toolName: toolPart.toolName,
-                                toolArgs: toolPart.input,
-                            });
-                            if (toolCall) {
-                                onToolCall?.(toolCall);
-                            }
+                            onToolCall?.(toolCallPart);
                         }
 
                         if (
-                            toolCallPart?.toolOutput !== undefined &&
+                            toolCallPart &&
+                            toolCallPart.toolResult !== null &&
                             toolCallPart.isPreliminary !== undefined
                         ) {
                             const outputKey = `${toolCallPart.toolCallId}:${String(
@@ -369,15 +400,12 @@ export function useAiAgentThreadStreamMutation() {
                             )}`;
                             if (!notifiedToolOutputIds.has(outputKey)) {
                                 notifiedToolOutputIds.add(outputKey);
-                                const toolResult = parseStreamRawToolResult({
+                                onToolResult?.({
                                     toolName: toolCallPart.toolName,
                                     toolArgs: toolCallPart.toolArgs,
-                                    toolOutput: toolCallPart.toolOutput,
+                                    toolResult: toolCallPart.toolResult,
                                     isPreliminary: toolCallPart.isPreliminary,
-                                });
-                                if (toolResult) {
-                                    onToolResult?.(toolResult);
-                                }
+                                } as AiAgentToolResult);
                             }
                         }
 
@@ -470,16 +498,6 @@ export function useAiAgentThreadStreamMutation() {
 
                                     handledToolInputIds.add(part.toolCallId);
 
-                                    // Store raw tool args (will be validated in rendering components)
-                                    dispatch(
-                                        addToolCall({
-                                            threadUuid,
-                                            toolCallId: part.toolCallId,
-                                            toolName,
-                                            toolArgs: part.input,
-                                        }),
-                                    );
-
                                     // Special handling for improveContext - validate to access suggestedInstruction
                                     if (toolName === 'improveContext') {
                                         const improveContextArgs =
@@ -541,15 +559,6 @@ export function useAiAgentThreadStreamMutation() {
                                     }
 
                                     handledToolInputIds.add(part.toolCallId);
-
-                                    dispatch(
-                                        addToolCall({
-                                            threadUuid,
-                                            toolCallId: part.toolCallId,
-                                            toolName: part.toolName,
-                                            toolArgs: part.input,
-                                        }),
-                                    );
                                 }
                                 break;
                             case 'file':

--- a/packages/frontend/src/ee/features/aiCopilot/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/types.ts
@@ -1,6 +1,7 @@
 export type {
     AiAgentToolCall,
     AiAgentToolCallHandler,
+    AiAgentToolOutput,
     AiAgentToolResult,
     AiAgentToolResultHandler,
 } from './streaming/parseStreamRawToolResult';

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -6,7 +6,6 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useParams } from 'react-router';
-import { type StreamPart } from '../../ee/features/aiCopilot/store/aiAgentThreadStreamSlice';
 import { useAiAgentStoreSelector } from '../../ee/features/aiCopilot/store/hooks';
 import { getDashboard } from '../../hooks/dashboard/useDashboard';
 import { getSavedQuery } from '../../hooks/useSavedQuery';
@@ -18,34 +17,6 @@ const emptyFilters: DashboardFilters = {
     tableCalculations: [],
 };
 
-type ToolOutput = {
-    metadata?: {
-        status?: 'success' | 'error';
-    };
-};
-
-type ToolCallPart = Extract<StreamPart, { type: 'toolCall' }>;
-type EditContentToolArgs = {
-    type?: 'dashboard' | 'chart';
-    slug?: string;
-};
-
-const isToolOutput = (value: unknown): value is ToolOutput =>
-    typeof value === 'object' && value !== null;
-
-const isFinalEditContentToolCall = (part: StreamPart): part is ToolCallPart =>
-    part.type === 'toolCall' &&
-    part.toolName === 'editContent' &&
-    part.isPreliminary === false &&
-    part.toolOutput !== undefined;
-
-const getEditContentToolArgs = (
-    value: unknown,
-): EditContentToolArgs | undefined =>
-    typeof value === 'object' && value !== null
-        ? (value as EditContentToolArgs)
-        : undefined;
-
 const DashboardAiAgentContextBridge = () => {
     const queryClient = useQueryClient();
     const { projectUuid, dashboardUuid } = useParams<{
@@ -54,11 +25,6 @@ const DashboardAiAgentContextBridge = () => {
     }>();
     const dashboard = useDashboardContext((c) => c.dashboard);
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
-    const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
-    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
-    const dashboardTemporaryFilters = useDashboardContext(
-        (c) => c.dashboardTemporaryFilters,
-    );
     const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
     const setDashboardFilters = useDashboardContext(
@@ -88,44 +54,26 @@ const DashboardAiAgentContextBridge = () => {
         [dashboardUuid, projectUuid],
     );
 
-    const relevantResults = useMemo(
-        () => activeThreadParts.filter(isFinalEditContentToolCall),
+    const successfulEditContentResults = useMemo(
+        () =>
+            activeThreadParts.flatMap((part) =>
+                part.type === 'toolCall' &&
+                part.toolName === 'editContent' &&
+                part.isPreliminary === false &&
+                part.toolResult?.metadata.status === 'success'
+                    ? [part]
+                    : [],
+            ),
         [activeThreadParts],
     );
 
     const refreshDashboard = useCallback(async () => {
         if (!projectUuid || !dashboardUuid) return;
 
-        console.log(
-            '[DashboardAiAgentContextBridge] invalidating dashboard query',
-            {
-                slug: currentDashboardSlug,
-                queryKey: dashboardQueryKey,
-                before: {
-                    tiles: dashboardTiles,
-                    tabs: dashboardTabs,
-                    filters: dashboardFilters,
-                    temporaryFilters: dashboardTemporaryFilters,
-                },
-            },
-        );
-
         const freshDashboard = await queryClient.fetchQuery({
             queryKey: dashboardQueryKey,
             queryFn: () => getDashboard(dashboardUuid, projectUuid),
         });
-
-        console.log(
-            '[DashboardAiAgentContextBridge] applying fresh dashboard state',
-            {
-                slug: currentDashboardSlug,
-                after: {
-                    tiles: freshDashboard.tiles,
-                    tabs: freshDashboard.tabs,
-                    filters: freshDashboard.filters,
-                },
-            },
-        );
 
         setDashboardTiles(freshDashboard.tiles);
         setDashboardTabs(freshDashboard.tabs);
@@ -133,12 +81,7 @@ const DashboardAiAgentContextBridge = () => {
         setOriginalDashboardFilters(freshDashboard.filters);
         setDashboardTemporaryFilters(emptyFilters);
     }, [
-        currentDashboardSlug,
-        dashboardFilters,
         dashboardQueryKey,
-        dashboardTabs,
-        dashboardTemporaryFilters,
-        dashboardTiles,
         dashboardUuid,
         projectUuid,
         queryClient,
@@ -170,15 +113,6 @@ const DashboardAiAgentContextBridge = () => {
                 ),
             ];
 
-            console.log(
-                '[DashboardAiAgentContextBridge] refreshing chart tiles',
-                {
-                    slug: chartSlug,
-                    savedChartUuids,
-                    tileUuids: matchingTiles.map((tile) => tile.uuid),
-                },
-            );
-
             await Promise.all(
                 savedChartUuids.map(async (savedChartUuid) => {
                     const freshChart = await queryClient.fetchQuery({
@@ -206,36 +140,19 @@ const DashboardAiAgentContextBridge = () => {
     );
 
     useEffect(() => {
-        if (!currentDashboardSlug) return;
+        if (!currentDashboardSlug || !projectUuid || !dashboardUuid) return;
 
-        for (const part of relevantResults) {
+        for (const part of successfulEditContentResults) {
             if (handledToolCallIdsRef.current.has(part.toolCallId)) continue;
 
             handledToolCallIdsRef.current.add(part.toolCallId);
 
-            const toolArgs = getEditContentToolArgs(part.toolArgs);
-
-            if (toolArgs?.type !== 'dashboard' && toolArgs?.type !== 'chart') {
-                continue;
-            }
-
-            const toolOutput = part.toolOutput;
-            if (
-                !isToolOutput(toolOutput) ||
-                toolOutput.metadata?.status !== 'success' ||
-                !projectUuid ||
-                !dashboardUuid
-            ) {
-                continue;
-            }
-
-            switch (toolArgs.type) {
+            switch (part.toolArgs.type) {
                 case 'chart':
-                    if (!toolArgs.slug) continue;
-                    void refreshChartTiles(toolArgs.slug);
+                    void refreshChartTiles(part.toolArgs.slug);
                     continue;
                 case 'dashboard':
-                    if (toolArgs.slug !== currentDashboardSlug) continue;
+                    if (part.toolArgs.slug !== currentDashboardSlug) continue;
                     void refreshDashboard();
                     continue;
             }
@@ -244,9 +161,9 @@ const DashboardAiAgentContextBridge = () => {
         currentDashboardSlug,
         dashboardUuid,
         projectUuid,
-        relevantResults,
         refreshChartTiles,
         refreshDashboard,
+        successfulEditContentResults,
     ]);
 
     return null;


### PR DESCRIPTION
Closes:

### Description:

Refactors how tool call results are represented in the AI agent streaming pipeline. Previously, tool outputs were stored as untyped `toolOutput?: unknown` on stream parts. Now, tool results are parsed and typed at the point where stream chunks are processed in `getStreamToolCallPart`, producing a strongly-typed `toolResult` field (or `null` when no result has arrived yet) that is correlated with the tool's name and args.

The `StreamPart` type for `toolCall` entries is now derived directly from the typed `AiAgentToolCall` union, eliminating the separate inline type definition and ensuring the result schema is applied consistently. The `addToolCall` dispatch is consolidated to a single call site that fires for every tool call chunk, replacing the two separate dispatch locations that only fired on input-available events.

In `DashboardAiAgentContextBridge`, the `editContent` result filtering now uses the typed `toolResult.metadata.status` field directly instead of runtime `isToolOutput` guards and untyped casts, and leftover debug `console.log` calls have been removed.