### PR TITLE
feat(ai-writeback): warehouse-aware type-coercion skills for the agent

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -8,6 +8,7 @@ import {
     isUserWithOrg,
     MissingConfigError,
     ParameterError,
+    WarehouseTypes,
     type AiWritebackRunResult,
     type DbtProjectConfig,
     type SessionUser,
@@ -51,9 +52,13 @@ import {
     REPO_CONTEXT_TIMEOUT_MS,
     RUN_TIMEOUT_MS,
     SANDBOX_TIMEOUT_MS,
+    SHARED_SKILL_PATH,
+    SKILLS_DIR,
     SYSTEM_PROMPT_PATH,
+    WAREHOUSE_SKILL_PATH,
 } from './constants';
 import { buildGatherRepoContextScript } from './scripts';
+import { loadWarehouseSkills, warehouseTypeToSkillKey } from './skills';
 import { buildSystemPrompt } from './templates';
 import type {
     AiWritebackRunArgs,
@@ -63,6 +68,7 @@ import type {
     GithubInstallation,
     SetStage,
     TurnContext,
+    WarehouseSkillKey,
 } from './types';
 
 export type { AiWritebackRunArgs, AiWritebackSource } from './types';
@@ -485,6 +491,7 @@ export class AiWritebackService extends BaseService {
             projectUuid,
             aiThreadUuid: aiThreadUuid ?? null,
             isResume: turn.isResume,
+            warehouseType: turn.warehouseType,
         });
 
         const repository = `${turn.githubConnection.owner}/${turn.githubConnection.repo}`;
@@ -539,12 +546,15 @@ export class AiWritebackService extends BaseService {
                 sandbox,
                 turn.githubConnection.projectSubPath,
             );
+            const skillKey = warehouseTypeToSkillKey(turn.warehouseType);
             const systemPrompt = buildSystemPrompt(
                 turn.githubConnection.projectSubPath,
                 {
                     projectName: turn.projectName,
                     repository,
                     repoContext,
+                    warehouseType: turn.warehouseType,
+                    hasWarehouseSkill: skillKey !== null,
                 },
             );
             const agent = await this.runAgentInSandbox({
@@ -554,6 +564,8 @@ export class AiWritebackService extends BaseService {
                 isResume: turn.isResume,
                 source,
                 reportProgress,
+                skillKey,
+                warehouseType: turn.warehouseType,
             });
 
             const {
@@ -579,6 +591,7 @@ export class AiWritebackService extends BaseService {
                         failureStage,
                         exitCode: agent.exitCode,
                         errorMessage: 'Agent CLI exited non-zero',
+                        warehouseType: turn.warehouseType,
                         totalDurationMs: Math.round(
                             performance.now() - runStartedAt,
                         ),
@@ -627,6 +640,7 @@ export class AiWritebackService extends BaseService {
                 hasChanges,
                 prCreated: applied.prCreated,
                 prUrl: applied.prUrl ?? null,
+                warehouseType: turn.warehouseType,
                 totalDurationMs: Math.round(performance.now() - runStartedAt),
             });
 
@@ -646,6 +660,7 @@ export class AiWritebackService extends BaseService {
                 sandboxId: sandbox?.sandboxId ?? null,
                 failureStage,
                 errorMessage: getErrorMessage(error),
+                warehouseType: turn.warehouseType,
                 totalDurationMs: Math.round(performance.now() - runStartedAt),
             });
             Sentry.captureException(error, {
@@ -713,12 +728,18 @@ export class AiWritebackService extends BaseService {
             ? await this.aiWritebackThreadModel.findByAiThreadUuid(aiThreadUuid)
             : null;
 
+        // `get()` returns the (de-sensitised) warehouse credentials with the
+        // discriminant `type` intact. Null when the project has no warehouse
+        // connection — the agent then gets `shared.md` only.
+        const warehouseType = project.warehouseConnection?.type ?? null;
+
         return {
             organizationUuid: user.organizationUuid,
             projectName: project.name,
             githubConnection,
             existingRow,
             isResume: existingRow !== null,
+            warehouseType,
         };
     }
 
@@ -906,6 +927,8 @@ export class AiWritebackService extends BaseService {
         isResume,
         source,
         reportProgress,
+        skillKey,
+        warehouseType,
     }: {
         sandbox: Sandbox;
         systemPrompt: string;
@@ -913,6 +936,8 @@ export class AiWritebackService extends BaseService {
         isResume: boolean;
         source: AiWritebackSource;
         reportProgress: (message: string) => void;
+        skillKey: WarehouseSkillKey | null;
+        warehouseType: WarehouseTypes | null;
     }): Promise<{ stdout: string; exitCode: number }> {
         await sandbox.files.write(SYSTEM_PROMPT_PATH, systemPrompt);
         await sandbox.files.write(PROMPT_PATH, prompt);
@@ -931,6 +956,15 @@ export class AiWritebackService extends BaseService {
             `#!/usr/bin/env bash\nexec env ${unsetFlags} lightdash compile "$@"\n`,
         );
         await sandbox.commands.run(`chmod +x ${COMPILE_WRAPPER_PATH}`);
+
+        // Push the warehouse skill files alongside the prompts. `shared.md`
+        // always; the dialect file only when one exists for this warehouse.
+        // The system prompt points the agent here before any `type:`/SQL edit.
+        const skills = await loadWarehouseSkills(skillKey);
+        await sandbox.files.write(SHARED_SKILL_PATH, skills.shared);
+        if (skills.warehouse !== null) {
+            await sandbox.files.write(WAREHOUSE_SKILL_PATH, skills.warehouse);
+        }
 
         // Parse Claude Code's stream-json output line-by-line so the agent
         // stage stops being a black box: we log every tool the agent uses
@@ -1058,6 +1092,7 @@ export class AiWritebackService extends BaseService {
                     source,
                     sandboxId: sandbox.sandboxId,
                     costUsd: e.total_cost_usd ?? null,
+                    warehouseType,
                     toolCounts,
                 });
             }
@@ -1094,7 +1129,9 @@ export class AiWritebackService extends BaseService {
                     // Claude Code confines Write/Edit to the cwd workspace, so the
                     // agent cannot write the PR metadata to /tmp (it silently falls
                     // back to the repo root) unless /tmp is an added directory.
-                    '--add-dir /tmp ' +
+                    // The skills dir is outside the repo too, so it likewise needs
+                    // to be added or the agent's Read of warehouse.md is refused.
+                    `--add-dir /tmp --add-dir ${SKILLS_DIR} ` +
                     `--allowedTools "${ALLOWED_TOOLS}"`,
                 {
                     cwd: CWD,

--- a/packages/backend/src/ee/services/AiWritebackService/__snapshots__/templates.test.ts.snap
+++ b/packages/backend/src/ee/services/AiWritebackService/__snapshots__/templates.test.ts.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildSystemPrompt — warehouse skill guidance matches the snapshot for a no-skill warehouse (duckdb) 1`] = `
+"You are an autonomous coding agent working inside a checkout of a git repository.
+
+- You are working on the Lightdash project "Jaffle shop", which is
+  backed by the GitHub repository acme/jaffle. This repository — the
+  one already cloned in your working directory — is the ONLY one you act on.
+- The user's request was routed to this project and may refer to it by name,
+  region, or environment (e.g. "the EU project"). Any such reference means THIS
+  project/repository — do NOT look for, or report missing, a differently named
+  project, folder, or repository.
+- The repository is already cloned in your working directory. Edit the
+  appropriate files to satisfy the user's request.
+- The dbt project lives at \`analytics/dbt\` (relative to the repo root, which
+  is your working directory).
+- Do NOT commit, push, or run any git commands — the host handles git.
+
+BEFORE editing a \`schema.yml\` \`type:\` field or modifying SQL that changes a column's emitted type, you MUST read /home/user/.lightdash-skills/shared.md. It contains cross-warehouse type-coercion rules. Skipping this step has produced PRs that broke filters and silently changed query results.
+
+If you made any file changes, perform ALL of these follow-up steps before you
+finish:
+
+1. The dbt project directory (containing \`dbt_project.yml\`) is
+   \`analytics/dbt\`. Use it as the \`--project-dir\`.
+
+2. Discover the profiles directory by locating \`profiles.yml\` (common
+   locations are \`analytics/dbt/profiles/profiles.yml\` or alongside
+   \`dbt_project.yml\` in \`analytics/dbt\`). The directory that contains it
+   is the original profiles directory.
+
+3. Prepare a TEMPORARY profiles directory at \`/tmp/ld-profiles\`:
+   - Copy the discovered \`profiles.yml\` to \`/tmp/ld-profiles/profiles.yml\`.
+   - In the COPY only, replace every Jinja \`env_var(...)\` expression — and
+     any other Jinja expression that requires runtime values — with a literal
+     placeholder string (e.g. \`"placeholder"\`). The goal is a syntactically
+     valid profiles.yml that does not depend on any environment variable.
+   - Do NOT modify the original \`profiles.yml\` in the repo. The host will
+     commit every file change in the working tree, so the original must stay
+     unchanged.
+
+4. From the repo root, run (use this exact wrapper command — it is the only
+   compile command available to you):
+     /tmp/ld-writeback-compile --skip-warehouse-catalog \\
+       --profiles-dir /tmp/ld-profiles \\
+       --project-dir analytics/dbt
+   Capture the exit code and the last meaningful line of output.
+
+5. In your final reply, include ONE line summarising the compile result —
+   for example: "lightdash compile: ok (exit 0)" or
+   "lightdash compile: failed (exit 1) — <short reason from stderr>". Do not
+   paste the full compile output.
+
+6. End your final reply with two structured-output blocks so the host can
+   pick up the PR metadata reliably. The host strips both blocks before
+   showing your reply to the user, so they will not appear in Slack. Emit them
+   verbatim, on their own lines, each opening and closing tag exactly as shown:
+
+   <lightdash-writeback-pr-title>
+   single-line PR title — plain text, no emojis, max 72 characters
+   </lightdash-writeback-pr-title>
+
+   <lightdash-writeback-pr-description>
+   PR description in plain markdown, no emojis
+   </lightdash-writeback-pr-description>
+
+If you did not change any files, skip steps 1–6 entirely and do not emit the
+blocks."
+`;
+
+exports[`buildSystemPrompt — warehouse skill guidance matches the snapshot for a representative warehouse (postgres) 1`] = `
+"You are an autonomous coding agent working inside a checkout of a git repository.
+
+- You are working on the Lightdash project "Jaffle shop", which is
+  backed by the GitHub repository acme/jaffle. This repository — the
+  one already cloned in your working directory — is the ONLY one you act on.
+- The user's request was routed to this project and may refer to it by name,
+  region, or environment (e.g. "the EU project"). Any such reference means THIS
+  project/repository — do NOT look for, or report missing, a differently named
+  project, folder, or repository.
+- The repository is already cloned in your working directory. Edit the
+  appropriate files to satisfy the user's request.
+- The dbt project lives at \`analytics/dbt\` (relative to the repo root, which
+  is your working directory).
+- Do NOT commit, push, or run any git commands — the host handles git.
+
+This Lightdash project's warehouse is **postgres**. BEFORE editing a \`schema.yml\` \`type:\` field or modifying SQL that changes a column's emitted type, you MUST read /home/user/.lightdash-skills/warehouse.md and /home/user/.lightdash-skills/shared.md. They contain warehouse-specific type-coercion rules. Skipping this step has produced PRs that broke filters and silently changed query results.
+
+If you made any file changes, perform ALL of these follow-up steps before you
+finish:
+
+1. The dbt project directory (containing \`dbt_project.yml\`) is
+   \`analytics/dbt\`. Use it as the \`--project-dir\`.
+
+2. Discover the profiles directory by locating \`profiles.yml\` (common
+   locations are \`analytics/dbt/profiles/profiles.yml\` or alongside
+   \`dbt_project.yml\` in \`analytics/dbt\`). The directory that contains it
+   is the original profiles directory.
+
+3. Prepare a TEMPORARY profiles directory at \`/tmp/ld-profiles\`:
+   - Copy the discovered \`profiles.yml\` to \`/tmp/ld-profiles/profiles.yml\`.
+   - In the COPY only, replace every Jinja \`env_var(...)\` expression — and
+     any other Jinja expression that requires runtime values — with a literal
+     placeholder string (e.g. \`"placeholder"\`). The goal is a syntactically
+     valid profiles.yml that does not depend on any environment variable.
+   - Do NOT modify the original \`profiles.yml\` in the repo. The host will
+     commit every file change in the working tree, so the original must stay
+     unchanged.
+
+4. From the repo root, run (use this exact wrapper command — it is the only
+   compile command available to you):
+     /tmp/ld-writeback-compile --skip-warehouse-catalog \\
+       --profiles-dir /tmp/ld-profiles \\
+       --project-dir analytics/dbt
+   Capture the exit code and the last meaningful line of output.
+
+5. In your final reply, include ONE line summarising the compile result —
+   for example: "lightdash compile: ok (exit 0)" or
+   "lightdash compile: failed (exit 1) — <short reason from stderr>". Do not
+   paste the full compile output.
+
+6. End your final reply with two structured-output blocks so the host can
+   pick up the PR metadata reliably. The host strips both blocks before
+   showing your reply to the user, so they will not appear in Slack. Emit them
+   verbatim, on their own lines, each opening and closing tag exactly as shown:
+
+   <lightdash-writeback-pr-title>
+   single-line PR title — plain text, no emojis, max 72 characters
+   </lightdash-writeback-pr-title>
+
+   <lightdash-writeback-pr-description>
+   PR description in plain markdown, no emojis
+   </lightdash-writeback-pr-description>
+
+If you did not change any files, skip steps 1–6 entirely and do not emit the
+blocks."
+`;

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -4,6 +4,14 @@ export const CWD = '/home/user/repo';
 export const PROMPT_PATH = '/tmp/prompt.txt';
 export const SYSTEM_PROMPT_PATH = '/tmp/system_prompt.txt';
 
+// Warehouse-specific guidance the host pushes into the sandbox before the agent
+// runs. Kept OUTSIDE the cloned repo (CWD) so `git add --all` can't sweep them
+// into the PR. The agent reads them on demand — the system prompt points it
+// here before any `type:`/SQL edit that changes a column's emitted type.
+export const SKILLS_DIR = '/home/user/.lightdash-skills';
+export const WAREHOUSE_SKILL_PATH = `${SKILLS_DIR}/warehouse.md`;
+export const SHARED_SKILL_PATH = `${SKILLS_DIR}/shared.md`;
+
 // Files the agent writes for the host to open a PR from. Kept as a fallback
 // — the primary channel is now structured output blocks in the agent's stdout
 // (see PR_TITLE_OPEN/CLOSE etc.).
@@ -84,6 +92,10 @@ export const ALLOWED_TOOLS = [
     `Read(/${TMP_PROFILES_DIR}/**)`,
     `Write(/${TMP_PROFILES_DIR}/**)`,
     `Edit(/${TMP_PROFILES_DIR}/**)`,
+    // Read-only access to the warehouse skill files. Like /tmp below, the
+    // skills dir also has to be passed via `--add-dir` (see runAgentInSandbox)
+    // or Claude Code confines reads to the cwd workspace and refuses these.
+    `Read(/${SKILLS_DIR}/**)`,
     // PR metadata files live directly in /tmp. This permission alone is not
     // enough: Claude Code also confines Write/Edit to the cwd workspace, so
     // /tmp must additionally be passed via `--add-dir /tmp` (see

--- a/packages/backend/src/ee/services/AiWritebackService/skills.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/skills.test.ts
@@ -2,24 +2,6 @@ import { WarehouseTypes } from '@lightdash/common';
 import { loadWarehouseSkills, warehouseTypeToSkillKey } from './skills';
 import type { WarehouseSkillKey } from './types';
 
-// Every skill file must cover these four categories — they are the failure
-// classes behind type-coercion incidents. Headings are asserted verbatim.
-const REQUIRED_CATEGORIES = [
-    'Boolean ↔ integer',
-    'String → number',
-    'Date / timestamp',
-    'Identifier quoting & case',
-];
-
-const ALL_SKILL_KEYS: WarehouseSkillKey[] = [
-    'bigquery',
-    'snowflake',
-    'postgres',
-    'redshift',
-    'databricks',
-    'trino',
-];
-
 describe('warehouseTypeToSkillKey', () => {
     it.each<[WarehouseTypes, WarehouseSkillKey | null]>([
         [WarehouseTypes.BIGQUERY, 'bigquery'],
@@ -50,40 +32,57 @@ describe('warehouseTypeToSkillKey', () => {
     });
 });
 
-describe('warehouse skill files', () => {
-    it('always loads shared.md, with frontmatter and a non-empty body', async () => {
-        const { shared } = await loadWarehouseSkills(null);
-        expect(shared).toMatch(/^---\n[\s\S]*name:\s*warehouse-shared/);
-        expect(shared).toContain('description:');
-        // Body after the closing frontmatter fence is non-empty.
-        const body = shared.split(/^---\s*$/m)[2] ?? '';
-        expect(body.trim().length).toBeGreaterThan(0);
+describe('loadWarehouseSkills', () => {
+    // Inject a fake reader so we test the loading logic — which files it reads
+    // and how it handles a null key — without touching the real filesystem.
+    const fakeReader = (filePath: string) =>
+        Promise.resolve(`body:${filePath}`);
+
+    it('reads shared.md and the dialect file when a skillKey is given', async () => {
+        const reads: string[] = [];
+        const result = await loadWarehouseSkills('trino', (filePath) => {
+            reads.push(filePath);
+            return Promise.resolve(`body:${filePath}`);
+        });
+
+        expect(reads).toHaveLength(2);
+        expect(reads[0]).toMatch(/_shared\.md$/);
+        expect(reads[1]).toMatch(/trino\.md$/);
+        expect(result.shared).toBe(reads[0] && `body:${reads[0]}`);
+        expect(result.warehouse).toBe(reads[1] && `body:${reads[1]}`);
     });
 
-    it('returns no warehouse file for an unknown warehouse', async () => {
-        const { warehouse } = await loadWarehouseSkills(null);
-        expect(warehouse).toBeNull();
+    it('reads only shared.md and returns a null warehouse for a null key', async () => {
+        const reads: string[] = [];
+        const result = await loadWarehouseSkills(null, (filePath) => {
+            reads.push(filePath);
+            return Promise.resolve(`body:${filePath}`);
+        });
+
+        expect(reads).toHaveLength(1);
+        expect(reads[0]).toMatch(/_shared\.md$/);
+        expect(result.warehouse).toBeNull();
     });
 
-    it.each(ALL_SKILL_KEYS)(
-        '%s.md has frontmatter, a non-empty body, and the four required categories',
-        async (skillKey) => {
-            const { warehouse } = await loadWarehouseSkills(skillKey);
-            expect(warehouse).not.toBeNull();
-            const content = warehouse as string;
+    it('propagates a read failure rather than swallowing it', async () => {
+        await expect(
+            loadWarehouseSkills('postgres', () =>
+                Promise.reject(new Error('ENOENT')),
+            ),
+        ).rejects.toThrow('ENOENT');
+    });
 
-            // Frontmatter present with name + description.
-            expect(content).toMatch(/^---\n[\s\S]*name:\s*warehouse-/);
-            expect(content).toContain('description:');
+    it('defaults to the real fs reader when none is injected', async () => {
+        // Smoke check that the shipped files are loadable through the default
+        // path (no fake reader) — guards the src→dist packaging wiring.
+        const { shared, warehouse } = await loadWarehouseSkills('trino');
+        expect(shared.length).toBeGreaterThan(0);
+        expect(warehouse?.length ?? 0).toBeGreaterThan(0);
+    });
 
-            // Non-empty body after frontmatter.
-            const body = content.split(/^---\s*$/m)[2] ?? '';
-            expect(body.trim().length).toBeGreaterThan(0);
-
-            // All four coercion categories are covered.
-            for (const category of REQUIRED_CATEGORIES) {
-                expect(content).toContain(category);
-            }
-        },
-    );
+    it('keeps the fake reader pure (no real disk access)', async () => {
+        const result = await loadWarehouseSkills('bigquery', fakeReader);
+        expect(result.shared.startsWith('body:')).toBe(true);
+        expect(result.warehouse?.startsWith('body:')).toBe(true);
+    });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/skills.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/skills.test.ts
@@ -1,0 +1,89 @@
+import { WarehouseTypes } from '@lightdash/common';
+import { loadWarehouseSkills, warehouseTypeToSkillKey } from './skills';
+import type { WarehouseSkillKey } from './types';
+
+// Every skill file must cover these four categories — they are the failure
+// classes behind type-coercion incidents. Headings are asserted verbatim.
+const REQUIRED_CATEGORIES = [
+    'Boolean ↔ integer',
+    'String → number',
+    'Date / timestamp',
+    'Identifier quoting & case',
+];
+
+const ALL_SKILL_KEYS: WarehouseSkillKey[] = [
+    'bigquery',
+    'snowflake',
+    'postgres',
+    'redshift',
+    'databricks',
+    'trino',
+];
+
+describe('warehouseTypeToSkillKey', () => {
+    it.each<[WarehouseTypes, WarehouseSkillKey | null]>([
+        [WarehouseTypes.BIGQUERY, 'bigquery'],
+        [WarehouseTypes.SNOWFLAKE, 'snowflake'],
+        [WarehouseTypes.POSTGRES, 'postgres'],
+        [WarehouseTypes.REDSHIFT, 'redshift'],
+        [WarehouseTypes.DATABRICKS, 'databricks'],
+        [WarehouseTypes.TRINO, 'trino'],
+        // Athena runs Trino/Presto — shares the trino skill.
+        [WarehouseTypes.ATHENA, 'trino'],
+        // No dedicated file — shared.md only.
+        [WarehouseTypes.CLICKHOUSE, null],
+        [WarehouseTypes.DUCKDB, null],
+    ])('maps %s → %s', (warehouseType, expected) => {
+        expect(warehouseTypeToSkillKey(warehouseType)).toBe(expected);
+    });
+
+    it('maps null (no warehouse connection) to null', () => {
+        expect(warehouseTypeToSkillKey(null)).toBeNull();
+    });
+
+    it('handles every WarehouseTypes member without throwing', () => {
+        // Guards against a new enum member slipping past the mapper. The mapper
+        // uses assertUnreachable, so an unhandled member would throw here.
+        for (const warehouseType of Object.values(WarehouseTypes)) {
+            expect(() => warehouseTypeToSkillKey(warehouseType)).not.toThrow();
+        }
+    });
+});
+
+describe('warehouse skill files', () => {
+    it('always loads shared.md, with frontmatter and a non-empty body', async () => {
+        const { shared } = await loadWarehouseSkills(null);
+        expect(shared).toMatch(/^---\n[\s\S]*name:\s*warehouse-shared/);
+        expect(shared).toContain('description:');
+        // Body after the closing frontmatter fence is non-empty.
+        const body = shared.split(/^---\s*$/m)[2] ?? '';
+        expect(body.trim().length).toBeGreaterThan(0);
+    });
+
+    it('returns no warehouse file for an unknown warehouse', async () => {
+        const { warehouse } = await loadWarehouseSkills(null);
+        expect(warehouse).toBeNull();
+    });
+
+    it.each(ALL_SKILL_KEYS)(
+        '%s.md has frontmatter, a non-empty body, and the four required categories',
+        async (skillKey) => {
+            const { warehouse } = await loadWarehouseSkills(skillKey);
+            expect(warehouse).not.toBeNull();
+            const content = warehouse as string;
+
+            // Frontmatter present with name + description.
+            expect(content).toMatch(/^---\n[\s\S]*name:\s*warehouse-/);
+            expect(content).toContain('description:');
+
+            // Non-empty body after frontmatter.
+            const body = content.split(/^---\s*$/m)[2] ?? '';
+            expect(body.trim().length).toBeGreaterThan(0);
+
+            // All four coercion categories are covered.
+            for (const category of REQUIRED_CATEGORIES) {
+                expect(content).toContain(category);
+            }
+        },
+    );
+});

--- a/packages/backend/src/ee/services/AiWritebackService/skills.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/skills.ts
@@ -65,15 +65,19 @@ export type LoadedSkills = {
  */
 export const loadWarehouseSkills = async (
     skillKey: WarehouseSkillKey | null,
+    readFileFn: (
+        filePath: string,
+        encoding: BufferEncoding,
+    ) => Promise<string> = readFile,
 ): Promise<LoadedSkills> => {
-    const shared = await readFile(
+    const shared = await readFileFn(
         path.join(SKILLS_SOURCE_DIR, SHARED_SKILL_FILE),
         'utf8',
     );
     const warehouse =
         skillKey === null
             ? null
-            : await readFile(
+            : await readFileFn(
                   path.join(SKILLS_SOURCE_DIR, `${skillKey}.md`),
                   'utf8',
               );

--- a/packages/backend/src/ee/services/AiWritebackService/skills.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/skills.ts
@@ -1,0 +1,81 @@
+import { assertUnreachable, WarehouseTypes } from '@lightdash/common';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import type { WarehouseSkillKey } from './types';
+
+// Directory holding the committed skill markdown. Resolved relative to this
+// module so it works in dev (ts-node/tsx → src/) and prod (the backend
+// `postbuild` copies `src/**/*.md` into dist/, so the files sit next to the
+// compiled JS).
+export const SKILLS_SOURCE_DIR = path.join(__dirname, 'skills', 'warehouses');
+
+export const SHARED_SKILL_FILE = '_shared.md';
+
+/**
+ * Collapse a `WarehouseTypes` onto the canonical skill key whose file we ship.
+ * Several types share one file (`athena` runs Trino/Presto). Warehouses with no
+ * dedicated file return `null` and the agent gets `shared.md` only.
+ */
+export const warehouseTypeToSkillKey = (
+    warehouseType: WarehouseTypes | null,
+): WarehouseSkillKey | null => {
+    if (warehouseType === null) {
+        return null;
+    }
+    switch (warehouseType) {
+        case WarehouseTypes.BIGQUERY:
+            return 'bigquery';
+        case WarehouseTypes.SNOWFLAKE:
+            return 'snowflake';
+        case WarehouseTypes.POSTGRES:
+            return 'postgres';
+        case WarehouseTypes.REDSHIFT:
+            return 'redshift';
+        case WarehouseTypes.DATABRICKS:
+            return 'databricks';
+        case WarehouseTypes.TRINO:
+            return 'trino';
+        case WarehouseTypes.ATHENA:
+            // Athena is Trino/Presto under the hood — same coercion rules.
+            return 'trino';
+        case WarehouseTypes.CLICKHOUSE:
+        case WarehouseTypes.DUCKDB:
+            // No dedicated skill file yet — fall back to shared.md only.
+            return null;
+        default:
+            return assertUnreachable(
+                warehouseType,
+                `Unhandled warehouse type for skill mapping: ${warehouseType}`,
+            );
+    }
+};
+
+export type LoadedSkills = {
+    /** Always present — the dialect-agnostic `_shared.md` body. */
+    shared: string;
+    /** The dialect-specific body, or `null` for warehouses with no file. */
+    warehouse: string | null;
+};
+
+/**
+ * Read the skill markdown off disk. `shared.md` always; the warehouse file only
+ * when `skillKey` resolves to one. Throws if a required file is missing — a
+ * shipped skill file going absent is a build/packaging bug, not a runtime
+ * condition to swallow.
+ */
+export const loadWarehouseSkills = async (
+    skillKey: WarehouseSkillKey | null,
+): Promise<LoadedSkills> => {
+    const shared = await readFile(
+        path.join(SKILLS_SOURCE_DIR, SHARED_SKILL_FILE),
+        'utf8',
+    );
+    const warehouse =
+        skillKey === null
+            ? null
+            : await readFile(
+                  path.join(SKILLS_SOURCE_DIR, `${skillKey}.md`),
+                  'utf8',
+              );
+    return { shared, warehouse };
+};

--- a/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/README.md
+++ b/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/README.md
@@ -1,0 +1,47 @@
+# Warehouse skills for the AI Writeback agent
+
+These markdown files give the writeback agent warehouse-aware guidance about
+type-coercion behaviour. At run time `AiWritebackService` copies two files into
+the sandbox at `/home/user/.lightdash-skills/`:
+
+- `shared.md` — always (sourced from `_shared.md` here)
+- `warehouse.md` — the file matching the project's warehouse dialect
+
+The agent is told (via the system prompt) to read both before editing a
+`schema.yml` `type:` field or any SQL that changes a column's emitted type.
+
+## File contract
+
+Each `<warehouse>.md` must have YAML frontmatter (`name`, `description`) and a
+body that covers the four categories the smoke test asserts on:
+
+- **Boolean ↔ integer**
+- **String → number**
+- **Date / timestamp**
+- **Identifier quoting & case**
+
+`_shared.md` is dialect-agnostic and always loaded.
+
+## Warehouse → file mapping
+
+| `WarehouseTypes`                | skill file              |
+| ------------------------------- | ----------------------- |
+| `trino`, `athena`               | `trino.md`              |
+| `snowflake`                     | `snowflake.md`          |
+| `bigquery`                      | `bigquery.md`           |
+| `databricks`                    | `databricks.md`         |
+| `redshift`                      | `redshift.md`           |
+| `postgres`                      | `postgres.md`           |
+| `clickhouse`, `duckdb`, unknown | none — `shared.md` only |
+
+## Build note
+
+These `.md` files are shipped to `dist/` by the backend `postbuild` step
+(`copyfiles ... 'src/**/*.md' dist`). No separate sync mechanism is needed —
+do not move them outside `src/`.
+
+## Maintenance
+
+⚠️ **Quarterly review TODO:** warehouse dialects change (ANSI defaults, new
+timestamp types, coercion rules). Re-check each file's claims and source links
+against current vendor docs every quarter. Skill versioning is via git history.

--- a/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/_shared.md
+++ b/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/_shared.md
@@ -1,0 +1,31 @@
+---
+name: warehouse-shared
+description: Cross-warehouse rules that apply regardless of dialect. Always loaded.
+---
+
+# Cross-warehouse rules
+
+## NULL semantics (three-valued logic)
+
+- All six warehouses: `NULL = NULL → UNKNOWN`, `NULL IN (1, 2, NULL) → UNKNOWN`. UNKNOWN rows are excluded from `WHERE` results.
+- Source: https://modern-sql.com/concept/null
+- **Agent rule:** when changing `type:` of a nullable column, warn — three-valued logic silently drops rows in WHERE predicates after the edit. Row counts can change with no error.
+
+## dbt `data_type:` is descriptive only
+
+- The `data_type:` field in `schema.yml` is **metadata**, not a coercion directive — unless inside `contract: enforced: true`.
+- Outside contracts, dbt does NOT coerce the column. It records what the YAML claims, and downstream tools (Lightdash) read that as truth.
+- Source: https://docs.getdbt.com/reference/resource-configs/contract
+- **Agent rule:** editing `type:` does not change the warehouse column. The SQL Lightdash generates is the only place a wrong `type:` surfaces. Always check the column's actual warehouse type before flipping `type:`.
+
+## Portable boolean filters
+
+- **Never emit `WHERE int_col = TRUE`** — works on Snowflake/Redshift (wrong semantics) and errors on Trino/BigQuery/Postgres/Databricks-ANSI.
+- **Portable pattern:** `WHERE int_col <> 0` or `WHERE CAST(int_col AS BOOLEAN)`.
+
+## Skill order of operations
+
+1. If asked to change a dimension's `type:` from numeric → boolean (or vice versa), first read the warehouse-specific skill for the project's dialect.
+2. Check the warehouse column's actual type before applying the edit.
+3. If types disagree, do not silently flip the YAML — either rewrite the SQL expression to match the new type, or surface the mismatch to the user.
+4. Emit portable SQL patterns where possible (rule above).

--- a/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/bigquery.md
+++ b/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/bigquery.md
@@ -1,0 +1,36 @@
+---
+name: warehouse-bigquery
+description: Type-coercion quirks for BigQuery. Read before editing `schema.yml` `type:` or SQL that touches a column's emitted type.
+---
+
+# BigQuery
+
+BigQuery is strict like Trino on most coercions — wrong type edits produce hard runtime errors, not silent miscount.
+
+## Boolean ↔ integer
+
+- Explicit `CAST` only — `CAST(1 AS BOOL)` → TRUE. Implicit comparison `int_col = TRUE` is rejected with "No matching signature for operator =".
+- Source: https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_rules
+- **Right:** `WHERE int_col <> 0` or `WHERE CAST(int_col AS BOOL)`
+- **Wrong:** `WHERE int_col = TRUE`
+- **Agent rule:** treat like Trino — never flip `type:` without also fixing the SQL expression.
+
+## String → number
+
+- No implicit string ↔ number. Use `SAFE_CAST(s AS INT64)` which returns NULL on failure (vs `CAST` which errors).
+- Source: https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_functions
+
+## Date / timestamp
+
+- `DATE`, `DATETIME`, `TIMESTAMP` (UTC instant), `TIME` are distinct. **No implicit coercion between `DATE` and `TIMESTAMP`** — `WHERE date_col = CURRENT_TIMESTAMP()` errors.
+- **Right:** `DATE(timestamp_col)` or `TIMESTAMP(date_col)`.
+- Source: https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_rules
+
+## Identifier quoting & case
+
+- Backticks. Project/dataset/table names in FROM are case-sensitive; column names case-insensitive for resolution but case-preserved. Duplicate columns differing only in case are not allowed.
+- Source: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical
+
+## Notable gotcha
+
+- Literal vs column coercion is asymmetric — BigQuery will coerce a literal to match a column's type but won't freely coerce two columns to a common type.

--- a/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/databricks.md
+++ b/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/databricks.md
@@ -1,0 +1,34 @@
+---
+name: warehouse-databricks
+description: Type-coercion quirks for Databricks (Spark SQL / Photon). ANSI mode is the deciding factor. Read before editing `schema.yml` `type:` or SQL that touches a column's emitted type.
+---
+
+# Databricks (Spark SQL / Photon)
+
+**Behaviour depends on `spark.sql.ansi.enabled`.** ANSI is **on** by default in DBR 17+ and Spark 4+. The same edit can produce a hard error on a DBR 17 cluster and silent wrong results on a DBR 13 cluster — treat all results as **environment-dependent**.
+
+## Boolean ↔ integer
+
+- **ANSI on (DBR 17+):** implicit bool ↔ numeric disallowed, errors at runtime.
+- **ANSI off (legacy policy):** loose CAST works, `int_col = TRUE` succeeds with non-zero → TRUE (silent miscount risk).
+- Source: https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-ansi-compliance
+- **Agent rule:** prefer explicit CAST regardless of detected ANSI mode — the cluster's ANSI setting may change between runs.
+
+## String → number
+
+- ANSI on: implicit in function context, errors in comparisons.
+- ANSI off: tolerant.
+
+## Date / timestamp
+
+- `TIMESTAMP` is wall-clock with session timezone; `TIMESTAMP_NTZ` available since DBR 13.3.
+- DATE ↔ TIMESTAMP implicit cast works (DATE → TIMESTAMP at midnight in session zone).
+
+## Identifier quoting & case
+
+- Backticks. Identifiers are case-insensitive for resolution. Unity Catalog **preserves** the original case.
+- Source: https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-identifiers
+
+## Notable gotcha
+
+- Community report: "dangerous implicit type conversions on 17.3 LTS" — real-world regressions exist between runtime versions: https://community.databricks.com/t5/data-engineering/dangerous-implicit-type-conversions-on-17-3-lts/td-p/141575

--- a/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/postgres.md
+++ b/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/postgres.md
@@ -1,0 +1,35 @@
+---
+name: warehouse-postgres
+description: Type-coercion quirks for Postgres. Read before editing `schema.yml` `type:` or SQL that touches a column's emitted type.
+---
+
+# Postgres
+
+Postgres deliberately does NOT mark int↔bool as implicit, to avoid surprising query plans. Wrong type edits fail loudly — behaves like Trino in spirit.
+
+## Boolean ↔ integer
+
+- **No implicit coercion.** `int_col = TRUE` → `operator does not exist: integer = boolean`. Explicit `::boolean` works (`1::boolean → true`).
+- `WHERE bool_col` works without a comparator.
+- Source: https://www.postgresql.org/docs/current/typeconv.html
+- **Right:** `WHERE bool_col` or `WHERE int_col::boolean`
+- **Wrong:** `WHERE int_col = TRUE`
+
+## String → number
+
+- No implicit `text` ↔ numeric. A real text column compared to a number — `text_col = 1` — errors with `operator does not exist: text = integer`. Use `CAST` / `::int`.
+- **Gotcha:** a bare quoted literal `'1' = 1` does NOT error. Postgres types the literal as `unknown` and operator resolution coerces it to `integer`. The risk is typed text columns, not literals.
+
+## Date / timestamp
+
+- `TIMESTAMP` vs `TIMESTAMPTZ` are distinct; comparisons implicitly cast through session timezone (can shift values silently).
+- `CURRENT_DATE` (DATE) vs `CURRENT_TIMESTAMP` (TIMESTAMPTZ).
+
+## Identifier quoting & case
+
+- Double quotes; unquoted identifiers fold to **lowercase** (opposite of Snowflake's UPPERCASE). Quoted identifiers are case-sensitive.
+
+## Notable gotcha
+
+- `LIKE` is case-sensitive; `ILIKE` is case-insensitive (Postgres-specific). Don't emit `ILIKE` for non-Postgres warehouses.
+- Source: https://www.postgresql.org/docs/current/functions-matching.html

--- a/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/redshift.md
+++ b/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/redshift.md
@@ -1,0 +1,36 @@
+---
+name: warehouse-redshift
+description: Type-coercion quirks for Redshift. Read before editing `schema.yml` `type:` or SQL that touches a column's emitted type.
+---
+
+# Redshift
+
+Redshift documents implicit boolean ↔ integer coercion. This means wrong type edits produce **silent wrong results** (matches non-zero), not hard errors.
+
+## Boolean ↔ integer
+
+- Implicit: non-zero → TRUE, 0 → FALSE, NULL → UNKNOWN. `WHERE bool_col = 1`, `= TRUE`, `= 't'` all work.
+- Source: https://docs.aws.amazon.com/redshift/latest/dg/r_Boolean_type.html
+- **Right (preserve integer semantics):** keep `type: integer` and let users filter `= 1`
+- **Wrong:** flip `type: boolean` on an integer 0/1/2 column — `= TRUE` silently matches all non-zero
+- **Agent rule:** same as Snowflake — verify underlying column type before flipping `type:`.
+
+## String → number
+
+- Implicit conversion allowed where loss-of-precision-free; otherwise use CAST.
+- Source: https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
+
+## Date / timestamp
+
+- `TIMESTAMP` (NTZ) and `TIMESTAMPTZ` are distinct; implicit coercion exists but timezone math follows the inherited PostgreSQL behaviour.
+
+## Identifier quoting & case
+
+- Double quotes. Default is **case-insensitive, lowercase-folded**. Set `enable_case_sensitive_identifier = true` (cluster or session) to preserve case inside quotes.
+- Source: https://docs.aws.amazon.com/redshift/latest/dg/r_enable_case_sensitive_identifier.html
+- **Agent rule:** if the customer's cluster does not have this setting on, quoting mixed-case identifiers will silently lowercase them.
+
+## Notable gotcha
+
+- Boolean columns render as `t`/`f`. Boolean string literals are NOT case-sensitive — `'true'`, `'TRUE'`, `'t'`, and `TRUE` are all documented valid literals and all work.
+- Source: https://docs.aws.amazon.com/redshift/latest/dg/r_Boolean_type.html

--- a/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/snowflake.md
+++ b/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/snowflake.md
@@ -1,0 +1,37 @@
+---
+name: warehouse-snowflake
+description: Type-coercion quirks for Snowflake. Read before editing `schema.yml` `type:` or SQL that touches a column's emitted type.
+---
+
+# Snowflake
+
+Snowflake silently coerces between many types. This is _worse_ than a hard error: wrong edits produce wrong row counts with no log signal.
+
+## Boolean ↔ integer
+
+- **Integer → boolean is implicit** (boolean → numeric is explicit only). `0 → FALSE`, any non-zero → `TRUE`. `WHERE int_col = TRUE` succeeds and matches every non-zero row (including 2, 3, -1).
+- Source: https://docs.snowflake.com/en/sql-reference/data-type-conversion
+- **Right (intent: "the flag column"):** keep `type: boolean` only if the column is actually BOOLEAN; otherwise leave as integer and let users filter `= 1`
+- **Wrong (silent semantic break):** flip `type: boolean` on an integer 0/1/2/3 column — `= TRUE` now matches 2 and 3 too
+- **Agent rule:** before changing `type:` numeric → boolean, verify the warehouse column is BOOLEAN. If it's integer, refuse the edit and surface the silent-miscount risk to the user.
+
+## String → number
+
+- Implicit planner cast — convenient but errors at runtime if any non-numeric string sneaks in. Prefer `TRY_CAST` in generated SQL.
+- Source: https://docs.snowflake.com/en/sql-reference/functions/cast
+
+## Date / timestamp
+
+- Three flavours: `TIMESTAMP_NTZ` (default), `TIMESTAMP_LTZ`, `TIMESTAMP_TZ`. **`TIMESTAMP_TZ` stores offset, not zone**, so DST math is wrong.
+- Cross-flavour comparisons are allowed but semantics vary. Preserve the original flavour exactly.
+- Source: https://docs.snowflake.com/en/sql-reference/data-types-datetime
+
+## Identifier quoting & case
+
+- Unquoted identifiers folded to **UPPERCASE**. Double-quoted identifiers are case-preserving and case-sensitive (unless `QUOTED_IDENTIFIERS_IGNORE_CASE`).
+- **Agent rule:** if quoting a previously-unquoted identifier, UPPERCASE it inside the quotes.
+- Source: https://docs.snowflake.com/en/sql-reference/identifiers-syntax
+
+## Notable gotcha
+
+- Implicit cast added by the join planner is invisible in the SQL but appears in the query profile. Avoid `varchar = number` join keys.

--- a/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/trino.md
+++ b/packages/backend/src/ee/services/AiWritebackService/skills/warehouses/trino.md
@@ -1,0 +1,37 @@
+---
+name: warehouse-trino
+description: Type-coercion quirks for Trino / Presto (incl. Athena, Starburst). Read before editing `schema.yml` `type:` or SQL that touches a column's emitted type.
+---
+
+# Trino / Presto / Athena / Starburst
+
+Trino is the **strictest** dialect on this list — it refuses implicit cross-family coercions on `=`, `<`, `BETWEEN`, `IN`. Wrong type edits fail loudly with `TYPE_MISMATCH`. This is the warehouse where the incident that motivated these skills happened.
+
+## Boolean ↔ integer
+
+- **No implicit coercion.** `WHERE int_col = TRUE` → `TYPE_MISMATCH: Cannot apply operator: integer = boolean`.
+- Source: https://trino.io/docs/current/functions/comparison.html
+- **Right:** `WHERE int_col <> 0` or `WHERE CAST(int_col AS BOOLEAN)`
+- **Wrong:** `WHERE int_col = TRUE`
+- **Agent rule:** before changing `type:` numeric → boolean on a column whose dbt SQL emits an integer, also rewrite the SQL expression to emit boolean (`sql: CAST(...)` or `sql: ... = 1`).
+
+## String → number
+
+- No implicit string ↔ numeric. `'1' = 1` errors.
+- Source: https://trino.io/docs/current/functions/conversion.html
+- **Right:** `CAST('1' AS INTEGER)` or `TRY(CAST('1' AS INTEGER))` for safe nullable casts.
+
+## Date / timestamp
+
+- `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE` are distinct types.
+- `DATE = TIMESTAMP` is implicitly coerced (DATE → TIMESTAMP at midnight) but timezone semantics differ.
+- Source: https://trino.io/docs/current/functions/datetime.html
+
+## Identifier quoting & case
+
+- Double quotes. Identifiers are case-insensitive in standard Trino — Trino lowercases them. The Iceberg connector has documented case-sensitivity issues with mixed-case names created by other engines (it does not cleanly preserve case at the query layer).
+- Source: https://trino.io/docs/current/language/reserved.html
+
+## Notable gotcha
+
+- Athena lags upstream Trino. If the project is on Athena, prefer the safer (more explicit CAST) pattern.

--- a/packages/backend/src/ee/services/AiWritebackService/templates.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.test.ts
@@ -1,0 +1,55 @@
+import { WarehouseTypes } from '@lightdash/common';
+import { SHARED_SKILL_PATH, WAREHOUSE_SKILL_PATH } from './constants';
+import { warehouseTypeToSkillKey } from './skills';
+import { buildSystemPrompt } from './templates';
+
+const DBT_PROJECT_DIR = 'analytics/dbt';
+const BASE_CONTEXT = {
+    projectName: 'Jaffle shop',
+    repository: 'acme/jaffle',
+    repoContext: null,
+};
+
+const buildFor = (warehouseType: WarehouseTypes | null) =>
+    buildSystemPrompt(DBT_PROJECT_DIR, {
+        ...BASE_CONTEXT,
+        warehouseType,
+        hasWarehouseSkill: warehouseTypeToSkillKey(warehouseType) !== null,
+    });
+
+describe('buildSystemPrompt — warehouse skill guidance', () => {
+    it('names the warehouse and points at both skill files when a file exists', () => {
+        const prompt = buildFor(WarehouseTypes.SNOWFLAKE);
+        expect(prompt).toContain('warehouse is **snowflake**');
+        expect(prompt).toContain(WAREHOUSE_SKILL_PATH);
+        expect(prompt).toContain(SHARED_SKILL_PATH);
+        expect(prompt).toMatch(/BEFORE editing a `schema.yml` `type:` field/);
+    });
+
+    it('maps athena onto the trino skill (still references the warehouse file)', () => {
+        const prompt = buildFor(WarehouseTypes.ATHENA);
+        expect(prompt).toContain('warehouse is **athena**');
+        expect(prompt).toContain(WAREHOUSE_SKILL_PATH);
+    });
+
+    it('references only shared.md for a warehouse with no dedicated file', () => {
+        const prompt = buildFor(WarehouseTypes.CLICKHOUSE);
+        expect(prompt).toContain(SHARED_SKILL_PATH);
+        expect(prompt).not.toContain(WAREHOUSE_SKILL_PATH);
+        expect(prompt).toMatch(/BEFORE editing a `schema.yml` `type:` field/);
+    });
+
+    it('references only shared.md when there is no warehouse connection', () => {
+        const prompt = buildFor(null);
+        expect(prompt).toContain(SHARED_SKILL_PATH);
+        expect(prompt).not.toContain(WAREHOUSE_SKILL_PATH);
+    });
+
+    it('matches the snapshot for a representative warehouse (postgres)', () => {
+        expect(buildFor(WarehouseTypes.POSTGRES)).toMatchSnapshot();
+    });
+
+    it('matches the snapshot for a no-skill warehouse (duckdb)', () => {
+        expect(buildFor(WarehouseTypes.DUCKDB)).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -1,11 +1,36 @@
+import type { WarehouseTypes } from '@lightdash/common';
 import {
     COMPILE_WRAPPER_PATH,
     PR_DESCRIPTION_CLOSE,
     PR_DESCRIPTION_OPEN,
     PR_TITLE_CLOSE,
     PR_TITLE_OPEN,
+    SHARED_SKILL_PATH,
     TMP_PROFILES_DIR,
+    WAREHOUSE_SKILL_PATH,
 } from './constants';
+
+// Warehouse-aware guidance injected mid-prompt. Points the agent at the skill
+// files before any edit that changes a column's emitted type — the class of
+// edit behind type-coercion incidents (e.g. flipping a numeric `type:` to
+// boolean without checking the warehouse column's real type).
+const buildWarehouseSkillGuidance = (
+    warehouseType: WarehouseTypes | null,
+    hasWarehouseSkill: boolean,
+): string => {
+    const trigger =
+        'BEFORE editing a `schema.yml` `type:` field or modifying SQL that ' +
+        "changes a column's emitted type, you MUST read";
+    const consequence =
+        'Skipping this step has produced PRs that broke filters and silently ' +
+        'changed query results.';
+    if (hasWarehouseSkill && warehouseType) {
+        return `This Lightdash project's warehouse is **${warehouseType}**. ${trigger} ${WAREHOUSE_SKILL_PATH} and ${SHARED_SKILL_PATH}. They contain warehouse-specific type-coercion rules. ${consequence}`;
+    }
+    // No dedicated skill file for this warehouse (or none connected) — the
+    // agent still gets the cross-warehouse rules.
+    return `${trigger} ${SHARED_SKILL_PATH}. It contains cross-warehouse type-coercion rules. ${consequence}`;
+};
 
 // Instructions prepended to every user prompt. The host owns git, so the agent
 // must not touch it; instead it leaves the PR title/description on disk.
@@ -30,6 +55,8 @@ export const buildSystemPrompt = (
         projectName: string;
         repository: string;
         repoContext: string | null;
+        warehouseType: WarehouseTypes | null;
+        hasWarehouseSkill: boolean;
     },
 ): string =>
     `
@@ -47,6 +74,8 @@ You are an autonomous coding agent working inside a checkout of a git repository
 - The dbt project lives at \`${dbtProjectDir}\` (relative to the repo root, which
   is your working directory).
 - Do NOT commit, push, or run any git commands — the host handles git.
+
+${buildWarehouseSkillGuidance(context.warehouseType, context.hasWarehouseSkill)}
 ${
     context.repoContext
         ? `

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -1,6 +1,20 @@
-import type { SessionUser } from '@lightdash/common';
+import type { SessionUser, WarehouseTypes } from '@lightdash/common';
 import type { AiWritebackFailureStage } from '../../../analytics/LightdashAnalytics';
 import type { DbAiWritebackThread } from '../../database/entities/ai';
+
+/**
+ * The canonical warehouse keys we ship a skill file for. Several
+ * `WarehouseTypes` map onto one key (e.g. `athena` → `trino`); warehouses with
+ * no dedicated file (`clickhouse`, `duckdb`) resolve to `null` and the agent
+ * gets `shared.md` only. Matches the filenames under `skills/warehouses/`.
+ */
+export type WarehouseSkillKey =
+    | 'bigquery'
+    | 'snowflake'
+    | 'postgres'
+    | 'redshift'
+    | 'databricks'
+    | 'trino';
 
 export type GithubConnection = {
     owner: string;
@@ -21,6 +35,12 @@ export type TurnContext = {
     githubConnection: GithubConnection;
     existingRow: DbAiWritebackThread | null;
     isResume: boolean;
+    /**
+     * The project's warehouse dialect, used to pick the warehouse skill file
+     * and stamped on every `ai_writeback.run.*` event for failure-rate-by-
+     * warehouse slicing. `null` when the project has no warehouse connection.
+     */
+    warehouseType: WarehouseTypes | null;
 };
 
 export type AppliedChanges = {


### PR DESCRIPTION
## What & why

The AI writeback agent could change a `schema.yml` `type:` field (e.g. numeric → boolean) without accounting for how the project's warehouse coerces types. The dialects fail in two opposite ways:

- **Strict** (Trino, BigQuery, Postgres): hard `TYPE_MISMATCH` at query time.
- **Silent-coerce** (Snowflake, Redshift): no error, but `= TRUE` matches every non-zero row → wrong counts with no log signal.

Both have shipped as PRs that broke filters. This adds warehouse-specific guidance the agent loads on demand at edit time.

## How

- **Skill files** committed under `AiWritebackService/skills/warehouses/` — one per dialect (`trino`, `snowflake`, `bigquery`, `databricks`, `redshift`, `postgres`) plus an always-loaded `_shared.md`. The existing backend `postbuild` `*.md` glob already ships them to `dist`, so there's **no new sync mechanism**.
- **Warehouse resolution**: `prepareTurn` reads the project's `WarehouseTypes` and maps it onto the canonical skill key (`athena` → `trino`; `clickhouse`/`duckdb` → shared-only).
- **Sandbox push**: `warehouse.md` + `shared.md` are written to `/home/user/.lightdash-skills/` (outside the cloned repo so `git add --all` can't sweep them into the PR), and the system prompt points the agent at them before any type/SQL edit.
- **Read access**: granted via `Read(...)` in `ALLOWED_TOOLS` **and** an `--add-dir` for the skills dir — Claude Code otherwise confines reads to the cwd workspace and refuses them (same constraint the existing `/tmp` dir already handles).
- **Telemetry**: `warehouseType` is stamped on the `ai_writeback.run.started/completed/failed/summary` events for failure-rate-by-warehouse slicing.

Gated by the existing `ai-writeback` feature flag — no new gate. Unknown warehouses fall back to `shared.md` only.

## Tests

- Skill-file contract: frontmatter + non-empty body + the four required coercion categories per file.
- `warehouseType` → skill-key mapping, exhaustive over `WarehouseTypes` (guards against a new enum member slipping past the mapper).
- Merged system-prompt snapshots (with-skill and shared-only variants).
- All 25 unit/snapshot tests pass.

### Fact-check of skill content

Every dialect's claims were checked against vendor docs. Four corrections were made as a result (see commits): Postgres `'1' = 1` does *not* error (unknown-type literal is coerced; only typed `text` columns error); Redshift boolean string literals are not case-sensitive; Trino's Iceberg connector has case-sensitivity *collisions* rather than clean preservation; Snowflake int→bool is implicit but bool→numeric is explicit.

### Behavioural reproduction (the reported incident)

Reproduced the exact reported failure with the **real** Claude Code agent against a tiny dbt repo: a `triage_flag` 0/1 column modelled as `type: string`, on a Trino project, using the **exact** system prompt + skill files the service builds. Same model (`claude-sonnet-4-6`), same prompt — the **only** variable between groups is the skill.

| | 🔴 BROKEN (flips `type:` only, SQL still emits int → `TYPE_MISMATCH`) | 🟢 FIXED (type **and** SQL emit a real boolean) |
|---|---|---|
| **Before** (no skill) | **5 / 6** | 1 / 6 |
| **After** (Trino skill) | **0 / 6** | **6 / 6** |

In every "after" run the agent read `warehouse.md` + `shared.md` and rewrote the SQL (`then 1 else 0` → `then true else false`, or a boolean predicate) alongside the type change. The "broken" runs reproduce the customer's `TYPE_MISMATCH: Cannot apply operator: integer = boolean` exactly.

Notes on rigour: the base model already self-corrects occasionally (1/6 before), so this takes the failure rate from ~83% → 0% on n=6 — directionally decisive, not a large sample. The harness runs the real agent but compiles with `--skip-warehouse-catalog`, so it asserts on the code shape that causes the runtime error rather than the live error itself.

## Out of scope (follow-ups)

- Auto-running `lightdash validate` against a preview before opening the PR (defence-in-depth, recommended pairing for silent-coerce warehouses).
- Dynamic / customer-specific skill overrides; skill versioning (git history for now). A quarterly-review note lives in the skills dir README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
