### PR TITLE
feat(pull-requests): add pull requests UI

### DIFF
--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
@@ -1,0 +1,115 @@
+/* White paper wrapper: clip the table corners to the card radius */
+.tablePaper {
+    overflow: hidden;
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-ldDark-7)
+    );
+}
+
+.table {
+    /* Fixed layout + full width: columns honour their widths exactly, so the
+       Source/State tags never collapse and the Title absorbs the remainder. */
+    table-layout: fixed;
+    width: 100%;
+}
+
+/* Pull request medallion */
+.table th:nth-of-type(1),
+.table td:nth-of-type(1) {
+    width: 60px;
+}
+
+/* Created (relative time) */
+.table th:nth-of-type(2),
+.table td:nth-of-type(2) {
+    width: 120px;
+    white-space: nowrap;
+}
+
+/* Author */
+.table th:nth-of-type(3),
+.table td:nth-of-type(3) {
+    width: 160px;
+}
+
+/* Title (4th column) has no width → it takes all remaining space.
+   The source tag is appended inside this cell. */
+
+/* State */
+.table th:nth-of-type(5),
+.table td:nth-of-type(5) {
+    width: 90px;
+}
+
+/* Thread + PR icons share the same width */
+.table th:nth-of-type(6),
+.table td:nth-of-type(6),
+.table th:nth-of-type(7),
+.table td:nth-of-type(7) {
+    width: 72px;
+}
+
+/* Crisp sticky header */
+.thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.th {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-7)
+    );
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldDark-1)
+    );
+    white-space: nowrap;
+}
+
+/* Refined row hover */
+.row {
+    transition: background-color 120ms ease;
+}
+
+.row td {
+    border-top: 1px solid
+        light-dark(var(--mantine-color-ldGray-1), var(--mantine-color-ldDark-5));
+}
+
+.row:hover {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-6)
+    );
+}
+
+/* Dim the body while paging so the table doesn't jump between pages */
+.tbodyFetching {
+    opacity: 0.55;
+    transition: opacity 150ms ease;
+    pointer-events: none;
+}
+
+/* Artsy pull-request medallion: a soft shadow gives it a little lift */
+.medallion {
+    box-shadow: 0 1px 3px
+        light-dark(rgba(15, 18, 20, 0.08), rgba(0, 0, 0, 0.35));
+}
+
+/* Title text truncates (but doesn't grow) so the source tag sits inline
+   immediately after it rather than being pushed to the right edge */
+.title {
+    min-width: 0;
+    cursor: default;
+}
+
+/* The small source tag keeps its size at the end of the title */
+.sourceBadge {
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -1,0 +1,337 @@
+import { formatTimestamp, TimeFrames } from '@lightdash/common';
+import {
+    ActionIcon,
+    Alert,
+    Badge,
+    Center,
+    Group,
+    Pagination,
+    Paper,
+    Skeleton,
+    Stack,
+    Table,
+    Text,
+    ThemeIcon,
+    Title,
+    Tooltip,
+} from '@mantine-8/core';
+import {
+    IconAlertCircle,
+    IconBrandGithub,
+    IconBrandGitlab,
+    IconGitPullRequest,
+    IconMessageCircle,
+} from '@tabler/icons-react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { usePullRequestsTable } from '../hooks/usePullRequestsTable';
+import { type PullRequestRow } from '../types';
+import {
+    DEFAULT_PULL_REQUESTS_PAGE_SIZE,
+    EMPTY_VALUE,
+    getProviderLabel,
+    getSourceColor,
+    getSourceLabel,
+    getStateColor,
+    getStateLabel,
+    getThreadPath,
+} from '../utils';
+import classes from './PullRequestsPage.module.css';
+
+dayjs.extend(relativeTime);
+
+type Props = { projectUuid: string };
+
+const SKELETON_ROW_KEYS = [
+    'skeleton-0',
+    'skeleton-1',
+    'skeleton-2',
+    'skeleton-3',
+    'skeleton-4',
+] as const;
+
+const PullRequestRowItem: FC<{ row: PullRequestRow }> = ({ row }) => {
+    const threadPath = getThreadPath(row);
+    const ProviderIcon =
+        row.provider === 'github' ? IconBrandGithub : IconBrandGitlab;
+
+    return (
+        <Table.Tr className={classes.row}>
+            <Table.Td>
+                <ThemeIcon
+                    variant="light"
+                    color={getStateColor(row.state)}
+                    radius="xl"
+                    size={34}
+                    className={classes.medallion}
+                >
+                    <MantineIcon icon={IconGitPullRequest} size="md" />
+                </ThemeIcon>
+            </Table.Td>
+            <Table.Td>
+                <Tooltip
+                    label={formatTimestamp(row.createdAt, TimeFrames.MINUTE)}
+                    openDelay={300}
+                    withinPortal
+                >
+                    <Text size="sm" c="ldGray.7" span>
+                        {dayjs(row.createdAt).fromNow()}
+                    </Text>
+                </Tooltip>
+            </Table.Td>
+            <Table.Td>
+                {row.author ? (
+                    <Text size="sm" truncate>
+                        {row.author.name}
+                    </Text>
+                ) : (
+                    <Text size="sm" c="dimmed">
+                        Unknown
+                    </Text>
+                )}
+            </Table.Td>
+            <Table.Td>
+                <Group gap="xs" wrap="nowrap">
+                    {row.title ? (
+                        <Tooltip
+                            label={row.title}
+                            openDelay={400}
+                            multiline
+                            maw={420}
+                            withinPortal
+                        >
+                            <Text size="sm" truncate className={classes.title}>
+                                {row.title}
+                            </Text>
+                        </Tooltip>
+                    ) : (
+                        <Text size="sm" c="dimmed" className={classes.title}>
+                            {EMPTY_VALUE}
+                        </Text>
+                    )}
+                    <Badge
+                        size="xs"
+                        variant="outline"
+                        color={getSourceColor(row.source)}
+                        radius="sm"
+                        className={classes.sourceBadge}
+                    >
+                        {getSourceLabel(row.source)}
+                    </Badge>
+                </Group>
+            </Table.Td>
+            <Table.Td>
+                {row.state ? (
+                    <Badge
+                        variant="light"
+                        color={getStateColor(row.state)}
+                        radius="sm"
+                    >
+                        {getStateLabel(row.state)}
+                    </Badge>
+                ) : (
+                    <Text size="sm" c="dimmed">
+                        {EMPTY_VALUE}
+                    </Text>
+                )}
+            </Table.Td>
+            <Table.Td>
+                {threadPath !== null ? (
+                    <Tooltip label="Open thread" openDelay={300} withinPortal>
+                        <ActionIcon
+                            component={Link}
+                            to={threadPath}
+                            variant="subtle"
+                            color="gray"
+                            aria-label="Open thread"
+                        >
+                            <MantineIcon icon={IconMessageCircle} />
+                        </ActionIcon>
+                    </Tooltip>
+                ) : (
+                    <Text size="sm" c="dimmed">
+                        {EMPTY_VALUE}
+                    </Text>
+                )}
+            </Table.Td>
+            <Table.Td>
+                <Tooltip
+                    label={`View on ${getProviderLabel(row.provider)}`}
+                    openDelay={300}
+                    withinPortal
+                >
+                    <ActionIcon
+                        component="a"
+                        href={row.prUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        variant="subtle"
+                        color="dark"
+                        aria-label={`View pull request on ${getProviderLabel(
+                            row.provider,
+                        )}`}
+                    >
+                        <MantineIcon icon={ProviderIcon} />
+                    </ActionIcon>
+                </Tooltip>
+            </Table.Td>
+        </Table.Tr>
+    );
+};
+
+const PullRequestSkeletonRow: FC = () => (
+    <Table.Tr className={classes.row}>
+        <Table.Td>
+            <Skeleton height={34} width={34} circle />
+        </Table.Td>
+        <Table.Td>
+            <Skeleton height={12} width={90} radius="sm" />
+        </Table.Td>
+        <Table.Td>
+            <Skeleton height={12} width="70%" radius="sm" />
+        </Table.Td>
+        <Table.Td>
+            <Group gap="xs" wrap="nowrap">
+                <Skeleton height={12} width="80%" radius="sm" />
+                <Skeleton height={16} width={64} radius="sm" />
+            </Group>
+        </Table.Td>
+        <Table.Td>
+            <Skeleton height={18} width={56} radius="sm" />
+        </Table.Td>
+        <Table.Td>
+            <Skeleton height={24} width={24} circle />
+        </Table.Td>
+        <Table.Td>
+            <Skeleton height={24} width={24} circle />
+        </Table.Td>
+    </Table.Tr>
+);
+
+const PullRequestsTableShell: FC<{
+    children: React.ReactNode;
+    dimmed: boolean;
+}> = ({ children, dimmed }) => (
+    <Paper
+        withBorder
+        shadow="subtle"
+        radius="md"
+        className={classes.tablePaper}
+    >
+        <Table.ScrollContainer minWidth={720}>
+            <Table
+                verticalSpacing="sm"
+                horizontalSpacing="sm"
+                className={classes.table}
+            >
+                <Table.Thead className={classes.thead}>
+                    <Table.Tr>
+                        <Table.Th
+                            className={classes.th}
+                            aria-label="Pull request"
+                        />
+                        <Table.Th className={classes.th}>Created</Table.Th>
+                        <Table.Th className={classes.th}>Author</Table.Th>
+                        <Table.Th className={classes.th}>Title</Table.Th>
+                        <Table.Th className={classes.th}>State</Table.Th>
+                        <Table.Th className={classes.th}>Thread</Table.Th>
+                        <Table.Th className={classes.th}>PR</Table.Th>
+                    </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody
+                    className={dimmed ? classes.tbodyFetching : undefined}
+                >
+                    {children}
+                </Table.Tbody>
+            </Table>
+        </Table.ScrollContainer>
+    </Paper>
+);
+
+const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
+    const [page, setPage] = useState(1);
+    const { rows, pagination, isLoading, isFetching, error } =
+        usePullRequestsTable(projectUuid, {
+            page,
+            pageSize: DEFAULT_PULL_REQUESTS_PAGE_SIZE,
+        });
+
+    const totalResults = pagination?.totalResults ?? rows.length;
+
+    return (
+        <Stack gap="md">
+            <Stack gap="two">
+                <Title order={5}>Pull requests</Title>
+                <Text size="sm" c="dimmed">
+                    Pull requests opened from this project, including changes
+                    proposed by AI agents and the in-app editors.
+                </Text>
+            </Stack>
+
+            {error ? (
+                <Alert
+                    icon={<MantineIcon icon={IconAlertCircle} />}
+                    color="red"
+                    title="Failed to load pull requests"
+                >
+                    {error.error.message}
+                </Alert>
+            ) : isLoading ? (
+                <PullRequestsTableShell dimmed={false}>
+                    {SKELETON_ROW_KEYS.map((key) => (
+                        <PullRequestSkeletonRow key={key} />
+                    ))}
+                </PullRequestsTableShell>
+            ) : rows.length === 0 ? (
+                <Center p="xl">
+                    <Stack gap="xs" align="center">
+                        <MantineIcon
+                            icon={IconGitPullRequest}
+                            size="xl"
+                            color="ldGray.5"
+                        />
+                        <Text size="sm" c="dimmed">
+                            No pull requests yet.
+                        </Text>
+                        <Text size="xs" c="dimmed" ta="center" maw={360}>
+                            Changes proposed by AI agents and the in-app editors
+                            will appear here once a pull request is opened.
+                        </Text>
+                    </Stack>
+                </Center>
+            ) : (
+                <Stack gap="sm">
+                    <Text size="xs" c="dimmed">
+                        {totalResults} pull request
+                        {totalResults === 1 ? '' : 's'}
+                    </Text>
+
+                    <PullRequestsTableShell dimmed={isFetching}>
+                        {rows.map((row) => (
+                            <PullRequestRowItem
+                                key={row.pullRequestUuid}
+                                row={row}
+                            />
+                        ))}
+                    </PullRequestsTableShell>
+
+                    {(pagination?.totalPageCount ?? 1) > 1 ? (
+                        <Group justify="flex-end">
+                            <Pagination
+                                size="sm"
+                                total={pagination?.totalPageCount ?? 1}
+                                value={page}
+                                onChange={setPage}
+                            />
+                        </Group>
+                    ) : null}
+                </Stack>
+            )}
+        </Stack>
+    );
+};
+
+export default PullRequestsPage;

--- a/packages/frontend/src/features/pullRequests/hooks/useIsPullRequestsEnabled.ts
+++ b/packages/frontend/src/features/pullRequests/hooks/useIsPullRequestsEnabled.ts
@@ -1,0 +1,11 @@
+import { FeatureFlags } from '@lightdash/common';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+
+/**
+ * Returns whether the `pull-requests` feature flag is on. Gates the
+ * project-settings "Pull requests" section and route.
+ */
+export const useIsPullRequestsEnabled = (): boolean => {
+    const { data } = useServerFeatureFlag(FeatureFlags.PullRequests);
+    return data?.enabled ?? false;
+};

--- a/packages/frontend/src/features/pullRequests/hooks/usePullRequestsTable.ts
+++ b/packages/frontend/src/features/pullRequests/hooks/usePullRequestsTable.ts
@@ -1,0 +1,80 @@
+import {
+    type ApiError,
+    type ApiPullRequestsResponse,
+    type KnexPaginateArgs,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { lightdashApi } from '../../../api';
+import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
+import { type PullRequestAuthor, type PullRequestRow } from '../types';
+
+const getPullRequests = async (
+    projectUuid: string,
+    paginateArgs: KnexPaginateArgs,
+): Promise<ApiPullRequestsResponse['results']> =>
+    lightdashApi<ApiPullRequestsResponse['results']>({
+        url: `/projects/${projectUuid}/pull-requests?page=${paginateArgs.page}&pageSize=${paginateArgs.pageSize}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+/**
+ * Shared data hook for every Pull Requests table version. Fetches the paginated
+ * pull requests for the current page and resolves each author from the org
+ * members list. Returns render-ready rows plus pagination metadata.
+ */
+export const usePullRequestsTable = (
+    projectUuid: string,
+    paginateArgs: KnexPaginateArgs,
+) => {
+    const pullRequestsQuery = useQuery<
+        ApiPullRequestsResponse['results'],
+        ApiError
+    >({
+        queryKey: [
+            'pull-requests',
+            projectUuid,
+            paginateArgs.page,
+            paginateArgs.pageSize,
+        ],
+        queryFn: () => getPullRequests(projectUuid, paginateArgs),
+        keepPreviousData: true,
+    });
+
+    const usersQuery = useOrganizationUsers();
+
+    const authorsByUuid = useMemo(() => {
+        const map = new Map<string, PullRequestAuthor>();
+        (usersQuery.data ?? []).forEach((member) => {
+            map.set(member.userUuid, {
+                userUuid: member.userUuid,
+                name:
+                    `${member.firstName ?? ''} ${
+                        member.lastName ?? ''
+                    }`.trim() || member.email,
+                email: member.email,
+            });
+        });
+        return map;
+    }, [usersQuery.data]);
+
+    const rows = useMemo<PullRequestRow[]>(
+        () =>
+            (pullRequestsQuery.data?.data ?? []).map((pullRequest) => ({
+                ...pullRequest,
+                author: pullRequest.createdByUserUuid
+                    ? (authorsByUuid.get(pullRequest.createdByUserUuid) ?? null)
+                    : null,
+            })),
+        [pullRequestsQuery.data, authorsByUuid],
+    );
+
+    return {
+        rows,
+        pagination: pullRequestsQuery.data?.pagination,
+        isLoading: pullRequestsQuery.isInitialLoading,
+        isFetching: pullRequestsQuery.isFetching,
+        error: pullRequestsQuery.error,
+    };
+};

--- a/packages/frontend/src/features/pullRequests/types.ts
+++ b/packages/frontend/src/features/pullRequests/types.ts
@@ -1,0 +1,16 @@
+import { type PullRequestWithStatus } from '@lightdash/common';
+
+export type PullRequestAuthor = {
+    userUuid: string;
+    name: string;
+    email: string;
+};
+
+/**
+ * A pull request row ready for rendering: the API row plus the resolved author
+ * (from org members). `author` is null when the creator is unknown or not an
+ * org member.
+ */
+export type PullRequestRow = PullRequestWithStatus & {
+    author: PullRequestAuthor | null;
+};

--- a/packages/frontend/src/features/pullRequests/utils.ts
+++ b/packages/frontend/src/features/pullRequests/utils.ts
@@ -1,0 +1,88 @@
+import {
+    assertUnreachable,
+    PullRequestProvider,
+    PullRequestSource,
+    PullRequestState,
+} from '@lightdash/common';
+import { type PullRequestRow } from './types';
+
+export const DEFAULT_PULL_REQUESTS_PAGE_SIZE = 25;
+
+/** Empty-cell placeholder used when live title/state can't be resolved. */
+export const EMPTY_VALUE = '—';
+
+export const getSourceLabel = (source: PullRequestSource): string => {
+    switch (source) {
+        case PullRequestSource.CUSTOM_METRIC:
+            return 'Custom metric';
+        case PullRequestSource.CUSTOM_DIMENSION:
+            return 'Custom dimension';
+        case PullRequestSource.SQL_RUNNER:
+            return 'SQL runner';
+        case PullRequestSource.SOURCE_EDITOR:
+            return 'Source editor';
+        case PullRequestSource.AI_AGENT:
+            return 'AI agent';
+        default:
+            return assertUnreachable(source, `Unknown source ${source}`);
+    }
+};
+
+export const getStateLabel = (state: PullRequestState | null): string => {
+    if (state === null) return EMPTY_VALUE;
+    switch (state) {
+        case PullRequestState.OPEN:
+            return 'Open';
+        case PullRequestState.CLOSED:
+            return 'Closed';
+        case PullRequestState.MERGED:
+            return 'Merged';
+        default:
+            return assertUnreachable(state, `Unknown state ${state}`);
+    }
+};
+
+/** Mantine color for a PR state badge. */
+export const getStateColor = (state: PullRequestState | null): string => {
+    if (state === null) return 'gray';
+    switch (state) {
+        case PullRequestState.OPEN:
+            return 'green';
+        case PullRequestState.CLOSED:
+            return 'red';
+        case PullRequestState.MERGED:
+            return 'violet';
+        default:
+            return assertUnreachable(state, `Unknown state ${state}`);
+    }
+};
+
+export const getProviderLabel = (provider: PullRequestProvider): string =>
+    provider === PullRequestProvider.GITHUB ? 'GitHub' : 'GitLab';
+
+/** A distinct Mantine color per source, so each source tag reads differently. */
+export const getSourceColor = (source: PullRequestSource): string => {
+    switch (source) {
+        case PullRequestSource.CUSTOM_METRIC:
+            return 'blue';
+        case PullRequestSource.CUSTOM_DIMENSION:
+            return 'cyan';
+        case PullRequestSource.SQL_RUNNER:
+            return 'grape';
+        case PullRequestSource.SOURCE_EDITOR:
+            return 'orange';
+        case PullRequestSource.AI_AGENT:
+            return 'indigo';
+        default:
+            return assertUnreachable(source, `Unknown source ${source}`);
+    }
+};
+
+/**
+ * In-app AI agent thread path for a PR, or null when the PR didn't originate
+ * from an AI thread (no agent/thread to link to).
+ */
+export const getThreadPath = (row: PullRequestRow): string | null => {
+    if (!row.aiThreadUuid || !row.aiAgentUuid) return null;
+    return `/projects/${row.projectUuid}/ai-agents/${row.aiAgentUuid}/threads/${row.aiThreadUuid}`;
+};

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -23,6 +23,8 @@ import { SettingsValidator } from '../components/SettingsValidator';
 import VerifiedContentPanel from '../components/VerifiedContent/VerifiedContentPanel';
 import SettingsEmbed from '../ee/features/embed/SettingsEmbed';
 import { ProjectChangesets } from '../features/changesets/components/ProjectChangesets';
+import PullRequestsPage from '../features/pullRequests/components/PullRequestsPage';
+import { useIsPullRequestsEnabled } from '../features/pullRequests/hooks/useIsPullRequestsEnabled';
 import RecentlyDeletedPage from '../features/recentlyDeleted/components/RecentlyDeletedPage';
 import { useProject } from '../hooks/useProject';
 import useApp from '../providers/App/useApp';
@@ -36,6 +38,7 @@ const ProjectSettings: FC = () => {
     const { isInitialLoading, data: project, error } = useProject(projectUuid);
 
     const isSoftDeleteEnabled = health.data?.softDelete?.enabled ?? false;
+    const isPullRequestsEnabled = useIsPullRequestsEnabled();
 
     const routes = useMemo<RouteObject[]>(() => {
         if (!projectUuid) {
@@ -114,6 +117,16 @@ const ProjectSettings: FC = () => {
                 path: `/compilationHistory`,
                 element: <CompilationHistory projectUuid={projectUuid} />,
             },
+            ...(isPullRequestsEnabled
+                ? [
+                      {
+                          path: `/pullRequests`,
+                          element: (
+                              <PullRequestsPage projectUuid={projectUuid} />
+                          ),
+                      },
+                  ]
+                : []),
             {
                 path: `/preAggregates`,
                 children: [
@@ -151,7 +164,7 @@ const ProjectSettings: FC = () => {
                 element: <SettingsEmbed projectUuid={projectUuid} />,
             },
         ];
-    }, [projectUuid, isSoftDeleteEnabled]);
+    }, [projectUuid, isSoftDeleteEnabled, isPullRequestsEnabled]);
     const routesElements = useRoutes(routes);
 
     if (error) {

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -2,14 +2,12 @@ import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { Anchor, Box, ScrollArea, Stack, Text, Title } from '@mantine-8/core';
 import {
-    IconAppWindow,
     IconApps,
+    IconAppWindow,
     IconBolt,
     IconBrain,
     IconBrowser,
-    IconMessageCircle,
-    IconRobotFace,
-    IconSettings,
+    IconBrush,
     IconBuildingSkyscraper,
     IconCalendarStats,
     IconChecklist,
@@ -19,16 +17,19 @@ import {
     IconDatabaseExport,
     IconFileExport,
     IconFolders,
+    IconGitPullRequest,
     IconHistory,
     IconIdBadge2,
     IconKey,
     IconListCheck,
     IconLock,
-    IconBrush,
+    IconMessageCircle,
     IconPalette,
     IconPlug,
     IconRefresh,
     IconReportAnalytics,
+    IconRobotFace,
+    IconSettings,
     IconShieldCheck,
     IconTableOptions,
     IconTrash,
@@ -98,6 +99,7 @@ import { CustomRoleCreate } from '../ee/pages/customRoles/CustomRoleCreate';
 import { CustomRoleEdit } from '../ee/pages/customRoles/CustomRoleEdit';
 import { CustomRoles } from '../ee/pages/customRoles/CustomRoles';
 import DesignListPage from '../features/organizationDesigns/components/DesignListPage';
+import { useIsPullRequestsEnabled } from '../features/pullRequests/hooks/useIsPullRequestsEnabled';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
 import { useProject } from '../hooks/useProject';
@@ -136,6 +138,8 @@ const Settings: FC = () => {
     );
     const isServiceAccountFeatureFlagEnabled =
         serviceAccountsFlag?.enabled ?? false;
+
+    const isPullRequestsEnabled = useIsPullRequestsEnabled();
 
     const {
         health: {
@@ -754,6 +758,12 @@ const Settings: FC = () => {
             !matchPath(
                 {
                     path: '/generalSettings/projectManagement/:projectUuid/validator',
+                },
+                location.pathname,
+            ) &&
+            !matchPath(
+                {
+                    path: '/generalSettings/projectManagement/:projectUuid/pullRequests',
                 },
                 location.pathname,
             ) &&
@@ -1486,6 +1496,27 @@ const Settings: FC = () => {
                                             leftSection={
                                                 <MantineIcon
                                                     icon={IconDatabaseExport}
+                                                />
+                                            }
+                                        />
+                                    ) : null}
+
+                                    {isPullRequestsEnabled &&
+                                    user.ability?.can(
+                                        'view',
+                                        subject('SourceCode', {
+                                            organizationUuid:
+                                                project.organizationUuid,
+                                            projectUuid: project.projectUuid,
+                                        }),
+                                    ) ? (
+                                        <RouterNavLink
+                                            label="Pull requests"
+                                            exact
+                                            to={`/generalSettings/projectManagement/${project.projectUuid}/pullRequests`}
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconGitPullRequest}
                                                 />
                                             }
                                         />


### PR DESCRIPTION
## Summary

PR 4 of 4 for [PROD-7992](https://linear.app/lightdash/issue/PROD-7992). Adds the project-settings "Pull requests" table — the user-facing surface for the stack — gated behind the `pull-requests` feature flag.

Stacks on top of PR 3 (#23705), which added live provider status resolution.

Closes: https://linear.app/lightdash/issue/PROD-8025

## Changes

**Frontend** (`features/pullRequests/`)
- `PullRequestsPage` — paginated table: state medallion, created (relative), author (resolved from org members), title + source tag, state badge, thread link (AI-agent PRs), external PR link. Skeleton / error / empty states handled.
- `usePullRequestsTable` — fetches the current page and resolves authors from `useOrganizationUsers`.
- `useIsPullRequestsEnabled` — wraps the `pull-requests` flag lookup.
- Route in `ProjectSettings` and nav entry in `Settings`, both gated by the flag (nav also requires `view SourceCode`).

## Layout

```
Pull requests
+--------------------------------------------------------------+
| *  Created    Author     Title              State   thread pr|
+--------------------------------------------------------------+
| o  2h ago     A. Smith   Add revenue metric [open]    o    ^ |
| o  1d ago     -          Fix join           [merged]       ^ |
+--------------------------------------------------------------+
```

## Test plan

- [x] `pnpm -F frontend typecheck` (this branch in isolation)
- [x] Pre-commit eslint (lint-staged) + ts-unused-exports on changed files
- [ ] Not yet captured: UI screenshots / manual click-through with the flag on

🤖 Generated with [Claude Code](https://claude.com/claude-code)