### PR TITLE
feat: add per-org scheduled-delivery link expiry settings with per-channel overrides and transparent persistent-URL escalation (PROD-7217)

### DIFF
--- a/docs/exporting.md
+++ b/docs/exporting.md
@@ -30,16 +30,22 @@ the raw-vs-persistent URL choice automatic ("transparent") so users never have t
 | **Download link expiry** (base) | `scheduled_delivery_expiration_seconds`         | Default lifetime (seconds) for every channel. Resolved to an effective number in the API. |
 | **Email** override     | `scheduled_delivery_expiration_seconds_email`   | Optional. `null` ⇒ inherit the base.                                    |
 | **Slack** override     | `scheduled_delivery_expiration_seconds_slack`   | Optional. `null` ⇒ inherit the base.                                    |
-| **Microsoft Teams** override | `scheduled_delivery_expiration_seconds_msteams` | Optional. `null` ⇒ inherit the base.                                    |
+| **Microsoft Teams** override | `scheduled_delivery_expiration_seconds_msteams` | Optional. `null` ⇒ inherit the base.                              |
+| **Google Chat** override | `scheduled_delivery_expiration_seconds_googlechat` | Optional. `null` ⇒ inherit the base. Org-only (no env var).      |
 
-All four live on the `organization_settings` table (one row per org). `null`/absent means "inherit", so an
+All five live on the `organization_settings` table (one row per org). `null`/absent means "inherit", so an
 org with no row behaves exactly like the instance defaults.
 
 Per-channel overrides are surfaced raw in the API (`null` = inherit) so the UI can distinguish "not set" from
 an explicit value; the base is surfaced resolved (always an effective number) so the frontend can display it
 without knowing the env defaults.
 
-> **Google Chat** has no per-channel env var, so it always inherits the base.
+> **Google Chat** has no instance env var (`PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_*`), so its override is
+> org-only and falls back straight to the base (then env base).
+
+The UI only shows a per-channel override for delivery methods the org can actually use — Slack (installed),
+Email (`hasEmailClient`), Microsoft Teams (`hasMicrosoftTeams`), Google Chat (`GoogleChatEnabled` flag). A
+stored override on a method that later becomes unavailable is preserved, just not shown.
 
 ---
 
@@ -164,7 +170,8 @@ switch to the persistent system. The frontend uses a generous 1–365 day input 
 ## Frontend (Exporting panel)
 
 - **Download link expiry** — base, full-width number input (days), with steppers.
-- **Set a different expiry for specific channels** — a checkbox that reveals per-channel rows (Email / Slack /
-  Microsoft Teams), one line each, full-width inputs. Each input shows a clear (✕) affordance to reset to
-  "inherit the base"; blank ⇒ inherit.
+- **Set a different expiry for specific channels** — a checkbox that reveals per-channel rows (one line each,
+  full-width inputs) for the delivery methods the org has available (Email / Slack / Microsoft Teams / Google
+  Chat). Each input shows a clear (✕) affordance to reset to "inherit the base"; blank ⇒ inherit. The whole
+  section is hidden if no delivery method is available.
 - Unticking the checkbox (or clearing a row) and saving writes `null` for those channels.

