### PR TITLE
feat: gate ai content tools per agent

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -13,6 +13,7 @@ export type DbAiAgent = {
     tags: string[] | null;
     enable_data_access: boolean;
     enable_self_improvement: boolean;
+    enable_content_tools: boolean;
     /**
      * @deprecated Per-agent reasoning toggle was removed. The gating feature flag
      * `agent-reasoning` was never enabled so this column was effectively

--- a/packages/backend/src/ee/database/migrations/20260601120000_add_enable_content_tools_to_ai_agent.ts
+++ b/packages/backend/src/ee/database/migrations/20260601120000_add_enable_content_tools_to_ai_agent.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex';
+import { AiAgentTableName } from '../entities/aiAgent';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiAgentTableName, (table) => {
+        table.boolean('enable_content_tools').defaultTo(false).notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiAgentTableName, (table) => {
+        table.dropColumn('enable_content_tools');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -373,6 +373,7 @@ export class AiAgentModel {
                 imageUrl: `${AiAgentTableName}.image_url`,
                 enableDataAccess: `${AiAgentTableName}.enable_data_access`,
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
+                enableContentTools: `${AiAgentTableName}.enable_content_tools`,
                 version: `${AiAgentTableName}.version`,
                 groupAccess: this.database.raw(`
                     COALESCE(
@@ -506,6 +507,7 @@ export class AiAgentModel {
                 imageUrl: `${AiAgentTableName}.image_url`,
                 enableDataAccess: `${AiAgentTableName}.enable_data_access`,
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
+                enableContentTools: `${AiAgentTableName}.enable_content_tools`,
                 version: `${AiAgentTableName}.version`,
                 groupAccess: this.database.raw(`
                     COALESCE(
@@ -1666,6 +1668,7 @@ export class AiAgentModel {
             | 'spaceAccess'
             | 'enableDataAccess'
             | 'enableSelfImprovement'
+            | 'enableContentTools'
             | 'version'
             | 'mcpServerUuids'
         > & {
@@ -1691,6 +1694,7 @@ export class AiAgentModel {
                     image_url: null,
                     enable_data_access: args.enableDataAccess,
                     enable_self_improvement: args.enableSelfImprovement,
+                    enable_content_tools: args.enableContentTools ?? false,
                     version: args.version,
                     is_system: args.isSystem ?? false,
                 })
@@ -1790,6 +1794,7 @@ export class AiAgentModel {
                 spaceAccess,
                 enableDataAccess: agent.enable_data_access,
                 enableSelfImprovement: agent.enable_self_improvement,
+                enableContentTools: agent.enable_content_tools,
                 version: agent.version,
             };
         });
@@ -1841,6 +1846,7 @@ export class AiAgentModel {
                 spaceAccess: [],
                 enableDataAccess: true,
                 enableSelfImprovement: false,
+                enableContentTools: false,
                 version: 1,
                 mcpServerUuids: [],
                 isSystem: true,
@@ -1893,6 +1899,9 @@ export class AiAgentModel {
                               enable_self_improvement:
                                   args.enableSelfImprovement,
                           }
+                        : {}),
+                    ...(args.enableContentTools !== undefined
+                        ? { enable_content_tools: args.enableContentTools }
                         : {}),
                     ...(args.version !== undefined
                         ? { version: args.version }
@@ -2030,6 +2039,7 @@ export class AiAgentModel {
                 spaceAccess,
                 enableDataAccess: agent.enable_data_access,
                 enableSelfImprovement: agent.enable_self_improvement,
+                enableContentTools: agent.enable_content_tools,
                 version: agent.version,
             };
         });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2058,6 +2058,7 @@ export class AiAgentService extends BaseService {
             mcpServerUuids: body.mcpServerUuids,
             enableDataAccess: body.enableDataAccess,
             enableSelfImprovement: body.enableSelfImprovement,
+            enableContentTools: body.enableContentTools,
             version: body.version,
         });
 
@@ -2873,6 +2874,7 @@ export class AiAgentService extends BaseService {
             mcpServerUuids: body.mcpServerUuids,
             enableDataAccess: body.enableDataAccess,
             enableSelfImprovement: body.enableSelfImprovement,
+            enableContentTools: body.enableContentTools,
             version: body.version,
         });
 
@@ -5957,24 +5959,23 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         const enableSqlMode = options.enableSqlMode ?? false;
 
-        // Whether this prompt's caller identity can be trusted as the real
-        // sender. For Slack prompts that's only true when the org has
-        // `aiRequireOAuth` on; otherwise every message runs as the
-        // workspace installer and downstream CASL checks would evaluate
-        // against the installer's ability. Non-Slack callers are always
-        // the real sender, so default to true.
-        let aiRequireOAuth = true;
+        // Permission-sensitive tools need the prompt actor to be the real
+        // sender. Web prompts always are; Slack prompts are only trusted when
+        // Slack OAuth is required, otherwise the actor is the workspace
+        // installer.
+        let hasTrustedPromptUserIdentity = true;
         if (isSlackPrompt(prompt) && user.organizationUuid) {
             const slackSettings =
                 await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
                     user.organizationUuid,
                 );
-            aiRequireOAuth = !!slackSettings?.aiRequireOAuth;
+            hasTrustedPromptUserIdentity = !!slackSettings?.aiRequireOAuth;
         }
+        const promptProject = await this.projectModel.get(prompt.projectUuid);
 
         let canRunSql = enableSqlMode;
-        // Fail-closed: CASL would evaluate against the installer, not the sender.
-        if (canRunSql && !aiRequireOAuth) {
+        // Fail closed when CASL would evaluate against the installer.
+        if (canRunSql && !hasTrustedPromptUserIdentity) {
             this.logger.info(
                 `Disabling runSql for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
             );
@@ -5992,8 +5993,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 auditedAbility.cannot(
                     'manage',
                     subject('SqlRunner', {
-                        organizationUuid: user.organizationUuid,
-                        projectUuid: prompt.projectUuid,
+                        organizationUuid: promptProject.organizationUuid,
+                        projectUuid: promptProject.projectUuid,
                         metadata: {
                             promptUuid: prompt.promptUuid,
                             threadUuid: prompt.threadUuid,
@@ -6060,13 +6061,30 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 featureFlagId: FeatureFlags.AiWriteback,
             },
         );
-        if (aiWritebackEnabled && !aiRequireOAuth) {
+        if (aiWritebackEnabled && !hasTrustedPromptUserIdentity) {
             this.logger.info(
                 `Disabling proposeWriteback for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
             );
             aiWritebackEnabled = false;
         }
-        const availableSkills = agentRevampEnabled
+
+        const canUseContentTools =
+            agentRevampEnabled &&
+            agentSettings.enableContentTools &&
+            hasTrustedPromptUserIdentity &&
+            this.createAuditedAbility(user).can(
+                'manage',
+                subject('ContentAsCode', {
+                    organizationUuid: promptProject.organizationUuid,
+                    projectUuid: promptProject.projectUuid,
+                    metadata: {
+                        promptUuid: prompt.promptUuid,
+                        threadUuid: prompt.threadUuid,
+                        agentUuid: agentSettings.uuid,
+                    },
+                }),
+            );
+        const availableSkills = canUseContentTools
             ? await BuiltInSkills.getAiAgentSkills()
             : [];
         const modelProperties = getModel(this.lightdashConfig.ai.copilot, {
@@ -6094,6 +6112,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             telemetryEnabled: this.lightdashConfig.ai.copilot.telemetryEnabled,
             enableDataAccess: agentSettings.enableDataAccess,
             enableSelfImprovement: agentSettings.enableSelfImprovement,
+            enableContentTools: canUseContentTools,
             enableAiWriteback: aiWritebackEnabled,
             canRunSql,
             autoApproveSql: options.autoApproveSql ?? false,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -303,7 +303,7 @@ const getAgentTools = (
         getProjectInfo,
         listKnowledgeDocuments,
         getKnowledgeDocumentContent,
-        ...(args.enableAgentRevamp
+        ...(args.enableAgentRevamp && args.enableContentTools
             ? {
                   readContent,
                   editContent,

--- a/packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts
@@ -10,7 +10,7 @@ The writeback tool spawns a separate agent that edits the repo, runs \`lightdash
 
 **When NOT to use \`proposeWriteback\`:**
 - The user is asking a question about data (use the query/discovery tools instead).
-- The user wants to edit an existing chart or dashboard inside Lightdash — use \`editContent\` for that.
+- The user wants to edit an existing chart or dashboard inside Lightdash.
 - The user wants to propose an in-app change to a metric/dimension as a reviewable changeset rather than a pull request — use \`proposeChange\` for that.
 - The request is ambiguous about whether it should land in the repo. Ask one short clarifying question first.
 

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -80,6 +80,7 @@ export type AiAgentArgs = AnyAiModel & {
     telemetryEnabled: boolean;
     enableDataAccess: boolean;
     enableSelfImprovement: boolean;
+    enableContentTools: boolean;
     enableAiWriteback: boolean;
     canRunSql: boolean;
     autoApproveSql: boolean;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10397,7 +10397,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_':
+    'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -10482,6 +10482,10 @@ const models: TsoaRoute.Models = {
                         dataType: 'boolean',
                         required: true,
                     },
+                    enableContentTools: {
+                        dataType: 'boolean',
+                        required: true,
+                    },
                     version: { dataType: 'double', required: true },
                 },
                 validators: {},
@@ -10491,7 +10495,7 @@ const models: TsoaRoute.Models = {
     AiAgentSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_',
+            ref: 'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_',
             validators: {},
         },
     },
@@ -10997,7 +11001,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_':
+    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -11082,6 +11086,10 @@ const models: TsoaRoute.Models = {
                         dataType: 'boolean',
                         required: true,
                     },
+                    enableContentTools: {
+                        dataType: 'boolean',
+                        required: true,
+                    },
                     version: { dataType: 'double', required: true },
                 },
                 validators: {},
@@ -11091,7 +11099,7 @@ const models: TsoaRoute.Models = {
     AiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_',
+            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_',
             validators: {},
         },
     },
@@ -11680,6 +11688,7 @@ const models: TsoaRoute.Models = {
                             dataType: 'array',
                             array: { dataType: 'string' },
                         },
+                        enableContentTools: { dataType: 'boolean' },
                     },
                 },
             ],
@@ -11687,7 +11696,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__':
+    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version__':
         {
             dataType: 'refAlias',
             type: {
@@ -11809,6 +11818,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    enableContentTools: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     version: {
                         dataType: 'union',
                         subSchemas: [
@@ -11827,7 +11843,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__',
+                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version__',
                 },
                 {
                     dataType: 'nestedObjectLiteral',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11985,7 +11985,7 @@
                 "required": ["content", "mimeType", "originalFilename", "name"],
                 "type": "object"
             },
-            "Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_": {
+            "Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -12067,6 +12067,9 @@
                     "enableSelfImprovement": {
                         "type": "boolean"
                     },
+                    "enableContentTools": {
+                        "type": "boolean"
+                    },
                     "version": {
                         "type": "number",
                         "format": "double"
@@ -12089,13 +12092,14 @@
                     "spaceAccess",
                     "enableDataAccess",
                     "enableSelfImprovement",
+                    "enableContentTools",
                     "version"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgentSummary": {
-                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_"
+                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_"
             },
             "ApiAiAgentSummaryResponse": {
                 "properties": {
@@ -12572,7 +12576,7 @@
             "ApiAiAgentProjectThreadSummaryListResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_KnexPaginatedData_AiAgentProjectThreadSummary-Array__"
             },
-            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_": {
+            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -12654,6 +12658,9 @@
                     "enableSelfImprovement": {
                         "type": "boolean"
                     },
+                    "enableContentTools": {
+                        "type": "boolean"
+                    },
                     "version": {
                         "type": "number",
                         "format": "double"
@@ -12676,13 +12683,14 @@
                     "spaceAccess",
                     "enableDataAccess",
                     "enableSelfImprovement",
+                    "enableContentTools",
                     "version"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgent": {
-                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_"
+                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_"
             },
             "ApiAiAgentResponse": {
                 "properties": {
@@ -13275,13 +13283,16 @@
                                     "type": "string"
                                 },
                                 "type": "array"
+                            },
+                            "enableContentTools": {
+                                "type": "boolean"
                             }
                         },
                         "type": "object"
                     }
                 ]
             },
-            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__": {
+            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version__": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -13349,6 +13360,9 @@
                     "enableSelfImprovement": {
                         "type": "boolean"
                     },
+                    "enableContentTools": {
+                        "type": "boolean"
+                    },
                     "version": {
                         "type": "number",
                         "format": "double"
@@ -13360,7 +13374,7 @@
             "ApiUpdateAiAgent": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__"
+                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version__"
                     },
                     {
                         "properties": {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -140,6 +140,7 @@ export const baseAgentSchema = z.object({
     spaceAccess: z.array(z.string()),
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
+    enableContentTools: z.boolean(),
     version: z.number(),
 });
 
@@ -163,6 +164,7 @@ export type AiAgent = Pick<
     | 'spaceAccess'
     | 'enableDataAccess'
     | 'enableSelfImprovement'
+    | 'enableContentTools'
     | 'version'
 >;
 
@@ -184,6 +186,7 @@ export type AiAgentSummary = Pick<
     | 'spaceAccess'
     | 'enableDataAccess'
     | 'enableSelfImprovement'
+    | 'enableContentTools'
     | 'version'
 >;
 
@@ -303,6 +306,7 @@ export type ApiCreateAiAgent = Pick<
     | 'enableSelfImprovement'
     | 'version'
 > & {
+    enableContentTools?: boolean;
     mcpServerUuids?: string[];
 };
 
@@ -321,6 +325,7 @@ export type ApiUpdateAiAgent = Partial<
         | 'spaceAccess'
         | 'enableDataAccess'
         | 'enableSelfImprovement'
+        | 'enableContentTools'
         | 'version'
     >
 > & {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -71,6 +71,7 @@ const formSchema = z.object({
     mcpServerUuids: z.array(z.string()),
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
+    enableContentTools: z.boolean(),
     version: z.number(),
 });
 
@@ -138,6 +139,12 @@ export const AiAgentFormSetup = ({
     const isGroupsEnabled =
         userGroupsFeatureFlagQuery.isSuccess &&
         userGroupsFeatureFlagQuery.data.enabled;
+    const agentRevampFeatureFlagQuery = useServerFeatureFlag(
+        FeatureFlags.AiAgentRevamp,
+    );
+    const isAgentRevampEnabled =
+        agentRevampFeatureFlagQuery.isSuccess &&
+        agentRevampFeatureFlagQuery.data.enabled;
 
     const handlePersistedMcpServerChange = useCallback(
         (value: string[]) => {
@@ -371,6 +378,52 @@ export const AiAgentFormSetup = ({
                                     type: 'checkbox',
                                 })}
                             />
+                            {isAgentRevampEnabled && (
+                                <Switch
+                                    variant="subtle"
+                                    label={
+                                        <Group gap="xs">
+                                            <Text fz="sm" fw={500}>
+                                                Allow agent to manage Lightdash
+                                                content
+                                            </Text>
+                                            <Tooltip
+                                                label="Only works for users with content-as-code access (admins and developers)."
+                                                withArrow
+                                                withinPortal
+                                                multiline
+                                                position="right"
+                                                maw="300px"
+                                            >
+                                                <MantineIcon
+                                                    icon={IconInfoCircle}
+                                                />
+                                            </Tooltip>
+                                            <Badge
+                                                color="indigo"
+                                                radius="sm"
+                                                variant="light"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconSparkles}
+                                                    />
+                                                }
+                                            >
+                                                Beta
+                                            </Badge>
+                                        </Group>
+                                    }
+                                    description={
+                                        'Agent can build new dashboards and charts and update existing ones — add or rearrange tiles, organize tabs, change filters, and more.'
+                                    }
+                                    {...form.getInputProps(
+                                        'enableContentTools',
+                                        {
+                                            type: 'checkbox',
+                                        },
+                                    )}
+                                />
+                            )}
                             <Switch
                                 variant="subtle"
                                 label={

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -68,6 +68,7 @@ const formSchema = z.object({
     mcpServerUuids: z.array(z.string()),
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
+    enableContentTools: z.boolean(),
     version: z.number(),
 });
 
@@ -120,6 +121,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             mcpServerUuids: [],
             enableDataAccess: true,
             enableSelfImprovement: false,
+            enableContentTools: false,
             version: 2, // INFO: Default to v2 for now
         },
         validate: zodResolver(formSchema),
@@ -144,6 +146,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 mcpServerUuids: agentMcpServers?.map((mcp) => mcp.uuid) ?? [],
                 enableDataAccess: agent.enableDataAccess ?? false,
                 enableSelfImprovement: agent.enableSelfImprovement ?? false,
+                enableContentTools: agent.enableContentTools ?? false,
                 version: agent.version ?? 2, // INFO: Default to v2 for now
             };
             form.setValues(values);


### PR DESCRIPTION
Closes: ZAP-458

### Description
- Adds per-agent beta setting for AI content tools.
- Gates content tool exposure on `manage:ContentAsCode`, trusted Slack identity, rollout flag, and agent setting.
- Adds admin UI switch plus API/generated schema updates.
- Keeps writeback prompt from naming unavailable content tools.

### Verification
- `pnpm -F @lightdash/common typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- `pnpm -F backend test src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts`