### PR TITLE
fix(pivot): flatten total_columns count into a distinct_groups CTE for ClickHouse (PROD-8019)

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -4878,8 +4878,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // Distinct-groups CTE shape — both groupBy refs appear in the
             // SELECT DISTINCT list of the top-level distinct_groups CTE, and
             // total_columns counts over it directly (no CONCAT, no
-            // DISTINCT-CONCAT). The CTE split also fixes PROD-8019 for
-            // ClickHouse — see the dedicated test below.
+            // DISTINCT-CONCAT).
             expect(replaceWhitespace(result)).toContain(
                 'distinct_groups AS (SELECT DISTINCT "order_date_year", "payment_method" FROM filtered_rows)',
             );
@@ -4893,22 +4892,11 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).not.toContain('COUNT(DISTINCT concat(');
         });
 
-        test('total_columns counts via a top-level distinct_groups CTE, never a subquery nesting filtered_rows (#23697 / PROD-8019)', () => {
-            // https://github.com/lightdash/lightdash/issues/23697 / PROD-8019
-            // Repro: pivot any chart on ClickHouse v24+ (analyzer on by
-            // default). The previous shape wrapped the distinct count in a
-            // subquery that referenced the filtered_rows CTE from *inside*
-            // a later CTE definition:
-            //   total_columns AS (SELECT COUNT(*) FROM
-            //     (SELECT DISTINCT col FROM filtered_rows) AS distinct_groups)
-            // ClickHouse's analyzer cannot resolve a CTE identifier nested in
-            // a subquery within a subsequent CTE, so it threw "Unknown
-            // expression identifier ... FROM filtered_rows".
-            // Expectation: distinct_groups is promoted to its own top-level
-            // CTE so both references are direct CTE->CTE (distinct_groups ->
-            // filtered_rows, total_columns -> distinct_groups). This stays
-            // warehouse-agnostic and preserves the #19767 fix (no
-            // COUNT(DISTINCT CONCAT(...))).
+        test('total_columns counts via a top-level distinct_groups CTE, never a subquery nesting filtered_rows', () => {
+            // distinct_groups is its own top-level CTE so both references are
+            // direct CTE -> CTE (distinct_groups -> filtered_rows,
+            // total_columns -> distinct_groups), rather than nesting a subquery
+            // that references filtered_rows inside a later CTE.
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [
@@ -4941,13 +4929,12 @@ SELECT * FROM group_by_query LIMIT 50`);
                 'total_columns AS (SELECT COUNT(*) AS total_columns FROM distinct_groups)',
             );
 
-            // Negative: the ClickHouse-incompatible nested subquery must not
-            // appear anywhere — filtered_rows must never be referenced from
-            // inside a subquery within another CTE definition.
+            // Negative: filtered_rows must never be referenced from inside a
+            // subquery within another CTE definition.
             expect(result).not.toContain(
                 'FROM filtered_rows) AS distinct_groups',
             );
-            // And the #19767 invariant still holds.
+            // And no COUNT(DISTINCT CONCAT(...)).
             expect(result).not.toContain('COUNT(DISTINCT CONCAT(');
         });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -1821,9 +1821,12 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).toContain(
                 'SELECT "category", "date" FROM original_query group by "category", "date"',
             );
-            // Should calculate total_columns correctly using subquery approach
-            expect(result).toContain(
-                'SELECT COUNT(*) AS total_columns FROM (SELECT DISTINCT "category" FROM filtered_rows) AS distinct_groups',
+            // Should calculate total_columns via a top-level distinct_groups CTE
+            expect(replaceWhitespace(result)).toContain(
+                'distinct_groups AS (SELECT DISTINCT "category" FROM filtered_rows)',
+            );
+            expect(replaceWhitespace(result)).toContain(
+                'total_columns AS (SELECT COUNT(*) AS total_columns FROM distinct_groups)',
             );
         });
 
@@ -4872,16 +4875,80 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             const result = builder.toSql();
 
-            // Subquery-DISTINCT shape — both groupBy refs appear in the
-            // SELECT DISTINCT list inside the inner subquery.
+            // Distinct-groups CTE shape — both groupBy refs appear in the
+            // SELECT DISTINCT list of the top-level distinct_groups CTE, and
+            // total_columns counts over it directly (no CONCAT, no
+            // DISTINCT-CONCAT). The CTE split also fixes PROD-8019 for
+            // ClickHouse — see the dedicated test below.
             expect(replaceWhitespace(result)).toContain(
-                'total_columns AS (SELECT COUNT(*) AS total_columns FROM (SELECT DISTINCT "order_date_year", "payment_method" FROM filtered_rows) AS distinct_groups)',
+                'distinct_groups AS (SELECT DISTINCT "order_date_year", "payment_method" FROM filtered_rows)',
+            );
+            expect(replaceWhitespace(result)).toContain(
+                'total_columns AS (SELECT COUNT(*) AS total_columns FROM distinct_groups)',
             );
 
             // Negative: the bugged Redshift-incompatible form must not
             // appear anywhere. CONCAT-based counting was the original bug.
             expect(result).not.toContain('COUNT(DISTINCT CONCAT(');
             expect(result).not.toContain('COUNT(DISTINCT concat(');
+        });
+
+        test('total_columns counts via a top-level distinct_groups CTE, never a subquery nesting filtered_rows (#23697 / PROD-8019)', () => {
+            // https://github.com/lightdash/lightdash/issues/23697 / PROD-8019
+            // Repro: pivot any chart on ClickHouse v24+ (analyzer on by
+            // default). The previous shape wrapped the distinct count in a
+            // subquery that referenced the filtered_rows CTE from *inside*
+            // a later CTE definition:
+            //   total_columns AS (SELECT COUNT(*) FROM
+            //     (SELECT DISTINCT col FROM filtered_rows) AS distinct_groups)
+            // ClickHouse's analyzer cannot resolve a CTE identifier nested in
+            // a subquery within a subsequent CTE, so it threw "Unknown
+            // expression identifier ... FROM filtered_rows".
+            // Expectation: distinct_groups is promoted to its own top-level
+            // CTE so both references are direct CTE->CTE (distinct_groups ->
+            // filtered_rows, total_columns -> distinct_groups). This stays
+            // warehouse-agnostic and preserves the #19767 fix (no
+            // COUNT(DISTINCT CONCAT(...))).
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [
+                    { reference: 'order_date_year' },
+                    { reference: 'payment_method' },
+                ],
+                sortBy: [{ reference: 'date', direction: SortByDirection.ASC }],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // distinct_groups is a top-level CTE referencing filtered_rows directly.
+            expect(replaceWhitespace(result)).toContain(
+                'distinct_groups AS (SELECT DISTINCT "order_date_year", "payment_method" FROM filtered_rows)',
+            );
+            // total_columns counts over the distinct_groups CTE directly.
+            expect(replaceWhitespace(result)).toContain(
+                'total_columns AS (SELECT COUNT(*) AS total_columns FROM distinct_groups)',
+            );
+
+            // Negative: the ClickHouse-incompatible nested subquery must not
+            // appear anywhere — filtered_rows must never be referenced from
+            // inside a subquery within another CTE definition.
+            expect(result).not.toContain(
+                'FROM filtered_rows) AS distinct_groups',
+            );
+            // And the #19767 invariant still holds.
+            expect(result).not.toContain('COUNT(DISTINCT CONCAT(');
         });
 
         test('Named time-interval index columns sort chronologically via CASE WHEN, not alphabetically (#18245)', () => {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -358,28 +358,47 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Generates query that counts total distinct column combinations for pivot.
-     * Uses a subquery with SELECT DISTINCT for warehouse-agnostic counting.
+     * Generates the distinct_groups CTE body: the set of unique pivot-column
+     * combinations present in the filtered rows. Kept as a standalone CTE
+     * (rather than an inline subquery inside total_columns) so the reference to
+     * filteredRowsTable is a direct CTE -> CTE reference. ClickHouse's v24+
+     * analyzer cannot resolve a CTE identifier nested inside a subquery within
+     * a later CTE definition (PROD-8019 / #23697).
      * @param groupByColumns - Columns that are being pivoted
-     * @param valuesColumns - Value columns to multiply count by (only when metricsAsRows is false)
      * @param filteredRowsTable - Name of the CTE containing filtered rows
-     * @returns SQL query for counting total columns
+     * @returns SQL selecting distinct pivot-column combinations
      */
-    private getTotalColumnsSQL(
+    private getDistinctGroupsSQL(
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
-        valuesColumns: PivotConfiguration['valuesColumns'],
         filteredRowsTable: string,
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-        // Fallback to 1 when no valuesColumns to ensure at least one column per distinct group
-        // This maintains consistent pivot behavior even when only grouping without aggregations
-        const valuesCount = valuesColumns?.length || 1;
 
-        // Use subquery with SELECT DISTINCT to count unique column combinations
-        // This approach works across all warehouses without type casting issues
+        // SELECT DISTINCT over the groupBy columns counts unique column
+        // combinations without type casting — works across all warehouses
+        // (no COUNT(DISTINCT CONCAT(...)), which Redshift rejects — see #19767).
         const columnRefs = groupByColumns
             .map((col) => `${q}${col.reference}${q}`)
             .join(', ');
+
+        return `SELECT DISTINCT ${columnRefs} FROM ${filteredRowsTable}`;
+    }
+
+    /**
+     * Generates query that counts total distinct column combinations for pivot.
+     * Counts over the distinct_groups CTE (which already holds the unique
+     * pivot-column combinations) via a direct CTE reference.
+     * @param valuesColumns - Value columns to multiply count by (only when metricsAsRows is false)
+     * @param distinctGroupsTable - Name of the CTE containing distinct pivot-column combinations
+     * @returns SQL query for counting total columns
+     */
+    private getTotalColumnsSQL(
+        valuesColumns: PivotConfiguration['valuesColumns'],
+        distinctGroupsTable: string,
+    ): string {
+        // Fallback to 1 when no valuesColumns to ensure at least one column per distinct group
+        // This maintains consistent pivot behavior even when only grouping without aggregations
+        const valuesCount = valuesColumns?.length || 1;
 
         // When metricsAsRows is true, metrics become rows (not columns),
         // so we don't multiply by valuesCount
@@ -387,7 +406,7 @@ export class PivotQueryBuilder {
             !this.pivotConfiguration.metricsAsRows && valuesCount > 1;
         const multiplier = shouldMultiplyByValues ? ` * ${valuesCount}` : '';
 
-        return `SELECT COUNT(*)${multiplier} AS total_columns FROM (SELECT DISTINCT ${columnRefs} FROM ${filteredRowsTable}) AS distinct_groups`;
+        return `SELECT COUNT(*)${multiplier} AS total_columns FROM ${distinctGroupsTable}`;
     }
 
     /**
@@ -1590,10 +1609,13 @@ export class PivotQueryBuilder {
             maxColumnsPerValueColumnSql = ` and p.${q}column_index${q} <= ${maxColumnsPerValueColumn}`;
         }
 
-        const totalColumnsQuery = this.getTotalColumnsSQL(
+        const distinctGroupsQuery = this.getDistinctGroupsSQL(
             groupByColumns,
-            valuesColumns,
             'filtered_rows',
+        );
+        const totalColumnsQuery = this.getTotalColumnsSQL(
+            valuesColumns,
+            'distinct_groups',
         );
 
         // Build CTEs in correct dependency order:
@@ -1602,7 +1624,7 @@ export class PivotQueryBuilder {
         // 3. column_ranking, anchor_column (for metric-based row sorting - identifies first pivot column)
         // 4. row anchor CTEs (uses anchor_column to get metric value at first column only)
         // 5. row_ranking (when precomputed rankings are used)
-        // 6. pivot_query, filtered_rows, total_columns
+        // 6. pivot_query, filtered_rows, distinct_groups, total_columns
         // 7. pivot_table_calculations (if there are any pivot table calculations)
         const ctes = [
             `original_query AS (${userSql})`,
@@ -1627,6 +1649,7 @@ export class PivotQueryBuilder {
 
         ctes.push(
             `filtered_rows AS (SELECT * FROM ${pivotTableRef} WHERE ${q}row_index${q} <= ${rowLimit})`,
+            `distinct_groups AS (${distinctGroupsQuery})`,
             `total_columns AS (${totalColumnsQuery})`,
         );
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -358,12 +358,9 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Generates the distinct_groups CTE body: the set of unique pivot-column
-     * combinations present in the filtered rows. Kept as a standalone CTE
-     * (rather than an inline subquery inside total_columns) so the reference to
-     * filteredRowsTable is a direct CTE -> CTE reference. ClickHouse's v24+
-     * analyzer cannot resolve a CTE identifier nested inside a subquery within
-     * a later CTE definition (PROD-8019 / #23697).
+     * Generates the distinct_groups CTE body: the unique pivot-column
+     * combinations from the filtered rows. Kept as a standalone CTE so the
+     * reference to filteredRowsTable is a direct CTE -> CTE reference.
      * @param groupByColumns - Columns that are being pivoted
      * @param filteredRowsTable - Name of the CTE containing filtered rows
      * @returns SQL selecting distinct pivot-column combinations
@@ -374,9 +371,8 @@ export class PivotQueryBuilder {
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
-        // SELECT DISTINCT over the groupBy columns counts unique column
-        // combinations without type casting — works across all warehouses
-        // (no COUNT(DISTINCT CONCAT(...)), which Redshift rejects — see #19767).
+        // SELECT DISTINCT counts unique combinations without type casting,
+        // which works across all warehouses.
         const columnRefs = groupByColumns
             .map((col) => `${q}${col.reference}${q}`)
             .join(', ');
@@ -386,8 +382,6 @@ export class PivotQueryBuilder {
 
     /**
      * Generates query that counts total distinct column combinations for pivot.
-     * Counts over the distinct_groups CTE (which already holds the unique
-     * pivot-column combinations) via a direct CTE reference.
      * @param valuesColumns - Value columns to multiply count by (only when metricsAsRows is false)
      * @param distinctGroupsTable - Name of the CTE containing distinct pivot-column combinations
      * @returns SQL query for counting total columns


### PR DESCRIPTION
## Bug

ClickHouse v24+ users (analyzer on by default) see **"Unable to load visualization"** on any pivoted chart since v0.3053.0. Regression from #23672, which forced the SQL pivot path on for all warehouses by removing the `USE_SQL_PIVOT_RESULTS` flag — ClickHouse previously went through the legacy JS-pivot fallback, masking this code path.

Closes: PROD-8019
Closes: #23697

## Root cause

`PivotQueryBuilder.getTotalColumnsSQL` emitted the distinct-column count as a subquery referencing the `filtered_rows` CTE **from inside** the later `total_columns` CTE definition:

```sql
total_columns AS (SELECT COUNT(*) FROM (SELECT DISTINCT col FROM filtered_rows) AS distinct_groups)
```

ClickHouse's v24+ query analyzer cannot resolve a CTE identifier nested in a subquery within a subsequent CTE, throwing `Unknown expression identifier ... FROM filtered_rows`.

## Fix

Promote the distinct selection to its own top-level CTE so every reference is a direct CTE → CTE link:

```sql
filtered_rows   AS (SELECT * FROM pivot_query WHERE "row_index" <= 500),
distinct_groups AS (SELECT DISTINCT col FROM filtered_rows),
total_columns   AS (SELECT COUNT(*) AS total_columns FROM distinct_groups)
```

This is warehouse-agnostic and preserves the earlier #19767 invariant (no `COUNT(DISTINCT CONCAT(...))`, which Redshift rejects) — one code path satisfies both warehouses. The `* valuesCount` multiplier logic is unchanged.

## Changes

- Split `getTotalColumnsSQL` into `getDistinctGroupsSQL` (distinct combos) + `getTotalColumnsSQL` (count over `distinct_groups`).
- `getFullPivotSQL` pushes the extra `distinct_groups` CTE between `filtered_rows` and `total_columns`.
- Added a regression test (PROD-8019 / #23697); updated the #19767 test and the empty-values test to the new CTE shape.

## Verification

- TDD: new test fails before the fix, passes after.
- `PivotQueryBuilder.test.ts`: 131 passed.
- Full `QueryBuilder` suite: 422 passed (17 suites).
- Backend typecheck + lint clean.

⚠️ Not yet smoke-tested against a live ClickHouse v24+ instance — worth a manual check before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)