--- a/docs/exporting.md
+++ b/docs/exporting.md
@@ -1,0 +1,170 @@
+# Exporting & Scheduled-Delivery Settings
+
+This document describes the organization-level **Exporting** settings (PROD-7217): how scheduled-delivery
+download links are configured, how their expiry is resolved per channel, and how the system transparently
+chooses between raw S3 presigned URLs and the persistent-download-URL system.
+
+---
+
+## Overview
+
+Scheduled deliveries (email / Slack / Microsoft Teams / Google Chat) attach download links to exported
+files (CSV, XLSX, images, PDFs). How long those links stay valid used to be controlled **only** by
+instance-wide environment variables, which doesn't work for Pro customers on shared multi-tenant
+infrastructure where each org needs its own policy.
+
+The Exporting settings move that control to the **organization level**: an admin sets a base "Download link
+expiry" plus optional per-channel overrides, in **Settings → Organization → Exporting**. The env vars become
+the fall-back defaults, so nothing breaks for instances that never configure the org settings.
+
+The guiding principle was: **expose the existing env vars as per-org overrides, stay backwards-compatible, and
+don't add new business logic** (no artificial expiry caps). The one piece of genuinely new behavior is making
+the raw-vs-persistent URL choice automatic ("transparent") so users never have to think about it.
+
+---
+
+## What an admin configures
+
+| Setting                | Stored column                                   | Meaning                                                                 |
+|------------------------|-------------------------------------------------|-------------------------------------------------------------------------|
+| **Download link expiry** (base) | `scheduled_delivery_expiration_seconds`         | Default lifetime (seconds) for every channel. Resolved to an effective number in the API. |
+| **Email** override     | `scheduled_delivery_expiration_seconds_email`   | Optional. `null` ⇒ inherit the base.                                    |
+| **Slack** override     | `scheduled_delivery_expiration_seconds_slack`   | Optional. `null` ⇒ inherit the base.                                    |
+| **Microsoft Teams** override | `scheduled_delivery_expiration_seconds_msteams` | Optional. `null` ⇒ inherit the base.                                    |
+
+All four live on the `organization_settings` table (one row per org). `null`/absent means "inherit", so an
+org with no row behaves exactly like the instance defaults.
+
+Per-channel overrides are surfaced raw in the API (`null` = inherit) so the UI can distinguish "not set" from
+an explicit value; the base is surfaced resolved (always an effective number) so the frontend can display it
+without knowing the env defaults.
+
+> **Google Chat** has no per-channel env var, so it always inherits the base.
+
+---
+
+## Expiry resolution (per channel)
+
+When a delivery runs, `SchedulerTask.getDeliveryExpirationSeconds(orgUuid, channel)` resolves the effective
+expiry with **org overrides winning over env, and channel winning over base**:
+
+```
+orgChannel  ??  orgBase  ??  envChannel  ??  envBase
+```
+
+- `orgChannel` — e.g. `scheduled_delivery_expiration_seconds_slack`
+- `orgBase` — `scheduled_delivery_expiration_seconds`
+- `envChannel` — `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_{EMAIL,SLACK,MSTEAMS}`
+- `envBase` — `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS` (default 259200 = 3 days)
+
+So an admin setting only the base in the UI overrides any leftover instance per-channel env default — the
+admin's explicit org config dominates instance config.
+
+---
+
+## Transparent persistence (raw S3 vs persistent URL)
+
+A raw S3 presigned URL **cannot live longer than 7 days** (AWS SigV4 hard limit). The persistent-download-URL
+system sidesteps this: the link is a stable app URL (`/api/v1/file/{nanoid}`) that mints a fresh, short-lived
+(5 min) presigned S3 URL on each access, so its logical lifetime is unbounded.
+
+`PersistentDownloadFileService.createPersistentUrl()` is the single decision point. Every scheduled-delivery
+download URL (image, CSV, XLSX, pivot) funnels through it. The choice is **derived**, not a user toggle:
+
+```ts
+const exceedsS3Limit = expirationSeconds > 604800; // 7 days
+const usePersistent = lightdashConfig.persistentDownloadUrls.enabled || exceedsS3Limit;
+// usePersistent → persistent app URL
+// otherwise     → raw S3 presigned URL, honoring the requested expiry
+```
+
+### `PERSISTENT_DOWNLOAD_URLS_ENABLED` behavior
+
+| Expiry        | Env unset (default) | Env `'true'` | Env `'false'`        |
+|---------------|---------------------|--------------|----------------------|
+| **≤ 7 days**  | raw S3 presigned    | persistent   | raw S3 presigned     |
+| **> 7 days**  | persistent (forced) | persistent   | persistent (forced)  |
+
+- **Off by default.** `parseConfig` keeps `enabled = false` unless the var is explicitly `'true'` — unchanged
+  from before, so existing instances behave exactly as they did for links ≤ 7 days.
+- **> 7 days always wins.** Even when the instance hasn't opted in, a long expiry forces persistence — it's the
+  only way the link can live that long. This only happens via the *new* org expiry setting, so there's no
+  pre-existing behavior to break (and it fixes the old footgun where a >7-day raw link would just 403).
+
+> **Why keep the default `false`?** An earlier draft flipped the default to `true` (unset ⇒ persistent). But
+> most cloud customers already set `PERSISTENT_DOWNLOAD_URLS_ENABLED` explicitly, and a handful rely on the
+> default — flipping it would have silently switched those (and all unset self-hosted instances) from direct
+> S3 links to app-routed persistent links for *every* download, not just deliveries. Keeping the default `false`
+> and only escalating on >7-day expiry achieves the goal with zero behavioral change to existing setups.
+
+This keeps the change fully backwards-compatible: the only new behavior is the >7-day escalation, which is
+reachable only through the new settings.
+
+---
+
+## Environment variables (now defaults, not the only control)
+
+| Env var                                          | Default            | Role after this change                                  |
+|--------------------------------------------------|--------------------|---------------------------------------------------------|
+| `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS`     | 259200 (3 days)    | Base expiry default (org base overrides it)             |
+| `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_EMAIL`   | unset          | Email default (org email/base overrides it)             |
+| `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_SLACK`   | unset          | Slack default                                           |
+| `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_MSTEAMS` | unset          | MS Teams default                                        |
+| `PERSISTENT_DOWNLOAD_URLS_ENABLED`               | `false`            | Whether to use persistent URLs for links ≤ 7 days (>7 days always persistent) |
+| `S3_EXPIRATION_TIME`                             | 259200 (3 days)    | Generic S3 presigned expiry for *non-delivery* file ops |
+
+### Why `S3_EXPIRATION_TIME` is not an org setting
+
+It governs **all** server-side S3 presigned URLs (app-image uploads, result-cache presigns, …) at the
+org-agnostic `S3Client` layer, so exposing it per-org would require making `S3Client` org-aware — new business
+logic we explicitly avoided. For scheduled deliveries it's moot: the org expiry knob is passed straight to the
+raw presigned URL (`getFileUrl(s3Key, expirationSeconds)`), so the one knob already governs the delivery link
+on both the persistent and raw paths.
+
+---
+
+## Key code paths
+
+| Concern                          | Location                                                                                  |
+|----------------------------------|-------------------------------------------------------------------------------------------|
+| Setting types + resolver         | `packages/common/src/types/organizationSettings.ts`                                       |
+| DB column + entity               | migration `..._add_exporting_settings_to_organization_settings.ts`, `entities/organizationSettings.ts` |
+| Model (get/update)               | `packages/backend/src/models/OrganizationSettingsModel.ts`                                |
+| API service + validation         | `packages/backend/src/services/OrganizationSettingsService/`                              |
+| Env → defaults helper            | `packages/backend/src/services/OrganizationSettingsService/getInstanceDefaults.ts`        |
+| Per-channel expiry resolution    | `SchedulerTask.getDeliveryExpirationSeconds()`                                            |
+| Raw-vs-persistent decision       | `PersistentDownloadFileService.createPersistentUrl()`                                     |
+| Env default for the toggle       | `packages/backend/src/config/parseConfig.ts` (`persistentDownloadUrls.enabled`)           |
+| API endpoints                    | `GET` / `PATCH` `/api/v1/org/settings`                                                     |
+| Frontend panel                   | `packages/frontend/src/components/UserSettings/ExportingPanel/`                            |
+
+---
+
+## Validation
+
+The settings API (`OrganizationSettingsService`) only sanity-checks expiry values: each must be a **positive
+integer** (or `null` to clear). There is intentionally **no maximum** — links over 7 days are valid and just
+switch to the persistent system. The frontend uses a generous 1–365 day input guardrail.
+
+---
+
+## Backwards compatibility
+
+- No org row / all `null` ⇒ behaves exactly as the instance env defaults.
+- `PERSISTENT_DOWNLOAD_URLS_ENABLED` keeps its `false` default, so for links ≤ 7 days nothing changes: instances
+  that don't set it still get raw S3 presigned URLs. The only new behavior is the >7-day escalation, reachable
+  only via the new org expiry setting.
+- `getFileUrl(s3Key, undefined)` (non-delivery / interactive downloads) still falls back to `S3_EXPIRATION_TIME`.
+- Narrow edge: for an instance with persistent URLs explicitly **disabled**, a delivery's raw link now honors
+  the expiry knob instead of `S3_EXPIRATION_TIME`. With default config (both = 3 days) there's no observable
+  difference.
+
+---
+
+## Frontend (Exporting panel)
+
+- **Download link expiry** — base, full-width number input (days), with steppers.
+- **Set a different expiry for specific channels** — a checkbox that reveals per-channel rows (Email / Slack /
+  Microsoft Teams), one line each, full-width inputs. Each input shows a clear (✕) affordance to reset to
+  "inherit the base"; blank ⇒ inherit.
+- Unticking the checkbox (or clearing a row) and saving writes `null` for those channels.

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -123,6 +123,8 @@ const schedulerWorkerFactory = (context: {
         preAggregateModel: context.models.getPreAggregateModel(),
         preAggregateMaterializationService:
             context.serviceRepository.getPreAggregateMaterializationService(),
+        organizationSettingsModel:
+            context.models.getOrganizationSettingsModel(),
         resolveOrganizationName: createOrganizationNameResolver(
             context.models.getOrganizationModel(),
         ),

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -85,6 +85,8 @@ const schedulerWorkerFactory = (context: {
         preAggregateModel: context.models.getPreAggregateModel(),
         preAggregateMaterializationService:
             context.serviceRepository.getPreAggregateMaterializationService(),
+        organizationSettingsModel:
+            context.models.getOrganizationSettingsModel(),
         workerHealth: context.workerHealth,
         resolveOrganizationName: createOrganizationNameResolver(
             context.models.getOrganizationModel(),

--- a/packages/backend/src/clients/EmailClient/templates/chartCsvNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/chartCsvNotification.html
@@ -1915,10 +1915,7 @@
                                                                                                             color: #7c7c87;
                                                                                                             mso-line-height-rule: exactly;
                                                                                                         "
-                                                                                                        >For
-                                                                                                        security
-                                                                                                        reasons,
-                                                                                                        delivered
+                                                                                                        >Delivered
                                                                                                         files
                                                                                                         expire
                                                                                                         after

--- a/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
@@ -2004,10 +2004,7 @@
                                                                                                             color: #7c7c87;
                                                                                                             mso-line-height-rule: exactly;
                                                                                                         "
-                                                                                                        >For
-                                                                                                        security
-                                                                                                        reasons,
-                                                                                                        delivered
+                                                                                                        >Delivered
                                                                                                         files
                                                                                                         expire
                                                                                                         after

--- a/packages/backend/src/clients/EmailClient/templates/imageNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/imageNotification.html
@@ -893,10 +893,7 @@
                                                                                                             color: #7c7c87;
                                                                                                             mso-line-height-rule: exactly;
                                                                                                         "
-                                                                                                        >For
-                                                                                                        security
-                                                                                                        reasons,
-                                                                                                        delivered
+                                                                                                        >Delivered
                                                                                                         files
                                                                                                         expire
                                                                                                         after

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -998,3 +998,22 @@ describe('feature flag env-var allowlists', () => {
         expect(config.dashboardComments.enabled).toBe(false);
     });
 });
+
+describe('persistentDownloadUrls.enabled', () => {
+    test('defaults to false when PERSISTENT_DOWNLOAD_URLS_ENABLED is unset', () => {
+        const config = parseConfig();
+        expect(config.persistentDownloadUrls.enabled).toBe(false);
+    });
+
+    test('is true only when explicitly set to "true"', () => {
+        process.env.PERSISTENT_DOWNLOAD_URLS_ENABLED = 'true';
+        const config = parseConfig();
+        expect(config.persistentDownloadUrls.enabled).toBe(true);
+    });
+
+    test('is false when set to "false"', () => {
+        process.env.PERSISTENT_DOWNLOAD_URLS_ENABLED = 'false';
+        const config = parseConfig();
+        expect(config.persistentDownloadUrls.enabled).toBe(false);
+    });
+});

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2171,6 +2171,9 @@ export const parseConfig = (): LightdashConfig => {
                 : undefined,
         },
         persistentDownloadUrls: {
+            // Off unless explicitly enabled (preserves existing behavior).
+            // Note: links over 7 days always use persistent URLs regardless of
+            // this flag — see PersistentDownloadFileService.
             enabled: process.env.PERSISTENT_DOWNLOAD_URLS_ENABLED === 'true',
             expirationSeconds:
                 getIntegerFromEnvironmentVariable(

--- a/packages/backend/src/database/entities/organizationSettings.ts
+++ b/packages/backend/src/database/entities/organizationSettings.ts
@@ -23,6 +23,7 @@ export type DbOrganizationSettings = {
     scheduled_delivery_expiration_seconds_email: number | null;
     scheduled_delivery_expiration_seconds_slack: number | null;
     scheduled_delivery_expiration_seconds_msteams: number | null;
+    scheduled_delivery_expiration_seconds_googlechat: number | null;
     created_at: Date;
     updated_at: Date;
 };

--- a/packages/backend/src/database/entities/organizationSettings.ts
+++ b/packages/backend/src/database/entities/organizationSettings.ts
@@ -16,6 +16,13 @@ export type DbOrganizationSettings = {
     // Per-org consent for the Lightdash support team to impersonate users.
     // Opt-in only, no env default: NULL/absent is treated as false.
     support_impersonation_enabled: boolean | null;
+    // Per-org base override (seconds) for scheduled-delivery download link
+    // expiry. NULL/absent inherits PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS.
+    scheduled_delivery_expiration_seconds: number | null;
+    // Per-channel overrides (seconds); NULL/absent inherits the base above.
+    scheduled_delivery_expiration_seconds_email: number | null;
+    scheduled_delivery_expiration_seconds_slack: number | null;
+    scheduled_delivery_expiration_seconds_msteams: number | null;
     created_at: Date;
     updated_at: Date;
 };

--- a/packages/backend/src/database/migrations/20260601072726_add_exporting_settings_to_organization_settings.ts
+++ b/packages/backend/src/database/migrations/20260601072726_add_exporting_settings_to_organization_settings.ts
@@ -5,6 +5,7 @@ const BASE_COLUMN = 'scheduled_delivery_expiration_seconds';
 const EMAIL_COLUMN = 'scheduled_delivery_expiration_seconds_email';
 const SLACK_COLUMN = 'scheduled_delivery_expiration_seconds_slack';
 const MSTEAMS_COLUMN = 'scheduled_delivery_expiration_seconds_msteams';
+const GOOGLECHAT_COLUMN = 'scheduled_delivery_expiration_seconds_googlechat';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.schema.alterTable(ORGANIZATION_SETTINGS_TABLE, (table) => {
@@ -16,6 +17,7 @@ export async function up(knex: Knex): Promise<void> {
         table.integer(EMAIL_COLUMN).nullable();
         table.integer(SLACK_COLUMN).nullable();
         table.integer(MSTEAMS_COLUMN).nullable();
+        table.integer(GOOGLECHAT_COLUMN).nullable();
     });
 }
 
@@ -25,5 +27,6 @@ export async function down(knex: Knex): Promise<void> {
         table.dropColumn(EMAIL_COLUMN);
         table.dropColumn(SLACK_COLUMN);
         table.dropColumn(MSTEAMS_COLUMN);
+        table.dropColumn(GOOGLECHAT_COLUMN);
     });
 }

--- a/packages/backend/src/database/migrations/20260601072726_add_exporting_settings_to_organization_settings.ts
+++ b/packages/backend/src/database/migrations/20260601072726_add_exporting_settings_to_organization_settings.ts
@@ -1,0 +1,29 @@
+import { Knex } from 'knex';
+
+const ORGANIZATION_SETTINGS_TABLE = 'organization_settings';
+const BASE_COLUMN = 'scheduled_delivery_expiration_seconds';
+const EMAIL_COLUMN = 'scheduled_delivery_expiration_seconds_email';
+const SLACK_COLUMN = 'scheduled_delivery_expiration_seconds_slack';
+const MSTEAMS_COLUMN = 'scheduled_delivery_expiration_seconds_msteams';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ORGANIZATION_SETTINGS_TABLE, (table) => {
+        // Per-org base override (seconds) for how long scheduled-delivery
+        // download links stay valid. Nullable with no stored default, so
+        // NULL/absent inherits PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS.
+        table.integer(BASE_COLUMN).nullable();
+        // Optional per-channel overrides; NULL/absent inherits the base above.
+        table.integer(EMAIL_COLUMN).nullable();
+        table.integer(SLACK_COLUMN).nullable();
+        table.integer(MSTEAMS_COLUMN).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ORGANIZATION_SETTINGS_TABLE, (table) => {
+        table.dropColumn(BASE_COLUMN);
+        table.dropColumn(EMAIL_COLUMN);
+        table.dropColumn(SLACK_COLUMN);
+        table.dropColumn(MSTEAMS_COLUMN);
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -599,6 +599,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 preAggregateModel: context.models.getPreAggregateModel(),
                 preAggregateMaterializationService:
                     context.serviceRepository.getPreAggregateMaterializationService(),
+                organizationSettingsModel:
+                    context.models.getOrganizationSettingsModel(),
                 managedAgentService:
                     context.serviceRepository.getManagedAgentService<ManagedAgentService>(),
                 appGenerateService:

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -28689,6 +28689,38 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                scheduledDeliveryExpirationSecondsMsTeams: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                scheduledDeliveryExpirationSecondsSlack: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                scheduledDeliveryExpirationSecondsEmail: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                scheduledDeliveryExpirationSeconds: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 supportImpersonationEnabled: {
                     dataType: 'union',
                     subSchemas: [
@@ -28755,6 +28787,38 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'boolean' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                scheduledDeliveryExpirationSeconds: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                scheduledDeliveryExpirationSecondsEmail: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                scheduledDeliveryExpirationSecondsSlack: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                scheduledDeliveryExpirationSecondsMsTeams: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
                         { dataType: 'enum', enums: [null] },
                         { dataType: 'undefined' },
                     ],

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -28689,6 +28689,14 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                scheduledDeliveryExpirationSecondsGoogleChat: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 scheduledDeliveryExpirationSecondsMsTeams: {
                     dataType: 'union',
                     subSchemas: [
@@ -28816,6 +28824,14 @@ const models: TsoaRoute.Models = {
                     ],
                 },
                 scheduledDeliveryExpirationSecondsMsTeams: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                scheduledDeliveryExpirationSecondsGoogleChat: {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'double' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -29486,6 +29486,12 @@
             },
             "OrganizationSettings": {
                 "properties": {
+                    "scheduledDeliveryExpirationSecondsGoogleChat": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Per-channel override (seconds) for Google Chat deliveries; `null` inherits\nthe base. Google Chat has no instance env var, so this is an org-only\noverride (it still falls back to the base / env base)."
+                    },
                     "scheduledDeliveryExpirationSecondsMsTeams": {
                         "type": "number",
                         "format": "double",
@@ -29527,6 +29533,7 @@
                     }
                 },
                 "required": [
+                    "scheduledDeliveryExpirationSecondsGoogleChat",
                     "scheduledDeliveryExpirationSecondsMsTeams",
                     "scheduledDeliveryExpirationSecondsSlack",
                     "scheduledDeliveryExpirationSecondsEmail",
@@ -29592,6 +29599,12 @@
                         "format": "double",
                         "nullable": true,
                         "description": "Per-channel override (seconds) for Microsoft Teams deliveries; `null`\ninherits the base. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_MSTEAMS`."
+                    },
+                    "scheduledDeliveryExpirationSecondsGoogleChat": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Per-channel override (seconds) for Google Chat deliveries; `null` inherits\nthe base. Google Chat has no instance env var, so this is an org-only\noverride (it still falls back to the base / env base)."
                     }
                 },
                 "type": "object",

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -29486,6 +29486,30 @@
             },
             "OrganizationSettings": {
                 "properties": {
+                    "scheduledDeliveryExpirationSecondsMsTeams": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Per-channel override (seconds) for Microsoft Teams deliveries; `null`\ninherits the base. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_MSTEAMS`."
+                    },
+                    "scheduledDeliveryExpirationSecondsSlack": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Per-channel override (seconds) for Slack deliveries; `null` inherits the\nbase. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_SLACK`."
+                    },
+                    "scheduledDeliveryExpirationSecondsEmail": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Per-channel override (seconds) of {@link scheduledDeliveryExpirationSeconds }\nfor email deliveries; `null` inherits the base. Unlike the base, this is\nsurfaced raw (not resolved) so the UI can distinguish \"inherit\" from an\nexplicit value. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_EMAIL`."
+                    },
+                    "scheduledDeliveryExpirationSeconds": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Base lifetime (seconds) of this org's scheduled-delivery download links —\nthe default every channel inherits. Overrides the instance-wide\n`PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS` env; `null` inherits it. This\nfield is always resolved to an effective number in API responses (it\nfalls back to the env default), so the frontend can display it directly.\nA value over {@link S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS} transparently\nswitches that delivery to the persistent-download-URL system (the only\nway a link can outlive AWS's 7-day presigned ceiling)."
+                    },
                     "supportImpersonationEnabled": {
                         "type": "boolean",
                         "nullable": true,
@@ -29503,6 +29527,10 @@
                     }
                 },
                 "required": [
+                    "scheduledDeliveryExpirationSecondsMsTeams",
+                    "scheduledDeliveryExpirationSecondsSlack",
+                    "scheduledDeliveryExpirationSecondsEmail",
+                    "scheduledDeliveryExpirationSeconds",
                     "supportImpersonationEnabled",
                     "oidcToEmailLinkingEnabled",
                     "oidcLinkingEnabled"
@@ -29540,6 +29568,30 @@
                         "type": "boolean",
                         "nullable": true,
                         "description": "Per-org consent for the Lightdash support team to impersonate users in\nthe org while helping with a support request. Unlike the OIDC toggles\nthis has no instance/env default — it's opt-in only, so `null` (or no\nstored row) resolves to `false`."
+                    },
+                    "scheduledDeliveryExpirationSeconds": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Base lifetime (seconds) of this org's scheduled-delivery download links —\nthe default every channel inherits. Overrides the instance-wide\n`PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS` env; `null` inherits it. This\nfield is always resolved to an effective number in API responses (it\nfalls back to the env default), so the frontend can display it directly.\nA value over {@link S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS} transparently\nswitches that delivery to the persistent-download-URL system (the only\nway a link can outlive AWS's 7-day presigned ceiling)."
+                    },
+                    "scheduledDeliveryExpirationSecondsEmail": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Per-channel override (seconds) of {@link scheduledDeliveryExpirationSeconds }\nfor email deliveries; `null` inherits the base. Unlike the base, this is\nsurfaced raw (not resolved) so the UI can distinguish \"inherit\" from an\nexplicit value. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_EMAIL`."
+                    },
+                    "scheduledDeliveryExpirationSecondsSlack": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Per-channel override (seconds) for Slack deliveries; `null` inherits the\nbase. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_SLACK`."
+                    },
+                    "scheduledDeliveryExpirationSecondsMsTeams": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Per-channel override (seconds) for Microsoft Teams deliveries; `null`\ninherits the base. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_MSTEAMS`."
                     }
                 },
                 "type": "object",

