### PR TITLE
feat(pull-requests): resolve live status from GitHub/GitLab

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -5,6 +5,7 @@ import {
     LightdashError,
     NotFoundError,
     ParameterError,
+    PullRequestState,
     UnexpectedGitError,
 } from '@lightdash/common';
 import { App } from '@octokit/app';
@@ -430,6 +431,90 @@ export const getPullRequest = async ({
             state: response.data.state === 'closed' ? 'closed' : 'open',
             merged: response.data.merged === true,
         };
+    } catch (e) {
+        throw new UnexpectedGitError(getErrorMessage(e));
+    }
+};
+
+export type PullRequestMetadata = {
+    title: string;
+    state: PullRequestState;
+};
+
+const GITHUB_GRAPHQL_BATCH_SIZE = 100;
+
+const mapGithubPrState = (state: string): PullRequestState => {
+    switch (state) {
+        case 'MERGED':
+            return PullRequestState.MERGED;
+        case 'CLOSED':
+            return PullRequestState.CLOSED;
+        default:
+            return PullRequestState.OPEN;
+    }
+};
+
+/**
+ * Batch-resolve the live title/state for many pull requests in a single repo.
+ * Uses the GraphQL API with aliased `pullRequest(number:)` lookups so the whole
+ * batch costs one request instead of one REST call per PR. Numbers that cannot
+ * be resolved (deleted PR, no access) are simply absent from the result.
+ */
+export const getPullRequests = async ({
+    owner,
+    repo,
+    pullNumbers,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    pullNumbers: number[];
+    installationId?: string;
+    token?: string;
+}): Promise<Record<number, PullRequestMetadata>> => {
+    const { octokit, headers } = getOctokit(installationId, token);
+
+    const chunks: number[][] = [];
+    for (let i = 0; i < pullNumbers.length; i += GITHUB_GRAPHQL_BATCH_SIZE) {
+        chunks.push(pullNumbers.slice(i, i + GITHUB_GRAPHQL_BATCH_SIZE));
+    }
+
+    try {
+        const responses = await Promise.all(
+            chunks.map((chunk) => {
+                const aliases = chunk
+                    .map(
+                        (n) =>
+                            `pr${n}: pullRequest(number: ${n}) { number title state }`,
+                    )
+                    .join('\n');
+                const query = `query($owner: String!, $repo: String!) {
+                    repository(owner: $owner, name: $repo) {
+                        ${aliases}
+                    }
+                }`;
+                return octokit.graphql<{
+                    repository: Record<
+                        string,
+                        { number: number; title: string; state: string } | null
+                    >;
+                }>(query, { owner, repo, headers });
+            }),
+        );
+
+        const result: Record<number, PullRequestMetadata> = {};
+        responses.forEach((response) => {
+            Object.values(response.repository ?? {}).forEach((pr) => {
+                if (pr) {
+                    result[pr.number] = {
+                        title: pr.title,
+                        state: mapGithubPrState(pr.state),
+                    };
+                }
+            });
+        });
+        return result;
     } catch (e) {
         throw new UnexpectedGitError(getErrorMessage(e));
     }

--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -5,6 +5,7 @@ import {
     getErrorMessage,
     NotFoundError,
     ParameterError,
+    PullRequestState,
     UnexpectedGitError,
 } from '@lightdash/common';
 
@@ -295,6 +296,68 @@ export const createPullRequest = async ({
         title: mergeRequest.title,
         number: mergeRequest.iid,
     };
+};
+
+const GITLAB_MR_BATCH_SIZE = 100;
+
+const mapGitlabMrState = (state: string): PullRequestState => {
+    switch (state) {
+        case 'merged':
+            return PullRequestState.MERGED;
+        case 'closed':
+        case 'locked':
+            return PullRequestState.CLOSED;
+        default:
+            return PullRequestState.OPEN;
+    }
+};
+
+/**
+ * Batch-resolve the live title/state for many merge requests in a single
+ * project. Uses the `iids[]` filter so the whole batch costs one request per
+ * project. `iid`s that cannot be resolved are simply absent from the result.
+ */
+export const getMergeRequests = async ({
+    owner,
+    repo,
+    iids,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabApiParams & { iids: number[] }): Promise<
+    Record<number, { title: string; state: PullRequestState }>
+> => {
+    const projectId = getProjectId(owner, repo);
+
+    const chunks: number[][] = [];
+    for (let i = 0; i < iids.length; i += GITLAB_MR_BATCH_SIZE) {
+        chunks.push(iids.slice(i, i + GITLAB_MR_BATCH_SIZE));
+    }
+
+    const responses: Array<
+        Array<{ iid: number; title: string; state: string }>
+    > = await Promise.all(
+        chunks.map((chunk) => {
+            const params = chunk.map((iid) => `iids[]=${iid}`).join('&');
+            const url = getApiUrl(
+                hostDomain,
+                `/projects/${projectId}/merge_requests?${params}&per_page=${GITLAB_MR_BATCH_SIZE}`,
+            );
+            return makeGitlabRequest(url, token);
+        }),
+    );
+
+    const result: Record<number, { title: string; state: PullRequestState }> =
+        {};
+    responses.forEach((mergeRequests) => {
+        mergeRequests.forEach((mr) => {
+            result[mr.iid] = {
+                title: mr.title,
+                state: mapGitlabMrState(mr.state),
+            };
+        });
+    });
+
+    return result;
 };
 
 export const getBranches = async ({

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -492,42 +492,9 @@ Affected charts:
         projectUuid: string,
         quoteChar: `"` | `'`,
     ) {
-        const { owner, repo, branch, path, hostDomain, type } =
-            await this.getProjectRepo(projectUuid);
-        let token: string = '';
-        let installationId: string | undefined;
-
-        if (type === DbtProjectType.GITHUB) {
-            // GitHub logic - try app installation first, fallback to PAT
-            try {
-                installationId = await this.getInstallationId(user);
-                token = await this.getOrUpdateToken(user.organizationUuid!);
-            } catch {
-                const project =
-                    await this.projectModel.getWithSensitiveFields(projectUuid);
-                const connection =
-                    project.dbtConnection as DbtGithubProjectConfig;
-                token = connection.personal_access_token || '';
-                if (!token) {
-                    throw new ParameterError(
-                        'Invalid personal access token for GitHub project',
-                    );
-                }
-            }
-        } else if (type === DbtProjectType.GITLAB) {
-            // GitLab logic - only personal access tokens supported
-            const project =
-                await this.projectModel.getWithSensitiveFields(projectUuid);
-            const connection = project.dbtConnection as DbtGitlabProjectConfig;
-            token = connection.personal_access_token || '';
-            if (!token) {
-                throw new ParameterError(
-                    'Invalid personal access token for GitLab project',
-                );
-            }
-        } else {
-            throw new ParameterError(`Unsupported project type: ${type}`);
-        }
+        const { branch, path } = await this.getProjectRepo(projectUuid);
+        const { owner, repo, hostDomain, type, token, installationId } =
+            await this.getGitCredentials(user, projectUuid);
 
         const userName = `${snakeCaseName(
             user.firstName[0] || '',
@@ -1166,7 +1133,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
      * Get git credentials for a project (without generating a new branch name)
      * This is used for read/write operations on existing branches
      */
-    private async getGitCredentials(
+    async getGitCredentials(
         user: SessionUser,
         projectUuid: string,
     ): Promise<{

--- a/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
+++ b/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
@@ -1,23 +1,33 @@
 import { subject } from '@casl/ability';
 import {
+    DbtProjectType,
     FeatureFlags,
     ForbiddenError,
+    getErrorMessage,
     KnexPaginateArgs,
     KnexPaginatedData,
+    PullRequest,
+    PullRequestProvider,
     PullRequestState,
     PullRequestWithStatus,
     SessionUser,
 } from '@lightdash/common';
+import * as GithubClient from '../../clients/github/Github';
+import * as GitlabClient from '../../clients/gitlab/Gitlab';
 import type { LightdashConfig } from '../../config/parseConfig';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { PullRequestsModel } from '../../models/PullRequestsModel';
 import { BaseService } from '../BaseService';
+import { GitIntegrationService } from '../GitIntegrationService/GitIntegrationService';
 
 type PullRequestsServiceArguments = {
     lightdashConfig: LightdashConfig;
     pullRequestsModel: PullRequestsModel;
     featureFlagModel: FeatureFlagModel;
+    gitIntegrationService: GitIntegrationService;
 };
+
+type PullRequestMetadata = { title: string; state: PullRequestState };
 
 export class PullRequestsService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
@@ -26,11 +36,14 @@ export class PullRequestsService extends BaseService {
 
     private readonly featureFlagModel: FeatureFlagModel;
 
+    private readonly gitIntegrationService: GitIntegrationService;
+
     constructor(args: PullRequestsServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
         this.pullRequestsModel = args.pullRequestsModel;
         this.featureFlagModel = args.featureFlagModel;
+        this.gitIntegrationService = args.gitIntegrationService;
     }
 
     private async assertFeatureEnabled(user: SessionUser): Promise<void> {
@@ -43,6 +56,60 @@ export class PullRequestsService extends BaseService {
                 'Pull requests are not enabled for this organization',
             );
         }
+    }
+
+    /**
+     * Batch-resolve live title/state for a group of pull requests that share a
+     * provider + repo. Returns a map keyed by PR number. Any failure (lost
+     * access, deleted repo, bad token) resolves to an empty map so the caller
+     * falls back to the stored URL rather than failing the whole request.
+     */
+    private async resolveMetadata(
+        provider: PullRequestProvider,
+        owner: string,
+        repo: string,
+        prNumbers: number[],
+        credentials: {
+            type: DbtProjectType.GITHUB | DbtProjectType.GITLAB;
+            hostDomain?: string;
+            token: string;
+            installationId?: string;
+        },
+    ): Promise<Record<number, PullRequestMetadata>> {
+        try {
+            if (
+                provider === PullRequestProvider.GITHUB &&
+                credentials.type === DbtProjectType.GITHUB
+            ) {
+                return await GithubClient.getPullRequests({
+                    owner,
+                    repo,
+                    pullNumbers: prNumbers,
+                    installationId: credentials.installationId,
+                    token: credentials.token,
+                });
+            }
+            if (
+                provider === PullRequestProvider.GITLAB &&
+                credentials.type === DbtProjectType.GITLAB
+            ) {
+                return await GitlabClient.getMergeRequests({
+                    owner,
+                    repo,
+                    iids: prNumbers,
+                    token: credentials.token,
+                    hostDomain: credentials.hostDomain,
+                });
+            }
+        } catch (error) {
+            this.logger.warn('Failed to resolve pull request metadata', {
+                provider,
+                owner,
+                repo,
+                error: getErrorMessage(error),
+            });
+        }
+        return {};
     }
 
     async getPullRequests(
@@ -65,20 +132,78 @@ export class PullRequestsService extends BaseService {
             throw new ForbiddenError();
         }
 
+        // Paginate in the DB first, then resolve live metadata only for the
+        // current page of rows — never for the whole table.
         const { data: pullRequests, pagination } =
             await this.pullRequestsModel.getByProject(
                 projectUuid,
                 paginateArgs,
             );
+        if (pullRequests.length === 0) {
+            return { data: [], pagination };
+        }
 
-        // Live title/state resolution from the provider API is added in a later
-        // change; for now expose the stored rows with placeholder metadata.
+        // Resolving live metadata needs the project's git credentials; if they
+        // can't be resolved, still return the stored rows without title/state.
+        let credentials;
+        try {
+            credentials = await this.gitIntegrationService.getGitCredentials(
+                user,
+                projectUuid,
+            );
+        } catch (error) {
+            this.logger.warn(
+                'Could not resolve git credentials for pull requests',
+                { projectUuid, error: getErrorMessage(error) },
+            );
+            return {
+                data: pullRequests.map((pr) => ({
+                    ...pr,
+                    title: null,
+                    state: null,
+                })),
+                pagination,
+            };
+        }
+
+        // Group by provider + repo so each group is one batched API call.
+        const groups = new Map<string, PullRequest[]>();
+        pullRequests.forEach((pr) => {
+            const key = `${pr.provider}:${pr.owner}/${pr.repo}`;
+            const group = groups.get(key) ?? [];
+            group.push(pr);
+            groups.set(key, group);
+        });
+
+        const metadataByUuid = new Map<string, PullRequestMetadata>();
+        await Promise.all(
+            [...groups.values()].map(async (group) => {
+                const { provider, owner, repo } = group[0];
+                const metadata = await this.resolveMetadata(
+                    provider,
+                    owner,
+                    repo,
+                    group.map((pr) => pr.prNumber),
+                    credentials,
+                );
+                group.forEach((pr) => {
+                    const found = metadata[pr.prNumber];
+                    if (found) {
+                        metadataByUuid.set(pr.pullRequestUuid, found);
+                    }
+                });
+            }),
+        );
+
         return {
-            data: pullRequests.map((pr) => ({
-                ...pr,
-                title: `Pull request #${pr.prNumber}`,
-                state: PullRequestState.OPEN,
-            })),
+            data: pullRequests.map((pr) => {
+                const metadata = metadataByUuid.get(pr.pullRequestUuid);
+                return {
+                    ...pr,
+                    title: metadata?.title ?? null,
+                    state: metadata?.state ?? null,
+                };
+            }),
             pagination,
         };
     }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -440,6 +440,7 @@ export class ServiceRepository
                     lightdashConfig: this.context.lightdashConfig,
                     pullRequestsModel: this.models.getPullRequestsModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
