### PR TITLE
feat(ai-agents): navigate to dashboard on `createContent`/`editContent` tool result

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5034,26 +5034,37 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         patchedContent.slug.length > 0
                             ? patchedContent.slug
                             : slug;
+                    let uuid: string | undefined;
 
                     switch (currentContent.type) {
-                        case 'dashboard':
-                            await this.coderService.upsertDashboard(
-                                user,
-                                projectUuid,
-                                slug,
-                                patchedContent as typeof currentContent.content,
-                                { force: true },
-                            );
+                        case 'dashboard': {
+                            const promotionChanges =
+                                await this.coderService.upsertDashboard(
+                                    user,
+                                    projectUuid,
+                                    slug,
+                                    patchedContent as typeof currentContent.content,
+                                    { force: true },
+                                );
+                            uuid =
+                                promotionChanges.dashboards[0]?.data.uuid ??
+                                undefined;
                             break;
-                        case 'chart':
-                            await this.coderService.upsertChart(
-                                user,
-                                projectUuid,
-                                slug,
-                                patchedContent as typeof currentContent.content,
-                                { force: true },
-                            );
+                        }
+                        case 'chart': {
+                            const promotionChanges =
+                                await this.coderService.upsertChart(
+                                    user,
+                                    projectUuid,
+                                    slug,
+                                    patchedContent as typeof currentContent.content,
+                                    { force: true },
+                                );
+                            uuid =
+                                promotionChanges.charts[0]?.data.uuid ??
+                                undefined;
                             break;
+                        }
                         default:
                             return assertUnreachable(
                                 currentContent,
@@ -5061,10 +5072,36 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             );
                     }
 
-                    return readContent({
+                    const editedContent = await readContent({
                         slug: patchedSlug,
                         type,
                     });
+
+                    if (!uuid) {
+                        throw new NotFoundError(
+                            `Edited ${type} "${patchedSlug}" was not found`,
+                        );
+                    }
+
+                    switch (editedContent.type) {
+                        case 'dashboard':
+                            return {
+                                ...editedContent,
+                                uuid,
+                                url: `/projects/${projectUuid}/dashboards/${editedContent.content.slug}`,
+                            };
+                        case 'chart':
+                            return {
+                                ...editedContent,
+                                uuid,
+                                url: `/projects/${projectUuid}/saved/${editedContent.content.slug}`,
+                            };
+                        default:
+                            return assertUnreachable(
+                                editedContent,
+                                'Invalid content type',
+                            );
+                    }
                 },
             );
 
@@ -5091,11 +5128,23 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             const finalSlug =
                                 promotionChanges.dashboards[0]?.data.slug ??
                                 content.slug;