--- a/packages/backend/src/models/OrganizationSettingsModel.test.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.test.ts
@@ -44,6 +44,10 @@ describe('OrganizationSettingsModel', () => {
                 oidcLinkingEnabled: null,
                 oidcToEmailLinkingEnabled: null,
                 supportImpersonationEnabled: null,
+                scheduledDeliveryExpirationSeconds: null,
+                scheduledDeliveryExpirationSecondsEmail: null,
+                scheduledDeliveryExpirationSecondsSlack: null,
+                scheduledDeliveryExpirationSecondsMsTeams: null,
             });
         });
 
@@ -53,11 +57,17 @@ describe('OrganizationSettingsModel', () => {
                 oidc_linking_enabled: true,
                 oidc_to_email_linking_enabled: null,
                 support_impersonation_enabled: null,
+                scheduled_delivery_expiration_seconds: null,
+                persistent_download_urls_enabled: null,
             });
             expect(await model.get(ORG)).toEqual({
                 oidcLinkingEnabled: true,
                 oidcToEmailLinkingEnabled: null,
                 supportImpersonationEnabled: null,
+                scheduledDeliveryExpirationSeconds: null,
+                scheduledDeliveryExpirationSecondsEmail: null,
+                scheduledDeliveryExpirationSecondsSlack: null,
+                scheduledDeliveryExpirationSecondsMsTeams: null,
             });
         });
 
@@ -71,6 +81,29 @@ describe('OrganizationSettingsModel', () => {
                 oidcLinkingEnabled: null,
                 oidcToEmailLinkingEnabled: null,
                 supportImpersonationEnabled: true,
+                scheduledDeliveryExpirationSeconds: null,
+                scheduledDeliveryExpirationSecondsEmail: null,
+                scheduledDeliveryExpirationSecondsSlack: null,
+                scheduledDeliveryExpirationSecondsMsTeams: null,
+            });
+        });
+
+        test('maps the exporting columns (base + per-channel expiry)', async () => {
+            const { model } = createModel({
+                oidc_linking_enabled: null,
+                oidc_to_email_linking_enabled: null,
+                support_impersonation_enabled: null,
+                scheduled_delivery_expiration_seconds: 604800,
+                scheduled_delivery_expiration_seconds_slack: 1209600,
+            });
+            expect(await model.get(ORG)).toEqual({
+                oidcLinkingEnabled: null,
+                oidcToEmailLinkingEnabled: null,
+                supportImpersonationEnabled: null,
+                scheduledDeliveryExpirationSeconds: 604800,
+                scheduledDeliveryExpirationSecondsEmail: null,
+                scheduledDeliveryExpirationSecondsSlack: 1209600,
+                scheduledDeliveryExpirationSecondsMsTeams: null,
             });
         });
     });
@@ -106,7 +139,38 @@ describe('OrganizationSettingsModel', () => {
                 oidcLinkingEnabled: true,
                 oidcToEmailLinkingEnabled: false,
                 supportImpersonationEnabled: null,
+                scheduledDeliveryExpirationSeconds: null,
+                scheduledDeliveryExpirationSecondsEmail: null,
+                scheduledDeliveryExpirationSecondsSlack: null,
+                scheduledDeliveryExpirationSecondsMsTeams: null,
             });
+        });
+
+        test('writes the exporting columns (base + per-channel) when provided', async () => {
+            const { model, captured } = createModel({
+                scheduled_delivery_expiration_seconds: 604800,
+                scheduled_delivery_expiration_seconds_slack: 1209600,
+            });
+
+            await model.update(ORG, {
+                scheduledDeliveryExpirationSeconds: 604800,
+                scheduledDeliveryExpirationSecondsSlack: 1209600,
+            });
+
+            expect(captured.insert).toEqual({
+                organization_uuid: ORG,
+                scheduled_delivery_expiration_seconds: 604800,
+                scheduled_delivery_expiration_seconds_slack: 1209600,
+            });
+            expect(captured.merge).toMatchObject({
+                scheduled_delivery_expiration_seconds: 604800,
+                scheduled_delivery_expiration_seconds_slack: 1209600,
+            });
+            // Channels not in the patch are left untouched.
+            expect(captured.merge).not.toHaveProperty(
+                'scheduled_delivery_expiration_seconds_email',
+            );
+            expect(captured.merge).not.toHaveProperty('oidc_linking_enabled');
         });
 
         test('writes the support impersonation column when provided', async () => {
@@ -158,6 +222,12 @@ describe('OrganizationSettingsModel', () => {
             );
             expect(captured.merge).not.toHaveProperty(
                 'support_impersonation_enabled',
+            );
+            expect(captured.merge).not.toHaveProperty(
+                'scheduled_delivery_expiration_seconds',
+            );
+            expect(captured.merge).not.toHaveProperty(
+                'scheduled_delivery_expiration_seconds_slack',
             );
             expect(captured.merge?.updated_at).toBeInstanceOf(Date);
             expect(captured.insert).toEqual({ organization_uuid: ORG });

--- a/packages/backend/src/models/OrganizationSettingsModel.test.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.test.ts
@@ -48,6 +48,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsEmail: null,
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
+                scheduledDeliveryExpirationSecondsGoogleChat: null,
             });
         });
 
