### PR TITLE
feat(ai-agents): scroll to and highlight dashboard tile after AI creates or updates chart

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
@@ -26,6 +26,7 @@ import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types'
 import MantineIcon from '../MantineIcon';
 import { PolymorphicGroupButton } from '../PolymorphicGroupButton';
 import classes from './PreAggregateAuditIndicator.module.css';
+import { scrollToDashboardTile } from './scrollToDashboardTile';
 
 const NONE_KEY = 'none';
 
@@ -45,24 +46,6 @@ type TabGroup = {
     misses: TilePreAggregateStatus[];
     ineligible: TilePreAggregateStatus[];
 };
-
-function scrollToTile(tileUuid: string) {
-    const el = document.querySelector<HTMLElement>(
-        `[data-tile-uuid="${tileUuid}"]`,
-    );
-    if (!el) return;
-
-    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    el.style.borderRadius = 'var(--mantine-radius-md)';
-    el.animate(
-        [
-            { boxShadow: '0 0 0 0px transparent' },
-            { boxShadow: '0 0 0 2px var(--mantine-color-indigo-4)' },
-            { boxShadow: '0 0 0 0px transparent' },
-        ],
-        { duration: 1200, easing: 'ease-in-out' },
-    );
-}
 
 function TileDetail({ tile }: { tile: TilePreAggregateStatus }) {
     if (tile.hit && tile.preAggregateName) {
@@ -303,7 +286,7 @@ export function PreAggregateAuditDrawer({
     );
 
     const handleTileClick = useCallback((uuid: string) => {
-        scrollToTile(uuid);
+        scrollToDashboardTile(uuid);
     }, []);
 
     return (

--- a/packages/frontend/src/components/common/Dashboard/scrollToDashboardTile.ts
+++ b/packages/frontend/src/components/common/Dashboard/scrollToDashboardTile.ts
@@ -1,0 +1,23 @@
+export function scrollToDashboardTile(tileUuid: string) {
+    const el = document.querySelector<HTMLElement>(
+        `[data-tile-uuid="${tileUuid}"]`,
+    );
+    if (!el) return;
+
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.style.borderRadius = 'var(--mantine-radius-md)';
+    el.animate(
+        [
+            { boxShadow: '0 0 0 0px transparent' },
+            {
+                boxShadow: [
+                    '0 0 0 1px var(--mantine-color-indigo-3)',
+                    '0 0 24px -8px var(--mantine-color-indigo-5)',
+                    '0 0 0 4px color-mix(in srgb, var(--mantine-color-indigo-5) 10%, transparent)',
+                ].join(', '),
+            },
+            { boxShadow: '0 0 0 0px transparent' },
+        ],
+        { duration: 1200, easing: 'ease-in-out' },
+    );
+}

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -1,4 +1,5 @@
 import {
+    type Dashboard,
     type DashboardChartTile,
     type DashboardFilters,
     type DashboardTile,
@@ -7,6 +8,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useParams } from 'react-router';
+import { scrollToDashboardTile } from '../../components/common/Dashboard/scrollToDashboardTile';
 import { useAiAgentStoreSelector } from '../../ee/features/aiCopilot/store/hooks';
 import { getDashboard } from '../../hooks/dashboard/useDashboard';
 import { getSavedQuery } from '../../hooks/useSavedQuery';
@@ -27,7 +29,9 @@ const DashboardAiAgentContextBridge = () => {
     const dashboard = useDashboardContext((c) => c.dashboard);
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
+    const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
+    const setActiveTab = useDashboardContext((c) => c.setActiveTab);
     const setDashboardFilters = useDashboardContext(
         (c) => c.setDashboardFilters,
     );
@@ -48,11 +52,33 @@ const DashboardAiAgentContextBridge = () => {
     );
 
     const handledToolCallIdsRef = useRef<Set<string>>(new Set());
+    const pendingChartSlugToFocusRef = useRef<string | null>(null);
+    const focusRequestIdRef = useRef(0);
 
     const currentDashboardSlug = dashboard?.slug;
     const dashboardQueryKey = useMemo(
         () => ['saved_dashboard_query', dashboardUuid, projectUuid],
         [dashboardUuid, projectUuid],
+    );
+
+    const scrollToChartTile = useCallback(
+        (tile: DashboardChartTile, tabs: Dashboard['tabs']) => {
+            const focusRequestId = (focusRequestIdRef.current += 1);
+            const tab = tile.tabUuid
+                ? tabs.find(
+                      (dashboardTab) => dashboardTab.uuid === tile.tabUuid,
+                  )
+                : undefined;
+            if (tab) setActiveTab(tab);
+
+            window.requestAnimationFrame(() => {
+                window.requestAnimationFrame(() => {
+                    if (focusRequestId !== focusRequestIdRef.current) return;
+                    scrollToDashboardTile(tile.uuid);
+                });
+            });
+        },
+        [setActiveTab],
     );
 
     const successfulContentResults = useMemo(
@@ -70,7 +96,11 @@ const DashboardAiAgentContextBridge = () => {
     );
 
     const refreshChartTilesFromTiles = useCallback(
-        async (chartSlug: string, tiles: DashboardTile[] | undefined) => {
+        async (
+            chartSlug: string,
+            tiles: DashboardTile[] | undefined,
+            options?: { focusTile?: boolean },
+        ) => {
             if (!projectUuid || !dashboardUuid) return;
 
             const matchingTiles = (tiles ?? []).filter(
@@ -122,60 +152,86 @@ const DashboardAiAgentContextBridge = () => {
                     savedChartUuids.includes(query.queryKey[2] as string) &&
                     query.queryKey[3] === dashboardUuid,
             });
+
+            if (options?.focusTile) {
+                scrollToChartTile(matchingTiles[0], dashboardTabs);
+            }
         },
-        [dashboardUuid, projectUuid, queryClient],
+        [
+            dashboardTabs,
+            dashboardUuid,
+            projectUuid,
+            queryClient,
+            scrollToChartTile,
+        ],
     );
 
-    const refreshDashboard = useCallback(async () => {
-        if (!projectUuid || !dashboardUuid) return;
+    const refreshDashboard = useCallback(
+        async (chartSlugToFocus?: string) => {
+            if (!projectUuid || !dashboardUuid) return false;
 
-        await queryClient.invalidateQueries({
-            queryKey: dashboardQueryKey,
-            refetchType: 'none',
-        });
+            await queryClient.invalidateQueries({
+                queryKey: dashboardQueryKey,
+                refetchType: 'none',
+            });
 
-        const freshDashboard = await queryClient.fetchQuery({
-            queryKey: dashboardQueryKey,
-            queryFn: () => getDashboard(dashboardUuid, projectUuid),
-        });
+            const freshDashboard = await queryClient.fetchQuery({
+                queryKey: dashboardQueryKey,
+                queryFn: () => getDashboard(dashboardUuid, projectUuid),
+            });
 
-        const chartTiles = freshDashboard.tiles.filter(
-            isDashboardChartTileType,
-        );
+            const chartTiles = freshDashboard.tiles.filter(
+                isDashboardChartTileType,
+            );
 
-        setDashboardTiles(freshDashboard.tiles);
-        setDashboardTabs(freshDashboard.tabs);
-        setDashboardFilters(freshDashboard.filters);
-        setOriginalDashboardFilters(freshDashboard.filters);
-        setDashboardTemporaryFilters(emptyFilters);
+            setDashboardTiles(freshDashboard.tiles);
+            setDashboardTabs(freshDashboard.tabs);
+            setDashboardFilters(freshDashboard.filters);
+            setOriginalDashboardFilters(freshDashboard.filters);
+            setDashboardTemporaryFilters(emptyFilters);
 
-        await Promise.all(
-            [
-                ...new Set(
-                    chartTiles
-                        .map((tile) => tile.properties.chartSlug)
-                        .filter((slug): slug is string => !!slug),
+            await Promise.all(
+                [
+                    ...new Set(
+                        chartTiles
+                            .map((tile) => tile.properties.chartSlug)
+                            .filter((slug): slug is string => !!slug),
+                    ),
+                ].map((chartSlug) =>
+                    refreshChartTilesFromTiles(chartSlug, freshDashboard.tiles),
                 ),
-            ].map((chartSlug) =>
-                refreshChartTilesFromTiles(chartSlug, freshDashboard.tiles),
-            ),
-        );
-    }, [
-        dashboardQueryKey,
-        dashboardUuid,
-        projectUuid,
-        queryClient,
-        refreshChartTilesFromTiles,
-        setDashboardFilters,
-        setDashboardTabs,
-        setDashboardTemporaryFilters,
-        setDashboardTiles,
-        setOriginalDashboardFilters,
-    ]);
+            );
+
+            if (chartSlugToFocus) {
+                const tileToFocus = chartTiles.find(
+                    (tile) => tile.properties.chartSlug === chartSlugToFocus,
+                );
+                if (tileToFocus) {
+                    scrollToChartTile(tileToFocus, freshDashboard.tabs);
+                    return true;
+                }
+            }
+
+            return false;
+        },
+        [
+            dashboardQueryKey,
+            dashboardUuid,
+            projectUuid,
+            queryClient,
+            refreshChartTilesFromTiles,
+            scrollToChartTile,
+            setDashboardFilters,
+            setDashboardTabs,
+            setDashboardTemporaryFilters,
+            setDashboardTiles,
+            setOriginalDashboardFilters,
+        ],
+    );
 
     const refreshChartTiles = useCallback(
-        async (chartSlug: string) =>
-            refreshChartTilesFromTiles(chartSlug, dashboardTiles),
+        async (chartSlug: string, options?: { focusTile?: boolean }) =>
+            refreshChartTilesFromTiles(chartSlug, dashboardTiles, options),
         [dashboardTiles, refreshChartTilesFromTiles],
     );
 
@@ -206,15 +262,28 @@ const DashboardAiAgentContextBridge = () => {
                         part.toolName === 'createContent' &&
                         targetDashboardSlug === currentDashboardSlug
                     ) {
-                        void refreshDashboard();
+                        pendingChartSlugToFocusRef.current = contentSlug;
+                        void refreshDashboard(contentSlug).then((focused) => {
+                            if (
+                                focused &&
+                                pendingChartSlugToFocusRef.current ===
+                                    contentSlug
+                            ) {
+                                pendingChartSlugToFocusRef.current = null;
+                            }
+                        });
                         continue;
                     }
 
-                    void refreshChartTiles(contentSlug);
+                    void refreshChartTiles(contentSlug, { focusTile: true });
                     continue;
                 case 'dashboard':
                     if (contentSlug !== currentDashboardSlug) continue;
-                    void refreshDashboard();
+                    void refreshDashboard(
+                        pendingChartSlugToFocusRef.current ?? undefined,
+                    ).then((focused) => {
+                        if (focused) pendingChartSlugToFocusRef.current = null;
+                    });
                     continue;
             }
         }


### PR DESCRIPTION
Closes: [ZAP-446: I want to minimize the Agent chat and view content when clicking links in Agent chat](https://linear.app/lightdash/issue/ZAP-446/i-want-to-minimize-the-agent-chat-and-view-content-when-clicking-links)

### Description:

Extracts the `scrollToTile` function into a shared `scrollToDashboardTile` utility so it can be reused across the dashboard context bridge and the pre-aggregate audit indicator.

Improves the scroll-to-tile animation with a more polished highlight effect using a layered box shadow (outline ring, glow, and a soft color-mixed halo).

When the AI agent creates or updates a chart on the current dashboard, the dashboard now automatically scrolls to and highlights the relevant tile after refreshing. If the chart lives on a tab other than the currently active one, the correct tab is switched to before scrolling. A `pendingChartSlugToFocusRef` is used to track which chart should be focused across async dashboard refresh cycles, ensuring the focus targets the right tile even when a `createContent` tool call is followed by a `dashboard` refresh event.