-
-                            return readContent({
+                            const uuid =
+                                promotionChanges.dashboards[0]?.data.uuid;
+                            if (!uuid) {
+                                throw new NotFoundError(
+                                    `Created dashboard "${finalSlug}" was not found`,
+                                );
+                            }
+                            const createdContent = await readContent({
                                 slug: finalSlug,
                                 type,
                             });
+
+                            return {
+                                ...createdContent,
+                                uuid,
+                                url: `/projects/${projectUuid}/dashboards/${finalSlug}`,
+                            };
                         }
                         case 'chart': {
                             // TODO: Reject missing dashboardSlug targets for
@@ -5112,11 +5161,22 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             const finalSlug =
                                 promotionChanges.charts[0]?.data.slug ??
                                 content.slug;
-
-                            return readContent({
+                            const uuid = promotionChanges.charts[0]?.data.uuid;
+                            if (!uuid) {
+                                throw new NotFoundError(
+                                    `Created chart "${finalSlug}" was not found`,
+                                );
+                            }
+                            const createdContent = await readContent({
                                 slug: finalSlug,
                                 type,
                             });
+
+                            return {
+                                ...createdContent,
+                                uuid,
+                                url: `/projects/${projectUuid}/saved/${finalSlug}`,
+                            };
                         }
                         default:
                             return assertUnreachable(

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -528,20 +528,50 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
       "additionalProperties": false,
       "properties": {
         "metadata": {
-          "additionalProperties": false,
-          "properties": {
-            "status": {
-              "enum": [
-                "success",
-                "error",
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "const": "error",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
               ],
-              "type": "string",
+              "type": "object",
             },
-          },
-          "required": [
-            "status",
+            {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                },
+                "slug": {
+                  "type": "string",
+                },
+                "status": {
+                  "const": "success",
+                  "type": "string",
+                },
+                "url": {
+                  "type": "string",
+                },
+                "uuid": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+                "slug",
+                "name",
+                "uuid",
+                "url",
+              ],
+              "type": "object",
+            },
           ],
-          "type": "object",
         },
         "result": {
           "type": "string",
@@ -589,20 +619,50 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
       "additionalProperties": false,
       "properties": {
         "metadata": {
-          "additionalProperties": false,
-          "properties": {
-            "status": {
-              "enum": [
-                "success",
-                "error",
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "const": "error",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
               ],
-              "type": "string",
+              "type": "object",
             },
-          },
-          "required": [
-            "status",
+            {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                },
+                "slug": {
+                  "type": "string",
+                },
+                "status": {
+                  "const": "success",
+                  "type": "string",
+                },
+                "url": {
+                  "type": "string",
+                },
+                "uuid": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+                "slug",
+                "name",
+                "uuid",
+                "url",
+              ],
+              "type": "object",
+            },
           ],
-          "type": "object",
         },
         "result": {
           "type": "string",

--- a/packages/backend/src/ee/services/ai/tools/createContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/createContent.ts
@@ -24,6 +24,10 @@ export const getCreateContent = ({ createContent }: Dependencies) =>
                     result: JSON.stringify(result.content, null, 2),
                     metadata: {
                         status: 'success' as const,
+                        slug: result.content.slug,
+                        name: result.content.name,
+                        uuid: result.uuid,
+                        url: result.url,
                     },
                 };
             } catch (error) {

--- a/packages/backend/src/ee/services/ai/tools/editContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/editContent.ts
@@ -21,6 +21,10 @@ export const getEditContent = ({ editContent }: Dependencies) =>
                     result: JSON.stringify(result.content, null, 2),
                     metadata: {
                         status: 'success' as const,
+                        slug: result.content.slug,
+                        name: result.content.name,
+                        uuid: result.uuid,
+                        url: result.url,
                     },
                 };
             } catch (error) {

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -159,10 +159,14 @@ export type EditContentFn = (args: {
     | {
           type: 'dashboard';
           content: DashboardAsCode;
+          uuid: string;
+          url: string;
       }
     | {
           type: 'chart';
           content: ChartAsCode;
+          uuid: string;
+          url: string;
       }
 >;
 
@@ -180,10 +184,14 @@ export type CreateContentFn = (args: CreateContentArgs) => Promise<
     | {
           type: 'dashboard';
           content: DashboardAsCode;
+          uuid: string;
+          url: string;
       }
     | {
           type: 'chart';
           content: ChartAsCode;
+          uuid: string;
+          url: string;
       }
 >;
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolCreateContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolCreateContentArgs.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { baseOutputMetadataSchema } from '../outputMetadata';
 
 export const TOOL_CREATE_CONTENT_DESCRIPTION =
     'Create a new dashboard or chart, consult the skills for the required fields. Returns the created content with the final persisted slug.';
@@ -54,9 +53,20 @@ export const toolCreateContentArgsSchema = z.object({
 
 export type ToolCreateContentArgs = z.infer<typeof toolCreateContentArgsSchema>;
 
+const toolCreateContentMetadataSchema = z.discriminatedUnion('status', [
+    z.object({ status: z.literal('error') }),
+    z.object({
+        status: z.literal('success'),
+        slug: z.string(),
+        name: z.string(),
+        uuid: z.string(),
+        url: z.string(),
+    }),
+]);
+
 export const toolCreateContentOutputSchema = z.object({
     result: z.string(),
-    metadata: baseOutputMetadataSchema,
+    metadata: toolCreateContentMetadataSchema,
 });
 
 export type ToolCreateContentOutput = z.infer<

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditContentArgs.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { baseOutputMetadataSchema } from '../outputMetadata';
 
 export const TOOL_EDIT_CONTENT_DESCRIPTION =
     'Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting.';
@@ -16,9 +15,20 @@ export const toolEditContentArgsSchema = z.object({
         ),
 });
 
+const toolEditContentMetadataSchema = z.discriminatedUnion('status', [
+    z.object({ status: z.literal('error') }),
+    z.object({
+        status: z.literal('success'),
+        slug: z.string(),
+        name: z.string(),
+        uuid: z.string(),
+        url: z.string(),
+    }),
+]);
+
 export const toolEditContentOutputSchema = z.object({
     result: z.string(),
-    metadata: baseOutputMetadataSchema,
+    metadata: toolEditContentMetadataSchema,
 });
 
 export type ToolEditContentArgs = z.infer<typeof toolEditContentArgsSchema>;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -336,7 +336,14 @@ const AssistantBubbleContent: FC<{
     projectUuid: string;
     agentUuid: string;
     mcpServers?: AiMcpServer[];
-}> = ({ message, projectUuid, agentUuid, mcpServers }) => {
+    onDashboardLinkClick?: (url: string) => void;
+}> = ({
+    message,
+    projectUuid,
+    agentUuid,
+    mcpServers,
+    onDashboardLinkClick,
+}) => {
     const canManageAgents = useAiAgentPermission({
         action: 'manage',
         projectUuid,
@@ -654,6 +661,9 @@ const AssistantBubbleContent: FC<{
                                                 sqlRunnerLinkState={
                                                     sqlRunnerLinkState
                                                 }
+                                                onDashboardLinkClick={
+                                                    onDashboardLinkClick
+                                                }
                                             >
                                                 {children}
                                             </ContentLink>
@@ -848,6 +858,9 @@ const AssistantBubbleContent: FC<{
                                                     sqlRunnerLinkState={
                                                         sqlRunnerLinkState
                                                     }
+                                                    onDashboardLinkClick={
+                                                        onDashboardLinkClick
+                                                    }
                                                 >
                                                     {children}
                                                 </ContentLink>
@@ -904,6 +917,7 @@ type Props = {
     renderArtifactsInline?: boolean;
     showAddToEvalsButton?: boolean;
     mcpServers?: AiMcpServer[];
+    onDashboardLinkClick?: (url: string) => void;
 };
 
 export const AssistantBubble: FC<Props> = memo(
@@ -917,6 +931,7 @@ export const AssistantBubble: FC<Props> = memo(
         renderArtifactsInline = false,
         showAddToEvalsButton = false,
         mcpServers,
+        onDashboardLinkClick,
     }) => {
         const artifact = useAiAgentStoreSelector(
             (state) => state.aiArtifact.artifact,
@@ -1010,6 +1025,7 @@ export const AssistantBubble: FC<Props> = memo(
                     projectUuid={projectUuid}
                     agentUuid={agentUuid}
                     mcpServers={mcpServers}
+                    onDashboardLinkClick={onDashboardLinkClick}
                 />
 
                 {isArtifactAvailable && projectUuid && agentUuid && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -38,6 +38,7 @@ type Props = {
     agentUuid?: string;
     renderArtifactsInline?: boolean;
     showAddToEvalsButton?: boolean;
+    onDashboardLinkClick?: (url: string) => void;
 };
 
 const CompactionDivider = () => (
@@ -96,6 +97,7 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
     agentUuid,
     renderArtifactsInline = false,
     showAddToEvalsButton = false,
+    onDashboardLinkClick,
 }) => {
     const viewport = useRef<HTMLDivElement>(null);
     const { data: mcpServers } = useAgentAiMcpServers(projectUuid, agentUuid, {
@@ -174,6 +176,9 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                                 mcpServers={mcpServers}
                                                 renderArtifactsInline={
                                                     renderArtifactsInline
+                                                }
+                                                onDashboardLinkClick={
+                                                    onDashboardLinkClick
                                                 }
                                             />
                                         )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -6,8 +6,8 @@ import {
     IconLayoutDashboard,
     IconTerminal2,
 } from '@tabler/icons-react';
-import { type FC, type ReactNode } from 'react';
-import { Link } from 'react-router';
+import { type FC, type MouseEvent, type ReactNode } from 'react';
+import { Link, createPath, useLocation, useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
 import { setArtifact } from '../../store/aiArtifactSlice';
@@ -30,6 +30,12 @@ type ContentLinkProps = {
     projectUuid: string;
     agentUuid: string;
     sqlRunnerLinkState?: SqlRunnerLinkState | null;
+    onDashboardLinkClick?: (url: string) => void;
+};
+
+const getDashboardRouteKey = (pathname: string) => {
+    const match = pathname.match(/^\/projects\/([^/]+)\/dashboards\/([^/]+)/);
+    return match ? `${match[1]}/${match[2]}` : null;
 };
 
 export const ContentLink: FC<ContentLinkProps> = ({
@@ -40,11 +46,52 @@ export const ContentLink: FC<ContentLinkProps> = ({
     projectUuid,
     agentUuid,
     sqlRunnerLinkState,
+    onDashboardLinkClick,
 }) => {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const dashboardHref = typeof props.href === 'string' ? props.href : '';
     const dispatch = useAiAgentStoreDispatch();
     const currentArtifact = useAiAgentStoreSelector(
         (state) => state.aiArtifact.artifact,
     );
+
+    const handleDashboardClick = (e: MouseEvent<HTMLAnchorElement>) => {
+        if (
+            !dashboardHref ||
+            e.defaultPrevented ||
+            e.button !== 0 ||
+            e.metaKey ||
+            e.altKey ||
+            e.ctrlKey ||
+            e.shiftKey
+        ) {
+            return;
+        }
+
+        e.preventDefault();
+
+        const currentPath = createPath({
+            pathname: location.pathname,
+            search: location.search,
+        });
+        const targetUrl = new URL(dashboardHref, window.location.origin);
+        const targetPath = createPath({
+            pathname: targetUrl.pathname,
+            search: targetUrl.search,
+        });
+        const isCurrentDashboard =
+            getDashboardRouteKey(location.pathname) ===
+            getDashboardRouteKey(targetUrl.pathname);
+
+        if (isCurrentDashboard) return;
+
+        if (onDashboardLinkClick) {
+            onDashboardLinkClick(targetPath);
+        } else if (targetPath !== currentPath) {
+            void navigate(targetPath, { viewTransition: true });
+        }
+    };
 
     switch (contentType) {
         case 'dashboard-link':
@@ -52,7 +99,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
                 <Anchor
                     {...props}
                     data-content-link="true"
-                    target="_blank"
+                    onClick={handleDashboardClick}
                     fz="xs"
                     fw={500}
                     c="ldGray.8"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -1,6 +1,7 @@
 import { type AiAgentSummary } from '@lightdash/common';
 import { Center, Group, Loader, Stack, Text } from '@mantine-8/core';
-import { useState, type CSSProperties, type FC } from 'react';
+import { useCallback, useState, type CSSProperties, type FC } from 'react';
+import { createPath, useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import useApp from '../../../../../providers/App/useApp';
 import { useAiAgentSqlModeAvailable } from '../../hooks/useAiAgentSqlModeAvailable';
@@ -20,6 +21,8 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
+import { type AiAgentToolResult } from '../../types';
+import { getDashboardNavigationUrlFromContentToolResult } from '../../utils/contentToolResultNavigation';
 import { AiAgentNewThreadMcpConnections } from '../AiAgentNewThreadMcpConnections';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../ChatElements/AgentChatInput';
@@ -84,6 +87,7 @@ const NewThreadPanel: FC<{
     agents: AiAgentSummary[];
     style?: CSSProperties;
 }> = ({ projectUuid, agent, agents, style }) => {
+    const navigate = useNavigate();
     const dispatch = useAiAgentStoreDispatch();
     const pendingContext = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.pendingContext,
@@ -103,6 +107,24 @@ const NewThreadPanel: FC<{
         chartUuidOrSlug: chartUuid,
         dashboardUuidOrSlug: dashboardUuid,
     });
+
+    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+    // New threads have no uuid yet — keep the toggle in local state and seed
+    // the per-thread slice entry once the thread is created.
+    const [sqlMode, setSqlMode] = useState(false);
+    const dispatchToStore = useAiAgentStoreDispatch();
+    const handleToolResult = useCallback(
+        (toolResult: AiAgentToolResult) => {
+            const dashboardUrl = getDashboardNavigationUrlFromContentToolResult(
+                projectUuid,
+                toolResult,
+            );
+            if (!dashboardUrl) return;
+
+            void navigate(dashboardUrl, { viewTransition: true });
+        },
+        [navigate, projectUuid],
+    );
 
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
         useCreateAgentThreadMutation(projectUuid, {
@@ -130,13 +152,8 @@ const NewThreadPanel: FC<{
                     }),
                 );
             },
+            onToolResult: handleToolResult,
         });
-
-    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
-    // New threads have no uuid yet — keep the toggle in local state and seed
-    // the per-thread slice entry once the thread is created.
-    const [sqlMode, setSqlMode] = useState(false);
-    const dispatchToStore = useAiAgentStoreDispatch();
 
     const handleSubmit = ({
         message,
@@ -238,6 +255,8 @@ const ExistingThreadPanel: FC<{
     style?: CSSProperties;
 }> = ({ projectUuid, agent, agents, threadId, style }) => {
     const { user } = useApp();
+    const navigate = useNavigate();
+    const location = useLocation();
     const {
         data: thread,
         isLoading: isLoadingThread,
@@ -250,10 +269,25 @@ const ExistingThreadPanel: FC<{
         refetch,
     );
 
+    const handleToolResult = useCallback(
+        (toolResult: AiAgentToolResult) => {
+            const dashboardUrl = getDashboardNavigationUrlFromContentToolResult(
+                projectUuid,
+                toolResult,
+            );
+            if (!dashboardUrl) return;
+
+            void navigate(dashboardUrl, { viewTransition: true });
+        },
+        [navigate, projectUuid],
+    );
+
     const {
         mutateAsync: createAgentThreadMessage,
         isLoading: isCreatingMessage,
-    } = useCreateAgentThreadMessageMutation(projectUuid, agent.uuid, threadId);
+    } = useCreateAgentThreadMessageMutation(projectUuid, agent.uuid, threadId, {
+        onToolResult: handleToolResult,
+    });
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const sqlMode = useAiAgentStoreSelector(selectThreadSqlMode(threadId));
@@ -282,6 +316,19 @@ const ExistingThreadPanel: FC<{
 
     const headerTitle =
         thread?.title || thread?.firstMessage?.message || agent.name;
+
+    const handleDashboardLinkClick = useCallback(
+        (dashboardUrl: string) => {
+            const currentUrl = createPath({
+                pathname: location.pathname,
+                search: location.search,
+            });
+            if (dashboardUrl !== currentUrl) {
+                void navigate(dashboardUrl, { viewTransition: true });
+            }
+        },
+        [location.pathname, location.search, navigate],
+    );
 
     if (isLoadingThread || !thread) {
         return (
@@ -317,6 +364,7 @@ const ExistingThreadPanel: FC<{
                     projectUuid={projectUuid}
                     agentUuid={agent.uuid}
                     renderArtifactsInline
+                    onDashboardLinkClick={handleDashboardLinkClick}
                 >
                     <AgentChatInput
                         disabled={

--- a/packages/frontend/src/ee/features/aiCopilot/utils/contentToolResultNavigation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/contentToolResultNavigation.ts
@@ -1,0 +1,80 @@
+import { type AiAgentToolResult } from '../types';
+
+type LocationLike = {
+    pathname: string;
+    search: string;
+};
+
+const normalizePathname = (pathname: string): string =>
+    pathname.replace(/\/$/, '');
+
+const isSameLocation = (targetUrl: string, location: LocationLike): boolean => {
+    const target = new URL(targetUrl, window.location.origin);
+
+    return (
+        normalizePathname(target.pathname) ===
+            normalizePathname(location.pathname) &&
+        target.search === location.search
+    );
+};
+
+const getDashboardSlugFromContentToolResult = (
+    toolResult: AiAgentToolResult,
+): string | null => {
+    if (toolResult.isPreliminary) return null;
+
+    switch (toolResult.toolName) {
+        case 'createContent':
+            if (toolResult.toolArgs.type !== 'dashboard') return null;
+            if (toolResult.toolResult.metadata.status !== 'success')
+                return null;
+
+            return (
+                toolResult.toolResult.metadata.slug ??
+                toolResult.toolArgs.content.slug
+            );
+        case 'editContent':
+            if (toolResult.toolArgs.type !== 'dashboard') return null;
+            if (toolResult.toolResult.metadata.status !== 'success')
+                return null;
+
+            return (
+                toolResult.toolResult.metadata.slug ?? toolResult.toolArgs.slug
+            );
+        default:
+            return null;
+    }
+};
+
+const getDashboardUrlFromContentToolResult = (
+    projectUuid: string,
+    toolResult: AiAgentToolResult,
+): string | null => {
+    if (
+        (toolResult.toolName === 'createContent' ||
+            toolResult.toolName === 'editContent') &&
+        toolResult.toolArgs.type === 'dashboard' &&
+        toolResult.toolResult.metadata.status === 'success'
+    ) {
+        return toolResult.toolResult.metadata.url;
+    }
+
+    const dashboardSlug = getDashboardSlugFromContentToolResult(toolResult);
+    return dashboardSlug
+        ? `/projects/${projectUuid}/dashboards/${dashboardSlug}`
+        : null;
+};
+
+export const getDashboardNavigationUrlFromContentToolResult = (
+    projectUuid: string,
+    toolResult: AiAgentToolResult,
+    location: LocationLike = window.location,
+): string | null => {
+    const dashboardUrl = getDashboardUrlFromContentToolResult(
+        projectUuid,
+        toolResult,
+    );
+    if (!dashboardUrl || isSameLocation(dashboardUrl, location)) return null;
+
+    return dashboardUrl;
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -1,6 +1,6 @@
 import { type AiAgent } from '@lightdash/common';
 import { Box, Loader } from '@mantine-8/core';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
     Navigate,
     Outlet,
@@ -25,6 +25,11 @@ import {
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
 import { store as aiAgentStore } from '../../features/aiCopilot/store';
 import { openPanel } from '../../features/aiCopilot/store/aiAgentLauncherSlice';
+
+type NavigateFromAgentChatOptions = {
+    threadUuid?: string;
+    title?: string | null;
+};
 
 const AgentPage = () => {
     const { agentUuid, threadUuid, projectUuid } = useParams();
@@ -58,57 +63,76 @@ const AgentPage = () => {
     const { track } = useTracking();
     const { user } = useApp();
 
-    const handleMinimize = () => {
-        if (!agent || !projectUuid) return;
-        track({
-            name: EventName.AI_AGENT_CHAT_MINIMIZED,
-            properties: {
-                userId: user?.data?.userUuid,
-                organizationId: user?.data?.organizationUuid,
-                projectId: projectUuid,
-                agentUuid: agent.uuid,
-                threadUuid,
-            },
-        });
-        if (threadUuid) {
-            const dockTitle =
-                thread?.title ||
-                thread?.firstMessage?.message ||
-                'Conversation';
-            addDockItem({
-                threadId: threadUuid,
-                agentUuid: agent.uuid,
-                title: dockTitle,
+    const handleMinimize = useCallback(
+        (targetUrl?: string, options?: NavigateFromAgentChatOptions) => {
+            if (!agent || !projectUuid) return;
+            const panelThreadUuid = options?.threadUuid ?? threadUuid;
+            track({
+                name: EventName.AI_AGENT_CHAT_MINIMIZED,
+                properties: {
+                    userId: user?.data?.userUuid,
+                    organizationId: user?.data?.organizationUuid,
+                    projectId: projectUuid,
+                    agentUuid: agent.uuid,
+                    threadUuid: panelThreadUuid,
+                },
             });
-            aiAgentStore.dispatch(
-                openPanel({
-                    threadId: threadUuid,
+            if (panelThreadUuid) {
+                const dockTitle =
+                    options?.title ||
+                    (panelThreadUuid === threadUuid
+                        ? thread?.title || thread?.firstMessage?.message
+                        : undefined) ||
+                    'Conversation';
+                addDockItem({
+                    threadId: panelThreadUuid,
                     agentUuid: agent.uuid,
-                }),
+                    title: dockTitle,
+                });
+                aiAgentStore.dispatch(
+                    openPanel({
+                        threadId: panelThreadUuid,
+                        agentUuid: agent.uuid,
+                    }),
+                );
+            } else {
+                const chartUuid = searchParams.get('chartUuid');
+                const dashboardUuid = searchParams.get('dashboardUuid');
+                const pendingContext =
+                    chartUuid || dashboardUuid
+                        ? {
+                              chartUuid: chartUuid ?? undefined,
+                              dashboardUuid: dashboardUuid ?? undefined,
+                          }
+                        : null;
+                aiAgentStore.dispatch(
+                    openPanel({
+                        threadId: null,
+                        agentUuid: agent.uuid,
+                        pendingContext,
+                    }),
+                );
+            }
+            void navigate(
+                targetUrl ??
+                    launcherSession.consumeLastNonAgentUrl() ??
+                    `/projects/${projectUuid}/home`,
+                { viewTransition: true },
             );
-        } else {
-            const chartUuid = searchParams.get('chartUuid');
-            const dashboardUuid = searchParams.get('dashboardUuid');
-            const pendingContext =
-                chartUuid || dashboardUuid
-                    ? {
-                          chartUuid: chartUuid ?? undefined,
-                          dashboardUuid: dashboardUuid ?? undefined,
-                      }
-                    : null;
-            aiAgentStore.dispatch(
-                openPanel({
-                    threadId: null,
-                    agentUuid: agent.uuid,
-                    pendingContext,
-                }),
-            );
-        }
-        void navigate(
-            launcherSession.consumeLastNonAgentUrl() ??
-                `/projects/${projectUuid}/home`,
-        );
-    };
+        },
+        [
+            addDockItem,
+            agent,
+            navigate,
+            projectUuid,
+            searchParams,
+            thread,
+            threadUuid,
+            track,
+            user?.data?.organizationUuid,
+            user?.data?.userUuid,
+        ],
+    );
 
     if (isLoadingAgent) {
         return (
@@ -152,7 +176,7 @@ const AgentPage = () => {
                             />
                         ) : undefined
                     }
-                    onMinimize={handleMinimize}
+                    onMinimize={() => handleMinimize()}
                     settingsHref={
                         canManageAgents
                             ? `/projects/${projectUuid}/ai-agents/${agent.uuid}/edit`
@@ -161,7 +185,13 @@ const AgentPage = () => {
                 />
             }
         >
-            <Outlet context={{ agent, agents: agentsList ?? [] }} />
+            <Outlet
+                context={{
+                    agent,
+                    agents: agentsList ?? [],
+                    navigateFromAgentChat: handleMinimize,
+                }}
+            />
         </AiAgentPageLayout>
     );
 };
@@ -169,6 +199,10 @@ const AgentPage = () => {
 export interface AgentContext {
     agent: AiAgent;
     agents: AiAgent[];
+    navigateFromAgentChat: (
+        targetUrl: string,
+        options?: NavigateFromAgentChatOptions,
+    ) => void;
 }
 
 export default AgentPage;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,4 +1,5 @@
 import { Center, Loader } from '@mantine-8/core';
+import { useCallback } from 'react';
 import { useOutletContext, useParams } from 'react-router';
 import useApp from '../../../providers/App/useApp';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
@@ -21,6 +22,8 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../features/aiCopilot/store/hooks';
+import { type AiAgentToolResult } from '../../features/aiCopilot/types';
+import { getDashboardNavigationUrlFromContentToolResult } from '../../features/aiCopilot/utils/contentToolResultNavigation';
 import { type AgentContext } from './AgentPage';
 
 const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
@@ -44,12 +47,51 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
 
     const agentQuery = useAiAgent(projectUuid!, agentUuid!);
-    const { agent } = useOutletContext<AgentContext>();
+    const { agent, navigateFromAgentChat } = useOutletContext<AgentContext>();
 
     const canManage = useAiAgentPermission({
         action: 'manage',
         projectUuid,
     });
+
+    const handleToolResult = useCallback(
+        (toolResult: AiAgentToolResult) => {
+            if (!projectUuid) return;
+
+            const dashboardUrl = getDashboardNavigationUrlFromContentToolResult(
+                projectUuid,
+                toolResult,
+            );
+            if (!dashboardUrl) return;
+
+            navigateFromAgentChat(dashboardUrl, {
+                threadUuid,
+                title: thread?.title || thread?.firstMessage?.message,
+            });
+        },
+        [
+            navigateFromAgentChat,
+            projectUuid,
+            thread?.firstMessage?.message,
+            thread?.title,
+            threadUuid,
+        ],
+    );
+
+    const handleDashboardLinkClick = useCallback(
+        (dashboardUrl: string) => {
+            navigateFromAgentChat(dashboardUrl, {
+                threadUuid,
+                title: thread?.title || thread?.firstMessage?.message,
+            });
+        },
+        [
+            navigateFromAgentChat,
+            thread?.firstMessage?.message,
+            thread?.title,
+            threadUuid,
+        ],
+    );
 
     const {
         mutateAsync: createAgentThreadMessage,
@@ -58,6 +100,9 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         projectUuid!,
         agentUuid,
         threadUuid,
+        {
+            onToolResult: handleToolResult,
+        },
     );
 
     const { isStreaming, isPending } = usePendingThreadRefetch(
@@ -144,6 +189,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
             projectUuid={projectUuid}
             agentUuid={agentUuid}
             showAddToEvalsButton={canManage}
+            onDashboardLinkClick={handleDashboardLinkClick}
         >
             <AgentChatInput
                 disabled={inputDisabled}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -10,7 +10,14 @@ import {
     Title,
 } from '@mantine-8/core';
 import { IconInfoCircle } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -31,6 +38,8 @@ import {
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
 import { setThreadSqlMode } from '../../features/aiCopilot/store/aiAgentThreadModeSlice';
 import { useAiAgentStoreDispatch } from '../../features/aiCopilot/store/hooks';
+import { type AiAgentToolResult } from '../../features/aiCopilot/types';
+import { getDashboardNavigationUrlFromContentToolResult } from '../../features/aiCopilot/utils/contentToolResultNavigation';
 import { type AgentContext } from './AgentPage';
 
 const AiAgentNewThreadPage: FC = () => {
@@ -52,21 +61,50 @@ const AiAgentNewThreadPage: FC = () => {
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const [sqlMode, setSqlMode] = useState(false);
     const dispatch = useAiAgentStoreDispatch();
+    const { agent, agents, navigateFromAgentChat } =
+        useOutletContext<AgentContext>();
+    const createdThreadRef = useRef<{
+        uuid: string;
+        title: string;
+    } | null>(null);
+
+    const handleToolResult = useCallback(
+        (toolResult: AiAgentToolResult) => {
+            if (!projectUuid) return;
+
+            const dashboardUrl = getDashboardNavigationUrlFromContentToolResult(
+                projectUuid,
+                toolResult,
+            );
+            if (!dashboardUrl) return;
+
+            navigateFromAgentChat(dashboardUrl, {
+                threadUuid: createdThreadRef.current?.uuid,
+                title: createdThreadRef.current?.title,
+            });
+        },
+        [navigateFromAgentChat, projectUuid],
+    );
 
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
         useCreateAgentThreadMutation(projectUuid!, {
             // Seed the per-thread slice with the user's choice so subsequent
             // prompts in this thread default to the same state. Navigation
             // still happens (we only override the slice, not the routing).
-            onCreated: (thread) =>
+            onCreated: (thread) => {
+                createdThreadRef.current = {
+                    uuid: thread.uuid,
+                    title: thread.firstMessage.message,
+                };
                 dispatch(
                     setThreadSqlMode({
                         threadUuid: thread.uuid,
                         enabled: sqlModeAvailable && sqlMode,
                     }),
-                ),
+                );
+            },
+            onToolResult: handleToolResult,
         });
-    const { agent, agents } = useOutletContext<AgentContext>();
     const { data: verifiedQuestions } = useVerifiedQuestions(
         projectUuid,
         agentUuid,

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -1,6 +1,7 @@
 import {
     type DashboardChartTile,
     type DashboardFilters,
+    type DashboardTile,
     isDashboardChartTileType,
 } from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
@@ -54,11 +55,12 @@ const DashboardAiAgentContextBridge = () => {
         [dashboardUuid, projectUuid],
     );
 
-    const successfulEditContentResults = useMemo(
+    const successfulContentResults = useMemo(
         () =>
             activeThreadParts.flatMap((part) =>
                 part.type === 'toolCall' &&
-                part.toolName === 'editContent' &&
+                (part.toolName === 'createContent' ||
+                    part.toolName === 'editContent') &&
                 part.isPreliminary === false &&
                 part.toolResult?.metadata.status === 'success'
                     ? [part]
@@ -67,36 +69,11 @@ const DashboardAiAgentContextBridge = () => {
         [activeThreadParts],
     );
 
-    const refreshDashboard = useCallback(async () => {
-        if (!projectUuid || !dashboardUuid) return;
-
-        const freshDashboard = await queryClient.fetchQuery({
-            queryKey: dashboardQueryKey,
-            queryFn: () => getDashboard(dashboardUuid, projectUuid),
-        });
-
-        setDashboardTiles(freshDashboard.tiles);
-        setDashboardTabs(freshDashboard.tabs);
-        setDashboardFilters(freshDashboard.filters);
-        setOriginalDashboardFilters(freshDashboard.filters);
-        setDashboardTemporaryFilters(emptyFilters);
-    }, [
-        dashboardQueryKey,
-        dashboardUuid,
-        projectUuid,
-        queryClient,
-        setDashboardFilters,
-        setDashboardTabs,
-        setDashboardTemporaryFilters,
-        setDashboardTiles,
-        setOriginalDashboardFilters,
-    ]);
-
-    const refreshChartTiles = useCallback(
-        async (chartSlug: string) => {
+    const refreshChartTilesFromTiles = useCallback(
+        async (chartSlug: string, tiles: DashboardTile[] | undefined) => {
             if (!projectUuid || !dashboardUuid) return;
 
-            const matchingTiles = (dashboardTiles ?? []).filter(
+            const matchingTiles = (tiles ?? []).filter(
                 (tile): tile is DashboardChartTile =>
                     isDashboardChartTileType(tile) &&
                     tile.properties.chartSlug === chartSlug &&
@@ -115,8 +92,18 @@ const DashboardAiAgentContextBridge = () => {
 
             await Promise.all(
                 savedChartUuids.map(async (savedChartUuid) => {
+                    const queryKey = [
+                        'saved_query',
+                        savedChartUuid,
+                        projectUuid,
+                    ];
+                    await queryClient.invalidateQueries({
+                        queryKey,
+                        refetchType: 'none',
+                    });
+
                     const freshChart = await queryClient.fetchQuery({
-                        queryKey: ['saved_query', savedChartUuid, projectUuid],
+                        queryKey,
                         queryFn: () =>
                             getSavedQuery(savedChartUuid, projectUuid),
                     });
@@ -136,23 +123,97 @@ const DashboardAiAgentContextBridge = () => {
                     query.queryKey[3] === dashboardUuid,
             });
         },
-        [dashboardTiles, dashboardUuid, projectUuid, queryClient],
+        [dashboardUuid, projectUuid, queryClient],
+    );
+
+    const refreshDashboard = useCallback(async () => {
+        if (!projectUuid || !dashboardUuid) return;
+
+        await queryClient.invalidateQueries({
+            queryKey: dashboardQueryKey,
+            refetchType: 'none',
+        });
+
+        const freshDashboard = await queryClient.fetchQuery({
+            queryKey: dashboardQueryKey,
+            queryFn: () => getDashboard(dashboardUuid, projectUuid),
+        });
+
+        const chartTiles = freshDashboard.tiles.filter(
+            isDashboardChartTileType,
+        );
+
+        setDashboardTiles(freshDashboard.tiles);
+        setDashboardTabs(freshDashboard.tabs);
+        setDashboardFilters(freshDashboard.filters);
+        setOriginalDashboardFilters(freshDashboard.filters);
+        setDashboardTemporaryFilters(emptyFilters);
+
+        await Promise.all(
+            [
+                ...new Set(
+                    chartTiles
+                        .map((tile) => tile.properties.chartSlug)
+                        .filter((slug): slug is string => !!slug),
+                ),
+            ].map((chartSlug) =>
+                refreshChartTilesFromTiles(chartSlug, freshDashboard.tiles),
+            ),
+        );
+    }, [
+        dashboardQueryKey,
+        dashboardUuid,
+        projectUuid,
+        queryClient,
+        refreshChartTilesFromTiles,
+        setDashboardFilters,
+        setDashboardTabs,
+        setDashboardTemporaryFilters,
+        setDashboardTiles,
+        setOriginalDashboardFilters,
+    ]);
+
+    const refreshChartTiles = useCallback(
+        async (chartSlug: string) =>
+            refreshChartTilesFromTiles(chartSlug, dashboardTiles),
+        [dashboardTiles, refreshChartTilesFromTiles],
     );
 
     useEffect(() => {
         if (!currentDashboardSlug || !projectUuid || !dashboardUuid) return;
 
-        for (const part of successfulEditContentResults) {
+        for (const part of successfulContentResults) {
+            const contentSlug =
+                part.toolResult?.metadata.status === 'success'
+                    ? part.toolResult.metadata.slug
+                    : part.toolName === 'createContent'
+                      ? part.toolArgs.content.slug
+                      : part.toolArgs.slug;
+            const targetDashboardSlug =
+                part.toolName === 'createContent'
+                    ? 'dashboardSlug' in part.toolArgs.content
+                        ? part.toolArgs.content.dashboardSlug
+                        : undefined
+                    : undefined;
+
             if (handledToolCallIdsRef.current.has(part.toolCallId)) continue;
 
             handledToolCallIdsRef.current.add(part.toolCallId);
 
             switch (part.toolArgs.type) {
                 case 'chart':
-                    void refreshChartTiles(part.toolArgs.slug);
+                    if (
+                        part.toolName === 'createContent' &&
+                        targetDashboardSlug === currentDashboardSlug
+                    ) {
+                        void refreshDashboard();
+                        continue;
+                    }
+
+                    void refreshChartTiles(contentSlug);
                     continue;
                 case 'dashboard':
-                    if (part.toolArgs.slug !== currentDashboardSlug) continue;
+                    if (contentSlug !== currentDashboardSlug) continue;
                     void refreshDashboard();
                     continue;
             }
@@ -163,7 +224,7 @@ const DashboardAiAgentContextBridge = () => {
         projectUuid,
         refreshChartTiles,
         refreshDashboard,
-        successfulEditContentResults,
+        successfulContentResults,
     ]);
 
     return null;


### PR DESCRIPTION
Closes:

### Description:

When the AI agent successfully creates or edits a dashboard via `createContent` or `editContent` tool calls, the user is now automatically navigated to that dashboard. This works across all agent chat surfaces — the launcher panel (both new and existing threads), the full-page agent thread view, and the new thread page.

A new utility (`getDashboardNavigationUrlFromContentToolResult`) extracts the target dashboard URL from a tool result, skipping navigation if the user is already on that page.

The `handleMinimize` function in `AgentPage` has been extended to accept an optional target URL and thread metadata, allowing navigation to a dashboard while simultaneously docking the current conversation. This is exposed to child routes via the outlet context as `navigateFromAgentChat`.

The `DashboardAiAgentContextBridge` now handles `createContent` tool results in addition to `editContent`, refreshing the dashboard when a newly created chart is added to the current dashboard or when the current dashboard itself is created/edited. The `refreshDashboard` function also now eagerly refreshes all chart tiles after fetching fresh dashboard data.

The `runQuery` tool has been temporarily moved inside the dashboard-mode tool group (marked with a TODO to remove).