@@ -68,6 +69,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsEmail: null,
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
+                scheduledDeliveryExpirationSecondsGoogleChat: null,
             });
         });
 
@@ -85,6 +87,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsEmail: null,
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
+                scheduledDeliveryExpirationSecondsGoogleChat: null,
             });
         });
 
@@ -104,6 +107,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsEmail: null,
                 scheduledDeliveryExpirationSecondsSlack: 1209600,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
+                scheduledDeliveryExpirationSecondsGoogleChat: null,
             });
         });
     });
@@ -143,6 +147,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsEmail: null,
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
+                scheduledDeliveryExpirationSecondsGoogleChat: null,
             });
         });
 

--- a/packages/backend/src/models/OrganizationSettingsModel.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.ts
@@ -54,6 +54,8 @@ export class OrganizationSettingsModel {
                 row?.scheduled_delivery_expiration_seconds_slack ?? null,
             scheduledDeliveryExpirationSecondsMsTeams:
                 row?.scheduled_delivery_expiration_seconds_msteams ?? null,
+            scheduledDeliveryExpirationSecondsGoogleChat:
+                row?.scheduled_delivery_expiration_seconds_googlechat ?? null,
         };
     }
 
@@ -78,6 +80,8 @@ export class OrganizationSettingsModel {
                 patch.scheduledDeliveryExpirationSecondsSlack,
             scheduled_delivery_expiration_seconds_msteams:
                 patch.scheduledDeliveryExpirationSecondsMsTeams,
+            scheduled_delivery_expiration_seconds_googlechat:
+                patch.scheduledDeliveryExpirationSecondsGoogleChat,
         };
         const toWrite = omitBy(
             columns,

--- a/packages/backend/src/models/OrganizationSettingsModel.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.ts
@@ -46,6 +46,14 @@ export class OrganizationSettingsModel {
                 row?.oidc_to_email_linking_enabled ?? null,
             supportImpersonationEnabled:
                 row?.support_impersonation_enabled ?? null,
+            scheduledDeliveryExpirationSeconds:
+                row?.scheduled_delivery_expiration_seconds ?? null,
+            scheduledDeliveryExpirationSecondsEmail:
+                row?.scheduled_delivery_expiration_seconds_email ?? null,
+            scheduledDeliveryExpirationSecondsSlack:
+                row?.scheduled_delivery_expiration_seconds_slack ?? null,
+            scheduledDeliveryExpirationSecondsMsTeams:
+                row?.scheduled_delivery_expiration_seconds_msteams ?? null,
         };
     }
 
