### PR TITLE
fix(ai-agent): cap one writeback PR per Slack thread

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts
@@ -14,6 +14,12 @@ The writeback tool spawns a separate agent that edits the repo, runs \`lightdash
 - The user wants to propose an in-app change to a metric/dimension as a reviewable changeset rather than a pull request — use \`proposeChange\` for that.
 - The request is ambiguous about whether it should land in the repo. Ask one short clarifying question first.
 
+**One pull request per thread:**
+- Each Slack thread is bound to a single writeback pull request.
+- The first \`proposeWriteback\` call in a thread opens the PR; later calls update that same PR.
+- Follow-up edits, fixes, and refinements to the open PR should keep calling \`proposeWriteback\` in this thread.
+- If the user asks for a *different*, unrelated change after a PR has already been opened, do **not** call \`proposeWriteback\` again. Politely tell them that this thread is already tracking a pull request and ask them to start a new thread for the new change.
+
 **Writing the prompt for the writeback agent:**
 
 The writeback agent runs in a fresh sandbox with no memory of this conversation. The \`prompt\` argument must be a complete, self-contained instruction:


### PR DESCRIPTION
Closes [PROD-7990](https://linear.app/lightdash/issue/PROD-7990/tell-user-to-create-new-thread-for-another-pr-if-one-is-already).

## Description

Each Slack thread is bound to a single writeback PR — the first `proposeWriteback` call opens it, later calls update the same PR. The system prompt didn't say this, so when a user asked for a *different*, unrelated change in a thread that already had an open PR, the agent silently bundled the new change into the existing PR.

Updates `AI_WRITEBACK_SECTION` (`packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts`) to spell out the one-PR-per-thread rule and instruct the agent to politely decline a different request and ask the user to start a new thread.

```
Before                                  After
──────                                  ─────
PR open in thread.                      PR open in thread.
User: "now also add metric Y."          User: "now also add metric Y."
Agent: calls proposeWriteback,          Agent: "This thread is already
       bundles Y into existing PR.             tracking a PR. For an
                                                unrelated change, please
                                                start a new thread."

PR open in thread.                      PR open in thread.
User: "fix the typo in that metric."    User: "fix the typo in that metric."
Agent: calls proposeWriteback,          Agent: calls proposeWriteback,
       updates the open PR.                    updates the open PR.
       (unchanged — this is a                  (unchanged.)
        follow-up, not a new ask)
```

## Test plan

- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend lint` — clean
- [ ] Manual: in a Slack thread with an open writeback PR, ask the bot for an unrelated change — agent declines and points to a new thread
- [ ] Manual: in the same thread, ask the bot to refine the existing PR (typo fix, description tweak) — agent still calls `proposeWriteback` and updates the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)