### PR TITLE
feat(ai-writeback): emit explicit source field on run events

### DIFF
--- a/packages/backend/src/ee/controllers/AiWritebackController.ts
+++ b/packages/backend/src/ee/controllers/AiWritebackController.ts
@@ -73,6 +73,7 @@ export class AiWritebackController extends BaseController {
             user: toSessionUser(req.account),
             projectUuid,
             prompt,
+            source: 'api',
         });
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -511,6 +511,7 @@ export class AiAgentAdminService extends BaseService {
                 user,
                 projectUuid,
                 prompt: plan.promptText,
+                source: 'admin_review',
                 onProgress: (message) => {
                     void setStatus('running', message, agentUuid);
                 },

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5482,6 +5482,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         projectUuid,
                         prompt: args.prompt,
                         aiThreadUuid: prompt.threadUuid,
+                        source: isSlackPrompt(prompt) ? 'slack' : 'web',
                         onProgress: writebackProgressCallback,
                     }),
             );

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -55,6 +55,7 @@ import { buildGatherRepoContextScript } from './scripts';
 import { buildSystemPrompt } from './templates';
 import type {
     AiWritebackRunArgs,
+    AiWritebackSource,
     AppliedChanges,
     GithubConnection,
     GithubInstallation,
@@ -62,7 +63,7 @@ import type {
     TurnContext,
 } from './types';
 
-export type { AiWritebackRunArgs } from './types';
+export type { AiWritebackRunArgs, AiWritebackSource } from './types';
 
 const GATHER_REPO_CONTEXT_SANDBOX_PATH = '/tmp/gather-repo-context.sh';
 
@@ -452,7 +453,8 @@ export class AiWritebackService extends BaseService {
      *   branch (updates the existing PR), pause the sandbox again.
      */
     async run(args: AiWritebackRunArgs): Promise<AiWritebackRunResult> {
-        const { user, projectUuid, prompt, aiThreadUuid, onProgress } = args;
+        const { user, projectUuid, prompt, aiThreadUuid, source, onProgress } =
+            args;
         const runStartedAt = performance.now();
 
         // Wrap the optional onProgress in a try/catch so a misbehaving caller
@@ -477,6 +479,7 @@ export class AiWritebackService extends BaseService {
 
         this.logger.info('AI writeback run started', {
             event: 'ai_writeback.run.started',
+            source,
             projectUuid,
             aiThreadUuid: aiThreadUuid ?? null,
             isResume: turn.isResume,
@@ -494,6 +497,7 @@ export class AiWritebackService extends BaseService {
             // a stall is immediately attributable to the stage it happened in.
             this.logger.info('AI writeback stage complete', {
                 event: 'ai_writeback.run.stage',
+                source,
                 aiThreadUuid: aiThreadUuid ?? null,
                 stage: failureStage,
                 nextStage: stage,
@@ -546,6 +550,7 @@ export class AiWritebackService extends BaseService {
                 systemPrompt,
                 prompt,
                 isResume: turn.isResume,
+                source,
                 reportProgress,
             });
 
@@ -565,6 +570,7 @@ export class AiWritebackService extends BaseService {
                     'AI writeback agent exited non-zero, skipping PR',
                     {
                         event: 'ai_writeback.run.failed',
+                        source,
                         projectUuid,
                         aiThreadUuid: aiThreadUuid ?? null,
                         sandboxId: sandbox.sandboxId,
@@ -610,6 +616,7 @@ export class AiWritebackService extends BaseService {
 
             this.logger.info('AI writeback run completed', {
                 event: 'ai_writeback.run.completed',
+                source,
                 projectUuid,
                 aiThreadUuid: aiThreadUuid ?? null,
                 sandboxId: sandbox.sandboxId,
@@ -631,6 +638,7 @@ export class AiWritebackService extends BaseService {
         } catch (error) {
             this.logger.error('AI writeback run failed', {
                 event: 'ai_writeback.run.failed',
+                source,
                 projectUuid,
                 aiThreadUuid: aiThreadUuid ?? null,
                 sandboxId: sandbox?.sandboxId ?? null,
@@ -894,12 +902,14 @@ export class AiWritebackService extends BaseService {
         systemPrompt,
         prompt,
         isResume,
+        source,
         reportProgress,
     }: {
         sandbox: Sandbox;
         systemPrompt: string;
         prompt: string;
         isResume: boolean;
+        source: AiWritebackSource;
         reportProgress: (message: string) => void;
     }): Promise<{ stdout: string; exitCode: number }> {
         await sandbox.files.write(SYSTEM_PROMPT_PATH, systemPrompt);
@@ -1011,6 +1021,7 @@ export class AiWritebackService extends BaseService {
                                 (toolCounts[block.name] ?? 0) + 1;
                             this.logger.info('AI writeback agent tool call', {
                                 event: 'ai_writeback.run.tool',
+                                source,
                                 sandboxId: sandbox.sandboxId,
                                 toolName: block.name,
                                 summary: summarizeToolInput(block.input),
@@ -1027,6 +1038,7 @@ export class AiWritebackService extends BaseService {
             } else if (e.type === 'result') {
                 this.logger.info('AI writeback agent run summary', {
                     event: 'ai_writeback.run.summary',
+                    source,
                     sandboxId: sandbox.sandboxId,
                     costUsd: e.total_cost_usd ?? null,
                     toolCounts,

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -29,11 +29,24 @@ export type AppliedChanges = {
     pauseOnExit: boolean;
 };
 
+export type AiWritebackSource =
+    | 'slack'
+    | 'web'
+    | 'mcp'
+    | 'api'
+    | 'admin_review';
+
 export type AiWritebackRunArgs = {
     user: SessionUser;
     projectUuid: string;
     prompt: string;
     aiThreadUuid?: string;
+    /**
+     * Identifies the trigger surface so logs, metrics, and analytics can
+     * group runs by where they originated. Required so adding new triggers
+     * is a type-system change rather than a silent fallthrough.
+     */
+    source: AiWritebackSource;
     /**
      * Fired with a short, user-facing progress message each time the run
      * advances through a meaningful phase (e.g. "Starting sandbox",

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -435,6 +435,7 @@ export class McpService extends BaseService {
                         user,
                         projectUuid,
                         prompt: args.prompt,
+                        source: 'mcp',
                     });
 
                     const summary = result.prUrl


### PR DESCRIPTION
## Summary
- Adds a required `AiWritebackSource` enum (`slack` | `web` | `mcp` | `api` | `admin_review`) to `AiWritebackRunArgs` and stamps it on every run-level structured log event (`run.started`, `run.stage`, `run.tool`, `run.summary`, `run.completed`, `run.failed`).
- Each caller of `AiWritebackService.run()` now declares its trigger surface explicitly — HTTP controller → `api`, AI agent tool → `slack | web` (via existing `isSlackPrompt(prompt)` check), MCP tool → `mcp`, admin review classifier → `admin_review`.
- Removes the need for downstream consumers (Cloud Logging dashboards, BigQuery, analytics) to infer the trigger surface from the presence/absence of the graphile-worker `job` field, which was brittle and broke as soon as new triggers were added.

## Why
While exploring AI writeback telemetry in Cloud Logging, distinguishing Slack-triggered runs from web-triggered runs required correlating the absence of the `job` field with surrounding HTTP request traces. That heuristic doesn't survive new trigger surfaces (MCP, admin review, autopilot, future API callers), so a single explicit `source` field makes the data trivially groupable.

## Test plan
- [ ] `pnpm run typecheck` in `packages/backend` passes (verified locally)
- [ ] Trigger a writeback from each surface (Slack, web, MCP, API) and confirm the matching `source` value appears on the `ai_writeback.run.started` log entry
- [ ] Trigger from the admin review flow and confirm `source: "admin_review"` appears
- [ ] Verify Cloud Logging queries can now `WHERE json_payload.source = "slack"` cleanly without falling back to `job IS NOT NULL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)