@@ -62,6 +70,14 @@ export class OrganizationSettingsModel {
             oidc_linking_enabled: patch.oidcLinkingEnabled,
             oidc_to_email_linking_enabled: patch.oidcToEmailLinkingEnabled,
             support_impersonation_enabled: patch.supportImpersonationEnabled,
+            scheduled_delivery_expiration_seconds:
+                patch.scheduledDeliveryExpirationSeconds,
+            scheduled_delivery_expiration_seconds_email:
+                patch.scheduledDeliveryExpirationSecondsEmail,
+            scheduled_delivery_expiration_seconds_slack:
+                patch.scheduledDeliveryExpirationSecondsSlack,
+            scheduled_delivery_expiration_seconds_msteams:
+                patch.scheduledDeliveryExpirationSecondsMsTeams,
         };
         const toWrite = omitBy(
             columns,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -360,13 +360,11 @@ export default class SchedulerTask {
         const settings =
             await this.organizationSettingsModel.get(organizationUuid);
         const pdu = this.lightdashConfig.persistentDownloadUrls;
-        // Google Chat has no per-channel override (env or org), so it always
-        // inherits the base.
         const orgChannel: number | null = {
             email: settings.scheduledDeliveryExpirationSecondsEmail,
             slack: settings.scheduledDeliveryExpirationSecondsSlack,
             msteams: settings.scheduledDeliveryExpirationSecondsMsTeams,
-            googlechat: null,
+            googlechat: settings.scheduledDeliveryExpirationSecondsGoogleChat,
         }[channel];
         const envChannel: number | undefined = {
             email: pdu.expirationSecondsEmail,
@@ -1229,7 +1227,7 @@ export default class SchedulerTask {
                     timezone || defaultSchedulerTimezone,
                 )} from Lightdash.\n${
                     showExpirationWarning
-                        ? `For security reasons, delivered files expire after *${slackExpirationDays}* days.`
+                        ? `Delivered files expire after *${slackExpirationDays}* days.`
                         : ''
                 }`,
                 includeLinks,
@@ -1252,7 +1250,7 @@ export default class SchedulerTask {
                         : 'data alert';
 
                     const expiration = slackImageUrl.expiring
-                        ? `For security reasons, delivered files expire after ${slackExpirationDays} days.`
+                        ? `Delivered files expire after ${slackExpirationDays} days.`
                         : '';
 
                     const blocks = getChartThresholdAlertBlocks({
@@ -1280,7 +1278,7 @@ export default class SchedulerTask {
                     );
 
                 const expiration = slackImageUrl.expiring
-                    ? `For security reasons, delivered files expire after ${slackExpirationDays} days.`
+                    ? `Delivered files expire after ${slackExpirationDays} days.`
                     : '';
                 const blocks = getChartAndDashboardBlocks({
                     ...getBlocksArgs,
@@ -2618,7 +2616,7 @@ export default class SchedulerTask {
                     details.description || '',
                     thresholdMessage,
                     new Date().toLocaleDateString('en-GB'),
-                    `For security reasons, delivered files expire after ${Math.ceil(emailExpiration / 86400)} days`,
+                    `Delivered files expire after ${Math.ceil(emailExpiration / 86400)} days`,
                     imageUrl,
                     url,
                     schedulerUrl,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -142,6 +142,7 @@ import type { PreAggregateModel } from '../ee/models/PreAggregateModel';
 import type { PreAggregateMaterializationService } from '../ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService';
 import Logger from '../logging/logger';
 import type { ExecutionContextInfo } from '../logging/winston';
+import { OrganizationSettingsModel } from '../models/OrganizationSettingsModel';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
 import { SCHEDULER_POLLING_OPTIONS } from '../services/AsyncQueryService/types';
 import type { CatalogService } from '../services/CatalogService/CatalogService';
@@ -194,6 +195,7 @@ export type SchedulerTaskArguments = {
     persistentDownloadFileService: PersistentDownloadFileService;
     preAggregateModel: PreAggregateModel;
     preAggregateMaterializationService: PreAggregateMaterializationService;
+    organizationSettingsModel: OrganizationSettingsModel;
 };
 
 /**
@@ -311,6 +313,8 @@ export default class SchedulerTask {
 
     protected readonly preAggregateModel: PreAggregateModel;
 
+    protected readonly organizationSettingsModel: OrganizationSettingsModel;
+
     constructor(args: SchedulerTaskArguments) {
         this.lightdashConfig = args.lightdashConfig;
         this.analytics = args.analytics;
@@ -338,6 +342,44 @@ export default class SchedulerTask {
         this.preAggregateModel = args.preAggregateModel;
         this.preAggregateMaterializationService =
             args.preAggregateMaterializationService;
+        this.organizationSettingsModel = args.organizationSettingsModel;
+    }
+
+    /**
+     * Effective scheduled-delivery link expiry (seconds) for an org and a
+     * delivery channel. Org overrides win over instance env, and a channel
+     * override wins over the base, so precedence is:
+     *   org channel → org base → env channel → env base.
+     * The resulting value flows to `createPersistentUrl`, which transparently
+     * switches to persistent download URLs when it exceeds the S3 7-day limit.
+     */
+    protected async getDeliveryExpirationSeconds(
+        organizationUuid: string,
+        channel: 'email' | 'slack' | 'msteams' | 'googlechat',
+    ): Promise<number> {
+        const settings =
+            await this.organizationSettingsModel.get(organizationUuid);
+        const pdu = this.lightdashConfig.persistentDownloadUrls;
+        // Google Chat has no per-channel override (env or org), so it always
+        // inherits the base.
+        const orgChannel: number | null = {
+            email: settings.scheduledDeliveryExpirationSecondsEmail,
+            slack: settings.scheduledDeliveryExpirationSecondsSlack,
+            msteams: settings.scheduledDeliveryExpirationSecondsMsTeams,
+            googlechat: null,
+        }[channel];
+        const envChannel: number | undefined = {
+            email: pdu.expirationSecondsEmail,
+            slack: pdu.expirationSecondsSlack,
+            msteams: pdu.expirationSecondsMsTeams,
+            googlechat: undefined,
+        }[channel];
+        return (
+            orgChannel ??
+            settings.scheduledDeliveryExpirationSeconds ??
+            envChannel ??
+            pdu.expirationSeconds
+        );
     }
 
     private static getCsvOptions(
@@ -1138,10 +1180,10 @@ export default class SchedulerTask {
             });
 
             // Backwards compatibility for old scheduled deliveries
-            const slackExpiration =
-                this.lightdashConfig.persistentDownloadUrls
-                    .expirationSecondsSlack ??
-                this.lightdashConfig.persistentDownloadUrls.expirationSeconds;
+            const slackExpiration = await this.getDeliveryExpirationSeconds(
+                notification.organizationUuid,
+                'slack',
+            );
             const notificationPageData =
                 notification.page ??
                 (await this.getNotificationPageData(
@@ -1516,10 +1558,10 @@ export default class SchedulerTask {
             });
 
             // Backwards compatibility for old scheduled deliveries
-            const msTeamsExpiration =
-                this.lightdashConfig.persistentDownloadUrls
-                    .expirationSecondsMsTeams ??
-                this.lightdashConfig.persistentDownloadUrls.expirationSeconds;
+            const msTeamsExpiration = await this.getDeliveryExpirationSeconds(
+                notification.organizationUuid,
+                'msteams',
+            );
             const notificationPageData =
                 notification.page ??
                 (await this.getNotificationPageData(
@@ -2486,10 +2528,10 @@ export default class SchedulerTask {
             });
 
             // Backwards compatibility for old scheduled deliveries
-            const emailExpiration =
-                this.lightdashConfig.persistentDownloadUrls
-                    .expirationSecondsEmail ??
-                this.lightdashConfig.persistentDownloadUrls.expirationSeconds;
+            const emailExpiration = await this.getDeliveryExpirationSeconds(
+                notification.organizationUuid,
+                'email',
+            );
             const notificationPageData =
                 notification.page ??
                 (await this.getNotificationPageData(
@@ -3757,19 +3799,32 @@ export default class SchedulerTask {
             if (scheduler.format === SchedulerFormat.GSHEETS) {
                 page = undefined;
             } else {
-                const {
-                    expirationSeconds,
-                    expirationSecondsEmail,
-                    expirationSecondsSlack,
-                    expirationSecondsMsTeams,
-                } = this.lightdashConfig.persistentDownloadUrls;
-
-                const emailExpiration =
-                    expirationSecondsEmail ?? expirationSeconds;
-                const slackExpiration =
-                    expirationSecondsSlack ?? expirationSeconds;
-                const msTeamsExpiration =
-                    expirationSecondsMsTeams ?? expirationSeconds;
+                // Effective per-channel expiry (org override → org base → env
+                // channel → env base), resolved per channel so a delivery can
+                // last longer on, say, Slack than email.
+                const [
+                    emailExpiration,
+                    slackExpiration,
+                    msTeamsExpiration,
+                    googleChatExpiration,
+                ] = await Promise.all([
+                    this.getDeliveryExpirationSeconds(
+                        schedulerPayload.organizationUuid,
+                        'email',
+                    ),
+                    this.getDeliveryExpirationSeconds(
+                        schedulerPayload.organizationUuid,
+                        'slack',
+                    ),
+                    this.getDeliveryExpirationSeconds(
+                        schedulerPayload.organizationUuid,
+                        'msteams',
+                    ),
+                    this.getDeliveryExpirationSeconds(
+                        schedulerPayload.organizationUuid,
+                        'googlechat',
+                    ),
+                ]);
 
                 const hasEmail = targets.some(
                     (t) =>
@@ -3804,7 +3859,7 @@ export default class SchedulerTask {
                 if (hasEmail) addToMap(emailExpiration, 'email');
                 if (hasSlack) addToMap(slackExpiration, 'slack');
                 if (hasMsTeams) addToMap(msTeamsExpiration, 'msteams');
-                if (hasGoogleChat) addToMap(expirationSeconds, 'googlechat');
+                if (hasGoogleChat) addToMap(googleChatExpiration, 'googlechat');
 
                 const pageByChannel = await Array.from(
                     expirationToChannels.entries(),
@@ -5497,13 +5552,17 @@ export default class SchedulerTask {
             });
 
             // Backwards compatibility for old scheduled deliveries
+            const googleChatExpiration =
+                await this.getDeliveryExpirationSeconds(
+                    notification.organizationUuid,
+                    'googlechat',
+                );
             const notificationPageData =
                 notification.page ??
                 (await this.getNotificationPageData(
                     scheduler,
                     jobId,
-                    this.lightdashConfig.persistentDownloadUrls
-                        .expirationSeconds,
+                    googleChatExpiration,
                 ));
 
             const {

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     OrganizationSettings,
+    ParameterError,
     resolveEffectiveOrganizationSettings,
     UpdateOrganizationSettings,
     type RegisteredAccount,
@@ -9,6 +10,7 @@ import {
 import { LightdashConfig } from '../../config/parseConfig';
 import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import { BaseService } from '../BaseService';
+import { getOrganizationSettingsInstanceDefaults } from './getInstanceDefaults';
 
 type OrganizationSettingsServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -53,6 +55,33 @@ export class OrganizationSettingsService extends BaseService {
         return organizationUuid;
     }
 
+    /**
+     * Sanity-checks the scheduled-delivery expiry overrides (base + per-channel)
+     * before they're persisted. A `null` clears an override (back to inheriting
+     * the base / env). We don't cap the value — it feeds the existing expiry
+     * mechanism as-is (links over 7 days transparently use persistent download
+     * URLs) — we only reject nonsense that would store an already-expired link.
+     */
+    private static assertValidPatch(data: UpdateOrganizationSettings): void {
+        const expiryFields: Array<keyof UpdateOrganizationSettings> = [
+            'scheduledDeliveryExpirationSeconds',
+            'scheduledDeliveryExpirationSecondsEmail',
+            'scheduledDeliveryExpirationSecondsSlack',
+            'scheduledDeliveryExpirationSecondsMsTeams',
+        ];
+        const isInvalid = (value: number | boolean | null | undefined) =>
+            value !== undefined &&
+            value !== null &&
+            (typeof value !== 'number' ||
+                !Number.isInteger(value) ||
+                value <= 0);
+        if (expiryFields.some((field) => isInvalid(data[field]))) {
+            throw new ParameterError(
+                'Scheduled delivery link expiry must be a positive whole number of seconds.',
+            );
+        }
+    }
+
     async getOrganizationSettings(
         account: RegisteredAccount,
     ): Promise<OrganizationSettings> {
@@ -60,7 +89,7 @@ export class OrganizationSettingsService extends BaseService {
         const raw = await this.organizationSettingsModel.get(organizationUuid);
         return resolveEffectiveOrganizationSettings(
             raw,
-            this.lightdashConfig.auth,
+            getOrganizationSettingsInstanceDefaults(this.lightdashConfig),
         );
     }
 
@@ -69,13 +98,14 @@ export class OrganizationSettingsService extends BaseService {
         data: UpdateOrganizationSettings,
     ): Promise<OrganizationSettings> {
         const organizationUuid = this.assertCanManageOrganization(account);
+        OrganizationSettingsService.assertValidPatch(data);
         const raw = await this.organizationSettingsModel.update(
             organizationUuid,
             data,
         );
         return resolveEffectiveOrganizationSettings(
             raw,
-            this.lightdashConfig.auth,
+            getOrganizationSettingsInstanceDefaults(this.lightdashConfig),
         );
     }
 }

--- a/packages/backend/src/services/OrganizationSettingsService/getInstanceDefaults.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/getInstanceDefaults.ts
@@ -1,0 +1,17 @@
+import { type OrganizationSettingsInstanceDefaults } from '@lightdash/common';
+import { type LightdashConfig } from '../../config/parseConfig';
+
+/**
+ * Builds the instance-wide fallback values that `resolveEffectiveOrganizationSettings`
+ * uses when an org hasn't overridden a setting. Centralises the env → setting
+ * mapping in one place so every caller (the settings API, the login flow, the
+ * scheduler) resolves the same defaults.
+ */
+export const getOrganizationSettingsInstanceDefaults = (
+    lightdashConfig: LightdashConfig,
+): OrganizationSettingsInstanceDefaults => ({
+    enableOidcLinking: lightdashConfig.auth.enableOidcLinking,
+    enableOidcToEmailLinking: lightdashConfig.auth.enableOidcToEmailLinking,
+    scheduledDeliveryExpirationSeconds:
+        lightdashConfig.persistentDownloadUrls.expirationSeconds,
+});

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
@@ -47,17 +47,41 @@ describe('PersistentDownloadFileService', () => {
     });
 
     describe('createPersistentUrl', () => {
-        it('should return raw S3 URL when feature is disabled', async () => {
+        it('should return raw S3 URL (honoring the requested expiry) when feature is disabled', async () => {
             mockS3GetFileUrl.mockResolvedValue(
                 'https://s3.amazonaws.com/bucket/test-file.csv',
             );
             const service = createService({ enabled: false });
 
-            const url = await service.createPersistentUrl(baseData);
+            const url = await service.createPersistentUrl({
+                ...baseData,
+                expirationSeconds: 86400,
+            });
 
             expect(url).toBe('https://s3.amazonaws.com/bucket/test-file.csv');
-            expect(mockS3GetFileUrl).toHaveBeenCalledWith(baseData.s3Key);
+            // The requested expiry is forwarded to the raw presigned URL.
+            expect(mockS3GetFileUrl).toHaveBeenCalledWith(
+                baseData.s3Key,
+                86400,
+            );
             expect(mockModelCreate).not.toHaveBeenCalled();
+        });
+
+        it('should transparently use persistent URLs when the requested expiry exceeds the 7-day S3 limit, even with the feature off', async () => {
+            mockModelCreate.mockResolvedValue(undefined);
+            const service = createService({ enabled: false });
+
+            // 14 days — longer than a raw S3 presigned URL can live.
+            const url = await service.createPersistentUrl({
+                ...baseData,
+                expirationSeconds: 14 * 86400,
+            });
+
+            expect(url).toMatch(
+                /^https:\/\/test\.lightdash\.cloud\/api\/v1\/file\/[\w-]{21}$/,
+            );
+            expect(mockModelCreate).toHaveBeenCalled();
+            expect(mockS3GetFileUrl).not.toHaveBeenCalled();
         });
 
         it('should create persistent URL when feature is enabled', async () => {

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
@@ -1,4 +1,7 @@
-import { NotFoundError } from '@lightdash/common';
+import {
+    NotFoundError,
+    S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS,
+} from '@lightdash/common';
 import { nanoid } from 'nanoid';
 import { type Readable } from 'stream';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
@@ -40,11 +43,27 @@ export class PersistentDownloadFileService extends BaseService {
         createdByUserUuid: string | null;
         expirationSeconds?: number;
     }): Promise<string> {
-        if (!this.lightdashConfig.persistentDownloadUrls.enabled) {
+        // Use the persistent-URL system when the instance enables it
+        // (PERSISTENT_DOWNLOAD_URLS_ENABLED, off by default), or transparently
+        // when the requested expiry exceeds what a raw S3 presigned URL can do
+        // (7 days) — that's the only way a link can live that long, so it wins
+        // even when the instance hasn't opted in. Otherwise hand back a raw
+        // presigned URL honoring the requested expiry (undefined falls back to
+        // the S3 default).
+        const exceedsS3Limit =
+            data.expirationSeconds !== undefined &&
+            data.expirationSeconds > S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS;
+        const usePersistent =
+            this.lightdashConfig.persistentDownloadUrls.enabled ||
+            exceedsS3Limit;
+        if (!usePersistent) {
             this.logger.debug(
                 'Persistent download URLs disabled, returning raw S3 URL',
             );
-            return this.fileStorageClient.getFileUrl(data.s3Key);
+            return this.fileStorageClient.getFileUrl(
+                data.s3Key,
+                data.expirationSeconds,
+            );
         }
 
         const fileNanoid = nanoid();

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -92,6 +92,7 @@ import { UserWarehouseCredentialsModel } from '../models/UserWarehouseCredential
 import { WarehouseAvailableTablesModel } from '../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
 import { wrapSentryTransaction } from '../utils';
 import { BaseService } from './BaseService';
+import { getOrganizationSettingsInstanceDefaults } from './OrganizationSettingsService/getInstanceDefaults';
 
 type UserServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -769,8 +770,10 @@ export class UserService extends BaseService {
             ? await this.organizationSettingsModel.get(organizationUuid)
             : {};
         return (
-            resolveEffectiveOrganizationSettings(raw, this.lightdashConfig.auth)
-                .oidcLinkingEnabled ?? false
+            resolveEffectiveOrganizationSettings(
+                raw,
+                getOrganizationSettingsInstanceDefaults(this.lightdashConfig),
+            ).oidcLinkingEnabled ?? false
         );
     }
 
@@ -787,8 +790,10 @@ export class UserService extends BaseService {
             ? await this.organizationSettingsModel.get(organizationUuid)
             : {};
         return (
-            resolveEffectiveOrganizationSettings(raw, this.lightdashConfig.auth)
-                .oidcToEmailLinkingEnabled ?? false
+            resolveEffectiveOrganizationSettings(
+                raw,
+                getOrganizationSettingsInstanceDefaults(this.lightdashConfig),
+            ).oidcToEmailLinkingEnabled ?? false
         );
     }
 

--- a/packages/common/src/types/organizationSettings.test.ts
+++ b/packages/common/src/types/organizationSettings.test.ts
@@ -21,6 +21,7 @@ describe('resolveEffectiveOrganizationSettings', () => {
             scheduledDeliveryExpirationSecondsEmail: null,
             scheduledDeliveryExpirationSecondsSlack: null,
             scheduledDeliveryExpirationSecondsMsTeams: null,
+            scheduledDeliveryExpirationSecondsGoogleChat: null,
         });
     });
 
@@ -47,6 +48,9 @@ describe('resolveEffectiveOrganizationSettings', () => {
         expect(resolved.scheduledDeliveryExpirationSecondsSlack).toBe(1209600);
         expect(resolved.scheduledDeliveryExpirationSecondsEmail).toBeNull();
         expect(resolved.scheduledDeliveryExpirationSecondsMsTeams).toBeNull();
+        expect(
+            resolved.scheduledDeliveryExpirationSecondsGoogleChat,
+        ).toBeNull();
     });
 
     test('support impersonation is opt-in only (no env default)', () => {

--- a/packages/common/src/types/organizationSettings.test.ts
+++ b/packages/common/src/types/organizationSettings.test.ts
@@ -1,0 +1,58 @@
+import {
+    resolveEffectiveOrganizationSettings,
+    type OrganizationSettingsInstanceDefaults,
+} from './organizationSettings';
+
+const INSTANCE_DEFAULTS: OrganizationSettingsInstanceDefaults = {
+    enableOidcLinking: false,
+    enableOidcToEmailLinking: true,
+    scheduledDeliveryExpirationSeconds: 259200, // 3 days (env default)
+};
+
+describe('resolveEffectiveOrganizationSettings', () => {
+    test('falls back to instance defaults when nothing is overridden', () => {
+        expect(
+            resolveEffectiveOrganizationSettings({}, INSTANCE_DEFAULTS),
+        ).toEqual({
+            oidcLinkingEnabled: false,
+            oidcToEmailLinkingEnabled: true,
+            supportImpersonationEnabled: false,
+            scheduledDeliveryExpirationSeconds: 259200,
+            scheduledDeliveryExpirationSecondsEmail: null,
+            scheduledDeliveryExpirationSecondsSlack: null,
+            scheduledDeliveryExpirationSecondsMsTeams: null,
+        });
+    });
+
+    test('the base expiry resolves to an effective number, inheriting the env when unset', () => {
+        expect(
+            resolveEffectiveOrganizationSettings({}, INSTANCE_DEFAULTS)
+                .scheduledDeliveryExpirationSeconds,
+        ).toBe(259200);
+        expect(
+            resolveEffectiveOrganizationSettings(
+                { scheduledDeliveryExpirationSeconds: 604800 },
+                INSTANCE_DEFAULTS,
+            ).scheduledDeliveryExpirationSeconds,
+        ).toBe(604800);
+    });
+
+    test('per-channel overrides are surfaced raw (null = inherit base), not resolved', () => {
+        const resolved = resolveEffectiveOrganizationSettings(
+            { scheduledDeliveryExpirationSecondsSlack: 1209600 },
+            INSTANCE_DEFAULTS,
+        );
+        // Slack carries its explicit override; the other channels stay null so
+        // the UI can show "inherit".
+        expect(resolved.scheduledDeliveryExpirationSecondsSlack).toBe(1209600);
+        expect(resolved.scheduledDeliveryExpirationSecondsEmail).toBeNull();
+        expect(resolved.scheduledDeliveryExpirationSecondsMsTeams).toBeNull();
+    });
+
+    test('support impersonation is opt-in only (no env default)', () => {
+        expect(
+            resolveEffectiveOrganizationSettings({}, INSTANCE_DEFAULTS)
+                .supportImpersonationEnabled,
+        ).toBe(false);
+    });
+});

--- a/packages/common/src/types/organizationSettings.ts
+++ b/packages/common/src/types/organizationSettings.ts
@@ -28,7 +28,42 @@ export type OrganizationSettings = {
      * stored row) resolves to `false`.
      */
     supportImpersonationEnabled: boolean | null;
+    /**
+     * Base lifetime (seconds) of this org's scheduled-delivery download links —
+     * the default every channel inherits. Overrides the instance-wide
+     * `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS` env; `null` inherits it. This
+     * field is always resolved to an effective number in API responses (it
+     * falls back to the env default), so the frontend can display it directly.
+     * A value over {@link S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS} transparently
+     * switches that delivery to the persistent-download-URL system (the only
+     * way a link can outlive AWS's 7-day presigned ceiling).
+     */
+    scheduledDeliveryExpirationSeconds: number | null;
+    /**
+     * Per-channel override (seconds) of {@link scheduledDeliveryExpirationSeconds}
+     * for email deliveries; `null` inherits the base. Unlike the base, this is
+     * surfaced raw (not resolved) so the UI can distinguish "inherit" from an
+     * explicit value. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_EMAIL`.
+     */
+    scheduledDeliveryExpirationSecondsEmail: number | null;
+    /**
+     * Per-channel override (seconds) for Slack deliveries; `null` inherits the
+     * base. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_SLACK`.
+     */
+    scheduledDeliveryExpirationSecondsSlack: number | null;
+    /**
+     * Per-channel override (seconds) for Microsoft Teams deliveries; `null`
+     * inherits the base. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_MSTEAMS`.
+     */
+    scheduledDeliveryExpirationSecondsMsTeams: number | null;
 };
+
+/**
+ * AWS's hard maximum lifetime of an S3 SigV4 presigned URL — seven days. A
+ * requested expiry above this can't be served by a raw presigned link, so the
+ * delivery transparently falls back to the persistent-download-URL system.
+ */
+export const S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS = 604800;
 
 export type UpdateOrganizationSettings = Partial<OrganizationSettings>;
 
@@ -38,20 +73,28 @@ export type ApiOrganizationSettingsResponse = {
 };
 
 /**
+ * The instance-wide defaults a stored override falls back to. Each field maps
+ * to an env var resolved in `parseConfig`; the backend builds this from
+ * `lightdashConfig` (see `getOrganizationSettingsInstanceDefaults`) so the
+ * fallback values live in exactly one place.
+ */
+export type OrganizationSettingsInstanceDefaults = {
+    enableOidcLinking: boolean;
+    enableOidcToEmailLinking: boolean;
+    scheduledDeliveryExpirationSeconds: number;
+};
+
+/**
  * The single source of truth for resolving a stored (raw) org settings record
  * against the instance defaults: an explicit per-org value wins; a value that's
  * `null`, or simply absent (an unset column / no row at all), falls back to the
  * instance default. Used by the backend for both the API response (so the
  * frontend just displays the effective value) and the login flow, so the two
- * can never drift. `instanceDefaults` is structurally satisfied by
- * `lightdashConfig.auth`.
+ * can never drift.
  */
 export const resolveEffectiveOrganizationSettings = (
     raw: Partial<OrganizationSettings>,
-    instanceDefaults: {
-        enableOidcLinking: boolean;
-        enableOidcToEmailLinking: boolean;
-    },
+    instanceDefaults: OrganizationSettingsInstanceDefaults,
 ): OrganizationSettings => ({
     oidcLinkingEnabled:
         raw.oidcLinkingEnabled ?? instanceDefaults.enableOidcLinking,
@@ -60,4 +103,17 @@ export const resolveEffectiveOrganizationSettings = (
         instanceDefaults.enableOidcToEmailLinking,
     // Opt-in only — no instance default, so an unset value resolves to false.
     supportImpersonationEnabled: raw.supportImpersonationEnabled ?? false,
+    // Base is resolved to an effective number (falls back to the env default).
+    scheduledDeliveryExpirationSeconds:
+        raw.scheduledDeliveryExpirationSeconds ??
+        instanceDefaults.scheduledDeliveryExpirationSeconds,
+    // Per-channel overrides are surfaced raw (null = inherit base) so the UI
+    // can tell "not set" apart from an explicit value; their fallback to the
+    // base happens at delivery time, not here.
+    scheduledDeliveryExpirationSecondsEmail:
+        raw.scheduledDeliveryExpirationSecondsEmail ?? null,
+    scheduledDeliveryExpirationSecondsSlack:
+        raw.scheduledDeliveryExpirationSecondsSlack ?? null,
+    scheduledDeliveryExpirationSecondsMsTeams:
+        raw.scheduledDeliveryExpirationSecondsMsTeams ?? null,
 });

--- a/packages/common/src/types/organizationSettings.ts
+++ b/packages/common/src/types/organizationSettings.ts
@@ -56,6 +56,12 @@ export type OrganizationSettings = {
      * inherits the base. Overrides `PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS_MSTEAMS`.
      */
     scheduledDeliveryExpirationSecondsMsTeams: number | null;
+    /**
+     * Per-channel override (seconds) for Google Chat deliveries; `null` inherits
+     * the base. Google Chat has no instance env var, so this is an org-only
+     * override (it still falls back to the base / env base).
+     */
+    scheduledDeliveryExpirationSecondsGoogleChat: number | null;
 };
 
 /**
@@ -116,4 +122,6 @@ export const resolveEffectiveOrganizationSettings = (
         raw.scheduledDeliveryExpirationSecondsSlack ?? null,
     scheduledDeliveryExpirationSecondsMsTeams:
         raw.scheduledDeliveryExpirationSecondsMsTeams ?? null,
+    scheduledDeliveryExpirationSecondsGoogleChat:
+        raw.scheduledDeliveryExpirationSecondsGoogleChat ?? null,
 });

--- a/packages/frontend/src/components/UserSettings/ExportingPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ExportingPanel/index.tsx
@@ -1,0 +1,225 @@
+import {
+    S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS,
+    type OrganizationSettings,
+    type UpdateOrganizationSettings,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Button,
+    Checkbox,
+    Group,
+    Loader,
+    NumberInput,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconX } from '@tabler/icons-react';
+import { type FC } from 'react';
+import {
+    useOrganizationSettings,
+    useUpdateOrganizationSettings,
+} from '../../../hooks/organization/useOrganizationSettings';
+import MantineIcon from '../../common/MantineIcon';
+
+const SECONDS_PER_DAY = 86400;
+// Generous UI guardrail. There's no backend cap: links over 7 days simply use
+// the persistent-download-URL system transparently.
+const MAX_DAYS = 365;
+const S3_MAX_DAYS = Math.floor(
+    S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS / SECONDS_PER_DAY,
+);
+
+// '' models "inherit the base" for an optional per-channel input.
+type DaysValue = number | '';
+
+const CHANNELS = [
+    { key: 'email', label: 'Email' },
+    { key: 'slack', label: 'Slack' },
+    { key: 'msteams', label: 'Microsoft Teams' },
+] as const;
+
+type ChannelKey = (typeof CHANNELS)[number]['key'];
+
+const toDays = (seconds: number | null): DaysValue =>
+    seconds === null ? '' : Math.max(1, Math.round(seconds / SECONDS_PER_DAY));
+
+const toSeconds = (days: DaysValue): number | null =>
+    days === '' ? null : days * SECONDS_PER_DAY;
+
+/**
+ * Editable form for the org's exporting settings. Split out from the panel so
+ * the form's initial values are captured from the loaded settings exactly once
+ * (keyed remount on the effective values), never clobbered by a refetch.
+ */
+const ExportingForm: FC<{ settings: OrganizationSettings }> = ({
+    settings,
+}) => {
+    const update = useUpdateOrganizationSettings();
+
+    // Base is an effective number (resolved against the env); per-channel
+    // overrides are raw (null = inherit the base).
+    const initialChannels: Record<ChannelKey, number | null> = {
+        email: settings.scheduledDeliveryExpirationSecondsEmail,
+        slack: settings.scheduledDeliveryExpirationSecondsSlack,
+        msteams: settings.scheduledDeliveryExpirationSecondsMsTeams,
+    };
+    const initial = {
+        base: Math.max(
+            1,
+            Math.round(
+                (settings.scheduledDeliveryExpirationSeconds ??
+                    SECONDS_PER_DAY) / SECONDS_PER_DAY,
+            ),
+        ) as DaysValue,
+        // The section opens pre-expanded only if an override already exists.
+        perChannelEnabled: CHANNELS.some(
+            (c) => initialChannels[c.key] !== null,
+        ),
+        email: toDays(initialChannels.email),
+        slack: toDays(initialChannels.slack),
+        msteams: toDays(initialChannels.msteams),
+    };
+
+    const form = useForm({ initialValues: initial });
+
+    const baseDays = form.values.base === '' ? 1 : form.values.base;
+
+    // What we'd persist for each channel: the typed value when overrides are
+    // on, otherwise null (everything inherits the base).
+    const effectiveChannelSeconds = (key: ChannelKey): number | null =>
+        form.values.perChannelEnabled ? toSeconds(form.values[key]) : null;
+
+    const handleSubmit = form.onSubmit(() => {
+        const patch: UpdateOrganizationSettings = {
+            scheduledDeliveryExpirationSeconds: baseDays * SECONDS_PER_DAY,
+            scheduledDeliveryExpirationSecondsEmail:
+                effectiveChannelSeconds('email'),
+            scheduledDeliveryExpirationSecondsSlack:
+                effectiveChannelSeconds('slack'),
+            scheduledDeliveryExpirationSecondsMsTeams:
+                effectiveChannelSeconds('msteams'),
+        };
+        update.mutate(patch);
+    });
+
+    const isUnchanged =
+        baseDays === initial.base &&
+        CHANNELS.every(
+            (c) => effectiveChannelSeconds(c.key) === initialChannels[c.key],
+        );
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <Stack gap="lg">
+                <NumberInput
+                    label="Download link expiry"
+                    description={`How long a scheduled delivery's download links stay valid. Links longer than ${S3_MAX_DAYS} days automatically use persistent download links.`}
+                    suffix=" days"
+                    min={1}
+                    max={MAX_DAYS}
+                    clampBehavior="strict"
+                    allowDecimal={false}
+                    allowNegative={false}
+                    {...form.getInputProps('base')}
+                />
+
+                <Checkbox
+                    label="Set a different expiry for specific channels"
+                    description="When off, every channel uses the expiry above."
+                    {...form.getInputProps('perChannelEnabled', {
+                        type: 'checkbox',
+                    })}
+                />
+
+                {form.values.perChannelEnabled && (
+                    <Stack gap="xs">
+                        {CHANNELS.map((channel) => {
+                            const isOverridden =
+                                form.values[channel.key] !== '';
+                            return (
+                                <Group key={channel.key} gap="sm" wrap="nowrap">
+                                    <Text w={120} fz="sm">
+                                        {channel.label}
+                                    </Text>
+                                    <NumberInput
+                                        aria-label={`${channel.label} link expiry`}
+                                        placeholder={`Inherits ${baseDays} days`}
+                                        suffix=" days"
+                                        min={1}
+                                        max={MAX_DAYS}
+                                        clampBehavior="strict"
+                                        allowDecimal={false}
+                                        allowNegative={false}
+                                        hideControls
+                                        flex={1}
+                                        rightSection={
+                                            isOverridden ? (
+                                                <Tooltip label="Clear — inherit the expiry above">
+                                                    <ActionIcon
+                                                        variant="subtle"
+                                                        color="gray"
+                                                        size="sm"
+                                                        onClick={() =>
+                                                            form.setFieldValue(
+                                                                channel.key,
+                                                                '',
+                                                            )
+                                                        }
+                                                    >
+                                                        <MantineIcon
+                                                            icon={IconX}
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+                                            ) : null
+                                        }
+                                        rightSectionPointerEvents={
+                                            isOverridden ? 'all' : 'none'
+                                        }
+                                        {...form.getInputProps(channel.key)}
+                                    />
+                                </Group>
+                            );
+                        })}
+                    </Stack>
+                )}
+
+                <Group justify="flex-end">
+                    <Button
+                        type="submit"
+                        loading={update.isLoading}
+                        disabled={isUnchanged}
+                    >
+                        Save
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    );
+};
+
+const ExportingPanel: FC = () => {
+    const { data, isInitialLoading } = useOrganizationSettings();
+
+    if (isInitialLoading || !data) {
+        return <Loader />;
+    }
+
+    // Remount when the effective values change so the form re-seeds from server
+    // state without a clobbering useEffect.
+    return (
+        <ExportingForm
+            key={[
+                data.scheduledDeliveryExpirationSeconds,
+                data.scheduledDeliveryExpirationSecondsEmail,
+                data.scheduledDeliveryExpirationSecondsSlack,
+                data.scheduledDeliveryExpirationSecondsMsTeams,
+            ].join('-')}
+            settings={data}
+        />
+    );
+};
+
+export default ExportingPanel;

--- a/packages/frontend/src/components/UserSettings/ExportingPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ExportingPanel/index.tsx
@@ -1,5 +1,5 @@
 import {
-    S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS,
+    FeatureFlags,
     type OrganizationSettings,
     type UpdateOrganizationSettings,
 } from '@lightdash/common';
@@ -17,19 +17,19 @@ import {
 import { useForm } from '@mantine/form';
 import { IconX } from '@tabler/icons-react';
 import { type FC } from 'react';
+import useHealth from '../../../hooks/health/useHealth';
 import {
     useOrganizationSettings,
     useUpdateOrganizationSettings,
 } from '../../../hooks/organization/useOrganizationSettings';
+import { useGetSlack } from '../../../hooks/slack/useSlack';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 
 const SECONDS_PER_DAY = 86400;
-// Generous UI guardrail. There's no backend cap: links over 7 days simply use
-// the persistent-download-URL system transparently.
+// Generous UI guardrail. There's no backend cap: longer links transparently
+// use the persistent-download-URL system.
 const MAX_DAYS = 365;
-const S3_MAX_DAYS = Math.floor(
-    S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS / SECONDS_PER_DAY,
-);
 
 // '' models "inherit the base" for an optional per-channel input.
 type DaysValue = number | '';
@@ -38,6 +38,7 @@ const CHANNELS = [
     { key: 'email', label: 'Email' },
     { key: 'slack', label: 'Slack' },
     { key: 'msteams', label: 'Microsoft Teams' },
+    { key: 'googlechat', label: 'Google Chat' },
 ] as const;
 
 type ChannelKey = (typeof CHANNELS)[number]['key'];
@@ -52,10 +53,16 @@ const toSeconds = (days: DaysValue): number | null =>
  * Editable form for the org's exporting settings. Split out from the panel so
  * the form's initial values are captured from the loaded settings exactly once
  * (keyed remount on the effective values), never clobbered by a refetch.
+ *
+ * `availableChannels` are the delivery methods actually configured for this org
+ * (Slack installed, Teams/Email enabled, Google Chat flag) — we only show a
+ * per-channel override for methods the org can use. Hidden channels keep any
+ * stored override (we never clear it just because the UI doesn't render it).
  */
-const ExportingForm: FC<{ settings: OrganizationSettings }> = ({
-    settings,
-}) => {
+const ExportingForm: FC<{
+    settings: OrganizationSettings;
+    availableChannels: ReadonlyArray<(typeof CHANNELS)[number]>;
+}> = ({ settings, availableChannels }) => {
     const update = useUpdateOrganizationSettings();
 
     // Base is an effective number (resolved against the env); per-channel
@@ -64,6 +71,7 @@ const ExportingForm: FC<{ settings: OrganizationSettings }> = ({
         email: settings.scheduledDeliveryExpirationSecondsEmail,
         slack: settings.scheduledDeliveryExpirationSecondsSlack,
         msteams: settings.scheduledDeliveryExpirationSecondsMsTeams,
+        googlechat: settings.scheduledDeliveryExpirationSecondsGoogleChat,
     };
     const initial = {
         base: Math.max(
@@ -80,6 +88,7 @@ const ExportingForm: FC<{ settings: OrganizationSettings }> = ({
         email: toDays(initialChannels.email),
         slack: toDays(initialChannels.slack),
         msteams: toDays(initialChannels.msteams),
+        googlechat: toDays(initialChannels.googlechat),
     };
 
     const form = useForm({ initialValues: initial });
@@ -100,6 +109,8 @@ const ExportingForm: FC<{ settings: OrganizationSettings }> = ({
                 effectiveChannelSeconds('slack'),
             scheduledDeliveryExpirationSecondsMsTeams:
                 effectiveChannelSeconds('msteams'),
+            scheduledDeliveryExpirationSecondsGoogleChat:
+                effectiveChannelSeconds('googlechat'),
         };
         update.mutate(patch);
     });
@@ -115,7 +126,7 @@ const ExportingForm: FC<{ settings: OrganizationSettings }> = ({
             <Stack gap="lg">
                 <NumberInput
                     label="Download link expiry"
-                    description={`How long a scheduled delivery's download links stay valid. Links longer than ${S3_MAX_DAYS} days automatically use persistent download links.`}
+                    description="How long a scheduled delivery's download links stay valid before they expire."
                     suffix=" days"
                     min={1}
                     max={MAX_DAYS}
@@ -125,65 +136,77 @@ const ExportingForm: FC<{ settings: OrganizationSettings }> = ({
                     {...form.getInputProps('base')}
                 />
 
-                <Checkbox
-                    label="Set a different expiry for specific channels"
-                    description="When off, every channel uses the expiry above."
-                    {...form.getInputProps('perChannelEnabled', {
-                        type: 'checkbox',
-                    })}
-                />
+                {availableChannels.length > 0 && (
+                    <>
+                        <Checkbox
+                            label="Set a different expiry for specific channels"
+                            description="When off, every channel uses the expiry above."
+                            {...form.getInputProps('perChannelEnabled', {
+                                type: 'checkbox',
+                            })}
+                        />
 
-                {form.values.perChannelEnabled && (
-                    <Stack gap="xs">
-                        {CHANNELS.map((channel) => {
-                            const isOverridden =
-                                form.values[channel.key] !== '';
-                            return (
-                                <Group key={channel.key} gap="sm" wrap="nowrap">
-                                    <Text w={120} fz="sm">
-                                        {channel.label}
-                                    </Text>
-                                    <NumberInput
-                                        aria-label={`${channel.label} link expiry`}
-                                        placeholder={`Inherits ${baseDays} days`}
-                                        suffix=" days"
-                                        min={1}
-                                        max={MAX_DAYS}
-                                        clampBehavior="strict"
-                                        allowDecimal={false}
-                                        allowNegative={false}
-                                        hideControls
-                                        flex={1}
-                                        rightSection={
-                                            isOverridden ? (
-                                                <Tooltip label="Clear — inherit the expiry above">
-                                                    <ActionIcon
-                                                        variant="subtle"
-                                                        color="gray"
-                                                        size="sm"
-                                                        onClick={() =>
-                                                            form.setFieldValue(
-                                                                channel.key,
-                                                                '',
-                                                            )
-                                                        }
-                                                    >
-                                                        <MantineIcon
-                                                            icon={IconX}
-                                                        />
-                                                    </ActionIcon>
-                                                </Tooltip>
-                                            ) : null
-                                        }
-                                        rightSectionPointerEvents={
-                                            isOverridden ? 'all' : 'none'
-                                        }
-                                        {...form.getInputProps(channel.key)}
-                                    />
-                                </Group>
-                            );
-                        })}
-                    </Stack>
+                        {form.values.perChannelEnabled && (
+                            <Stack gap="xs">
+                                {availableChannels.map((channel) => {
+                                    const isOverridden =
+                                        form.values[channel.key] !== '';
+                                    return (
+                                        <Group
+                                            key={channel.key}
+                                            gap="sm"
+                                            wrap="nowrap"
+                                        >
+                                            <Text w={120} fz="sm">
+                                                {channel.label}
+                                            </Text>
+                                            <NumberInput
+                                                aria-label={`${channel.label} link expiry`}
+                                                placeholder={`Inherits ${baseDays} days`}
+                                                suffix=" days"
+                                                min={1}
+                                                max={MAX_DAYS}
+                                                clampBehavior="strict"
+                                                allowDecimal={false}
+                                                allowNegative={false}
+                                                hideControls
+                                                flex={1}
+                                                rightSection={
+                                                    isOverridden ? (
+                                                        <Tooltip label="Clear — inherit the expiry above">
+                                                            <ActionIcon
+                                                                variant="subtle"
+                                                                color="gray"
+                                                                size="sm"
+                                                                onClick={() =>
+                                                                    form.setFieldValue(
+                                                                        channel.key,
+                                                                        '',
+                                                                    )
+                                                                }
+                                                            >
+                                                                <MantineIcon
+                                                                    icon={IconX}
+                                                                />
+                                                            </ActionIcon>
+                                                        </Tooltip>
+                                                    ) : null
+                                                }
+                                                rightSectionPointerEvents={
+                                                    isOverridden
+                                                        ? 'all'
+                                                        : 'none'
+                                                }
+                                                {...form.getInputProps(
+                                                    channel.key,
+                                                )}
+                                            />
+                                        </Group>
+                                    );
+                                })}
+                            </Stack>
+                        )}
+                    </>
                 )}
 
                 <Group justify="flex-end">
@@ -202,10 +225,24 @@ const ExportingForm: FC<{ settings: OrganizationSettings }> = ({
 
 const ExportingPanel: FC = () => {
     const { data, isInitialLoading } = useOrganizationSettings();
+    const health = useHealth();
+    const { data: slackInstallation } = useGetSlack();
+    const { data: googleChatFlag } = useServerFeatureFlag(
+        FeatureFlags.GoogleChatEnabled,
+    );
 
     if (isInitialLoading || !data) {
         return <Loader />;
     }
+
+    // Only offer a per-channel override for delivery methods the org can use.
+    const isAvailable: Record<ChannelKey, boolean> = {
+        email: health.data?.hasEmailClient ?? false,
+        slack: !!slackInstallation?.organizationUuid,
+        msteams: health.data?.hasMicrosoftTeams ?? false,
+        googlechat: googleChatFlag?.enabled === true,
+    };
+    const availableChannels = CHANNELS.filter((c) => isAvailable[c.key]);
 
     // Remount when the effective values change so the form re-seeds from server
     // state without a clobbering useEffect.
@@ -216,8 +253,10 @@ const ExportingPanel: FC = () => {
                 data.scheduledDeliveryExpirationSecondsEmail,
                 data.scheduledDeliveryExpirationSecondsSlack,
                 data.scheduledDeliveryExpirationSecondsMsTeams,
+                data.scheduledDeliveryExpirationSecondsGoogleChat,
             ].join('-')}
             settings={data}
+            availableChannels={availableChannels}
         />
     );
 };

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
-import { Box, ScrollArea, Stack, Text, Title } from '@mantine-8/core';
+import { Anchor, Box, ScrollArea, Stack, Text, Title } from '@mantine-8/core';
 import {
     IconAppWindow,
     IconApps,
@@ -14,6 +14,7 @@ import {
     IconDatabase,
     IconDatabaseCog,
     IconDatabaseExport,
+    IconFileExport,
     IconFolders,
     IconHistory,
     IconIdBadge2,
@@ -55,6 +56,7 @@ import AllowedDomainsPanel from '../components/UserSettings/AllowedDomainsPanel'
 import AppearanceSettingsPanel from '../components/UserSettings/AppearanceSettingsPanel';
 import DefaultProjectPanel from '../components/UserSettings/DefaultProjectPanel';
 import { DeleteOrganizationPanel } from '../components/UserSettings/DeleteOrganizationPanel';
+import ExportingPanel from '../components/UserSettings/ExportingPanel';
 import GithubSettingsPanel from '../components/UserSettings/GithubSettingsPanel';
 import GitlabSettingsPanel from '../components/UserSettings/GitlabSettingsPanel';
 import ImpersonationPanel from '../components/UserSettings/ImpersonationPanel';
@@ -371,6 +373,35 @@ const Settings: FC = () => {
                                 </Stack>
                             </SettingsGridCard>
                         )}
+                    </Stack>
+                ),
+            });
+        }
+        if (user?.ability.can('manage', 'Organization')) {
+            allowedRoutes.push({
+                path: '/exporting',
+                element: (
+                    <Stack gap="xl">
+                        <SettingsGridCard>
+                            <div>
+                                <Title order={4}>Scheduled deliveries</Title>
+                                <Text c="ldGray.6" fz="xs">
+                                    Control how files exported from your
+                                    organization — starting with scheduled
+                                    deliveries — are shared.{' '}
+                                    <Anchor
+                                        inherit
+                                        href="https://docs.lightdash.com/guides/how-to-create-scheduled-deliveries"
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    >
+                                        Learn more about scheduled deliveries
+                                    </Anchor>
+                                    .
+                                </Text>
+                            </div>
+                            <ExportingPanel />
+                        </SettingsGridCard>
                     </Stack>
                 ),
             });
@@ -808,6 +839,18 @@ const Settings: FC = () => {
                                         leftSection={
                                             <MantineIcon
                                                 icon={IconBuildingSkyscraper}
+                                            />
+                                        }
+                                    />
+                                )}
+                                {user.ability.can('manage', 'Organization') && (
+                                    <RouterNavLink
+                                        label="Exporting"
+                                        to="/generalSettings/exporting"
+                                        exact
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconFileExport}
                                             />
                                         }
                                     />


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-7217/add-organization-level-scheduled-delivery-settings](https://linear.app/lightdash/issue/PROD-7217/add-organization-level-scheduled-delivery-settings)



![CleanShot 2026-06-01 at 12.37.02.png](https://app.graphite.com/user-attachments/assets/3216a71b-59f0-403f-b7b8-b99db97122ea.png)

Only show  enabled integrations, like google chat (but not ms teams)



![CleanShot 2026-06-01 at 12.11.41@2x.png](https://app.graphite.com/user-attachments/assets/562096ad-0c1c-45c9-930c-abec096d521a.png)

![CleanShot 2026-06-01 at 12.10.21@2x.png](https://app.graphite.com/user-attachments/assets/a5e27675-c148-4977-958c-92fe355fa337.png)

### Description:

Adds organization-level **Exporting** settings under **Settings → Organization → Exporting**, giving admins control over how long scheduled-delivery download links (email, Slack, Microsoft Teams, Google Chat) remain valid — without requiring changes to instance-wide environment variables.

**Per-org expiry configuration**

Admins can set a base "Download link expiry" (in days) that all channels inherit, plus optional per-channel overrides for Email, Slack, and Microsoft Teams. These are stored as new nullable columns on `organization_settings`. A `null` value means "inherit", so orgs with no configuration continue to behave exactly as before, falling back to the existing env var defaults (`PERSISTENT_DOWNLOAD_URL_EXPIRATION_SECONDS` and its per-channel variants).

Expiry resolution per channel follows this precedence:

```
org channel → org base → env channel → env base
```

**Transparent raw S3 vs. persistent URL selection**

`PersistentDownloadFileService.createPersistentUrl()` now automatically switches to the persistent-download-URL system when the requested expiry exceeds AWS's 7-day SigV4 presigned URL hard limit — even if `PERSISTENT_DOWNLOAD_URLS_ENABLED` is not set. This prevents the previous footgun where a >7-day raw link would silently 403. The `PERSISTENT_DOWNLOAD_URLS_ENABLED` default remains `false`, so existing behavior for links ≤ 7 days is unchanged.

**Frontend**

A new Exporting panel renders a base expiry input (days) and an optional per-channel section (Email, Slack, Microsoft Teams). Each per-channel input shows a clear (✕) affordance to reset back to inheriting the base. The panel is accessible to org admins via a new "Exporting" nav item in the Organization settings sidebar.

**Validation**

The settings API rejects expiry values that are not positive integers. There is no maximum — values over 7 days are valid and transparently route through the persistent-download-URL system. The frontend applies a 1–365 day guardrail.