+                    gitIntegrationService: this.getGitIntegrationService(),
                 }),
         );
     }


### PR DESCRIPTION
## Summary

PR 3 of 4 for [PROD-7992](https://linear.app/lightdash/issue/PROD-7992). Replaces the placeholder metadata with live PR/MR title and state fetched from the GitHub/GitLab API, batched one request per repo for the current page.

Stacks on top of PR 2 (#23704), which added the service, controller, and feature flag.

Closes: https://linear.app/lightdash/issue/PROD-8024

## Changes

**Clients**
- `Github.getPullRequests` — one GraphQL request per repo using aliased `pullRequest(number:)` lookups, chunked at 100. Maps `MERGED`/`CLOSED`/else -> `PullRequestState`.
- `Gitlab.getMergeRequests` — `iids[]` batch filter per project, chunked at 100. Maps `merged`/`closed`+`locked`/else.

**Service**
- `GitIntegrationService.getGitCredentials` made public (an existing caller refactored to use it).
- `PullRequestsService.getPullRequests` groups the page by `provider:owner/repo`, resolves each group once, and fills `title`/`state`. Any failure (missing credentials, lost access, deleted PR) falls back to `null` title/state — the stored `prUrl` always remains usable.

## Resolution / fallback

```
page rows
  -> group by provider:owner/repo
       -> one batched provider call per group
            |- hit         -> { title, state }
            \- miss/error  -> null title/state (prUrl still shown)
```

## Notes

Provider/credential errors are logged via `getErrorMessage(error)` rather than the raw error object, so octokit's `Authorization` header is never written to logs.

## Test plan

- [x] `pnpm -F backend typecheck` (this branch in isolation)
- [x] Pre-commit eslint (lint-staged) on changed files
- [ ] Not yet run: live fetch against a real GitHub/GitLab project

🤖 Generated with [Claude Code](https://claude.com/claude-code)