### PR TITLE
fix(scheduler): require manage:GoogleSheets to create google sheets syncs

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -1692,6 +1692,22 @@ export class DashboardService
 
         const { projectUuid, organizationUuid } =
             await this.checkCreateScheduledDeliveryAccess(user, dashboardUuid);
+
+        if (newScheduler.format === SchedulerFormat.GSHEETS) {
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'manage',
+                    subject('GoogleSheets', {
+                        organizationUuid,
+                        projectUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
+        }
+
         const scheduler = await this.schedulerModel.createScheduler({
             ...newScheduler,
             createdBy: user.userUuid,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -1782,6 +1782,22 @@ export class SavedChartService
 
         const { projectUuid, organizationUuid } =
             await this.checkCreateScheduledDeliveryAccess(user, chartUuid);
+
+        if (newScheduler.format === SchedulerFormat.GSHEETS) {
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'manage',
+                    subject('GoogleSheets', {
+                        organizationUuid,
+                        projectUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
+        }
+
         const scheduler = await this.schedulerModel.createScheduler({
             ...newScheduler,
             createdBy: user.userUuid,

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -17,6 +17,7 @@ import {
     Project,
     QueryExecutionContext,
     SchedulerAndTargets,
+    SchedulerFormat,
     SessionUser,
     SqlChart,
     SqlRunnerPivotQueryBody,
@@ -867,11 +868,27 @@ export class SavedSqlService
         savedSqlUuid: string,
         newScheduler: CreateSchedulerAndTargetsWithoutIds,
     ): Promise<SchedulerAndTargets> {
-        await this.checkCreateScheduledDeliveryAccess(
-            user,
-            projectUuid,
-            savedSqlUuid,
-        );
+        const { organizationUuid } =
+            await this.checkCreateScheduledDeliveryAccess(
+                user,
+                projectUuid,
+                savedSqlUuid,
+            );
+
+        if (newScheduler.format === SchedulerFormat.GSHEETS) {
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'manage',
+                    subject('GoogleSheets', {
+                        organizationUuid,
+                        projectUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
+        }
 
         if (!isValidFrequency(newScheduler.cron)) {
             throw new ParameterError(

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -846,7 +846,8 @@ const SavedChartsHeader: FC = () => {
                                     </Menu.Item>
                                 )}
                                 {userCanManageChart &&
-                                    hasGoogleDriveEnabled && (
+                                    hasGoogleDriveEnabled &&
+                                    userCanCreateDeliveriesAndAlerts && (
                                         <Can
                                             I="manage"
                                             this={subject('GoogleSheets', {

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -124,6 +124,14 @@ export const HeaderView: FC = () => {
         }),
     );
 
+    const canCreateScheduledDeliveries = user.data?.ability?.can(
+        'create',
+        subject('ScheduledDeliveries', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+
     const hasGoogleDriveEnabled =
         health.data?.auth.google.oauth2ClientId !== undefined &&
         health.data?.auth.google.googleDriveApiKey !== undefined;
@@ -233,29 +241,33 @@ export const HeaderView: FC = () => {
                                     >
                                         Add to dashboard
                                     </Menu.Item>
-                                    {hasGoogleDriveEnabled && (
-                                        <Can
-                                            I="manage"
-                                            this={subject('GoogleSheets', {
-                                                organizationUuid:
-                                                    user.data?.organizationUuid,
-                                                projectUuid,
-                                            })}
-                                        >
-                                            <Menu.Item
-                                                icon={
-                                                    <MantineIcon
-                                                        icon={
-                                                            IconCirclesRelation
-                                                        }
-                                                    />
-                                                }
-                                                onClick={syncModalHandlers.open}
+                                    {hasGoogleDriveEnabled &&
+                                        canCreateScheduledDeliveries && (
+                                            <Can
+                                                I="manage"
+                                                this={subject('GoogleSheets', {
+                                                    organizationUuid:
+                                                        user.data
+                                                            ?.organizationUuid,
+                                                    projectUuid,
+                                                })}
                                             >
-                                                Google Sheets Sync
-                                            </Menu.Item>
-                                        </Can>
-                                    )}
+                                                <Menu.Item
+                                                    icon={
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconCirclesRelation
+                                                            }
+                                                        />
+                                                    }
+                                                    onClick={
+                                                        syncModalHandlers.open
+                                                    }
+                                                >
+                                                    Google Sheets Sync
+                                                </Menu.Item>
+                                            </Can>
+                                        )}
                                     {canPromoteChart && (
                                         <Tooltip
                                             label="You must enable first an upstream project in settings > Data ops"

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     getHumanReadableCronExpression,
     type Scheduler,
@@ -24,6 +25,7 @@ import MantineModal, {
 } from '../../../components/common/MantineModal';
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
 import { useProject } from '../../../hooks/useProject';
+import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import ConfirmPauseSchedulerModal from '../../scheduler/components/ConfirmPauseSchedulerModal';
@@ -122,6 +124,7 @@ export const SyncModalView: FC<Props> = ({
 
     const { activeProjectUuid } = useActiveProjectUuid();
     const { data: project } = useProject(activeProjectUuid);
+    const { user } = useApp();
 
     if (!project) return null;
 
@@ -164,79 +167,117 @@ export const SyncModalView: FC<Props> = ({
                     }
                 >
                     <Stack>
-                        {schedulers.map((sync) => (
-                            <Paper
-                                key={sync.schedulerUuid}
-                                p="sm"
-                                withBorder
-                                style={{
-                                    overflow: 'hidden',
-                                }}
-                            >
-                                <Group wrap="nowrap" justify="space-between">
-                                    <Stack gap="xs">
-                                        <Text fz="sm" fw={600} truncate>
-                                            {sync.name}
-                                        </Text>
+                        {schedulers.map((sync) => {
+                            const canManageSync =
+                                user.data?.ability?.can(
+                                    'manage',
+                                    subject('GoogleSheets', {
+                                        organizationUuid:
+                                            user.data?.organizationUuid,
+                                        projectUuid: activeProjectUuid,
+                                    }),
+                                ) &&
+                                user.data?.ability?.can(
+                                    'manage',
+                                    subject('ScheduledDeliveries', {
+                                        organizationUuid:
+                                            user.data?.organizationUuid,
+                                        projectUuid: activeProjectUuid,
+                                        userUuid: sync.createdBy,
+                                    }),
+                                );
 
-                                        <Text size="xs" c="ldGray.6">
-                                            {getHumanReadableCronExpression(
-                                                sync.cron,
-                                                sync.timezone ||
-                                                    project.schedulerTimezone,
-                                            )}
-                                        </Text>
-                                    </Stack>
+                            return (
+                                <Paper
+                                    key={sync.schedulerUuid}
+                                    p="sm"
+                                    withBorder
+                                    style={{
+                                        overflow: 'hidden',
+                                    }}
+                                >
+                                    <Group
+                                        wrap="nowrap"
+                                        justify="space-between"
+                                    >
+                                        <Stack gap="xs">
+                                            <Text fz="sm" fw={600} truncate>
+                                                {sync.name}
+                                            </Text>
 
-                                    <Group wrap="nowrap" gap="xs">
-                                        <ToggleSyncEnabled scheduler={sync} />
+                                            <Text size="xs" c="ldGray.6">
+                                                {getHumanReadableCronExpression(
+                                                    sync.cron,
+                                                    sync.timezone ||
+                                                        project.schedulerTimezone,
+                                                )}
+                                            </Text>
+                                        </Stack>
 
-                                        <SendNowButton
-                                            schedulerUuid={sync.schedulerUuid}
-                                        />
-
-                                        <Tooltip withinPortal label="Edit">
-                                            <ActionIcon
-                                                variant="light"
-                                                radius="md"
-                                                color="ldDark.9"
-                                                onClick={() => {
-                                                    setAction(
-                                                        SyncModalAction.EDIT,
-                                                    );
-                                                    setCurrentSchedulerUuid(
-                                                        sync.schedulerUuid,
-                                                    );
-                                                }}
-                                            >
-                                                <MantineIcon
-                                                    color="ldDark.9"
-                                                    icon={IconPencil}
+                                        {canManageSync && (
+                                            <Group wrap="nowrap" gap="xs">
+                                                <ToggleSyncEnabled
+                                                    scheduler={sync}
                                                 />
-                                            </ActionIcon>
-                                        </Tooltip>
 
-                                        <Tooltip withinPortal label="Delete">
-                                            <ActionIcon
-                                                variant="light"
-                                                color="red"
-                                                radius="md"
-                                                onClick={() => {
-                                                    setAction(
-                                                        SyncModalAction.DELETE,
-                                                    );
-                                                    setCurrentSchedulerUuid(
-                                                        sync.schedulerUuid,
-                                                    );
-                                                }}
-                                            >
-                                                <MantineIcon icon={IconTrash} />
-                                            </ActionIcon>
-                                        </Tooltip>
+                                                <SendNowButton
+                                                    schedulerUuid={
+                                                        sync.schedulerUuid
+                                                    }
+                                                />
+
+                                                <Tooltip
+                                                    withinPortal
+                                                    label="Edit"
+                                                >
+                                                    <ActionIcon
+                                                        variant="light"
+                                                        radius="md"
+                                                        color="ldDark.9"
+                                                        onClick={() => {
+                                                            setAction(
+                                                                SyncModalAction.EDIT,
+                                                            );
+                                                            setCurrentSchedulerUuid(
+                                                                sync.schedulerUuid,
+                                                            );
+                                                        }}
+                                                    >
+                                                        <MantineIcon
+                                                            color="ldDark.9"
+                                                            icon={IconPencil}
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+
+                                                <Tooltip
+                                                    withinPortal
+                                                    label="Delete"
+                                                >
+                                                    <ActionIcon
+                                                        variant="light"
+                                                        color="red"
+                                                        radius="md"
+                                                        onClick={() => {
+                                                            setAction(
+                                                                SyncModalAction.DELETE,
+                                                            );
+                                                            setCurrentSchedulerUuid(
+                                                                sync.schedulerUuid,
+                                                            );
+                                                        }}
+                                                    >
+                                                        <MantineIcon
+                                                            icon={IconTrash}
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+                                            </Group>
+                                        )}
                                     </Group>
-                                </Group>
-                            </Paper>
-                        ))}
+                                </Paper>
+                            );
+                        })}
 
                         {isFetchingNextPage && (
                             <Stack align="center" mt="md">


### PR DESCRIPTION
Closes: SPK-463

### Description:

Creating a Google Sheets sync only required `create:ScheduledDeliveries`, while deleting one required both `manage:ScheduledDeliveries` and `manage:GoogleSheets` — an inconsistent permission gate. This enforces `manage:GoogleSheets` when creating a GSHEETS scheduler across the chart, SQL chart, and dashboard create paths, mirroring the deletion check. The frontend now also checks both permissions: the create menu entries require `create:ScheduledDeliveries` alongside `manage:GoogleSheets`, and the previously ungated per-sync action buttons (edit/delete/toggle/send) in the sync modal are gated on `manage:GoogleSheets` and `manage:ScheduledDeliveries`.