### PR TITLE
feat(ai-agents): add routing instructions editor to AI router settings

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -1,6 +1,7 @@
 import {
     Badge,
     Box,
+    Divider,
     Group,
     Loader,
     Stack,
@@ -11,7 +12,7 @@ import {
 import { IconSparkles } from '@tabler/icons-react';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
-import { SettingsGridCard } from '../../../../../../components/common/Settings/SettingsCard';
+import { SettingsCard } from '../../../../../../components/common/Settings/SettingsCard';
 import {
     useAiOrganizationSettings,
     useUpdateAiOrganizationSettings,
@@ -20,6 +21,7 @@ import {
     useAiRouterConfig,
     useUpsertAiRouterConfig,
 } from '../../../hooks/useAiRouter';
+import { AiRouterInstructionsCard } from './AiRouterInstructionsCard';
 
 export const AiGeneralSettingsPage = () => {
     const { data: settings, isInitialLoading: isSettingsLoading } =
@@ -48,39 +50,44 @@ export const AiGeneralSettingsPage = () => {
                 </Group>
             ) : (
                 <>
-                    <SettingsGridCard>
-                        <Box>
-                            <Group gap="xs" mb={4}>
-                                <Title order={5}>
-                                    Enable AI features for users
-                                </Title>
-                                {settings.isTrial && (
-                                    <Badge
-                                        leftSection={
-                                            <MantineIcon
-                                                icon={IconSparkles}
-                                                size={12}
-                                            />
-                                        }
-                                        radius="sm"
-                                        variant="light"
-                                        color="indigo"
-                                        size="sm"
-                                        tt="none"
-                                        fw={500}
-                                    >
-                                        Free trial
-                                    </Badge>
-                                )}
-                            </Group>
-                            <Text c="dimmed" fz="xs">
-                                Show AI features (homepage entry, navbar action,
-                                and agent chat) to everyone in this
-                                organization. Disable to hide them while keeping
-                                existing data intact.
-                            </Text>
-                        </Box>
-                        <Group justify="flex-end">
+                    <SettingsCard>
+                        <Group
+                            justify="space-between"
+                            wrap="nowrap"
+                            align="flex-start"
+                            gap="md"
+                        >
+                            <Box maw={620}>
+                                <Group gap="xs" mb={4}>
+                                    <Title order={5}>
+                                        Enable AI features for users
+                                    </Title>
+                                    {settings.isTrial && (
+                                        <Badge
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconSparkles}
+                                                    size={12}
+                                                />
+                                            }
+                                            radius="sm"
+                                            variant="light"
+                                            color="gray"
+                                            size="sm"
+                                            tt="none"
+                                            fw={500}
+                                        >
+                                            Free trial
+                                        </Badge>
+                                    )}
+                                </Group>
+                                <Text c="dimmed" fz="xs">
+                                    Show AI features (homepage entry, navbar
+                                    action, and agent chat) to everyone in this
+                                    organization. Disable to hide them while
+                                    keeping existing data intact.
+                                </Text>
+                            </Box>
                             <Switch
                                 size="md"
                                 checked={settings.aiAgentsVisible}
@@ -93,36 +100,51 @@ export const AiGeneralSettingsPage = () => {
                                 }
                             />
                         </Group>
-                    </SettingsGridCard>
+                    </SettingsCard>
 
-                    <SettingsGridCard>
-                        <Box>
-                            <Title order={5} mb={4}>
-                                AI Router
-                            </Title>
-                            <Text c="dimmed" fz="xs">
-                                {settings.aiAgentsVisible
-                                    ? 'Route user questions to the best agent automatically, instead of asking users to pick.'
-                                    : 'Enable AI features first to use the Router.'}
-                            </Text>
-                        </Box>
-                        <Group justify="flex-end">
-                            <Switch
-                                size="md"
-                                checked={isRouterEnabled}
-                                disabled={
-                                    isUpdatingRouter ||
-                                    isRouterLoading ||
-                                    !settings.aiAgentsVisible
-                                }
-                                onChange={(event) =>
-                                    upsertRouter({
-                                        enabled: event.currentTarget.checked,
-                                    })
-                                }
-                            />
-                        </Group>
-                    </SettingsGridCard>
+                    <SettingsCard>
+                        <Stack gap="md">
+                            <Group
+                                justify="space-between"
+                                wrap="nowrap"
+                                align="flex-start"
+                                gap="md"
+                            >
+                                <Box maw={620}>
+                                    <Title order={5} mb={4}>
+                                        AI Router
+                                    </Title>
+                                    <Text c="dimmed" fz="xs">
+                                        {settings.aiAgentsVisible
+                                            ? 'Route user questions to the best agent automatically, instead of asking users to pick.'
+                                            : 'Enable AI features first to use the Router.'}
+                                    </Text>
+                                </Box>
+                                <Switch
+                                    size="md"
+                                    checked={isRouterEnabled}
+                                    disabled={
+                                        isUpdatingRouter ||
+                                        isRouterLoading ||
+                                        !settings.aiAgentsVisible
+                                    }
+                                    onChange={(event) =>
+                                        upsertRouter({
+                                            enabled:
+                                                event.currentTarget.checked,
+                                        })
+                                    }
+                                />
+                            </Group>
+
+                            {settings.aiAgentsVisible && isRouterEnabled && (
+                                <>
+                                    <Divider mx="calc(var(--mantine-spacing-md) * -1)" />
+                                    <AiRouterInstructionsCard />
+                                </>
+                            )}
+                        </Stack>
+                    </SettingsCard>
                 </>
             )}
         </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiRouterInstructionsCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiRouterInstructionsCard.tsx
@@ -1,0 +1,235 @@
+import {
+    Box,
+    Button,
+    Group,
+    Loader,
+    Select,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { useBlocker } from 'react-router';
+import { type SuggestionsItem } from '../../../../../../features/comments/types';
+import { useActiveProjectUuid } from '../../../../../../hooks/useActiveProject';
+import { useProjects } from '../../../../../../hooks/useProjects';
+import { useTimeAgo } from '../../../../../../hooks/useTimeAgo';
+import {
+    useAiRouterInstruction,
+    useUpsertAiRouterInstruction,
+} from '../../../hooks/useAiRouter';
+import { useProjectAiAgents } from '../../../hooks/useProjectAiAgents';
+import { extractTaggedAgentUuids } from '../../../utils/aiRouterInstructions';
+import { AiRouterInstructionsEditor } from './AiRouterInstructionsEditor';
+
+// Split out so the relative-time hook only runs when there is a saved version.
+const SavedAtLabel: FC<{ savedAt: Date | string }> = ({ savedAt }) => {
+    const timeAgo = useTimeAgo(savedAt);
+    return (
+        <Text c="dimmed" fz="xs">
+            Saved {timeAgo}
+        </Text>
+    );
+};
+
+type FormProps = {
+    projectUuid: string;
+    initialInstruction: string;
+    savedAt: Date | string | null;
+    suggestions: SuggestionsItem[];
+    onDirtyChange: (isDirty: boolean) => void;
+};
+
+const AiRouterInstructionsForm: FC<FormProps> = ({
+    projectUuid,
+    initialInstruction,
+    savedAt,
+    suggestions,
+    onDirtyChange,
+}) => {
+    const [draft, setDraft] = useState(initialInstruction);
+    const { mutate: save, isLoading: isSaving } =
+        useUpsertAiRouterInstruction(projectUuid);
+
+    const hasChanges = draft.trim() !== initialInstruction.trim();
+    const hasUnsavedChanges = hasChanges && !isSaving;
+
+    // Surface dirtiness to the parent so it can guard project switches, which
+    // remount this form and would otherwise discard the draft silently.
+    useEffect(() => {
+        onDirtyChange(hasUnsavedChanges);
+        return () => onDirtyChange(false);
+    }, [hasUnsavedChanges, onDirtyChange]);
+
+    useBlocker(({ currentLocation, nextLocation }) => {
+        if (
+            !hasUnsavedChanges ||
+            currentLocation.pathname === nextLocation.pathname
+        ) {
+            return false;
+        }
+        return !window.confirm(
+            'You have unsaved routing instructions. Are you sure you want to leave without saving?',
+        );
+    });
+
+    // Guards full-page unload (refresh, tab close) the in-app blocker can't see.
+    useEffect(() => {
+        if (!hasUnsavedChanges) return undefined;
+        const handler = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+        window.addEventListener('beforeunload', handler);
+        return () => window.removeEventListener('beforeunload', handler);
+    }, [hasUnsavedChanges]);
+
+    return (
+        <Stack gap="xs">
+            <AiRouterInstructionsEditor
+                suggestions={suggestions}
+                initialInstruction={initialInstruction}
+                disabled={isSaving}
+                onChange={setDraft}
+            />
+            <Group justify="flex-end" gap="md">
+                {savedAt && <SavedAtLabel savedAt={savedAt} />}
+                <Button
+                    size="xs"
+                    disabled={!hasChanges}
+                    loading={isSaving}
+                    onClick={() =>
+                        save({
+                            instruction: draft,
+                            taggedAgentUuids: extractTaggedAgentUuids(draft),
+                        })
+                    }
+                >
+                    Save instructions
+                </Button>
+            </Group>
+        </Stack>
+    );
+};
+
+export const AiRouterInstructionsCard: FC = () => {
+    const { data: projects, isInitialLoading: isProjectsLoading } =
+        useProjects();
+    const { activeProjectUuid, isLoading: isActiveProjectLoading } =
+        useActiveProjectUuid();
+    const [selectedProjectUuid, setSelectedProjectUuid] = useState<
+        string | null
+    >(null);
+    const [isFormDirty, setIsFormDirty] = useState(false);
+
+    const projectUuid =
+        selectedProjectUuid ??
+        activeProjectUuid ??
+        projects?.[0]?.projectUuid ??
+        null;
+
+    // Switching projects remounts the form and discards its draft, which the
+    // route/unload guards can't catch, so confirm here before changing.
+    const handleProjectChange = (nextProjectUuid: string | null) => {
+        if (
+            isFormDirty &&
+            nextProjectUuid !== projectUuid &&
+            !window.confirm(
+                'You have unsaved routing instructions. Are you sure you want to switch projects without saving?',
+            )
+        ) {
+            return;
+        }
+        setSelectedProjectUuid(nextProjectUuid);
+    };
+
+    const agentsQuery = useProjectAiAgents({
+        projectUuid: projectUuid ?? undefined,
+        redirectOnUnauthorized: false,
+    });
+    const instructionQuery = useAiRouterInstruction(projectUuid ?? undefined);
+
+    const suggestions = useMemo<SuggestionsItem[]>(
+        () =>
+            (agentsQuery.data ?? []).map((agent) => ({
+                id: agent.uuid,
+                label: agent.name,
+                disabled: false,
+            })),
+        [agentsQuery.data],
+    );
+
+    const projectOptions = useMemo(
+        () =>
+            (projects ?? []).map((project) => ({
+                value: project.projectUuid,
+                label: project.name,
+            })),
+        [projects],
+    );
+
+    const isLoading =
+        instructionQuery.isInitialLoading || agentsQuery.isInitialLoading;
+    const hasTooFewAgents =
+        !agentsQuery.isInitialLoading && suggestions.length < 2;
+
+    return (
+        <Stack gap="md">
+            <Box>
+                <Title order={6} mb={4}>
+                    Routing instructions
+                </Title>
+                <Text c="dimmed" fz="xs">
+                    Tell the router how to direct questions for a project. For
+                    example, send billing questions to a specific agent. Type @
+                    to tag an agent. Rules guide the router but never override
+                    an agent's access restrictions.
+                </Text>
+            </Box>
+
+            <Select
+                label="Project"
+                placeholder="Select a project"
+                data={projectOptions}
+                value={projectUuid}
+                onChange={handleProjectChange}
+                disabled={isProjectsLoading || isActiveProjectLoading}
+                maw={320}
+                searchable
+            />
+
+            {!isProjectsLoading && projectOptions.length === 0 && (
+                <Text c="dimmed" fz="xs">
+                    No projects available to configure.
+                </Text>
+            )}
+
+            {projectUuid && hasTooFewAgents && (
+                <Text c="dimmed" fz="xs">
+                    This project has fewer than two accessible agents, so the
+                    router won't run here yet. You can still prepare
+                    instructions.
+                </Text>
+            )}
+
+            {!projectUuid ? null : isLoading ? (
+                <Group justify="center">
+                    <Loader size="sm" />
+                </Group>
+            ) : (
+                <AiRouterInstructionsForm
+                    key={`${projectUuid}-${
+                        instructionQuery.data?.instructionVersionUuid ?? 'new'
+                    }`}
+                    projectUuid={projectUuid}
+                    initialInstruction={
+                        instructionQuery.data?.instruction ?? ''
+                    }
+                    savedAt={instructionQuery.data?.createdAt ?? null}
+                    suggestions={suggestions}
+                    onDirtyChange={setIsFormDirty}
+                />
+            )}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiRouterInstructionsEditor.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiRouterInstructionsEditor.module.css
@@ -1,0 +1,36 @@
+.editor {
+    border: 1px solid var(--mantine-color-default-border);
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-body);
+    padding: 7px 12px;
+    cursor: text;
+    transition: border-color 150ms ease;
+}
+
+.editor:focus-within {
+    border-color: var(--mantine-primary-color-filled);
+}
+
+.editor :global(.ProseMirror) {
+    min-height: 120px;
+    font-size: var(--mantine-font-size-sm);
+    line-height: var(--mantine-line-height);
+    outline: none;
+}
+
+.editor :global(.ProseMirror p) {
+    margin: 0;
+}
+
+.editor :global(.ProseMirror p.is-editor-empty:first-child::before) {
+    content: attr(data-placeholder);
+    color: var(--mantine-color-placeholder);
+    pointer-events: none;
+    height: 0;
+    float: left;
+}
+
+.mention {
+    color: light-dark(var(--mantine-color-blue-7), var(--mantine-color-blue-4));
+    font-weight: 500;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiRouterInstructionsEditor.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiRouterInstructionsEditor.tsx
@@ -1,0 +1,97 @@
+import { Box } from '@mantine-8/core';
+import Mention from '@tiptap/extension-mention';
+import Placeholder from '@tiptap/extension-placeholder';
+import { EditorContent, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import { useCallback, type FC } from 'react';
+import { generateSuggestionWrapper } from '../../../../../../features/comments/components/CommentWithMentions/generateSuggestionWrapper';
+import { type SuggestionsItem } from '../../../../../../features/comments/types';
+import { instructionTextToHtml } from '../../../utils/aiRouterInstructions';
+import styles from './AiRouterInstructionsEditor.module.css';
+
+const RouterMention = Mention.extend({
+    addAttributes() {
+        return {
+            id: {
+                default: null,
+                parseHTML: (element) => element.getAttribute('data-id'),
+                renderHTML: (attributes) =>
+                    attributes.id ? { 'data-id': attributes.id } : {},
+            },
+            label: {
+                default: null,
+                parseHTML: (element) => element.getAttribute('data-label'),
+                renderHTML: (attributes) =>
+                    attributes.label ? { 'data-label': attributes.label } : {},
+            },
+        };
+    },
+});
+
+type Props = {
+    suggestions: SuggestionsItem[];
+    initialInstruction: string;
+    disabled?: boolean;
+    onChange: (instruction: string) => void;
+};
+
+export const AiRouterInstructionsEditor: FC<Props> = ({
+    suggestions,
+    initialInstruction,
+    disabled = false,
+    onChange,
+}) => {
+    const editor = useEditor({
+        extensions: [
+            StarterKit.configure({
+                blockquote: false,
+                codeBlock: false,
+                horizontalRule: false,
+            }),
+            Placeholder.configure({
+                placeholder:
+                    'e.g. Route billing and invoicing questions to @Finance Agent. Type @ to tag an agent.',
+            }),
+            RouterMention.configure({
+                suggestion: generateSuggestionWrapper(suggestions),
+                renderText: ({ node }) =>
+                    typeof node.attrs.label === 'string' &&
+                    typeof node.attrs.id === 'string'
+                        ? `@[${node.attrs.label}](${node.attrs.id})`
+                        : '',
+                renderHTML: ({ node }) => [
+                    'span',
+                    {
+                        class: styles.mention,
+                        'data-type': 'mention',
+                        'data-id': node.attrs.id,
+                        'data-label': node.attrs.label,
+                    },
+                    `@${
+                        typeof node.attrs.label === 'string'
+                            ? node.attrs.label
+                            : ''
+                    }`,
+                ],
+            }),
+        ],
+        editable: !disabled,
+        content: instructionTextToHtml(initialInstruction),
+        editorProps: {
+            attributes: {
+                'aria-label': 'Routing instructions',
+                'aria-multiline': 'true',
+                role: 'textbox',
+            },
+        },
+        onUpdate: ({ editor: ed }) => onChange(ed.getText()),
+    });
+
+    const focusEditor = useCallback(() => editor?.commands.focus(), [editor]);
+
+    return (
+        <Box className={styles.editor} onClick={focusEditor}>
+            <EditorContent editor={editor} />
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
@@ -1,9 +1,11 @@
 import {
     type AiRouter,
     type AiRouterDecisionCommitRequest,
+    type AiRouterInstruction,
     type AiRouterRouteRequest,
     type AiRouterRouteResponseResult,
     type ApiError,
+    type UpsertAiRouterInstructionRequest,
     type UpsertAiRouterRequest,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -81,3 +83,54 @@ export const useAiRouterCommit = () =>
     >({
         mutationFn: commitDecision,
     });
+
+const instructionQueryKey = (projectUuid: string) => [
+    'ai-router-instruction',
+    projectUuid,
+];
+
+const getAiRouterInstruction = (projectUuid: string) =>
+    lightdashApi<AiRouterInstruction | null>({
+        url: `${ROUTER_BASE}/instructions/${projectUuid}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useAiRouterInstruction = (projectUuid: string | undefined) =>
+    useQuery<AiRouterInstruction | null, ApiError>({
+        queryKey: instructionQueryKey(projectUuid ?? ''),
+        queryFn: () => getAiRouterInstruction(projectUuid!),
+        enabled: !!projectUuid,
+        retry: false,
+    });
+
+const upsertAiRouterInstruction = (
+    projectUuid: string,
+    body: UpsertAiRouterInstructionRequest,
+) =>
+    lightdashApi<AiRouterInstruction>({
+        url: `${ROUTER_BASE}/instructions/${projectUuid}`,
+        method: 'PUT',
+        body: JSON.stringify(body),
+    });
+
+export const useUpsertAiRouterInstruction = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<
+        AiRouterInstruction,
+        ApiError,
+        UpsertAiRouterInstructionRequest
+    >({
+        mutationFn: (body) => upsertAiRouterInstruction(projectUuid, body),
+        onSuccess: (data) => {
+            queryClient.setQueryData(instructionQueryKey(projectUuid), data);
+            showToastSuccess({ title: 'Routing instructions saved' });
+        },
+        onError: ({ error }) =>
+            showToastApiError({
+                title: 'Failed to save routing instructions',
+                apiError: error,
+            }),
+    });
+};

--- a/packages/frontend/src/ee/features/aiCopilot/utils/aiRouterInstructions.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/aiRouterInstructions.ts
@@ -1,0 +1,47 @@
+/**
+ * Router instructions are stored as free text where tagged agents are embedded
+ * as `@[Agent Name](agent-uuid)` tokens. These helpers convert between that
+ * canonical text form and the HTML the tiptap editor reads/writes, and extract
+ * the tagged agent UUIDs for the backend's `taggedAgentUuids` sidecar.
+ */
+
+const MENTION_TOKEN = /@\[([^\]]+)\]\(([^)]+)\)/g;
+
+const escapeHtml = (value: string): string =>
+    value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+
+export const extractTaggedAgentUuids = (instruction: string): string[] => {
+    const uuids = new Set<string>();
+    for (const match of instruction.matchAll(MENTION_TOKEN)) {
+        uuids.add(match[2]);
+    }
+    return [...uuids];
+};
+
+const buildMentionSpan = (label: string, id: string): string =>
+    `<span data-type="mention" data-id="${escapeHtml(id)}" data-label="${escapeHtml(
+        label,
+    )}">@${escapeHtml(label)}</span>`;
+
+export const instructionTextToHtml = (instruction: string): string => {
+    if (!instruction) return '';
+    return instruction
+        .split('\n')
+        .map((line) => {
+            let html = '';
+            let lastIndex = 0;
+            for (const match of line.matchAll(MENTION_TOKEN)) {
+                const matchIndex = match.index ?? 0;
+                html += escapeHtml(line.slice(lastIndex, matchIndex));
+                html += buildMentionSpan(match[1], match[2]);
+                lastIndex = matchIndex + match[0].length;
+            }
+            html += escapeHtml(line.slice(lastIndex));
+            return `<p>${html || '<br>'}</p>`;
+        })
+        .join('');
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

> Stacked on #23677

### Description:

UI for authoring **per-project AI Router routing instructions** (backend in #23677).

- Routing instructions live **inside the AI Router card**, below a divider, and are only shown when the router is enabled.
- **Project picker** seeded from the active project (overridable), so it agrees with the rest of Settings.
- **Rich editor** (TipTap) with `@`-mention tagging of agents; tagged agents serialize to `@[Name](uuid)` tokens and are extracted into `taggedAgentUuids`. Validated against the project on save.
- **Save state**: "Saved X ago" timestamp next to the Save button, enabled only when there are changes.
- **Unsaved-changes guards**: in-app navigation confirm (`useBlocker`) plus a `beforeunload` prompt for refresh / tab close.
- Hooks: `useAiRouterInstruction`, `useUpsertAiRouterInstruction`.
- Built with Mantine v8 throughout (no v6 `RichTextEditor`); the editor matches native input styling (md radius, default border, focus ring).

<!-- Even better add a screenshot / gif / loom -->
