### PR TITLE
fix(ai-writeback): scrub secrets from the dbt compile environment

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -36,6 +36,8 @@ import {
     CLAUDE_MODEL,
     COMMIT_AUTHOR_EMAIL,
     COMMIT_AUTHOR_NAME,
+    COMPILE_STRIPPED_ENV_VARS,
+    COMPILE_WRAPPER_PATH,
     CWD,
     GIT_TIMEOUT_MS,
     GIT_USERNAME,
@@ -914,6 +916,21 @@ export class AiWritebackService extends BaseService {
     }): Promise<{ stdout: string; exitCode: number }> {
         await sandbox.files.write(SYSTEM_PROMPT_PATH, systemPrompt);
         await sandbox.files.write(PROMPT_PATH, prompt);
+
+        // Install the compile wrapper. The agent runs ${COMPILE_WRAPPER_PATH}
+        // (allowlisted) instead of `lightdash compile` directly, and the wrapper
+        // drops secrets from the environment before exec'ing the real CLI — so a
+        // malicious dbt model in the checkout cannot read them via Jinja
+        // `env_var(...)` during the compile. `exec` keeps the process tree flat;
+        // the `unset` list is fixed (no interpolation of untrusted input).
+        const unsetFlags = COMPILE_STRIPPED_ENV_VARS.map(
+            (name) => `-u ${name}`,
+        ).join(' ');
+        await sandbox.files.write(
+            COMPILE_WRAPPER_PATH,
+            `#!/usr/bin/env bash\nexec env ${unsetFlags} lightdash compile "$@"\n`,
+        );
+        await sandbox.commands.run(`chmod +x ${COMPILE_WRAPPER_PATH}`);
 
         // Parse Claude Code's stream-json output line-by-line so the agent
         // stage stops being a black box: we log every tool the agent uses

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -47,6 +47,25 @@ export const GIT_TIMEOUT_MS = 5 * 60 * 1000;
 // leak into the PR.
 export const TMP_PROFILES_DIR = '/tmp/ld-profiles';
 
+// Wrapper the agent runs instead of `lightdash compile` directly. It strips
+// secrets from the environment before exec'ing the real compile, so a
+// malicious dbt model cannot read them via Jinja `env_var(...)` during the
+// compile (the agent process holds ANTHROPIC_API_KEY to authenticate the CLI,
+// and bash children would otherwise inherit it). The agent is allowlisted to
+// this wrapper only — not raw `lightdash compile` — so the scrub is enforced
+// regardless of what the agent decides to run. Written into the sandbox at
+// runtime by runAgentInSandbox.
+export const COMPILE_WRAPPER_PATH = '/tmp/ld-writeback-compile';
+
+// Environment variables stripped from the compile child by the wrapper above.
+// ANTHROPIC_API_KEY is the only secret currently in the agent's env, but we
+// also drop common token vars defensively in case that changes.
+export const COMPILE_STRIPPED_ENV_VARS = [
+    'ANTHROPIC_API_KEY',
+    'GITHUB_TOKEN',
+    'GH_TOKEN',
+];
+
 // Fine-grained tool permissions for the Claude Code CLI — used in place of
 // `--dangerously-skip-permissions`. Follows Claude Code's `--allowedTools`
 // syntax: `Tool(specifier)`, where `//path` denotes an absolute filesystem
@@ -54,8 +73,8 @@ export const TMP_PROFILES_DIR = '/tmp/ld-profiles';
 //   - read/edit/write/glob/grep over the cloned repo at CWD
 //   - read/write/edit under TMP_PROFILES_DIR (the patched profiles copy)
 //   - write to the two PR metadata files the host reads after the run
-//   - bash scoped to `lightdash compile` and the file ops needed to set up
-//     the temporary profiles dir
+//   - bash scoped to the compile wrapper (COMPILE_WRAPPER_PATH) and the file
+//     ops needed to set up the temporary profiles dir
 export const ALLOWED_TOOLS = [
     `Read(/${CWD}/**)`,
     `Glob(/${CWD}/**)`,
@@ -71,7 +90,9 @@ export const ALLOWED_TOOLS = [
     // runAgentInSandbox). Without that the agent's /tmp write is refused and it
     // falls back to the repo root, where the host has to scrub it.
     `Write(//tmp/**)`,
-    'Bash(lightdash compile:*)',
+    // Compile only via the secret-stripping wrapper, never raw
+    // `lightdash compile` — see COMPILE_WRAPPER_PATH.
+    `Bash(${COMPILE_WRAPPER_PATH}:*)`,
     'Bash(mkdir:*)',
     'Bash(cp:*)',
 ].join(',');

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -1,4 +1,5 @@
 import {
+    COMPILE_WRAPPER_PATH,
     PR_DESCRIPTION_CLOSE,
     PR_DESCRIPTION_OPEN,
     PR_TITLE_CLOSE,
@@ -85,8 +86,9 @@ finish:
      commit every file change in the working tree, so the original must stay
      unchanged.
 
-4. From the repo root, run:
-     lightdash compile --skip-warehouse-catalog \\
+4. From the repo root, run (use this exact wrapper command — it is the only
+   compile command available to you):
+     ${COMPILE_WRAPPER_PATH} --skip-warehouse-catalog \\
        --profiles-dir ${TMP_PROFILES_DIR} \\
        --project-dir ${dbtProjectDir}
    Capture the exit code and the last meaningful line of output.


### PR DESCRIPTION
## What

Hardens the AI writeback sandbox so a user-controlled dbt project cannot read the agent's secrets during `lightdash compile`.

## Background

The writeback sandbox runs the agent (`claude -p`) with `ANTHROPIC_API_KEY` in its environment (so the CLI can authenticate). The agent then runs `lightdash compile` as an allowed Bash tool — and that compile child **inherits the key**. dbt evaluates Jinja during compile with no allowlist on `env_var()`, so a malicious dbt model in the checkout, e.g.:

```sql
select '{{ env_var("ANTHROPIC_API_KEY") }}' as x
```

materialises the key into compiled output.

## Severity: defense-in-depth (not a demonstrated exploit)

I tested this end-to-end and could **not** weaponise it into actual theft:
- The agent tool allowlist has **no network** (`curl`/arbitrary bash), so no silent exfil.
- Compiled output lands in gitignored `target/`, so it isn't committed on its own.
- A prompt-injection attempt (malicious model + instructions to copy the secret into a tracked file) was **refused twice** by the model, which even flagged the attack in the PR description.

So this isn't "the sandbox leaks API keys" — it's that a production secret sits in the environment of a process that evaluates untrusted templates, and the only thing currently stopping disclosure is the model continuing to refuse injection (a probabilistic control).

## Fix

The agent is now allowlisted to a small wrapper (`COMPILE_WRAPPER_PATH`, written into the sandbox at runtime) instead of raw `lightdash compile`. The wrapper:

```bash
exec env -u ANTHROPIC_API_KEY -u GITHUB_TOKEN -u GH_TOKEN lightdash compile "$@"
```

strips the secrets from the environment before exec'ing the real CLI, so the dbt child never sees them. This converts a probabilistic control (the model saying no) into a **deterministic** one (the secret is physically absent from the compile process), and doesn't depend on dbt-Jinja hardening or macro auditing.

- `constants.ts`: add `COMPILE_WRAPPER_PATH` + `COMPILE_STRIPPED_ENV_VARS`; allowlist `Bash(<wrapper>:*)` instead of `Bash(lightdash compile:*)`.
- `AiWritebackService.ts`: write + `chmod +x` the wrapper into the sandbox before the agent run.
- `templates.ts`: system-prompt compile step now invokes the wrapper.

## Testing

Local PoC with a secret-safe canary model (`env_var('ANTHROPIC_API_KEY') | length`, the key's length, never its value):

| | compiled output |
|---|---|
| current (key in compile env) | `select 108 as klen` |
| with wrapper (`env -u …`) | `select 0 as klen` |

Real key length is 108; through the wrapper dbt sees length 0 — the variable is physically absent from the child. No real key value was ever printed or committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)