### PR TITLE
feat(pull-requests): add pull requests model

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -214,6 +214,10 @@ import {
     ProjectTableName,
 } from '../database/entities/projects';
 import {
+    PullRequestsTable,
+    PullRequestsTableName,
+} from '../database/entities/pullRequests';
+import {
     QueryHistoryTable,
     QueryHistoryTableName,
 } from '../database/entities/queryHistory';
@@ -515,6 +519,7 @@ declare module 'knex/types/tables' {
         [DownloadAuditTableName]: DownloadAuditTable;
         [GithubAppInstallationTableName]: GithubAppInstallationTable;
         [GitlabAppInstallationTableName]: GitlabAppInstallationTable;
+        [PullRequestsTableName]: PullRequestsTable;
         [DashboardTileCommentsTableName]: DashboardTileCommentsTable;
         [AiThreadTableName]: AiThreadTable;
         [AiSlackThreadTableName]: AiSlackThreadTable;

--- a/packages/backend/src/database/entities/pullRequests.ts
+++ b/packages/backend/src/database/entities/pullRequests.ts
@@ -1,0 +1,35 @@
+import { PullRequestProvider, PullRequestSource } from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const PullRequestsTableName = 'pull_requests';
+
+export type DbPullRequest = {
+    pull_request_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    created_by_user_uuid: string | null;
+    provider: PullRequestProvider;
+    source: PullRequestSource;
+    owner: string;
+    repo: string;
+    pr_number: number;
+    pr_url: string;
+    created_at: Date;
+};
+
+export type PullRequestsTable = Knex.CompositeTableType<
+    DbPullRequest,
+    // insert type
+    Pick<
+        DbPullRequest,
+        | 'organization_uuid'
+        | 'project_uuid'
+        | 'created_by_user_uuid'
+        | 'provider'
+        | 'source'
+        | 'owner'
+        | 'repo'
+        | 'pr_number'
+        | 'pr_url'
+    >
+>;

--- a/packages/backend/src/database/migrations/20260531213013_add_pull_requests_table.ts
+++ b/packages/backend/src/database/migrations/20260531213013_add_pull_requests_table.ts
@@ -1,0 +1,58 @@
+import { Knex } from 'knex';
+
+const PullRequestsTableName = 'pull_requests';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(PullRequestsTableName, (table) => {
+        table
+            .uuid('pull_request_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+
+        // 'github' | 'gitlab' (PullRequestProvider)
+        table.text('provider').notNullable();
+        // 'custom_metric' | 'custom_dimension' | 'sql_runner' |
+        // 'source_editor' | 'ai_agent' (PullRequestSource)
+        table.text('source').notNullable();
+
+        // Immutable identifiers used to resolve the PR's live
+        // title/state from the GitHub/GitLab API at runtime.
+        table.text('owner').notNullable();
+        table.text('repo').notNullable();
+        table.integer('pr_number').notNullable();
+
+        // Display value and fallback when the live fetch fails.
+        table.text('pr_url').notNullable();
+
+        table
+            .timestamp('created_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['project_uuid']);
+        table.unique(['provider', 'owner', 'repo', 'pr_number']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(PullRequestsTableName);
+}

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -71,13 +71,15 @@ export type DbAiWritebackThread = {
     ai_thread_uuid: string;
     sandbox_id: string;
     pr_url: string;
+    pull_request_uuid: string | null;
     created_at: Date;
 };
 
 export type AiWritebackThreadTable = Knex.CompositeTableType<
     DbAiWritebackThread,
-    Pick<DbAiWritebackThread, 'ai_thread_uuid' | 'sandbox_id' | 'pr_url'>,
-    Pick<DbAiWritebackThread, 'sandbox_id'>
+    Pick<DbAiWritebackThread, 'ai_thread_uuid' | 'sandbox_id' | 'pr_url'> &
+        Partial<Pick<DbAiWritebackThread, 'pull_request_uuid'>>,
+    Pick<DbAiWritebackThread, 'sandbox_id' | 'pull_request_uuid'>
 >;
 
 export const AiPromptTableName = 'ai_prompt';

--- a/packages/backend/src/ee/database/migrations/20260531220000_add_pull_request_uuid_to_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260531220000_add_pull_request_uuid_to_ai_writeback_thread.ts
@@ -1,0 +1,34 @@
+import { Knex } from 'knex';
+
+const AiWritebackThreadTableName = 'ai_writeback_thread';
+const PullRequestsTableName = 'pull_requests';
+const ColumnName = 'pull_request_uuid';
+
+export async function up(knex: Knex): Promise<void> {
+    const hasColumn = await knex.schema.hasColumn(
+        AiWritebackThreadTableName,
+        ColumnName,
+    );
+    if (!hasColumn) {
+        await knex.schema.alterTable(AiWritebackThreadTableName, (table) => {
+            table
+                .uuid(ColumnName)
+                .nullable()
+                .references('pull_request_uuid')
+                .inTable(PullRequestsTableName)
+                .onDelete('SET NULL');
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    const hasColumn = await knex.schema.hasColumn(
+        AiWritebackThreadTableName,
+        ColumnName,
+    );
+    if (hasColumn) {
+        await knex.schema.alterTable(AiWritebackThreadTableName, (table) => {
+            table.dropColumn(ColumnName);
+        });
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -42,6 +42,7 @@ import { PinnedListModel } from './PinnedListModel';
 import { ProjectCompileLogModel } from './ProjectCompileLogModel';
 import { ProjectModel } from './ProjectModel/ProjectModel';
 import { ProjectParametersModel } from './ProjectParametersModel';
+import { PullRequestsModel } from './PullRequestsModel';
 import { QueryHistoryModel } from './QueryHistoryModel/QueryHistoryModel';
 import { ResourceViewItemModel } from './ResourceViewItemModel';
 import { RolesModel } from './RolesModel';
@@ -104,6 +105,7 @@ export type ModelManifest = {
     pinnedListModel: PinnedListModel;
     projectModel: ProjectModel;
     projectCompileLogModel: ProjectCompileLogModel;
+    pullRequestsModel: PullRequestsModel;
     resourceViewItemModel: ResourceViewItemModel;
     rolesModel: RolesModel;
     savedChartModel: SavedChartModel;
@@ -339,6 +341,13 @@ export class ModelRepository
         return this.getModel(
             'groupsModel',
             () => new GroupsModel({ database: this.database }),
+        );
+    }
+
+    public getPullRequestsModel(): PullRequestsModel {
+        return this.getModel(
+            'pullRequestsModel',
+            () => new PullRequestsModel({ database: this.database }),
         );
     }
 

--- a/packages/backend/src/models/PullRequestsModel.ts
+++ b/packages/backend/src/models/PullRequestsModel.ts
@@ -1,0 +1,183 @@
+import {
+    KnexPaginateArgs,
+    KnexPaginatedData,
+    PullRequest,
+    PullRequestProvider,
+    PullRequestSource,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    DbPullRequest,
+    PullRequestsTableName,
+} from '../database/entities/pullRequests';
+import KnexPaginate from '../database/pagination';
+import {
+    AiThreadTableName,
+    AiWritebackThreadTableName,
+} from '../ee/database/entities/ai';
+
+type PullRequestsModelArguments = {
+    database: Knex;
+};
+
+type CreatePullRequest = {
+    organizationUuid: string;
+    projectUuid: string;
+    createdByUserUuid: string | null;
+    provider: PullRequestProvider;
+    source: PullRequestSource;
+    owner: string;
+    repo: string;
+    prNumber: number;
+    prUrl: string;
+};
+
+type AiThreadInfo = { aiThreadUuid: string; aiAgentUuid: string | null };
+
+const mapDbPullRequest = (
+    row: DbPullRequest,
+    aiThread: AiThreadInfo | null,
+): PullRequest => ({
+    pullRequestUuid: row.pull_request_uuid,
+    organizationUuid: row.organization_uuid,
+    projectUuid: row.project_uuid,
+    createdByUserUuid: row.created_by_user_uuid,
+    provider: row.provider,
+    source: row.source,
+    owner: row.owner,
+    repo: row.repo,
+    prNumber: row.pr_number,
+    prUrl: row.pr_url,
+    aiThreadUuid: aiThread?.aiThreadUuid ?? null,
+    aiAgentUuid: aiThread?.aiAgentUuid ?? null,
+    createdAt: row.created_at,
+});
+
+export class PullRequestsModel {
+    readonly database: Knex;
+
+    // Cached result of whether the enterprise ai_writeback_thread table exists.
+    private aiWritebackTableExists: boolean | undefined;
+
+    constructor(args: PullRequestsModelArguments) {
+        this.database = args.database;
+    }
+
+    /**
+     * Maps pull request uuids to the AI thread that produced them. The link
+     * lives on the enterprise `ai_writeback_thread` table, which only exists
+     * when the AI write-back feature is installed — so we skip the lookup
+     * entirely (returning an empty map) in deployments without it.
+     */
+    private async getAiThreadInfo(
+        pullRequestUuids: string[],
+    ): Promise<Map<string, AiThreadInfo>> {
+        const result = new Map<string, AiThreadInfo>();
+        if (pullRequestUuids.length === 0) {
+            return result;
+        }
+
+        if (this.aiWritebackTableExists === undefined) {
+            this.aiWritebackTableExists = await this.database.schema.hasTable(
+                AiWritebackThreadTableName,
+            );
+        }
+        if (!this.aiWritebackTableExists) {
+            return result;
+        }
+
+        const rows = await this.database(AiWritebackThreadTableName)
+            .innerJoin(
+                AiThreadTableName,
+                `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiWritebackThreadTableName}.ai_thread_uuid`,
+            )
+            .whereIn(
+                `${AiWritebackThreadTableName}.pull_request_uuid`,
+                pullRequestUuids,
+            )
+            .whereNotNull(`${AiWritebackThreadTableName}.pull_request_uuid`)
+            .select(
+                `${AiWritebackThreadTableName}.pull_request_uuid`,
+                `${AiWritebackThreadTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.agent_uuid`,
+            );
+
+        rows.forEach((row) => {
+            if (row.pull_request_uuid) {
+                result.set(row.pull_request_uuid, {
+                    aiThreadUuid: row.ai_thread_uuid,
+                    aiAgentUuid: row.agent_uuid ?? null,
+                });
+            }
+        });
+        return result;
+    }
+
+    async create(data: CreatePullRequest): Promise<PullRequest> {
+        const [row] = await this.database(PullRequestsTableName)
+            .insert({
+                organization_uuid: data.organizationUuid,
+                project_uuid: data.projectUuid,
+                created_by_user_uuid: data.createdByUserUuid,
+                provider: data.provider,
+                source: data.source,
+                owner: data.owner,
+                repo: data.repo,
+                pr_number: data.prNumber,
+                pr_url: data.prUrl,
+            })
+            .returning('*');
+
+        // A newly created PR has no ai_writeback_thread link yet.
+        return mapDbPullRequest(row, null);
+    }
+
+    async getByProject(
+        projectUuid: string,
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<PullRequest[]>> {
+        const query = this.database(PullRequestsTableName)
+            .where('project_uuid', projectUuid)
+            .orderBy('created_at', 'desc')
+            .select<DbPullRequest[]>('*');
+
+        const { data, pagination } = await KnexPaginate.paginate(
+            query,
+            paginateArgs,
+        );
+
+        const threadInfo = await this.getAiThreadInfo(
+            data.map((row) => row.pull_request_uuid),
+        );
+
+        return {
+            data: data.map((row) =>
+                mapDbPullRequest(
+                    row,
+                    threadInfo.get(row.pull_request_uuid) ?? null,
+                ),
+            ),
+            pagination,
+        };
+    }
+
+    async find(pullRequestUuid: string): Promise<PullRequest | null> {
+        const row = await this.database(PullRequestsTableName)
+            .where('pull_request_uuid', pullRequestUuid)
+            .first();
+
+        if (!row) {
+            return null;
+        }
+
+        const threadInfo = await this.getAiThreadInfo([pullRequestUuid]);
+        return mapDbPullRequest(row, threadInfo.get(pullRequestUuid) ?? null);
+    }
+
+    async delete(pullRequestUuid: string): Promise<void> {
+        await this.database(PullRequestsTableName)
+            .where('pull_request_uuid', pullRequestUuid)
+            .delete();
+    }
+}

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -120,6 +120,7 @@ import { type FieldValueSearchResult } from './fieldMatch';
 import { type DashboardFilters } from './filter';
 import {
     type ApiGitFileContent,
+    type ApiPullRequestsResponse,
     type GitBranch,
     type GitFileOrDirectory,
     type GitIntegrationConfiguration,
@@ -1014,6 +1015,7 @@ type ApiResults =
     | ApiMetricsCatalog['results']
     | ApiMetricsExplorerQueryResults['results']
     | ApiGroupListResponse['results']
+    | ApiPullRequestsResponse['results']
     | ApiCreateTagResponse['results']
     | ApiChartAsCodeListResponse['results']
     | ApiSqlChartAsCodeListResponse['results']

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -1,3 +1,5 @@
+import { type KnexPaginatedData } from './knex-paginate';
+
 export type GitIntegrationConfiguration = {
     enabled: boolean;
     installationId?: string;
@@ -6,6 +8,65 @@ export type GitIntegrationConfiguration = {
 export type PullRequestCreated = {
     prTitle: string;
     prUrl: string;
+};
+
+export enum PullRequestProvider {
+    GITHUB = 'github',
+    GITLAB = 'gitlab',
+}
+
+export enum PullRequestSource {
+    CUSTOM_METRIC = 'custom_metric',
+    CUSTOM_DIMENSION = 'custom_dimension',
+    SQL_RUNNER = 'sql_runner',
+    SOURCE_EDITOR = 'source_editor',
+    AI_AGENT = 'ai_agent',
+}
+
+export enum PullRequestState {
+    OPEN = 'open',
+    CLOSED = 'closed',
+    MERGED = 'merged',
+}
+
+/**
+ * A pull request created by a write-back. Only immutable identifiers are
+ * persisted; the live title/state are resolved at runtime from the
+ * GitHub/GitLab API using provider + owner + repo + prNumber.
+ */
+export type PullRequest = {
+    pullRequestUuid: string;
+    organizationUuid: string;
+    projectUuid: string;
+    createdByUserUuid: string | null;
+    provider: PullRequestProvider;
+    source: PullRequestSource;
+    owner: string;
+    repo: string;
+    prNumber: number;
+    prUrl: string;
+    /**
+     * The AI thread that produced this PR, when it originated from an AI
+     * write-back (source `ai_agent`). Null for non-AI PRs, or in deployments
+     * without the enterprise AI write-back feature.
+     */
+    aiThreadUuid: string | null;
+    /**
+     * The AI agent that owns the thread above. Paired with `aiThreadUuid` to
+     * build the in-app thread link. Null whenever `aiThreadUuid` is null.
+     */
+    aiAgentUuid: string | null;
+    createdAt: Date;
+};
+
+/**
+ * A stored pull request enriched with its live title/state resolved from the
+ * provider API. `title`/`state` are null when the live lookup fails (e.g. the
+ * PR was deleted or the token lost access) — `prUrl` always remains usable.
+ */
+export type PullRequestWithStatus = PullRequest & {
+    title: string | null;
+    state: PullRequestState | null;
 };
 
 export type ApiGitFileContent = {
@@ -76,4 +137,11 @@ export type CreateGitPullRequestRequest = {
 export type ApiGitPullRequestCreatedResponse = {
     status: 'ok';
     results: PullRequestCreated;
+};
+
+// Response listing the pull requests created for a project, enriched with
+// live title/state resolved from the provider API.
+export type ApiPullRequestsResponse = {
+    status: 'ok';
+    results: KnexPaginatedData<PullRequestWithStatus[]>;
 };


### PR DESCRIPTION
## Summary

PR 1 of 4 for [PROD-7992](https://linear.app/lightdash/issue/PROD-7992). Adds the data layer for write-back pull requests: a `pull_requests` table storing only the immutable identifiers of a PR (provider + owner + repo + number) plus its origin, and an optional link from `ai_writeback_thread` back to the row it produced.

Bottom of the stack — branches off `main`.

Closes: https://linear.app/lightdash/issue/PROD-8022

## Stack

```
PR4  prod-8025  UI
PR3  prod-8024  GitHub/GitLab integration
PR2  prod-8023  service + controller
PR1  prod-8022  model   <- this PR
main
```

## Changes

**Migrations**
- `pull_requests` (core): `provider`, `source`, `owner`, `repo`, `pr_number`, `pr_url`, `created_by_user_uuid`, org/project FKs. `UNIQUE(provider, owner, repo, pr_number)`, indexed on `project_uuid`. Org/project FK `ON DELETE CASCADE`; `created_by_user_uuid` `ON DELETE SET NULL`.
- `ai_writeback_thread.pull_request_uuid` -> `pull_requests(pull_request_uuid)` (`ON DELETE SET NULL`, EE). Nullable; idempotent (guards on `hasColumn`).

**Model**
- `PullRequestsModel` — `create`, `getByProject` (paginated, newest first), `find`, `delete`. `getByProject`/`find` join `ai_writeback_thread` -> `ai_thread` to attach `aiThreadUuid` / `aiAgentUuid`, guarded by `hasTable` so non-EE deployments skip the lookup.

**Types** (`@lightdash/common`)
- `PullRequestProvider`, `PullRequestSource`, `PullRequestState` enums; `PullRequest`, `PullRequestWithStatus`; `ApiPullRequestsResponse`.

## Schema

```
pull_requests
  pull_request_uuid    pk
  organization_uuid    fk -> organizations  (cascade)
  project_uuid         fk -> projects       (cascade)  [indexed]
  created_by_user_uuid fk -> users          (set null)
  provider | source | owner | repo | pr_number | pr_url
  UNIQUE(provider, owner, repo, pr_number)

ai_writeback_thread
  pull_request_uuid    fk -> pull_requests  (set null)  [new, EE]
```

## Test plan

- [x] `pnpm -F backend typecheck` (this branch in isolation)
- [x] `pnpm -F common build`
- [x] Pre-commit eslint (lint-staged) on changed files
- [ ] Not yet run: `pnpm -F backend migrate` against a fresh DB

## Notes

`PullRequestsModel.create` does a plain insert and has no caller in this stack yet, so the `(provider, owner, repo, pr_number)` grain (global vs per-project) is still an open decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)