### PR TITLE
fix(ai-agents): disable chat input until pinned context is ready

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -94,10 +94,14 @@ const NewThreadPanel: FC<{
 
     const { addItem: addDockItem } = useLauncherDock(projectUuid);
 
-    const { contextInput, previewItems } = usePinnedContext({
+    const {
+        contextInput,
+        previewItems,
+        isReady: isPinnedContextReady,
+    } = usePinnedContext({
         projectUuid,
-        chartUuid,
-        dashboardUuid,
+        chartUuidOrSlug: chartUuid,
+        dashboardUuidOrSlug: dashboardUuid,
     });
 
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
@@ -141,6 +145,7 @@ const NewThreadPanel: FC<{
         message: string;
         toolHints: string[];
     }) => {
+        if (!isPinnedContextReady) return;
         void createAgentThread({
             agentUuid: agent.uuid,
             prompt: message,
@@ -212,6 +217,7 @@ const NewThreadPanel: FC<{
                 <AgentChatInput
                     onSubmit={handleSubmit}
                     loading={isCreatingThread}
+                    disabled={!isPinnedContextReady}
                     placeholder={`Ask ${agent.name} anything...`}
                     projectUuid={projectUuid}
                     agentUuid={agent.uuid}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
@@ -9,8 +9,8 @@ import { useSavedQuery } from '../../../../hooks/useSavedQuery';
 
 type Args = {
     projectUuid: string | undefined;
-    chartUuid?: string | null;
-    dashboardUuid?: string | null;
+    chartUuidOrSlug?: string | null;
+    dashboardUuidOrSlug?: string | null;
 };
 
 const sortPinnedContext = <
@@ -32,66 +32,83 @@ const sortPinnedContext = <
  */
 export const usePinnedContext = ({
     projectUuid,
-    chartUuid,
-    dashboardUuid,
+    chartUuidOrSlug,
+    dashboardUuidOrSlug,
 }: Args) => {
     const { data: chart } = useSavedQuery({
-        uuidOrSlug: chartUuid ?? undefined,
+        uuidOrSlug: chartUuidOrSlug ?? undefined,
         projectUuid,
     });
     const { data: dashboard } = useDashboardQuery({
-        uuidOrSlug: dashboardUuid ?? undefined,
+        uuidOrSlug: dashboardUuidOrSlug ?? undefined,
         projectUuid,
     });
+    const isReady =
+        (!chartUuidOrSlug || !!chart?.uuid) &&
+        (!dashboardUuidOrSlug || !!dashboard?.uuid);
 
     const contextInput: AiPromptContextInput = useMemo(() => {
         const items: AiPromptContextInput = [];
-        if (chartUuid) {
+        if (chart?.uuid) {
             items.push({
                 type: 'chart',
-                chartUuid,
+                chartUuid: chart.uuid,
                 chartSlug: chart?.slug ?? null,
             });
         }
-        if (dashboardUuid) {
+        if (dashboard?.uuid) {
             items.push({
                 type: 'dashboard',
-                dashboardUuid,
+                dashboardUuid: dashboard.uuid,
                 dashboardSlug: dashboard?.slug ?? null,
             });
         }
         return sortPinnedContext(items);
-    }, [chartUuid, dashboardUuid, chart?.slug, dashboard?.slug]);
+    }, [chart?.uuid, dashboard?.uuid, chart?.slug, dashboard?.slug]);
+
+    const chartKind = useMemo(
+        () =>
+            chart?.chartConfig
+                ? (getChartKind(
+                      chart.chartConfig.type,
+                      chart.chartConfig.config,
+                  ) ?? null)
+                : null,
+        [chart?.chartConfig],
+    );
 
     const previewItems: AiPromptContextItem[] = useMemo(() => {
         const items: AiPromptContextItem[] = [];
-        if (chartUuid) {
+        if (chart?.uuid) {
             items.push({
                 type: 'chart',
-                chartUuid,
+                chartUuid: chart.uuid,
                 chartSlug: chart?.slug ?? null,
                 displayName: chart?.name ?? null,
                 pinnedVersionUuid: null,
-                chartKind: chart?.chartConfig
-                    ? (getChartKind(
-                          chart.chartConfig.type,
-                          chart.chartConfig.config,
-                      ) ?? null)
-                    : null,
+                chartKind,
                 runtimeOverrides: null,
             });
         }
-        if (dashboardUuid) {
+        if (dashboard?.uuid) {
             items.push({
                 type: 'dashboard',
-                dashboardUuid,
+                dashboardUuid: dashboard.uuid,
                 dashboardSlug: dashboard?.slug ?? null,
                 displayName: dashboard?.name ?? null,
                 pinnedVersionUuid: null,
             });
         }
         return sortPinnedContext(items);
-    }, [chartUuid, dashboardUuid, chart, dashboard?.name, dashboard?.slug]);
+    }, [
+        chart?.uuid,
+        chart?.slug,
+        chart?.name,
+        chartKind,
+        dashboard?.uuid,
+        dashboard?.name,
+        dashboard?.slug,
+    ]);
 
-    return { contextInput, previewItems };
+    return { contextInput, previewItems, isReady };
 };

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -39,10 +39,14 @@ const AiAgentNewThreadPage: FC = () => {
     const chartUuid = searchParams.get('chartUuid');
     const dashboardUuid = searchParams.get('dashboardUuid');
 
-    const { contextInput, previewItems } = usePinnedContext({
+    const {
+        contextInput,
+        previewItems,
+        isReady: isPinnedContextReady,
+    } = usePinnedContext({
         projectUuid,
-        chartUuid,
-        dashboardUuid,
+        chartUuidOrSlug: chartUuid,
+        dashboardUuidOrSlug: dashboardUuid,
     });
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
@@ -109,6 +113,7 @@ const AiAgentNewThreadPage: FC = () => {
     const onSubmit = useCallback(
         ({ message, toolHints }: { message: string; toolHints: string[] }) => {
             if (!agentUuid) return;
+            if (!isPinnedContextReady) return;
             setPendingPrompt('');
             void createAgentThread({
                 agentUuid,
@@ -140,6 +145,7 @@ const AiAgentNewThreadPage: FC = () => {
             selectedModel,
             showExtendedThinking,
             extendedThinking,
+            isPinnedContextReady,
         ],
     );
 
@@ -262,6 +268,7 @@ const AiAgentNewThreadPage: FC = () => {
                     <AgentChatInput
                         onSubmit={onSubmit}
                         loading={isCreatingThread}
+                        disabled={!isPinnedContextReady}
                         placeholder={`Ask ${agent.name} anything about your data...`}
                         projectUuid={projectUuid}
                         agentUuid={agent.uuid}


### PR DESCRIPTION
Closes:

### Description:

The `usePinnedContext` hook now accepts `chartUuidOrSlug` and `dashboardUuidOrSlug` instead of raw UUIDs, and resolves the actual UUIDs by waiting for the chart/dashboard data to load before building context inputs.

An `isReady` flag is returned from `usePinnedContext` that is `true` only when all provided slugs/UUIDs have been resolved to their corresponding data. The chat input is disabled and thread creation is blocked until this ready state is achieved, preventing threads from being created with incomplete or unresolved context.