### PR TITLE
feat(pivot): replace group-header rows with `rowSpan`-merged dimension cells (PROD-7938)

### DIFF
--- a/docs/superpowers/plans/2026-05-29-prod-7938-pivot-rowspan-merge.md
+++ b/docs/superpowers/plans/2026-05-29-prod-7938-pivot-rowspan-merge.md
@@ -1,0 +1,605 @@
+# Pivot `rowSpan`-Merged Dimension Cells Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the grouping-only `showRowGrouping` rendering in the pivot table (separate TanStack group-header rows) with top-aligned `rowSpan`-merged dimension cells, blank empty cells, and no virtualization in that mode.
+
+**Architecture:** A new pure helper computes per-row/per-column `rowSpan` info from the flat row order (consecutive run-length encoding, nested-aware). `PivotTable` stops engaging TanStack grouping in grouping-only mode (`showRowGrouping && !showSubtotals`), renders the flat row model un-virtualized, and the cell renderer emits `rowSpan` on block-start cells / `null` on absorbed cells. Subtotals mode and the flag-off path are untouched.
+
+**Tech Stack:** React 19, `@tanstack/react-table` v8, `@tanstack/react-virtual`, Vitest, CSS modules, `@lightdash/common` types.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-prod-7938-pivot-rowspan-merge-design.md`
+
+---
+
+## File Structure
+
+- **Create** `packages/frontend/src/components/common/PivotTable/getRowSpanMerges.ts`
+  Pure helpers: `getGroupedDimColumnIds` (which index-dim columns merge) and `getRowSpanMerges` (per-row/per-column `{ isBlockStart, rowSpan }`). No React, fully unit-testable.
+- **Create** `packages/frontend/src/components/common/PivotTable/getRowSpanMerges.test.ts`
+  Vitest unit tests for both helpers.
+- **Modify** `packages/frontend/src/components/common/PivotTable/PivotTable.module.css`
+  Add `.mergedDimCell { vertical-align: top; }`.
+- **Modify** `packages/frontend/src/components/common/PivotTable/index.tsx`
+  Use the helpers in the grouping `useEffect`, precompute spans, disable virtualization in merge mode, and emit `rowSpan` / blank cells in the body cell renderer.
+
+No `@lightdash/common`, backend, API-generation, or migration changes.
+
+---
+
+## Task 1: Pure span helpers + unit tests
+
+**Files:**
+- Create: `packages/frontend/src/components/common/PivotTable/getRowSpanMerges.ts`
+- Test: `packages/frontend/src/components/common/PivotTable/getRowSpanMerges.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `getRowSpanMerges.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { getGroupedDimColumnIds, getRowSpanMerges } from './getRowSpanMerges';
+
+// Builds a getRawValue reader over an array of plain row objects.
+const reader =
+    (rows: Record<string, unknown>[]) =>
+    (rowIndex: number, columnId: string) =>
+        rows[rowIndex]?.[columnId];
+
+describe('getGroupedDimColumnIds', () => {
+    it('returns index dims in column order minus the leaf dim', () => {
+        const indexValueTypes = [
+            { fieldId: 'month' },
+            { fieldId: 'tier' },
+        ] as never;
+        const columnOrder = ['month', 'tier', 'metric_a', 'metric_b'];
+        expect(getGroupedDimColumnIds(indexValueTypes, columnOrder)).toEqual([
+            'month',
+        ]);
+    });
+
+    it('returns empty when there is only a single index dim', () => {
+        const indexValueTypes = [{ fieldId: 'month' }] as never;
+        expect(
+            getGroupedDimColumnIds(indexValueTypes, ['month', 'metric_a']),
+        ).toEqual([]);
+    });
+
+    it('returns empty when there are no index dims', () => {
+        expect(getGroupedDimColumnIds([] as never, ['metric_a'])).toEqual([]);
+    });
+});
+
+describe('getRowSpanMerges', () => {
+    it('merges consecutive equal values in a single column', () => {
+        const rows = [
+            { month: '2026-02' },
+            { month: '2026-02' },
+            { month: '2026-01' },
+        ];
+        const merges = getRowSpanMerges(rows.length, ['month'], reader(rows));
+        expect(merges.get('month')).toEqual([
+            { isBlockStart: true, rowSpan: 2 },
+            { isBlockStart: false, rowSpan: 0 },
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+    });
+
+    it('does not merge non-adjacent equal values', () => {
+        const rows = [{ month: 'A' }, { month: 'B' }, { month: 'A' }];
+        const merges = getRowSpanMerges(rows.length, ['month'], reader(rows));
+        expect(merges.get('month')).toEqual([
+            { isBlockStart: true, rowSpan: 1 },
+            { isBlockStart: true, rowSpan: 1 },
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+    });
+
+    it('computes nested spans: outer dim spans wider than inner', () => {
+        const rows = [
+            { a: 'x', b: 'p' },
+            { a: 'x', b: 'p' },
+            { a: 'x', b: 'q' },
+            { a: 'y', b: 'p' },
+        ];
+        const merges = getRowSpanMerges(rows.length, ['a', 'b'], reader(rows));
+        expect(merges.get('a')).toEqual([
+            { isBlockStart: true, rowSpan: 3 },
+            { isBlockStart: false, rowSpan: 0 },
+            { isBlockStart: false, rowSpan: 0 },
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+        expect(merges.get('b')).toEqual([
+            { isBlockStart: true, rowSpan: 2 },
+            { isBlockStart: false, rowSpan: 0 },
+            { isBlockStart: true, rowSpan: 1 },
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+    });
+
+    it('does not merge an inner value repeating under a different outer value', () => {
+        const rows = [
+            { a: 'x', b: 'p' },
+            { a: 'y', b: 'p' },
+        ];
+        const merges = getRowSpanMerges(rows.length, ['a', 'b'], reader(rows));
+        expect(merges.get('b')).toEqual([
+            { isBlockStart: true, rowSpan: 1 },
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+    });
+
+    it('handles a single row', () => {
+        const rows = [{ month: 'A' }];
+        const merges = getRowSpanMerges(rows.length, ['month'], reader(rows));
+        expect(merges.get('month')).toEqual([{ isBlockStart: true, rowSpan: 1 }]);
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm -F frontend exec vitest run src/components/common/PivotTable/getRowSpanMerges.test.ts`
+Expected: FAIL — cannot resolve `./getRowSpanMerges` (module not created yet).
+
+- [ ] **Step 3: Write the helper implementation**
+
+Create `getRowSpanMerges.ts`:
+
+```typescript
+import { type PivotData } from '@lightdash/common';
+
+export type RowSpanMerge = {
+    isBlockStart: boolean;
+    rowSpan: number;
+};
+
+/**
+ * The row-index dimension columns that get visually merged in grouping-only
+ * mode: the index dimensions in column order, minus the last one. The leaf
+ * dimension stays per-row, matching the existing showRowGrouping behaviour
+ * (grouping on the leaf would produce one group per row). Shared with the
+ * TanStack grouping setup so the two stay in sync.
+ */
+export const getGroupedDimColumnIds = (
+    indexValueTypes: PivotData['indexValueTypes'],
+    columnOrder: string[],
+): string[] => {
+    const indexDimIds = new Set(
+        indexValueTypes.map((valueType) => valueType.fieldId),
+    );
+    return columnOrder
+        .filter((columnId) => indexDimIds.has(columnId))
+        .slice(0, -1);
+};
+
+/**
+ * Computes per-row, per-column rowSpan-merge info over the FLAT row order using
+ * consecutive run-length encoding. A block starts when the prefix tuple of
+ * grouped values (outer..this column) changes from the previous row; the
+ * block-start row carries the full rowSpan, absorbed rows carry rowSpan 0.
+ *
+ * Using the prefix (not just this column's own value) yields correct nested
+ * spans: an outer-dimension change always starts a new block for inner
+ * dimensions, and an inner value repeating under a different outer value is not
+ * merged. This is consecutive-only by design — it preserves the existing row
+ * order rather than globally regrouping (see the spec's "Ordering assumption").
+ *
+ * @param rowCount   total number of (flat) rows
+ * @param columnIds  grouped dimension column ids, outer -> inner
+ * @param getRawValue reads the comparable raw value for (rowIndex, columnId)
+ */
+export const getRowSpanMerges = (
+    rowCount: number,
+    columnIds: string[],
+    getRawValue: (rowIndex: number, columnId: string) => unknown,
+): Map<string, RowSpanMerge[]> => {
+    const result = new Map<string, RowSpanMerge[]>();
+
+    columnIds.forEach((columnId, columnIndex) => {
+        const prefix = columnIds.slice(0, columnIndex + 1);
+        const spans: RowSpanMerge[] = new Array<RowSpanMerge>(rowCount);
+        let blockStartRow = 0;
+
+        for (let row = 0; row < rowCount; row += 1) {
+            const startsNewBlock =
+                row === 0 ||
+                prefix.some(
+                    (id) => getRawValue(row, id) !== getRawValue(row - 1, id),
+                );
+
+            if (startsNewBlock) {
+                blockStartRow = row;
+                spans[row] = { isBlockStart: true, rowSpan: 1 };
+            } else {
+                spans[blockStartRow].rowSpan += 1;
+                spans[row] = { isBlockStart: false, rowSpan: 0 };
+            }
+        }
+
+        result.set(columnId, spans);
+    });
+
+    return result;
+};
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm -F frontend exec vitest run src/components/common/PivotTable/getRowSpanMerges.test.ts`
+Expected: PASS — all 9 tests green.
+
+- [ ] **Step 5: Lint the new files**
+
+Run: `pnpm -F frontend lint`
+Expected: no errors. If `ResultValue` is reported unused, remove it from the import in `getRowSpanMerges.ts` and re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/src/components/common/PivotTable/getRowSpanMerges.ts packages/frontend/src/components/common/PivotTable/getRowSpanMerges.test.ts
+git commit -m "feat(pivot): add getRowSpanMerges helper for merged row grouping"
+```
+
+---
+
+## Task 2: Add the top-align CSS class
+
+**Files:**
+- Modify: `packages/frontend/src/components/common/PivotTable/PivotTable.module.css`
+
+- [ ] **Step 1: Inspect the file**
+
+Run: `cat packages/frontend/src/components/common/PivotTable/PivotTable.module.css`
+Confirm it contains the existing `.stickyColumn` / `.fixedLayout` classes referenced by `pivotStyles`.
+
+- [ ] **Step 2: Append the merged-cell class**
+
+Add at the end of the file:
+
+```css
+.mergedDimCell {
+    vertical-align: top;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/frontend/src/components/common/PivotTable/PivotTable.module.css
+git commit -m "feat(pivot): add mergedDimCell top-align style"
+```
+
+---
+
+## Task 3: Wire merge rendering into `PivotTable`
+
+All edits are in `packages/frontend/src/components/common/PivotTable/index.tsx`. Make every edit, then run the verification gate (Step 7) once before committing so the repo compiles at the commit boundary.
+
+The merge mode is exactly the existing `groupingOnlyMode` constant (`showRowGrouping && !showSubtotals`, line 220). Because the `showRowGrouping` prop is already flag-gated upstream in `useTableConfig`, `groupingOnlyMode === true` ⇔ flag on + row grouping on + subtotals off ⇔ merge mode. Reuse it directly; do **not** add a new boolean.
+
+**Files:**
+- Modify: `packages/frontend/src/components/common/PivotTable/index.tsx`
+
+- [ ] **Step 1: Import the helpers**
+
+Find the existing import block for `./getFrozenColumnLayout` (around line 82-85):
+
+```typescript
+import {
+    getFrozenColumnLayout,
+    type FrozenColumnEntry,
+} from './getFrozenColumnLayout';
+```
+
+Add immediately after it:
+
+```typescript
+import {
+    getGroupedDimColumnIds,
+    getRowSpanMerges,
+} from './getRowSpanMerges';
+```
+
+- [ ] **Step 2: Refactor the grouping `useEffect` to use the shared helper and skip merge mode**
+
+Replace the whole `useEffect` at lines 950-988 (the one that begins with the comment `// TODO: Remove code duplicated from non-pivot table version.`) with:
+
+```typescript
+    useEffect(() => {
+        // Grouping is driven by subtotals only. Row-grouping without subtotals
+        // (groupingOnlyMode) now renders a FLAT row model with merged rowSpan
+        // cells (see getRowSpanMerges / the body renderer below), so it must
+        // NOT engage the TanStack grouping machinery.
+        const groupingActive =
+            showSubtotals || (showRowGrouping && !groupingOnlyMode);
+        if (groupingActive) {
+            const sortedColumns = getGroupedDimColumnIds(
+                data.indexValueTypes,
+                table.getState().columnOrder,
+            );
+
+            if (!isEqual(sortedColumns, table.getState().grouping)) {
+                table.setGrouping(sortedColumns);
+            }
+        } else if (table.getState().grouping.length > 0) {
+            table.resetGrouping();
+        }
+    }, [
+        showSubtotals,
+        showRowGrouping,
+        groupingOnlyMode,
+        data.indexValueTypes,
+        table,
+        columnOrder,
+    ]);
+```
+
+(This preserves the exact grouped-column set the old inline code produced —
+`columnOrder.filter(isIndexDim).slice(0, -1)` — and only changes *when*
+grouping is engaged.)
+
+- [ ] **Step 3: Precompute the rowSpan merges**
+
+Find `const virtualRows = rowVirtualizer.getVirtualItems();` (line 669). Add immediately after it:
+
+```typescript
+
+    // Grouping-only mode renders a flat row model and visually merges repeated
+    // row-index dimension values with rowSpan instead of TanStack group rows.
+    const rowSpanMergesByColumnId = useMemo(() => {
+        if (!groupingOnlyMode) return null;
+        const groupedColumnIds = getGroupedDimColumnIds(
+            data.indexValueTypes,
+            columnOrder,
+        );
+        if (groupedColumnIds.length === 0) return null;
+        return getRowSpanMerges(rows.length, groupedColumnIds, (rowIndex, columnId) => {
+            const cell = rows[rowIndex]?.getValue(columnId) as
+                | { value?: ResultValue }
+                | undefined;
+            return cell?.value?.raw;
+        });
+    }, [groupingOnlyMode, data.indexValueTypes, columnOrder, rows]);
+
+    // In merge mode, render every row (no virtualization) so rowSpans stay
+    // contiguous — a block's first row must never be unmounted while its
+    // absorbed siblings are visible.
+    const renderedBodyRows = groupingOnlyMode
+        ? rows.map((row, rowIndex) => ({ row, rowIndex }))
+        : virtualRows.map((virtualRow) => ({
+              row: rows[virtualRow.index],
+              rowIndex: virtualRow.index,
+          }));
+```
+
+(`useMemo`, `ResultValue`, `rows`, `columnOrder`, and `virtualRows` are all already in scope / imported.)
+
+- [ ] **Step 4: Disable virtualization padding + iterate `renderedBodyRows` in the body**
+
+In the `<Table.Body>` block (lines 1466-1485), change the top padding guard, the map source, and the per-row destructuring.
+
+Replace:
+
+```typescript
+            <Table.Body>
+                {paddingTop > 0 && (
+                    <VirtualizedArea
+                        cellCount={cellsCountWithRowNumber}
+                        height={paddingTop}
+                    />
+                )}
+
+                {virtualRows.map((virtualRow) => {
+                    const rowIndex = virtualRow.index;
+                    const row = rows[rowIndex];
+                    if (!row) return null;
+
+                    const toggleExpander = row.getToggleExpandedHandler();
+```
+
+with:
+
+```typescript
+            <Table.Body>
+                {!groupingOnlyMode && paddingTop > 0 && (
+                    <VirtualizedArea
+                        cellCount={cellsCountWithRowNumber}
+                        height={paddingTop}
+                    />
+                )}
+
+                {renderedBodyRows.map(({ row, rowIndex }) => {
+                    if (!row) return null;
+
+                    const toggleExpander = row.getToggleExpandedHandler();
+```
+
+- [ ] **Step 5: Fix the first-row measure ref + bottom padding guard**
+
+(a) Inside the row map, find the `measureRef` definition (lines 1490-1493):
+
+```typescript
+                                const measureRef =
+                                    virtualRow.index === 0
+                                        ? measureCellRef(cell.column.id)
+                                        : undefined;
+```
+
+Replace `virtualRow.index === 0` with `rowIndex === 0`:
+
+```typescript
+                                const measureRef =
+                                    rowIndex === 0
+                                        ? measureCellRef(cell.column.id)
+                                        : undefined;
+```
+
+(b) Find the bottom padding block (around line 1856):
+
+```typescript
+                {paddingBottom > 0 && (
+                    <VirtualizedArea
+                        cellCount={cellsCountWithRowNumber}
+                        height={paddingBottom}
+```
+
+Change its guard to:
+
+```typescript
+                {!groupingOnlyMode && paddingBottom > 0 && (
+                    <VirtualizedArea
+                        cellCount={cellsCountWithRowNumber}
+                        height={paddingBottom}
+```
+
+- [ ] **Step 6a: Skip absorbed cells in the cell renderer**
+
+Find the start of the non-row-number cell logic — immediately after the `ROW_NUMBER_COLUMN_ID` branch closes (`}` at line 1538) and before `const meta = cell.column.columnDef.meta;` (line 1540). Insert:
+
+```typescript
+
+                                // Grouping-only mode: merge repeated row-index
+                                // dimension values with rowSpan. The block's
+                                // first row renders the value spanning the
+                                // block; absorbed rows render no <td> so the
+                                // span covers their position.
+                                const rowSpanMerge =
+                                    rowSpanMergesByColumnId?.get(cell.column.id)?.[
+                                        rowIndex
+                                    ];
+                                if (rowSpanMerge && !rowSpanMerge.isBlockStart) {
+                                    return null;
+                                }
+```
+
+- [ ] **Step 6b: Emit `rowSpan` + top-align class on block-start cells**
+
+Find the `<TableCellComponent` opening (line 1708-1713):
+
+```typescript
+                                return (
+                                    <TableCellComponent
+                                        key={`value-${rowIndex}-${colIndex}-${data.pivotConfig.metricsAsRows}`}
+                                        ref={measureRef}
+                                        className={stickyCellProps.className}
+                                        style={stickyCellProps.style}
+```
+
+Replace the `className` line and add a `rowSpan` prop:
+
+```typescript
+                                return (
+                                    <TableCellComponent
+                                        key={`value-${rowIndex}-${colIndex}-${data.pivotConfig.metricsAsRows}`}
+                                        ref={measureRef}
+                                        rowSpan={rowSpanMerge?.rowSpan}
+                                        className={
+                                            rowSpanMerge
+                                                ? `${pivotStyles.mergedDimCell}${
+                                                      stickyCellProps.className
+                                                          ? ` ${stickyCellProps.className}`
+                                                          : ''
+                                                  }`
+                                                : stickyCellProps.className
+                                        }
+                                        style={stickyCellProps.style}
+```
+
+(`rowSpan` is `undefined` for non-merged cells, so it is not rendered. It passes through `LightTable.Cell`'s `...rest` onto the underlying `<td>`.)
+
+- [ ] **Step 6c: Render empty data cells blank in merge mode**
+
+Find the final content branch (lines 1843-1848):
+
+```typescript
+                                        ) : cell.getIsPlaceholder() ? null : (
+                                            flexRender(
+                                                cell.column.columnDef.cell,
+                                                cell.getContext(),
+                                            )
+                                        )}
+```
+
+Replace with:
+
+```typescript
+                                        ) : cell.getIsPlaceholder() ? null : groupingOnlyMode &&
+                                          isDataColumn &&
+                                          value == null ? null : (
+                                            flexRender(
+                                                cell.column.columnDef.cell,
+                                                cell.getContext(),
+                                            )
+                                        )}
+```
+
+(`isDataColumn` is defined at line 1542; `value` at line 1577. `value == null`
+matches both `null` and `undefined`, i.e. an empty pivot cell. Returning `null`
+suppresses both the `∅`/`-` placeholder and any bar-display background.)
+
+- [ ] **Step 7: Verification gate — typecheck, lint, build, unit tests**
+
+Run each and confirm clean before committing:
+
+```bash
+pnpm -F frontend typecheck
+pnpm -F frontend lint
+pnpm -F frontend exec vitest run src/components/common/PivotTable/getRowSpanMerges.test.ts
+```
+
+Expected: typecheck PASS, lint PASS (no unused `VirtualizedArea`/`virtualRows` — both are still used in the non-merge path), tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/frontend/src/components/common/PivotTable/index.tsx
+git commit -m "feat(pivot): render merged rowSpan cells for row grouping (PROD-7938)"
+```
+
+---
+
+## Task 4: Manual browser verification
+
+No automated UI test exists for `PivotTable` rowSpan rendering; verify in the running app. The `PivotRowGrouping` feature flag must be enabled for the test user (it gates the "Group repeated row values" toggle).
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm the feature flag is enabled**
+
+The "Group repeated row values" toggle only appears when `PivotRowGrouping` is on for `demo@lightdash.com`. If the toggle is missing in Step 3, enable the flag for the demo user before continuing.
+
+- [ ] **Step 2: Build a grouped pivot (metrics as columns)**
+
+In the running app (login `demo@lightdash.com` / `demo_password!`):
+1. Open an Explore / chart with at least **two dimensions** and **one pivot dimension** with a couple of distinct values (so metrics render as columns under each pivot value), plus 1-2 metrics.
+2. Switch the visualization to **Table**, enable **pivot** on the pivot dimension, keep **"Show metrics as rows" OFF**.
+3. Sort by the outer row dimension so its values are contiguous (the standard pivot ordering).
+
+- [ ] **Step 3: Enable row grouping and verify the merged look**
+
+Turn on **"Group repeated row values"** (subtotals OFF) and confirm against the target (spec screenshot 1 / "Target look"):
+- The grouped (non-leaf) dimension value renders **once per run**, **top-aligned**, vertically spanning its block — **no separate group-header row**.
+- The leaf dimension and metric cells render **per row**.
+- Empty data cells are **blank** — no `∅`, no `-`, no bar background.
+- Row numbers are **sequential** (`1, 2, 3 …`) with no blank-numbered rows.
+- Frozen/sticky left columns still align (scroll horizontally to check).
+- Scroll vertically through a long table — merged cells stay aligned (virtualization is off in this mode).
+
+- [ ] **Step 4: Verify the untouched paths**
+
+- Turn **"Group repeated row values" OFF** → table returns to the plain per-row rendering (values repeated, `∅`/`-` shown), virtualization active.
+- Turn **subtotals ON** → subtotal/aggregate rows render exactly as before (TanStack grouping unchanged), `∅`/`-` shown.
+
+- [ ] **Step 5: Record the result**
+
+Confirm all checks pass. If anything is off (alignment, sticky columns, conditional-formatting colors on merged cells), note it and return to Task 3 to adjust — do not claim completion until the merged look matches the target and the untouched paths are verified.
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** activation via existing `groupingOnlyMode`/flag (Task 3 Steps 1-2), flat row model / no TanStack grouping (Step 2), nested consecutive span computation (Task 1), rowSpan + top-align rendering (Step 6a/6b + Task 2 CSS), blank empty cells (Step 6c), virtualization disabled (Steps 3-5), header rework explicitly out of scope (none needed), subtotals/flag-off untouched (Step 2 + Task 4 Step 4). All covered.
+- **Placeholder scan:** none — every code step contains complete code.
+- **Type/name consistency:** `getGroupedDimColumnIds`, `getRowSpanMerges`, `RowSpanMerge { isBlockStart, rowSpan }`, `rowSpanMergesByColumnId`, `renderedBodyRows`, `rowSpanMerge`, `groupingOnlyMode` used identically across tasks.

--- a/docs/superpowers/specs/2026-05-29-prod-7938-pivot-rowspan-merge-design.md
+++ b/docs/superpowers/specs/2026-05-29-prod-7938-pivot-rowspan-merge-design.md
@@ -116,6 +116,17 @@ getRowSpanMerges(rows, columnIds, getCellRawValue)
   different outer values does not get wrongly merged.
 - Absorbed rows get `{ isBlockStart: false, rowSpan: 0 }`.
 
+**Ordering assumption.** This is **consecutive** run-length encoding on the existing
+flat row order — it merges adjacent equal values and **preserves the user's row
+order**. It does *not* globally regroup non-adjacent equal values the way the current
+TanStack `getGroupedRowModelLightdash` does (that model buckets by first appearance and
+reorders). For the standard pivot ordering — sorted by the index dimensions, as in the
+target screenshots — the two are identical, and this matches the ticket's own sketch
+("comparing the row-index-dim tuple to the previous row's"). Avoiding a reorder also
+keeps `rowIndex` aligned with `data.indexValues[rowIndex]` / `dataValues[rowIndex]` and
+all the per-row conditional-formatting / cell-menu lookups, which a permutation would
+break.
+
 This helper is the testable core. Unit tests cover: single grouped dim, two nested
 dims, repeated inner value under different outer values, all-distinct, all-same,
 single row.

--- a/docs/superpowers/specs/2026-05-29-prod-7938-pivot-rowspan-merge-design.md
+++ b/docs/superpowers/specs/2026-05-29-prod-7938-pivot-rowspan-merge-design.md
@@ -1,0 +1,171 @@
+# PROD-7938 — `rowSpan`-merged dimension cells for `showRowGrouping`
+
+**Status:** Approved (design)
+**Date:** 2026-05-29
+**Ticket:** PROD-7938 (follow-up to PROD-5901 / PR #23474)
+**Author:** Yegor + Claude
+
+## Problem
+
+The `showRowGrouping` feature (shipped in PR #23474, behind the `PivotRowGrouping`
+feature flag) visually deduplicates repeated row-index dimension values in pivot
+tables without rendering subtotal rows. Today it reuses TanStack's grouping
+machinery, which renders each grouped dimension value as a **separate group-header
+row** above its data rows, leaving the dimension cell blank on the data rows
+themselves.
+
+This looks "a bit off": the group value sits on its own line taking vertical space
+with everything else blank, data rows have an empty dimension cell, empty data cells
+show `∅`/`-`, and row numbers are absent on group-header rows.
+
+We want the real-spreadsheet-pivot look instead: the dimension value **vertically
+merges** (`rowSpan`) across the block of rows it applies to.
+
+### Current look (to replace)
+
+```
+┌────┬──────────────────┬───────────────────┬───────────────── express ──────────────────┐
+│ #  │ Order date month │ Shipping Cost Tier │ Total order amount │ Total completed order…  │
+├────┼──────────────────┼────────────────────┼────────────────────┼─────────────────────────┤
+│    │ 2026-02          │                    │                    │                         │  ← group-header row
+│ 2  │                  │ Premium ($30+)     │ $130.00            │ $74.00                  │
+│ 3  │                  │ High ($20-$30)     │ -                  │ -                       │
+│    │ 2026-01          │                    │                    │                         │  ← group-header row
+│ 4  │                  │ Premium ($30+)     │ $63.50             │ $63.50                  │
+└────┴──────────────────┴────────────────────┴────────────────────┴─────────────────────────┘
+```
+
+### Target look
+
+```
+┌────┬──────────────────┬────────────────────┬────────────────────┬─────────────────────────┐
+│ #  │ Order date month │ Shipping Cost Tier │ Total order amount │ Total completed order…  │
+├────┼──────────────────┼────────────────────┼────────────────────┼─────────────────────────┤
+│ 1  │ 2026-02          │ Premium ($30+)     │ $130.00            │ $74.00                  │  ┐ rowSpan=2
+│ 2  │ (merged, top)    │ High ($20-$30)     │ (blank, not -)     │ (blank)                 │  ┘ top-aligned
+│ 3  │ 2026-01          │ Premium ($30+)     │ $63.50             │ $63.50                  │
+└────┴──────────────────┴────────────────────┴────────────────────┴─────────────────────────┘
+```
+
+## Scope
+
+**In scope** — the `metrics-as-columns` grouping-only path:
+`showRowGrouping === true && showSubtotals === false`, gated by the existing
+`PivotRowGrouping` flag.
+
+**Out of scope (deferred / unchanged):**
+- `showSubtotals === true` rendering — keeps current TanStack grouping + aggregate rows.
+- `metricsAsRows` — the `showRowGrouping` toggle is currently disabled when
+  `metricsAsRows` is on; re-enabling + covering it is a fast-follow, not this PR.
+- The `metricsAsRows` `PERIOD_START` header rework mentioned in the original ticket.
+- A new feature flag or per-chart config field. We replace the look wholesale under
+  the existing `PivotRowGrouping` flag (feature is days old and still flag-gated, so
+  the old look is not a relied-upon GA behavior).
+
+## Design
+
+All changes are in `packages/frontend/src/components/common/PivotTable/` plus one new
+pure helper + unit test. No `@lightdash/common`, backend, or migration changes.
+
+### 1. Activation
+
+The `showRowGrouping` prop `PivotTable` receives is **already flag-gated** upstream in
+`useTableConfig` (`showRowGrouping: isPivotRowGroupingEnabled && showRowGrouping`), so
+inside `PivotTable` the merge mode is simply:
+
+```
+const isRowSpanMergeMode = showRowGrouping && !showSubtotals;
+```
+
+When `false`, every code path below falls back to today's behavior, so flag-off (prop
+is `false`) and subtotals-on are untouched.
+
+### 2. Row model — flat, no TanStack grouping (this mode only)
+
+`index.tsx:957` `useEffect` currently sets `groupingActive = showSubtotals ||
+showRowGrouping` and calls `table.setGrouping(...)`. Change it so grouping is set only
+when it's genuinely needed for aggregate rows:
+
+```
+const groupingActive = showSubtotals || (showRowGrouping && !isRowSpanMergeMode);
+```
+
+In merge mode, grouping is **not** set, so `table.getRowModel()` returns the flat core
+rows (data rows only, no group/aggregate/placeholder rows). This is the ticket's "no
+TanStack grouping — keep the row model flat."
+
+### 3. Span computation — nested run-length encoding (pure helper, unit-tested)
+
+New file `getRowSpanMerges.ts` (alongside `getFrozenColumnLayout.ts`), with a pure
+function:
+
+```
+// columnIds: grouped dim columns, outer→inner order
+// rows: ordered flat rows; reader extracts the comparable value for (row, columnId)
+getRowSpanMerges(rows, columnIds, getCellRawValue)
+  => Map<columnId, Array<{ isBlockStart: boolean; rowSpan: number }>>  // indexed by row position
+```
+
+- **Grouped dim columns** = the same set the code groups on today: the index-dim
+  columns (`data.indexValueTypes` mapped through `columnOrder`) **minus the last**
+  (`.slice(0, -1)`). The leaf dim stays per-row, matching current behavior.
+- For column *i*, a **block starts** when the **prefix tuple** `values[0..i]` differs
+  from the previous row's; `rowSpan` = run length over which that prefix stays equal.
+  Using the prefix (not just column *i*'s own value) yields correct **nested** spans:
+  an outer dim spans wider than an inner dim, and an inner value repeating under two
+  different outer values does not get wrongly merged.
+- Absorbed rows get `{ isBlockStart: false, rowSpan: 0 }`.
+
+This helper is the testable core. Unit tests cover: single grouped dim, two nested
+dims, repeated inner value under different outer values, all-distinct, all-same,
+single row.
+
+### 4. Cell rendering
+
+In the body cell renderer, for a **grouped dim column** in merge mode:
+- `isBlockStart` → render the value with `rowSpan={span}`, **top-aligned**
+  (vertical-align top).
+- otherwise → return `null` so no `<td>` is emitted; the block-start cell's `rowSpan`
+  visually covers the position (standard HTML rowSpan; works with the flat row model).
+
+Leaf dim cells, the metric/data cells, and the row-number cell render per-row as
+today. Row numbers are naturally sequential `1, 2, 3…` (no group-header rows to skip).
+
+### 5. Empty data cells → blank
+
+In merge mode, a data cell whose value is empty (`null`/missing raw value) renders
+**fully blank** — no `∅`, no `-`, and no bar-display background. Scoped to merge mode
+only; all other tables keep `∅`/`-`. (Implementation: intercept in the data-cell
+branch of the renderer when the raw value is absent, before `getFormattedValueCell` /
+bar-display would emit a placeholder.)
+
+### 6. Virtualization — disabled in this mode
+
+The body currently maps over `virtualRows` with `VirtualizedArea` padding rows
+(`index.tsx:1466-1474`). In merge mode, iterate over all `rows` directly and skip the
+padding rows, so `rowSpan`s are contiguous and correct (a block's first row is never
+unmounted while its absorbed siblings are visible). Perf is acceptable for the
+expected table sizes; a row-count cap can be added later only if real tables jank.
+
+## Files touched
+
+- `packages/frontend/src/components/common/PivotTable/getRowSpanMerges.ts` — new pure helper
+- `packages/frontend/src/components/common/PivotTable/getRowSpanMerges.test.ts` — new unit tests
+- `packages/frontend/src/components/common/PivotTable/index.tsx` — grouping `useEffect`,
+  body row iteration (virtualization), cell renderer (rowSpan + top-align + blank empties)
+
+## Testing
+
+- **Unit:** `getRowSpanMerges` (the cases listed in §3).
+- **Manual (browser):** a pivot with 2 row-index dims, metrics as columns,
+  `showRowGrouping` on, `showSubtotals` off — verify merged top-aligned cells, blank
+  empty data cells, sequential row numbers; verify flag-off and subtotals-on are
+  unchanged.
+
+## Risks
+
+- Disabling virtualization in merge mode could be slow for very large grouped tables.
+  Mitigation: validate during implementation; add a row cap fallback only if needed.
+- Switching the grouping-only path off TanStack grouping must not affect column
+  ordering, frozen/sticky columns, or conditional formatting. Verify these in the
+  browser pass.

--- a/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
+++ b/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
@@ -42,3 +42,7 @@
         var(--mantine-color-ldGray-1)
     );
 }
+
+.mergedDimCell {
+    vertical-align: top;
+}

--- a/packages/frontend/src/components/common/PivotTable/getRowSpanMerges.test.ts
+++ b/packages/frontend/src/components/common/PivotTable/getRowSpanMerges.test.ts
@@ -1,3 +1,5 @@
+import { FieldType } from '@lightdash/common';
+import type { PivotData } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import { getGroupedDimColumnIds, getRowSpanMerges } from './getRowSpanMerges';
 
@@ -8,10 +10,10 @@ const reader =
 
 describe('getGroupedDimColumnIds', () => {
     it('returns index dims in column order minus the leaf dim', () => {
-        const indexValueTypes = [
-            { fieldId: 'month' },
-            { fieldId: 'tier' },
-        ] as never;
+        const indexValueTypes: PivotData['indexValueTypes'] = [
+            { type: FieldType.DIMENSION, fieldId: 'month' },
+            { type: FieldType.DIMENSION, fieldId: 'tier' },
+        ];
         const columnOrder = ['month', 'tier', 'metric_a', 'metric_b'];
         expect(getGroupedDimColumnIds(indexValueTypes, columnOrder)).toEqual([
             'month',
@@ -19,14 +21,20 @@ describe('getGroupedDimColumnIds', () => {
     });
 
     it('returns empty when there is only a single index dim', () => {
-        const indexValueTypes = [{ fieldId: 'month' }] as never;
+        const indexValueTypes: PivotData['indexValueTypes'] = [
+            { type: FieldType.DIMENSION, fieldId: 'month' },
+        ];
         expect(
             getGroupedDimColumnIds(indexValueTypes, ['month', 'metric_a']),
         ).toEqual([]);
     });
 
     it('returns empty when there are no index dims', () => {
-        expect(getGroupedDimColumnIds([] as never, ['metric_a'])).toEqual([]);
+        expect(
+            getGroupedDimColumnIds([] as PivotData['indexValueTypes'], [
+                'metric_a',
+            ]),
+        ).toEqual([]);
     });
 });
 
@@ -95,5 +103,15 @@ describe('getRowSpanMerges', () => {
         expect(merges.get('month')).toEqual([
             { isBlockStart: true, rowSpan: 1 },
         ]);
+    });
+
+    it('returns an empty map when columnIds is empty', () => {
+        const rows = [{ month: 'A' }];
+        expect(getRowSpanMerges(rows.length, [], reader(rows)).size).toBe(0);
+    });
+
+    it('returns empty span arrays when rowCount is 0', () => {
+        const merges = getRowSpanMerges(0, ['month'], reader([]));
+        expect(merges.get('month')).toEqual([]);
     });
 });

--- a/packages/frontend/src/components/common/PivotTable/getRowSpanMerges.test.ts
+++ b/packages/frontend/src/components/common/PivotTable/getRowSpanMerges.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { getGroupedDimColumnIds, getRowSpanMerges } from './getRowSpanMerges';
+
+// Builds a getRawValue reader over an array of plain row objects.
+const reader =
+    (rows: Record<string, unknown>[]) => (rowIndex: number, columnId: string) =>
+        rows[rowIndex]?.[columnId];
+
+describe('getGroupedDimColumnIds', () => {
+    it('returns index dims in column order minus the leaf dim', () => {
+        const indexValueTypes = [
+            { fieldId: 'month' },
+            { fieldId: 'tier' },
+        ] as never;
+        const columnOrder = ['month', 'tier', 'metric_a', 'metric_b'];
+        expect(getGroupedDimColumnIds(indexValueTypes, columnOrder)).toEqual([
+            'month',
+        ]);
+    });
+
+    it('returns empty when there is only a single index dim', () => {
+        const indexValueTypes = [{ fieldId: 'month' }] as never;
+        expect(
+            getGroupedDimColumnIds(indexValueTypes, ['month', 'metric_a']),
+        ).toEqual([]);
+    });
+
+    it('returns empty when there are no index dims', () => {
+        expect(getGroupedDimColumnIds([] as never, ['metric_a'])).toEqual([]);
+    });
+});
+
+describe('getRowSpanMerges', () => {
+    it('merges consecutive equal values in a single column', () => {
+        const rows = [
+            { month: '2026-02' },
+            { month: '2026-02' },
+            { month: '2026-01' },
+        ];
+        const merges = getRowSpanMerges(rows.length, ['month'], reader(rows));
+        expect(merges.get('month')).toEqual([
+            { isBlockStart: true, rowSpan: 2 },
+            { isBlockStart: false, rowSpan: 0 },
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+    });
+
+    it('does not merge non-adjacent equal values', () => {
+        const rows = [{ month: 'A' }, { month: 'B' }, { month: 'A' }];
+        const merges = getRowSpanMerges(rows.length, ['month'], reader(rows));
+        expect(merges.get('month')).toEqual([
+            { isBlockStart: true, rowSpan: 1 },
+            { isBlockStart: true, rowSpan: 1 },
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+    });
+
+    it('computes nested spans: outer dim spans wider than inner', () => {
+        const rows = [
+            { a: 'x', b: 'p' },
+            { a: 'x', b: 'p' },
+            { a: 'x', b: 'q' },
+            { a: 'y', b: 'p' },
+        ];
+        const merges = getRowSpanMerges(rows.length, ['a', 'b'], reader(rows));
+        expect(merges.get('a')).toEqual([
+            { isBlockStart: true, rowSpan: 3 },
+            { isBlockStart: false, rowSpan: 0 },
+            { isBlockStart: false, rowSpan: 0 },
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+        expect(merges.get('b')).toEqual([
+            { isBlockStart: true, rowSpan: 2 },
+            { isBlockStart: false, rowSpan: 0 },
+            { isBlockStart: true, rowSpan: 1 },
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+    });
+
+    it('does not merge an inner value repeating under a different outer value', () => {
+        const rows = [
+            { a: 'x', b: 'p' },
+            { a: 'y', b: 'p' },
+        ];
+        const merges = getRowSpanMerges(rows.length, ['a', 'b'], reader(rows));
+        expect(merges.get('b')).toEqual([
+            { isBlockStart: true, rowSpan: 1 },
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+    });
+
+    it('handles a single row', () => {
+        const rows = [{ month: 'A' }];
+        const merges = getRowSpanMerges(rows.length, ['month'], reader(rows));
+        expect(merges.get('month')).toEqual([
+            { isBlockStart: true, rowSpan: 1 },
+        ]);
+    });
+});

--- a/packages/frontend/src/components/common/PivotTable/getRowSpanMerges.ts
+++ b/packages/frontend/src/components/common/PivotTable/getRowSpanMerges.ts
@@ -1,0 +1,75 @@
+import { type PivotData } from '@lightdash/common';
+
+export type RowSpanMerge = {
+    isBlockStart: boolean;
+    rowSpan: number;
+};
+
+/**
+ * The row-index dimension columns that get visually merged in grouping-only
+ * mode: the index dimensions in column order, minus the last one. The leaf
+ * dimension stays per-row, matching the existing showRowGrouping behaviour
+ * (grouping on the leaf would produce one group per row). Shared with the
+ * TanStack grouping setup so the two stay in sync.
+ */
+export const getGroupedDimColumnIds = (
+    indexValueTypes: PivotData['indexValueTypes'],
+    columnOrder: string[],
+): string[] => {
+    const indexDimIds = new Set(
+        indexValueTypes.map((valueType) => valueType.fieldId),
+    );
+    return columnOrder
+        .filter((columnId) => indexDimIds.has(columnId))
+        .slice(0, -1);
+};
+
+/**
+ * Computes per-row, per-column rowSpan-merge info over the FLAT row order using
+ * consecutive run-length encoding. A block starts when the prefix tuple of
+ * grouped values (outer..this column) changes from the previous row; the
+ * block-start row carries the full rowSpan, absorbed rows carry rowSpan 0.
+ *
+ * Using the prefix (not just this column's own value) yields correct nested
+ * spans: an outer-dimension change always starts a new block for inner
+ * dimensions, and an inner value repeating under a different outer value is not
+ * merged. This is consecutive-only by design — it preserves the existing row
+ * order rather than globally regrouping (see the spec's "Ordering assumption").
+ *
+ * @param rowCount   total number of (flat) rows
+ * @param columnIds  grouped dimension column ids, outer -> inner
+ * @param getRawValue reads the comparable raw value for (rowIndex, columnId)
+ */
+export const getRowSpanMerges = (
+    rowCount: number,
+    columnIds: string[],
+    getRawValue: (rowIndex: number, columnId: string) => unknown,
+): Map<string, RowSpanMerge[]> => {
+    const result = new Map<string, RowSpanMerge[]>();
+
+    columnIds.forEach((columnId, columnIndex) => {
+        const prefix = columnIds.slice(0, columnIndex + 1);
+        const spans: RowSpanMerge[] = new Array<RowSpanMerge>(rowCount);
+        let blockStartRow = 0;
+
+        for (let row = 0; row < rowCount; row += 1) {
+            const startsNewBlock =
+                row === 0 ||
+                prefix.some(
+                    (id) => getRawValue(row, id) !== getRawValue(row - 1, id),
+                );
+
+            if (startsNewBlock) {
+                blockStartRow = row;
+                spans[row] = { isBlockStart: true, rowSpan: 1 };
+            } else {
+                spans[blockStartRow].rowSpan += 1;
+                spans[row] = { isBlockStart: false, rowSpan: 0 };
+            }
+        }
+
+        result.set(columnId, spans);
+    });
+
+    return result;
+};

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -83,6 +83,7 @@ import {
     getFrozenColumnLayout,
     type FrozenColumnEntry,
 } from './getFrozenColumnLayout';
+import { getGroupedDimColumnIds, getRowSpanMerges } from './getRowSpanMerges';
 import pivotStyles from './PivotTable.module.css';
 import TotalCellMenu from './TotalCellMenu';
 import ValueCellMenu from './ValueCellMenu';
@@ -668,6 +669,37 @@ const PivotTable: FC<PivotTableProps> = ({
     });
     const virtualRows = rowVirtualizer.getVirtualItems();
 
+    // Grouping-only mode renders a flat row model and visually merges repeated
+    // row-index dimension values with rowSpan instead of TanStack group rows.
+    const rowSpanMergesByColumnId = useMemo(() => {
+        if (!groupingOnlyMode) return null;
+        const groupedColumnIds = getGroupedDimColumnIds(
+            data.indexValueTypes,
+            columnOrder,
+        );
+        if (groupedColumnIds.length === 0) return null;
+        return getRowSpanMerges(
+            rows.length,
+            groupedColumnIds,
+            (rowIndex, columnId) => {
+                const cell = rows[rowIndex]?.getValue(columnId) as
+                    | { value?: ResultValue }
+                    | undefined;
+                return cell?.value?.raw;
+            },
+        );
+    }, [groupingOnlyMode, data.indexValueTypes, columnOrder, rows]);
+
+    // In merge mode, render every row (no virtualization) so rowSpans stay
+    // contiguous — a block's first row must never be unmounted while its
+    // absorbed siblings are visible.
+    const renderedBodyRows = groupingOnlyMode
+        ? rows.map((row, rowIndex) => ({ row, rowIndex }))
+        : virtualRows.map((virtualRow) => ({
+              row: rows[virtualRow.index],
+              rowIndex: virtualRow.index,
+          }));
+
     const getColumnTotalValueFromAxis = useCallback(
         (total: unknown, colIndex: number): ResultValue | null => {
             const value = last(data.headerValues)?.[colIndex];
@@ -948,40 +980,28 @@ const PivotTable: FC<PivotTableProps> = ({
     }, [hideRowNumbers, data.cellsCount]);
 
     useEffect(() => {
-        // TODO: Remove code duplicated from non-pivot table version.
-        // Grouping is driven by either subtotals (renders aggregate rows) or
-        // row-grouping (visually dedups row dims without aggregates).
-        // Both reuse the same TanStack setGrouping machinery; the cell
-        // renderer downstream conditionally suppresses subtotal content
-        // when only row-grouping is on.
-        const groupingActive = showSubtotals || showRowGrouping;
+        // Grouping is driven by subtotals only. Row-grouping without subtotals
+        // (groupingOnlyMode) now renders a FLAT row model with merged rowSpan
+        // cells (see getRowSpanMerges / the body renderer below), so it must
+        // NOT engage the TanStack grouping machinery.
+        const groupingActive =
+            showSubtotals || (showRowGrouping && !groupingOnlyMode);
         if (groupingActive) {
-            const groupedColumns = data.indexValueTypes.map(
-                (valueType) => valueType.fieldId,
+            const sortedColumns = getGroupedDimColumnIds(
+                data.indexValueTypes,
+                table.getState().columnOrder,
             );
-
-            const sortedColumns = table
-                .getState()
-                .columnOrder.reduce<string[]>((acc, sortedId) => {
-                    return groupedColumns.includes(sortedId)
-                        ? [...acc, sortedId]
-                        : acc;
-                }, [])
-                // The last dimension column essentially groups rows for each unique value in that column.
-                // Grouping on it would result in many useless expandable groups containing just one item.
-                .slice(0, -1);
 
             if (!isEqual(sortedColumns, table.getState().grouping)) {
                 table.setGrouping(sortedColumns);
             }
-        } else {
-            if (table.getState().grouping.length > 0) {
-                table.resetGrouping();
-            }
+        } else if (table.getState().grouping.length > 0) {
+            table.resetGrouping();
         }
     }, [
         showSubtotals,
         showRowGrouping,
+        groupingOnlyMode,
         data.indexValueTypes,
         table,
         columnOrder,
@@ -1464,16 +1484,14 @@ const PivotTable: FC<PivotTableProps> = ({
             </Table.Head>
 
             <Table.Body>
-                {paddingTop > 0 && (
+                {!groupingOnlyMode && paddingTop > 0 && (
                     <VirtualizedArea
                         cellCount={cellsCountWithRowNumber}
                         height={paddingTop}
                     />
                 )}
 
-                {virtualRows.map((virtualRow) => {
-                    const rowIndex = virtualRow.index;
-                    const row = rows[rowIndex];
+                {renderedBodyRows.map(({ row, rowIndex }) => {
                     if (!row) return null;
 
                     const toggleExpander = row.getToggleExpandedHandler();
@@ -1488,7 +1506,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 // Column widths are uniform across rows (CSS table
                                 // layout), so one measurement per column is enough.
                                 const measureRef =
-                                    virtualRow.index === 0
+                                    rowIndex === 0
                                         ? measureCellRef(cell.column.id)
                                         : undefined;
                                 if (cell.column.id === ROW_NUMBER_COLUMN_ID) {
@@ -1535,6 +1553,22 @@ const PivotTable: FC<PivotTableProps> = ({
                                                   )}
                                         </Table.Cell>
                                     );
+                                }
+
+                                // Grouping-only mode: merge repeated row-index
+                                // dimension values with rowSpan. The block's
+                                // first row renders the value spanning the
+                                // block; absorbed rows render no <td> so the
+                                // span covers their position.
+                                const rowSpanMerge =
+                                    rowSpanMergesByColumnId?.get(
+                                        cell.column.id,
+                                    )?.[rowIndex];
+                                if (
+                                    rowSpanMerge &&
+                                    !rowSpanMerge.isBlockStart
+                                ) {
+                                    return null;
                                 }
 
                                 const meta = cell.column.columnDef.meta;
@@ -1709,7 +1743,16 @@ const PivotTable: FC<PivotTableProps> = ({
                                     <TableCellComponent
                                         key={`value-${rowIndex}-${colIndex}-${data.pivotConfig.metricsAsRows}`}
                                         ref={measureRef}
-                                        className={stickyCellProps.className}
+                                        rowSpan={rowSpanMerge?.rowSpan}
+                                        className={
+                                            rowSpanMerge
+                                                ? `${pivotStyles.mergedDimCell}${
+                                                      stickyCellProps.className
+                                                          ? ` ${stickyCellProps.className}`
+                                                          : ''
+                                                  }`
+                                                : stickyCellProps.className
+                                        }
                                         style={stickyCellProps.style}
                                         isMinimal={isMinimal}
                                         withAlignRight={isNumericItem(item)}
@@ -1840,7 +1883,9 @@ const PivotTable: FC<PivotTableProps> = ({
                                                     cell.getContext(),
                                                 )
                                             )
-                                        ) : cell.getIsPlaceholder() ? null : (
+                                        ) : cell.getIsPlaceholder() ? null : groupingOnlyMode &&
+                                          isDataColumn &&
+                                          value == null ? null : (
                                             flexRender(
                                                 cell.column.columnDef.cell,
                                                 cell.getContext(),
@@ -1853,7 +1898,7 @@ const PivotTable: FC<PivotTableProps> = ({
                     );
                 })}
 
-                {paddingBottom > 0 && (
+                {!groupingOnlyMode && paddingBottom > 0 && (
                     <VirtualizedArea
                         cellCount={cellsCountWithRowNumber}
                         height={paddingBottom}

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -1610,6 +1610,17 @@ const PivotTable: FC<PivotTableProps> = ({
                                     cell.getValue() as ResultRow[0];
                                 const value = fullValue?.value;
 
+                                // In merge mode an empty pivot data cell renders
+                                // blank instead of the `∅`/`-` placeholder. An
+                                // empty cell still carries a value wrapper whose
+                                // `raw` is null (formatted as `∅`), or no wrapper
+                                // at all, so we key off `value?.raw`; a real
+                                // `raw: 0`/`''` is kept.
+                                const isBlankMergeDataCell =
+                                    groupingOnlyMode &&
+                                    isDataColumn &&
+                                    value?.raw == null;
+
                                 // Build rowFields for this cell's pivot context only
                                 // This ensures field comparisons use values from the same pivot column
                                 const currentHeaderInfo =
@@ -1888,13 +1899,8 @@ const PivotTable: FC<PivotTableProps> = ({
                                                     cell.getContext(),
                                                 )
                                             )
-                                        ) : cell.getIsPlaceholder() ? null : // blank instead of the `∅`/`-` placeholder. An empty // In merge mode an empty pivot data cell renders
-                                        // cell still carries a value wrapper whose `raw` is
-                                        // null (formatted as `∅`), or no wrapper at all, so we
-                                        // key off `value?.raw`. A real `raw: 0`/`''` is kept.
-                                        groupingOnlyMode &&
-                                          isDataColumn &&
-                                          value?.raw == null ? null : (
+                                        ) : cell.getIsPlaceholder() ||
+                                          isBlankMergeDataCell ? null : (
                                             flexRender(
                                                 cell.column.columnDef.cell,
                                                 cell.getContext(),

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -1743,7 +1743,12 @@ const PivotTable: FC<PivotTableProps> = ({
                                     <TableCellComponent
                                         key={`value-${rowIndex}-${colIndex}-${data.pivotConfig.metricsAsRows}`}
                                         ref={measureRef}
-                                        rowSpan={rowSpanMerge?.rowSpan}
+                                        rowSpan={
+                                            rowSpanMerge &&
+                                            rowSpanMerge.rowSpan > 1
+                                                ? rowSpanMerge.rowSpan
+                                                : undefined
+                                        }
                                         className={
                                             rowSpanMerge
                                                 ? `${pivotStyles.mergedDimCell}${
@@ -1883,7 +1888,11 @@ const PivotTable: FC<PivotTableProps> = ({
                                                     cell.getContext(),
                                                 )
                                             )
-                                        ) : cell.getIsPlaceholder() ? null : groupingOnlyMode &&
+                                        ) : cell.getIsPlaceholder() ? null : // for this row/column) renders blank instead of the // In merge mode, an empty pivot data cell (no data
+                                        // `∅`/`-` placeholder. `value` is undefined/null only
+                                        // when the cell is absent — a real `raw: 0`/`''`/`null`
+                                        // still has a non-null `value` wrapper, so it is unaffected.
+                                        groupingOnlyMode &&
                                           isDataColumn &&
                                           value == null ? null : (
                                             flexRender(

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -1888,13 +1888,13 @@ const PivotTable: FC<PivotTableProps> = ({
                                                     cell.getContext(),
                                                 )
                                             )
-                                        ) : cell.getIsPlaceholder() ? null : // for this row/column) renders blank instead of the // In merge mode, an empty pivot data cell (no data
-                                        // `∅`/`-` placeholder. `value` is undefined/null only
-                                        // when the cell is absent — a real `raw: 0`/`''`/`null`
-                                        // still has a non-null `value` wrapper, so it is unaffected.
+                                        ) : cell.getIsPlaceholder() ? null : // blank instead of the `∅`/`-` placeholder. An empty // In merge mode an empty pivot data cell renders
+                                        // cell still carries a value wrapper whose `raw` is
+                                        // null (formatted as `∅`), or no wrapper at all, so we
+                                        // key off `value?.raw`. A real `raw: 0`/`''` is kept.
                                         groupingOnlyMode &&
                                           isDataColumn &&
-                                          value == null ? null : (
+                                          value?.raw == null ? null : (
                                             flexRender(
                                                 cell.column.columnDef.cell,
                                                 cell.getContext(),


### PR DESCRIPTION
Closes: PROD-7938

### Description:

Replaces the TanStack group-header row rendering in the pivot table's `showRowGrouping` mode (when subtotals are off) with HTML `rowSpan`-merged dimension cells, giving the table a real spreadsheet-pivot appearance.

**Before:** Each grouped dimension value rendered as a separate group-header row above its data rows, leaving dimension cells blank on data rows, showing `∅`/`-` in empty data cells, and producing non-sequential row numbers.

**After:** The grouped dimension value renders once per consecutive run, top-aligned and vertically spanning its block via `rowSpan`. Leaf dimension and metric cells render per-row as before. Empty pivot data cells are fully blank (no `∅`/`-`). Row numbers are sequential with no gaps.

Key changes:

- **New pure helper `getRowSpanMerges.ts`** computes per-row/per-column `{ isBlockStart, rowSpan }` using nested consecutive run-length encoding. A block starts when the prefix tuple of grouped dimension values changes from the previous row, ensuring outer dimensions span wider than inner ones and an inner value repeating under a different outer value is never incorrectly merged.
- **`getGroupedDimColumnIds`** extracts the mergeable dimension columns (all index dims except the leaf) and is shared between the span computation and the TanStack grouping setup to keep them in sync.
- **TanStack grouping is no longer engaged** in grouping-only mode (`showRowGrouping && !showSubtotals`). The flat row model is used directly, keeping `rowIndex` aligned with all per-row lookups (conditional formatting, cell menus, etc.). The subtotals path is untouched.
- **Virtualization is disabled** in merge mode so `rowSpan` blocks remain contiguous — a block-start row is never unmounted while its absorbed siblings are visible.
- Absorbed rows return `null` from the cell renderer (no `<td>` emitted); block-start cells receive `rowSpan` and the `mergedDimCell` top-align CSS class.