### PR TITLE
feat: add per-org export limits (query max rows + CSV cells) with `pro-limits` feature flag and admin panel (PROD-7214)

### DIFF
--- a/docs/export-limits.md
+++ b/docs/export-limits.md
@@ -14,7 +14,7 @@ Instance-wide env vars used to be the only control over query/export size:
 |---|---|---|---|
 | `LIGHTDASH_QUERY_MAX_LIMIT` | `lightdashConfig.query.maxLimit` | 5000 (Cloud: 100000) | Max **rows** a query may return — and the **ceiling** for the per-org query limit |
 | `LIGHTDASH_CSV_CELLS_LIMIT` | `lightdashConfig.query.csvCellsLimit` | 100000 | Default max **cells** (rows × columns) a CSV/Excel export may contain |
-| `LIGHTDASH_CSV_CELLS_MAX_LIMIT` | `lightdashConfig.query.csvCellsMaxLimit` | 5000000 | **Ceiling** an org admin may raise the per-org CSV cells limit to |
+| `LIGHTDASH_CSV_MAX_LIMIT` | `lightdashConfig.query.csvMaxLimit` | 5000000 | **Ceiling** an org admin may raise the per-org CSV cells limit to |
 
 On shared multi-tenant Cloud infra each org needs its own policy (a customer with a 100k-row × 86-column query
 needs ~8.6M cells, while others should stay capped). The **Limits** panel lets an admin override both
@@ -41,15 +41,15 @@ Both are surfaced **resolved** in the API (always an effective number, falling b
 frontend can display them directly. Validation (`OrganizationSettingsService`): each must be a **positive
 integer** no larger than the Postgres `integer` column ceiling; `queryLimit` additionally cannot exceed
 `LIGHTDASH_QUERY_MAX_LIMIT`, and `csvCellsLimit` cannot exceed the **effective cap =
-`max(LIGHTDASH_CSV_CELLS_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT)`** (default 5,000,000).
+`max(LIGHTDASH_CSV_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT)`** (default 5,000,000).
 
-### Why `max(CSV_CELLS_MAX_LIMIT, CSV_CELLS_LIMIT)` and not just `CSV_CELLS_MAX_LIMIT`?
+### Why `max(CSV_MAX_LIMIT, CSV_CELLS_LIMIT)` and not just `CSV_MAX_LIMIT`?
 
 Several Cloud customers already set `LIGHTDASH_CSV_CELLS_LIMIT` above the 5M default (up to 50M). If the cap
 were a plain 5M, their **panel would reject its own inherited value** (the effective limit shown, e.g. 50M,
 exceeds 5M → every Save fails). Taking the max with the instance default guarantees the cap is never below what
 the instance already runs, so no existing instance is forced below its own limit, while new instances get a
-clean 5M ceiling. The ceiling is exposed to the panel via `/health` (`query.csvCellsMaxLimit`), and the
+clean 5M ceiling. The ceiling is exposed to the panel via `/health` (`query.csvMaxLimit`), and the
 query-rows ceiling via `query.queryMaxLimit`, so the panel's input bounds and helper text match the backend.
 
 ---
@@ -69,7 +69,7 @@ value_:
 | `defaultLimit` | `min(LIGHTDASH_QUERY_DEFAULT_LIMIT, effective maxLimit)` | new-query default (so it's never above the org limit) |
 | `csvCellsLimit` | effective CSV cells (`csvCellsLimit ?? LIGHTDASH_CSV_CELLS_LIMIT`) | export "limited to N cells" messaging |
 | `queryMaxLimit` | instance ceiling (`LIGHTDASH_QUERY_MAX_LIMIT`) | admin panel "Up to" hint |
-| `csvCellsMaxLimit` | instance ceiling (`max(CSV_CELLS_MAX_LIMIT, CSV_CELLS_LIMIT)`) | admin panel "Up to" hint |
+| `csvMaxLimit` | instance ceiling (`max(CSV_CELLS_MAX_LIMIT, CSV_CELLS_LIMIT)`) | admin panel "Up to" hint |
 
 Unauthenticated callers (the login page) have no org, so they see the instance defaults — unchanged behavior.
 
@@ -121,8 +121,8 @@ can't leak to ungated orgs, since an override only exists if it was written thro
 | Concern | Location |
 |---|---|
 | Setting types + resolver | `packages/common/src/types/organizationSettings.ts` (`queryLimit`, `csvCellsLimit`) |
-| CSV cap config | `parseConfig.ts` (`query.csvCellsMaxLimit` from `LIGHTDASH_CSV_CELLS_MAX_LIMIT`) |
-| Org-aware health | `HealthService.ts` (`query.maxLimit` / `defaultLimit` / `csvCellsLimit` effective; `queryMaxLimit` / `csvCellsMaxLimit` ceilings) |
+| CSV cap config | `parseConfig.ts` (`query.csvMaxLimit` from `LIGHTDASH_CSV_MAX_LIMIT`) |
+| Org-aware health | `HealthService.ts` (`query.maxLimit` / `defaultLimit` / `csvCellsLimit` effective; `queryMaxLimit` / `csvMaxLimit` ceilings) |
 | Feature flag | `packages/common/src/types/featureFlags.ts` (`ProLimits = 'pro-limits'`) |
 | DB column + entity | migration `..._add_export_limits_to_organization_settings.ts`, `entities/organizationSettings.ts` |
 | Model + service validation | `OrganizationSettingsModel.ts`, `OrganizationSettingsService.ts` |

--- a/docs/export-limits.md
+++ b/docs/export-limits.md
@@ -13,7 +13,8 @@ Two instance-wide env vars used to be the only control over export size:
 | Env var | Config path | Default | What it limits |
 |---|---|---|---|
 | `LIGHTDASH_QUERY_MAX_LIMIT` | `lightdashConfig.query.maxLimit` | 5000 (Cloud: 100000) | Max **rows** a query/export can return |
-| `LIGHTDASH_CSV_CELLS_LIMIT` | `lightdashConfig.query.csvCellsLimit` | 100000 | Max **cells** (rows × columns) a CSV/Excel export can contain |
+| `LIGHTDASH_CSV_CELLS_LIMIT` | `lightdashConfig.query.csvCellsLimit` | 100000 | Default max **cells** (rows × columns) a CSV/Excel export can contain |
+| `LIGHTDASH_CSV_MAX_LIMIT` | `lightdashConfig.query.csvMaxLimit` | 5000000 | **Ceiling** an org admin may raise the per-org CSV cells limit to |
 
 On shared multi-tenant Cloud infra each org needs its own policy (a customer with a 100k-row × 86-column query
 needs ~8.6M cells, while others should stay capped). The **Limits** panel lets an admin override both
@@ -31,13 +32,21 @@ This reuses the same `organization_settings` infrastructure as the scheduled-del
 | Setting | Stored column | API field | Meaning |
 |---|---|---|---|
 | **Maximum query rows** | `query_max_limit` | `queryMaxLimit` | Overrides `LIGHTDASH_QUERY_MAX_LIMIT`. `null` ⇒ inherit. |
-| **Maximum CSV/Excel cells** | `csv_cells_limit` | `csvCellsLimit` | Overrides `LIGHTDASH_CSV_CELLS_LIMIT`. `null` ⇒ inherit. Capped at {@link MAX_CSV_CELLS_LIMIT} = 50,000,000. |
+| **Maximum CSV/Excel cells** | `csv_cells_limit` | `csvCellsLimit` | Overrides `LIGHTDASH_CSV_CELLS_LIMIT`. `null` ⇒ inherit. Capped (see below). |
 
 Both are surfaced **resolved** in the API (always an effective number, falling back to the env default) so the
 frontend can display them directly. Validation (`OrganizationSettingsService`): each must be a **positive
-integer**; `csvCellsLimit` additionally cannot exceed **50,000,000** (the highest value any Cloud customer sets
-today — a sane ceiling that still allows wide exports without inviting OOM-scale requests). There is no max on
-`queryMaxLimit`.
+integer**; `csvCellsLimit` additionally cannot exceed the **effective cap = `max(LIGHTDASH_CSV_MAX_LIMIT,
+LIGHTDASH_CSV_CELLS_LIMIT)`** (default 5,000,000). `queryMaxLimit` has no max.
+
+### Why `max(CSV_MAX_LIMIT, CSV_CELLS_LIMIT)` and not just `CSV_MAX_LIMIT`?
+
+Several Cloud customers already set `LIGHTDASH_CSV_CELLS_LIMIT` above the 5M default (up to 50M). If the cap
+were a plain 5M, their **panel would reject its own inherited value** (the effective limit shown, e.g. 50M,
+exceeds 5M → every Save fails). Taking the max with the instance default guarantees the cap is never below what
+the instance already runs, so no existing instance is forced below its own limit, while new instances get a
+clean 5M ceiling. The effective cap is exposed to the frontend via `/health` (`query.csvMaxLimit`) so the panel's
+input bound and helper text match the backend.
 
 ---
 
@@ -68,8 +77,10 @@ default, so behavior is identical to before.
 
 > **Not made org-aware:** `HealthService` (instance status) and `EmailClient` (decorative "max cells" messaging)
 > still read the instance config. The in-app explorer's row-limit input max also still comes from `/health`
-> (instance default) — the server enforces the org limit regardless; surfacing the org max in that UI hint is a
-> possible follow-up.
+> (instance default), **by design**: the server always enforces the org limit, and the instance limits are
+> deliberately generous (larger than what nearly all orgs need), so the rare org-vs-instance mismatch is a
+> harmless cosmetic edge — not worth surfacing org limits to every (non-admin) user via the unauthenticated
+> `/health` path.
 
 ---
 
@@ -89,7 +100,8 @@ The flag only gates **panel visibility/configuration**. Backend enforcement of a
 
 | Concern | Location |
 |---|---|
-| Setting types + resolver | `packages/common/src/types/organizationSettings.ts` (`queryMaxLimit`, `csvCellsLimit`, `MAX_CSV_CELLS_LIMIT`) |
+| Setting types + resolver | `packages/common/src/types/organizationSettings.ts` (`queryMaxLimit`, `csvCellsLimit`) |
+| CSV cap config + health exposure | `parseConfig.ts` (`query.csvMaxLimit`), `HealthService.ts` (`query.csvMaxLimit` = max with default) |
 | Feature flag | `packages/common/src/types/featureFlags.ts` (`ProLimits = 'pro-limits'`) |
 | DB column + entity | migration `..._add_export_limits_to_organization_settings.ts`, `entities/organizationSettings.ts` |
 | Model + service validation | `OrganizationSettingsModel.ts`, `OrganizationSettingsService.ts` |

--- a/docs/export-limits.md
+++ b/docs/export-limits.md
@@ -1,20 +1,20 @@
 # Organization-level Limits
 
-This document describes the per-organization **Limits** settings (PROD-7214): the max rows a query/export
-may return and the max cells a CSV/Excel export may contain, moved from instance-wide env vars to org-level
+This document describes the per-organization **Limits** settings (PROD-7214): the max rows a query may
+return and the max cells a CSV/Excel export may contain, moved from instance-wide env vars to org-level
 overrides.
 
 ---
 
 ## Overview
 
-Two instance-wide env vars used to be the only control over export size:
+Instance-wide env vars used to be the only control over query/export size:
 
 | Env var | Config path | Default | What it limits |
 |---|---|---|---|
-| `LIGHTDASH_QUERY_MAX_LIMIT` | `lightdashConfig.query.maxLimit` | 5000 (Cloud: 100000) | Max **rows** a query/export can return |
-| `LIGHTDASH_CSV_CELLS_LIMIT` | `lightdashConfig.query.csvCellsLimit` | 100000 | Default max **cells** (rows × columns) a CSV/Excel export can contain |
-| `LIGHTDASH_CSV_MAX_LIMIT` | `lightdashConfig.query.csvMaxLimit` | 5000000 | **Ceiling** an org admin may raise the per-org CSV cells limit to |
+| `LIGHTDASH_QUERY_MAX_LIMIT` | `lightdashConfig.query.maxLimit` | 5000 (Cloud: 100000) | Max **rows** a query may return — and the **ceiling** for the per-org query limit |
+| `LIGHTDASH_CSV_CELLS_LIMIT` | `lightdashConfig.query.csvCellsLimit` | 100000 | Default max **cells** (rows × columns) a CSV/Excel export may contain |
+| `LIGHTDASH_CSV_CELLS_MAX_LIMIT` | `lightdashConfig.query.csvCellsMaxLimit` | 5000000 | **Ceiling** an org admin may raise the per-org CSV cells limit to |
 
 On shared multi-tenant Cloud infra each org needs its own policy (a customer with a 100k-row × 86-column query
 needs ~8.6M cells, while others should stay capped). The **Limits** panel lets an admin override both
@@ -25,39 +25,65 @@ This reuses the same `organization_settings` infrastructure as the scheduled-del
 (see [exporting.md](./exporting.md)): typed columns, a tri-state resolver (`null` = inherit env), and the
 `GET`/`PATCH /api/v1/org/settings` API.
 
+The two limits are **independent** — the query-row limit never affects CSV exports and vice versa, exactly as
+the two env vars always behaved.
+
 ---
 
 ## What an admin configures
 
 | Setting | Stored column | API field | Meaning |
 |---|---|---|---|
-| **Maximum query rows** | `query_max_limit` | `queryMaxLimit` | Overrides `LIGHTDASH_QUERY_MAX_LIMIT`. `null` ⇒ inherit. |
+| **Maximum query rows** | `query_limit` | `queryLimit` | Overrides `LIGHTDASH_QUERY_MAX_LIMIT`. `null` ⇒ inherit. Capped at the env value. |
 | **Maximum CSV/Excel cells** | `csv_cells_limit` | `csvCellsLimit` | Overrides `LIGHTDASH_CSV_CELLS_LIMIT`. `null` ⇒ inherit. Capped (see below). |
 
 Both are surfaced **resolved** in the API (always an effective number, falling back to the env default) so the
 frontend can display them directly. Validation (`OrganizationSettingsService`): each must be a **positive
-integer**; `csvCellsLimit` additionally cannot exceed the **effective cap = `max(LIGHTDASH_CSV_MAX_LIMIT,
-LIGHTDASH_CSV_CELLS_LIMIT)`** (default 5,000,000). `queryMaxLimit` has no max.
+integer** no larger than the Postgres `integer` column ceiling; `queryLimit` additionally cannot exceed
+`LIGHTDASH_QUERY_MAX_LIMIT`, and `csvCellsLimit` cannot exceed the **effective cap =
+`max(LIGHTDASH_CSV_CELLS_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT)`** (default 5,000,000).
 
-### Why `max(CSV_MAX_LIMIT, CSV_CELLS_LIMIT)` and not just `CSV_MAX_LIMIT`?
+### Why `max(CSV_CELLS_MAX_LIMIT, CSV_CELLS_LIMIT)` and not just `CSV_CELLS_MAX_LIMIT`?
 
 Several Cloud customers already set `LIGHTDASH_CSV_CELLS_LIMIT` above the 5M default (up to 50M). If the cap
 were a plain 5M, their **panel would reject its own inherited value** (the effective limit shown, e.g. 50M,
 exceeds 5M → every Save fails). Taking the max with the instance default guarantees the cap is never below what
 the instance already runs, so no existing instance is forced below its own limit, while new instances get a
-clean 5M ceiling. The effective cap is exposed to the frontend via `/health` (`query.csvMaxLimit`) so the panel's
-input bound and helper text match the backend.
+clean 5M ceiling. The ceiling is exposed to the panel via `/health` (`query.csvCellsMaxLimit`), and the
+query-rows ceiling via `query.queryMaxLimit`, so the panel's input bounds and helper text match the backend.
 
 ---
 
 ## Enforcement
+
+### Org-aware `/health` (the explorer / SQL runner)
+
+`/health` is the source the frontend uses to bound the explorer's row-limit selector and the new-query default.
+`HealthService.getHealthState(user)` resolves the **effective** limits for the requesting user's org (override
+⇒ else env default) and exposes them so the per-org limit takes effect in the UI — _regardless of the env
+value_:
+
+| `health.query` field | Value | Used by |
+|---|---|---|
+| `maxLimit` | effective query limit (`queryLimit ?? LIGHTDASH_QUERY_MAX_LIMIT`) | explorer / SQL-runner row-limit selector max |
+| `defaultLimit` | `min(LIGHTDASH_QUERY_DEFAULT_LIMIT, effective maxLimit)` | new-query default (so it's never above the org limit) |
+| `csvCellsLimit` | effective CSV cells (`csvCellsLimit ?? LIGHTDASH_CSV_CELLS_LIMIT`) | export "limited to N cells" messaging |
+| `queryMaxLimit` | instance ceiling (`LIGHTDASH_QUERY_MAX_LIMIT`) | admin panel "Up to" hint |
+| `csvCellsMaxLimit` | instance ceiling (`max(CSV_CELLS_MAX_LIMIT, CSV_CELLS_LIMIT)`) | admin panel "Up to" hint |
+
+Unauthenticated callers (the login page) have no org, so they see the instance defaults — unchanged behavior.
+
+This is a **UI clamp**, not a query-execution change: the explorer's "Run query" selector can't request more
+than the org limit, and CSV exports (which set their own `csvLimit` and bypass the selector) stay independent.
+
+### Backend limit resolution (CSV/Excel exports, SQL runner, field search)
 
 `organization_settings` overrides are read at query/export time via a single helper:
 
 ```ts
 // services/OrganizationSettingsService/resolveExportLimits.ts
 resolveOrganizationExportLimits(organizationSettingsModel, lightdashConfig.query, organizationUuid)
-//   → { maxLimit: queryMaxLimit ?? env, csvCellsLimit: csvCellsLimit ?? env }
+//   → { maxLimit: queryLimit ?? env, csvCellsLimit: csvCellsLimit ?? env }
 ```
 
 `OrganizationSettingsModel` is injected into the services that enforce limits, and the resolved values replace
@@ -70,17 +96,11 @@ the previous `lightdashConfig.query.{maxLimit,csvCellsLimit}` reads at these sit
 | `PivotTableService` | `downloadAsyncPivotTableCsv` (cell limit + truncation check) |
 | `CsvService` | gsheets-delivery truncation check (limit supplied by `SchedulerTask` from the org) |
 | `ExcelService` | static class — receives the resolved `csvCellsLimit` as a parameter from `AsyncQueryService` |
+| `HealthService` | effective query / CSV limits exposed to the frontend (see above) |
 
 `organizationUuid` is already available at every enforcement site (from the project/chart/dashboard/account in
-scope). Backwards-compatible: with no override (`queryMaxLimit`/`csvCellsLimit` null) the helper returns the env
+scope). Backwards-compatible: with no override (`queryLimit`/`csvCellsLimit` null) the helper returns the env
 default, so behavior is identical to before.
-
-> **Not made org-aware:** `HealthService` (instance status) and `EmailClient` (decorative "max cells" messaging)
-> still read the instance config. The in-app explorer's row-limit input max also still comes from `/health`
-> (instance default), **by design**: the server always enforces the org limit, and the instance limits are
-> deliberately generous (larger than what nearly all orgs need), so the rare org-vs-instance mismatch is a
-> harmless cosmetic edge — not worth surfacing org limits to every (non-admin) user via the unauthenticated
-> `/health` path.
 
 ---
 
@@ -91,8 +111,8 @@ Unlike the scheduled-delivery Exporting panel, the **Limits** panel is gated beh
 that should configure it. Enable it via `LIGHTDASH_ENABLE_FEATURE_FLAGS=pro-limits` (self-hosted escape hatch),
 a `feature_flags` row, or a per-org `feature_flag_overrides` row.
 
-The flag only gates **panel visibility/configuration**. Backend enforcement of any stored override is always on
-(it can't leak to ungated orgs, since an override only exists if it was written through the flag-gated UI/API).
+The flag only gates **panel visibility/configuration**. Resolution of any stored override is always on (it
+can't leak to ungated orgs, since an override only exists if it was written through the flag-gated UI/API).
 
 ---
 
@@ -100,8 +120,9 @@ The flag only gates **panel visibility/configuration**. Backend enforcement of a
 
 | Concern | Location |
 |---|---|
-| Setting types + resolver | `packages/common/src/types/organizationSettings.ts` (`queryMaxLimit`, `csvCellsLimit`) |
-| CSV cap config + health exposure | `parseConfig.ts` (`query.csvMaxLimit`), `HealthService.ts` (`query.csvMaxLimit` = max with default) |
+| Setting types + resolver | `packages/common/src/types/organizationSettings.ts` (`queryLimit`, `csvCellsLimit`) |
+| CSV cap config | `parseConfig.ts` (`query.csvCellsMaxLimit` from `LIGHTDASH_CSV_CELLS_MAX_LIMIT`) |
+| Org-aware health | `HealthService.ts` (`query.maxLimit` / `defaultLimit` / `csvCellsLimit` effective; `queryMaxLimit` / `csvCellsMaxLimit` ceilings) |
 | Feature flag | `packages/common/src/types/featureFlags.ts` (`ProLimits = 'pro-limits'`) |
 | DB column + entity | migration `..._add_export_limits_to_organization_settings.ts`, `entities/organizationSettings.ts` |
 | Model + service validation | `OrganizationSettingsModel.ts`, `OrganizationSettingsService.ts` |

--- a/docs/export-limits.md
+++ b/docs/export-limits.md
@@ -111,8 +111,10 @@ Unlike the scheduled-delivery Exporting panel, the **Limits** panel is gated beh
 that should configure it. Enable it via `LIGHTDASH_ENABLE_FEATURE_FLAGS=pro-limits` (self-hosted escape hatch),
 a `feature_flags` row, or a per-org `feature_flag_overrides` row.
 
-The flag only gates **panel visibility/configuration**. Resolution of any stored override is always on (it
-can't leak to ungated orgs, since an override only exists if it was written through the flag-gated UI/API).
+The flag gates **both** the panel (frontend) **and** the update API: `OrganizationSettingsService.updateOrganizationSettings`
+rejects changes to `query_limit`/`csv_cells_limit` for an org without the flag (`ForbiddenError`), so the gate
+can't be bypassed with a direct `PATCH`. The other org-settings fields (scheduled delivery) are not gated.
+**Reads and enforcement** of any already-stored override are always on — only writing the limits is gated.
 
 ---
 

--- a/docs/export-limits.md
+++ b/docs/export-limits.md
@@ -1,0 +1,97 @@
+# Organization-level Limits
+
+This document describes the per-organization **Limits** settings (PROD-7214): the max rows a query/export
+may return and the max cells a CSV/Excel export may contain, moved from instance-wide env vars to org-level
+overrides.
+
+---
+
+## Overview
+
+Two instance-wide env vars used to be the only control over export size:
+
+| Env var | Config path | Default | What it limits |
+|---|---|---|---|
+| `LIGHTDASH_QUERY_MAX_LIMIT` | `lightdashConfig.query.maxLimit` | 5000 (Cloud: 100000) | Max **rows** a query/export can return |
+| `LIGHTDASH_CSV_CELLS_LIMIT` | `lightdashConfig.query.csvCellsLimit` | 100000 | Max **cells** (rows × columns) a CSV/Excel export can contain |
+
+On shared multi-tenant Cloud infra each org needs its own policy (a customer with a 100k-row × 86-column query
+needs ~8.6M cells, while others should stay capped). The **Limits** panel lets an admin override both
+per-org, stored in `organization_settings`. The env vars become the fallback defaults, so nothing changes for
+orgs that don't override.
+
+This reuses the same `organization_settings` infrastructure as the scheduled-delivery settings
+(see [exporting.md](./exporting.md)): typed columns, a tri-state resolver (`null` = inherit env), and the
+`GET`/`PATCH /api/v1/org/settings` API.
+
+---
+
+## What an admin configures
+
+| Setting | Stored column | API field | Meaning |
+|---|---|---|---|
+| **Maximum query rows** | `query_max_limit` | `queryMaxLimit` | Overrides `LIGHTDASH_QUERY_MAX_LIMIT`. `null` ⇒ inherit. |
+| **Maximum CSV/Excel cells** | `csv_cells_limit` | `csvCellsLimit` | Overrides `LIGHTDASH_CSV_CELLS_LIMIT`. `null` ⇒ inherit. Capped at {@link MAX_CSV_CELLS_LIMIT} = 50,000,000. |
+
+Both are surfaced **resolved** in the API (always an effective number, falling back to the env default) so the
+frontend can display them directly. Validation (`OrganizationSettingsService`): each must be a **positive
+integer**; `csvCellsLimit` additionally cannot exceed **50,000,000** (the highest value any Cloud customer sets
+today — a sane ceiling that still allows wide exports without inviting OOM-scale requests). There is no max on
+`queryMaxLimit`.
+
+---
+
+## Enforcement
+
+`organization_settings` overrides are read at query/export time via a single helper:
+
+```ts
+// services/OrganizationSettingsService/resolveExportLimits.ts
+resolveOrganizationExportLimits(organizationSettingsModel, lightdashConfig.query, organizationUuid)
+//   → { maxLimit: queryMaxLimit ?? env, csvCellsLimit: csvCellsLimit ?? env }
+```
+
+`OrganizationSettingsModel` is injected into the services that enforce limits, and the resolved values replace
+the previous `lightdashConfig.query.{maxLimit,csvCellsLimit}` reads at these sites:
+
+| Service | Sites |
+|---|---|
+| `ProjectService` | `runMetricQuery` (CSV via `applyMetricQueryLimit`), `runSqlQuery` (max rows), field-values metric query |
+| `AsyncQueryService` | saved-chart / dashboard-chart / underlying-data CSV exports, field-value search, XLSX pivot |
+| `PivotTableService` | `downloadAsyncPivotTableCsv` (cell limit + truncation check) |
+| `CsvService` | gsheets-delivery truncation check (limit supplied by `SchedulerTask` from the org) |
+| `ExcelService` | static class — receives the resolved `csvCellsLimit` as a parameter from `AsyncQueryService` |
+
+`organizationUuid` is already available at every enforcement site (from the project/chart/dashboard/account in
+scope). Backwards-compatible: with no override (`queryMaxLimit`/`csvCellsLimit` null) the helper returns the env
+default, so behavior is identical to before.
+
+> **Not made org-aware:** `HealthService` (instance status) and `EmailClient` (decorative "max cells" messaging)
+> still read the instance config. The in-app explorer's row-limit input max also still comes from `/health`
+> (instance default) — the server enforces the org limit regardless; surfacing the org max in that UI hint is a
+> possible follow-up.
+
+---
+
+## Access — the `pro-limits` feature flag
+
+Unlike the scheduled-delivery Exporting panel, the **Limits** panel is gated behind the
+`FeatureFlags.ProLimits` (`pro-limits`) feature flag — it's a Pro capability, so only enable the panel for orgs
+that should configure it. Enable it via `LIGHTDASH_ENABLE_FEATURE_FLAGS=pro-limits` (self-hosted escape hatch),
+a `feature_flags` row, or a per-org `feature_flag_overrides` row.
+
+The flag only gates **panel visibility/configuration**. Backend enforcement of any stored override is always on
+(it can't leak to ungated orgs, since an override only exists if it was written through the flag-gated UI/API).
+
+---
+
+## Key code paths
+
+| Concern | Location |
+|---|---|
+| Setting types + resolver | `packages/common/src/types/organizationSettings.ts` (`queryMaxLimit`, `csvCellsLimit`, `MAX_CSV_CELLS_LIMIT`) |
+| Feature flag | `packages/common/src/types/featureFlags.ts` (`ProLimits = 'pro-limits'`) |
+| DB column + entity | migration `..._add_export_limits_to_organization_settings.ts`, `entities/organizationSettings.ts` |
+| Model + service validation | `OrganizationSettingsModel.ts`, `OrganizationSettingsService.ts` |
+| Limit resolution helper | `services/OrganizationSettingsService/resolveExportLimits.ts` |
+| Frontend panel | `packages/frontend/src/components/UserSettings/LimitsPanel/`, gated route/nav in `pages/Settings.tsx` |

--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -20,7 +20,7 @@ export const lightdashConfigWithNoSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
-        csvCellsMaxLimit: 5000000,
+        csvMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
@@ -59,7 +59,7 @@ export const lightdashConfigWithBasicSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
-        csvCellsMaxLimit: 5000000,
+        csvMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
@@ -85,7 +85,7 @@ export const lightdashConfigWithOauth2SMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
-        csvCellsMaxLimit: 5000000,
+        csvMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
@@ -107,7 +107,7 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
-        csvCellsMaxLimit: 5000000,
+        csvMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,

--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -20,6 +20,7 @@ export const lightdashConfigWithNoSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
+        csvMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
@@ -58,6 +59,7 @@ export const lightdashConfigWithBasicSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
+        csvMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
@@ -83,6 +85,7 @@ export const lightdashConfigWithOauth2SMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
+        csvMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
@@ -104,6 +107,7 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
+        csvMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,

--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -20,7 +20,7 @@ export const lightdashConfigWithNoSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
-        csvMaxLimit: 5000000,
+        csvCellsMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
@@ -59,7 +59,7 @@ export const lightdashConfigWithBasicSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
-        csvMaxLimit: 5000000,
+        csvCellsMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
@@ -85,7 +85,7 @@ export const lightdashConfigWithOauth2SMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
-        csvMaxLimit: 5000000,
+        csvCellsMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
@@ -107,7 +107,7 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
-        csvMaxLimit: 5000000,
+        csvCellsMaxLimit: 5000000,
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -218,7 +218,7 @@ export const lightdashConfigMock: LightdashConfig = {
         maxLimit: 5000,
         defaultLimit: 500,
         csvCellsLimit: 100000,
-        csvMaxLimit: 5000000,
+        csvCellsMaxLimit: 5000000,
         timezone: undefined,
         retryQueryOnTransientErrors: true,
         enableTimezoneSupport: undefined,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -218,7 +218,7 @@ export const lightdashConfigMock: LightdashConfig = {
         maxLimit: 5000,
         defaultLimit: 500,
         csvCellsLimit: 100000,
-        csvCellsMaxLimit: 5000000,
+        csvMaxLimit: 5000000,
         timezone: undefined,
         retryQueryOnTransientErrors: true,
         enableTimezoneSupport: undefined,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -218,6 +218,7 @@ export const lightdashConfigMock: LightdashConfig = {
         maxLimit: 5000,
         defaultLimit: 500,
         csvCellsLimit: 100000,
+        csvMaxLimit: 5000000,
         timezone: undefined,
         retryQueryOnTransientErrors: true,
         enableTimezoneSupport: undefined,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1076,7 +1076,7 @@ export type LightdashConfig = {
         maxLimit: number;
         defaultLimit: number;
         csvCellsLimit: number;
-        csvCellsMaxLimit: number;
+        csvMaxLimit: number;
         timezone: string | undefined;
         maxPageSize: number;
         retryQueryOnTransientErrors: boolean;
@@ -2046,10 +2046,9 @@ export const parseConfig = (): LightdashConfig => {
             // Ceiling an org admin can set the per-org CSV cells limit to. The
             // effective cap is max(this, csvCellsLimit) so an instance whose
             // default already exceeds it is never forced below its own default.
-            csvCellsMaxLimit:
-                getIntegerFromEnvironmentVariable(
-                    'LIGHTDASH_CSV_CELLS_MAX_LIMIT',
-                ) || 5000000,
+            csvMaxLimit:
+                getIntegerFromEnvironmentVariable('LIGHTDASH_CSV_MAX_LIMIT') ||
+                5000000,
             timezone: process.env.LIGHTDASH_QUERY_TIMEZONE,
             maxPageSize:
                 getIntegerFromEnvironmentVariable(

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2034,7 +2034,7 @@ export const parseConfig = (): LightdashConfig => {
             maxLimit:
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_QUERY_MAX_LIMIT',
-                ) || 100000,
+                ) || 5000,
             defaultLimit:
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_QUERY_DEFAULT_LIMIT',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1076,6 +1076,7 @@ export type LightdashConfig = {
         maxLimit: number;
         defaultLimit: number;
         csvCellsLimit: number;
+        csvMaxLimit: number;
         timezone: string | undefined;
         maxPageSize: number;
         retryQueryOnTransientErrors: boolean;
@@ -2042,6 +2043,12 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_CSV_CELLS_LIMIT',
                 ) || 100000,
+            // Ceiling an org admin can set the per-org CSV cells limit to. The
+            // effective cap is max(this, csvCellsLimit) so an instance whose
+            // default already exceeds it is never forced below its own default.
+            csvMaxLimit:
+                getIntegerFromEnvironmentVariable('LIGHTDASH_CSV_MAX_LIMIT') ||
+                5000000,
             timezone: process.env.LIGHTDASH_QUERY_TIMEZONE,
             maxPageSize:
                 getIntegerFromEnvironmentVariable(

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2034,7 +2034,7 @@ export const parseConfig = (): LightdashConfig => {
             maxLimit:
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_QUERY_MAX_LIMIT',
-                ) || 5000,
+                ) || 100000,
             defaultLimit:
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_QUERY_DEFAULT_LIMIT',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1076,7 +1076,7 @@ export type LightdashConfig = {
         maxLimit: number;
         defaultLimit: number;
         csvCellsLimit: number;
-        csvMaxLimit: number;
+        csvCellsMaxLimit: number;
         timezone: string | undefined;
         maxPageSize: number;
         retryQueryOnTransientErrors: boolean;
@@ -2046,9 +2046,10 @@ export const parseConfig = (): LightdashConfig => {
             // Ceiling an org admin can set the per-org CSV cells limit to. The
             // effective cap is max(this, csvCellsLimit) so an instance whose
             // default already exceeds it is never forced below its own default.
-            csvMaxLimit:
-                getIntegerFromEnvironmentVariable('LIGHTDASH_CSV_MAX_LIMIT') ||
-                5000000,
+            csvCellsMaxLimit:
+                getIntegerFromEnvironmentVariable(
+                    'LIGHTDASH_CSV_CELLS_MAX_LIMIT',
+                ) || 5000000,
             timezone: process.env.LIGHTDASH_QUERY_TIMEZONE,
             maxPageSize:
                 getIntegerFromEnvironmentVariable(

--- a/packages/backend/src/database/entities/organizationSettings.ts
+++ b/packages/backend/src/database/entities/organizationSettings.ts
@@ -26,7 +26,7 @@ export type DbOrganizationSettings = {
     scheduled_delivery_expiration_seconds_googlechat: number | null;
     // Per-org export limits; NULL/absent inherits the instance env defaults
     // (LIGHTDASH_QUERY_MAX_LIMIT / LIGHTDASH_CSV_CELLS_LIMIT).
-    query_max_limit: number | null;
+    query_limit: number | null;
     csv_cells_limit: number | null;
     created_at: Date;
     updated_at: Date;

--- a/packages/backend/src/database/entities/organizationSettings.ts
+++ b/packages/backend/src/database/entities/organizationSettings.ts
@@ -24,6 +24,10 @@ export type DbOrganizationSettings = {
     scheduled_delivery_expiration_seconds_slack: number | null;
     scheduled_delivery_expiration_seconds_msteams: number | null;
     scheduled_delivery_expiration_seconds_googlechat: number | null;
+    // Per-org export limits; NULL/absent inherits the instance env defaults
+    // (LIGHTDASH_QUERY_MAX_LIMIT / LIGHTDASH_CSV_CELLS_LIMIT).
+    query_max_limit: number | null;
+    csv_cells_limit: number | null;
     created_at: Date;
     updated_at: Date;
 };

--- a/packages/backend/src/database/migrations/20260601105552_add_export_limits_to_organization_settings.ts
+++ b/packages/backend/src/database/migrations/20260601105552_add_export_limits_to_organization_settings.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+const ORGANIZATION_SETTINGS_TABLE = 'organization_settings';
+const QUERY_MAX_LIMIT_COLUMN = 'query_max_limit';
+const CSV_CELLS_LIMIT_COLUMN = 'csv_cells_limit';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ORGANIZATION_SETTINGS_TABLE, (table) => {
+        // Per-org export limits. Nullable with no stored default, so NULL/absent
+        // inherits the instance LIGHTDASH_QUERY_MAX_LIMIT / LIGHTDASH_CSV_CELLS_LIMIT.
+        table.integer(QUERY_MAX_LIMIT_COLUMN).nullable();
+        table.integer(CSV_CELLS_LIMIT_COLUMN).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ORGANIZATION_SETTINGS_TABLE, (table) => {
+        table.dropColumn(QUERY_MAX_LIMIT_COLUMN);
+        table.dropColumn(CSV_CELLS_LIMIT_COLUMN);
+    });
+}

--- a/packages/backend/src/database/migrations/20260601105552_add_export_limits_to_organization_settings.ts
+++ b/packages/backend/src/database/migrations/20260601105552_add_export_limits_to_organization_settings.ts
@@ -1,21 +1,21 @@
 import { Knex } from 'knex';
 
 const ORGANIZATION_SETTINGS_TABLE = 'organization_settings';
-const QUERY_MAX_LIMIT_COLUMN = 'query_max_limit';
+const QUERY_LIMIT_COLUMN = 'query_limit';
 const CSV_CELLS_LIMIT_COLUMN = 'csv_cells_limit';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.schema.alterTable(ORGANIZATION_SETTINGS_TABLE, (table) => {
         // Per-org export limits. Nullable with no stored default, so NULL/absent
         // inherits the instance LIGHTDASH_QUERY_MAX_LIMIT / LIGHTDASH_CSV_CELLS_LIMIT.
-        table.integer(QUERY_MAX_LIMIT_COLUMN).nullable();
+        table.integer(QUERY_LIMIT_COLUMN).nullable();
         table.integer(CSV_CELLS_LIMIT_COLUMN).nullable();
     });
 }
 
 export async function down(knex: Knex): Promise<void> {
     await knex.schema.alterTable(ORGANIZATION_SETTINGS_TABLE, (table) => {
-        table.dropColumn(QUERY_MAX_LIMIT_COLUMN);
+        table.dropColumn(QUERY_LIMIT_COLUMN);
         table.dropColumn(CSV_CELLS_LIMIT_COLUMN);
     });
 }

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -345,6 +345,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getSpacePermissionService(),
                     contentVerificationModel:
                         models.getContentVerificationModel(),
+                    organizationSettingsModel:
+                        models.getOrganizationSettingsModel(),
                 }),
             instanceConfigurationService: ({
                 models,
@@ -454,6 +456,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getAdminNotificationService(),
                     spacePermissionService:
                         repository.getSpacePermissionService(),
+                    organizationSettingsModel:
+                        models.getOrganizationSettingsModel(),
                 }),
             cacheService: ({ models, context, clients }) =>
                 new CommercialCacheService({

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -29126,6 +29126,22 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                csvCellsLimit: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                queryMaxLimit: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 scheduledDeliveryExpirationSecondsGoogleChat: {
                     dataType: 'union',
                     subSchemas: [
@@ -29269,6 +29285,22 @@ const models: TsoaRoute.Models = {
                     ],
                 },
                 scheduledDeliveryExpirationSecondsGoogleChat: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                queryMaxLimit: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                csvCellsLimit: {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'double' },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -29134,7 +29134,7 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
-                queryMaxLimit: {
+                queryLimit: {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'double' },
@@ -29292,7 +29292,7 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
-                queryMaxLimit: {
+                queryLimit: {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'double' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -29890,7 +29890,7 @@
                         "nullable": true,
                         "description": "Max number of cells (rows × columns) a CSV/Excel export may contain for\nthis org (overrides `LIGHTDASH_CSV_CELLS_LIMIT`; `null` inherits it).\nAlways resolved to an effective number in API responses."
                     },
-                    "queryMaxLimit": {
+                    "queryLimit": {
                         "type": "number",
                         "format": "double",
                         "nullable": true,
@@ -29944,7 +29944,7 @@
                 },
                 "required": [
                     "csvCellsLimit",
-                    "queryMaxLimit",
+                    "queryLimit",
                     "scheduledDeliveryExpirationSecondsGoogleChat",
                     "scheduledDeliveryExpirationSecondsMsTeams",
                     "scheduledDeliveryExpirationSecondsSlack",
@@ -30018,7 +30018,7 @@
                         "nullable": true,
                         "description": "Per-channel override (seconds) for Google Chat deliveries; `null` inherits\nthe base. Google Chat has no instance env var, so this is an org-only\noverride (it still falls back to the base / env base)."
                     },
-                    "queryMaxLimit": {
+                    "queryLimit": {
                         "type": "number",
                         "format": "double",
                         "nullable": true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -29884,6 +29884,18 @@
             },
             "OrganizationSettings": {
                 "properties": {
+                    "csvCellsLimit": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Max number of cells (rows × columns) a CSV/Excel export may contain for\nthis org (overrides `LIGHTDASH_CSV_CELLS_LIMIT`; `null` inherits it).\nAlways resolved to an effective number in API responses."
+                    },
+                    "queryMaxLimit": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Max number of rows a query/export may return for this org (overrides the\ninstance-wide `LIGHTDASH_QUERY_MAX_LIMIT`; `null` inherits it). Always\nresolved to an effective number in API responses so the frontend can\ndisplay it directly."
+                    },
                     "scheduledDeliveryExpirationSecondsGoogleChat": {
                         "type": "number",
                         "format": "double",
@@ -29931,6 +29943,8 @@
                     }
                 },
                 "required": [
+                    "csvCellsLimit",
+                    "queryMaxLimit",
                     "scheduledDeliveryExpirationSecondsGoogleChat",
                     "scheduledDeliveryExpirationSecondsMsTeams",
                     "scheduledDeliveryExpirationSecondsSlack",
@@ -30003,6 +30017,18 @@
                         "format": "double",
                         "nullable": true,
                         "description": "Per-channel override (seconds) for Google Chat deliveries; `null` inherits\nthe base. Google Chat has no instance env var, so this is an org-only\noverride (it still falls back to the base / env base)."
+                    },
+                    "queryMaxLimit": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Max number of rows a query/export may return for this org (overrides the\ninstance-wide `LIGHTDASH_QUERY_MAX_LIMIT`; `null` inherits it). Always\nresolved to an effective number in API responses so the frontend can\ndisplay it directly."
+                    },
+                    "csvCellsLimit": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true,
+                        "description": "Max number of cells (rows × columns) a CSV/Excel export may contain for\nthis org (overrides `LIGHTDASH_CSV_CELLS_LIMIT`; `null` inherits it).\nAlways resolved to an effective number in API responses."
                     }
                 },
                 "type": "object",

--- a/packages/backend/src/models/OrganizationSettingsModel.test.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.test.ts
@@ -49,6 +49,8 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
+                queryMaxLimit: null,
+                csvCellsLimit: null,
             });
         });
 
@@ -70,6 +72,8 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
+                queryMaxLimit: null,
+                csvCellsLimit: null,
             });
         });
 
@@ -88,6 +92,8 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
+                queryMaxLimit: null,
+                csvCellsLimit: null,
             });
         });
 
@@ -108,6 +114,8 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsSlack: 1209600,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
+                queryMaxLimit: null,
+                csvCellsLimit: null,
             });
         });
     });
@@ -148,6 +156,8 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
+                queryMaxLimit: null,
+                csvCellsLimit: null,
             });
         });
 

--- a/packages/backend/src/models/OrganizationSettingsModel.test.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.test.ts
@@ -49,7 +49,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
-                queryMaxLimit: null,
+                queryLimit: null,
                 csvCellsLimit: null,
             });
         });
@@ -72,7 +72,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
-                queryMaxLimit: null,
+                queryLimit: null,
                 csvCellsLimit: null,
             });
         });
@@ -92,7 +92,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
-                queryMaxLimit: null,
+                queryLimit: null,
                 csvCellsLimit: null,
             });
         });
@@ -114,7 +114,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsSlack: 1209600,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
-                queryMaxLimit: null,
+                queryLimit: null,
                 csvCellsLimit: null,
             });
         });
@@ -156,7 +156,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsSlack: null,
                 scheduledDeliveryExpirationSecondsMsTeams: null,
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
-                queryMaxLimit: null,
+                queryLimit: null,
                 csvCellsLimit: null,
             });
         });

--- a/packages/backend/src/models/OrganizationSettingsModel.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.ts
@@ -56,7 +56,7 @@ export class OrganizationSettingsModel {
                 row?.scheduled_delivery_expiration_seconds_msteams ?? null,
             scheduledDeliveryExpirationSecondsGoogleChat:
                 row?.scheduled_delivery_expiration_seconds_googlechat ?? null,
-            queryMaxLimit: row?.query_max_limit ?? null,
+            queryLimit: row?.query_limit ?? null,
             csvCellsLimit: row?.csv_cells_limit ?? null,
         };
     }
@@ -84,7 +84,7 @@ export class OrganizationSettingsModel {
                 patch.scheduledDeliveryExpirationSecondsMsTeams,
             scheduled_delivery_expiration_seconds_googlechat:
                 patch.scheduledDeliveryExpirationSecondsGoogleChat,
-            query_max_limit: patch.queryMaxLimit,
+            query_limit: patch.queryLimit,
             csv_cells_limit: patch.csvCellsLimit,
         };
         const toWrite = omitBy(

--- a/packages/backend/src/models/OrganizationSettingsModel.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.ts
@@ -56,6 +56,8 @@ export class OrganizationSettingsModel {
                 row?.scheduled_delivery_expiration_seconds_msteams ?? null,
             scheduledDeliveryExpirationSecondsGoogleChat:
                 row?.scheduled_delivery_expiration_seconds_googlechat ?? null,
+            queryMaxLimit: row?.query_max_limit ?? null,
+            csvCellsLimit: row?.csv_cells_limit ?? null,
         };
     }
 
@@ -82,6 +84,8 @@ export class OrganizationSettingsModel {
                 patch.scheduledDeliveryExpirationSecondsMsTeams,
             scheduled_delivery_expiration_seconds_googlechat:
                 patch.scheduledDeliveryExpirationSecondsGoogleChat,
+            query_max_limit: patch.queryMaxLimit,
+            csv_cells_limit: patch.csvCellsLimit,
         };
         const toWrite = omitBy(
             columns,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -153,6 +153,7 @@ import { DashboardService } from '../services/DashboardService/DashboardService'
 import { DeployService } from '../services/DeployService';
 import { ExcelService } from '../services/ExcelService/ExcelService';
 import type { FeatureFlagService } from '../services/FeatureFlag/FeatureFlagService';
+import { resolveOrganizationExportLimits } from '../services/OrganizationSettingsService/resolveExportLimits';
 import { PersistentDownloadFileService } from '../services/PersistentDownloadFileService/PersistentDownloadFileService';
 import { getDashboardParametersValuesMap } from '../services/ProjectService/parameters';
 import { ProjectService } from '../services/ProjectService/ProjectService';
@@ -2409,7 +2410,15 @@ export default class SchedulerTask {
                 );
             }
 
-            const truncated = this.csvService.couldBeTruncated(rows);
+            const { csvCellsLimit } = await resolveOrganizationExportLimits(
+                this.organizationSettingsModel,
+                this.lightdashConfig.query,
+                payload.organizationUuid,
+            );
+            const truncated = this.csvService.couldBeTruncated(
+                rows,
+                csvCellsLimit,
+            );
 
             await this.schedulerService.logSchedulerJob({
                 ...baseLog,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -283,7 +283,7 @@ const getMockedAsyncQueryService = (
             persistentDownloadFileService: {} as PersistentDownloadFileService,
             organizationSettingsModel: {
                 get: jest.fn(async () => ({
-                    queryMaxLimit: null,
+                    queryLimit: null,
                     csvCellsLimit: null,
                 })),
             } as unknown as OrganizationSettingsModel,
@@ -296,7 +296,7 @@ const getMockedAsyncQueryService = (
         spacePermissionService: {} as SpacePermissionService,
         organizationSettingsModel: {
             get: jest.fn(async () => ({
-                queryMaxLimit: null,
+                queryLimit: null,
                 csvCellsLimit: null,
             })),
         } as unknown as OrganizationSettingsModel,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -42,6 +42,7 @@ import type { GroupsModel } from '../../models/GroupsModel';
 import type { JobModel } from '../../models/JobModel/JobModel';
 import type { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import type { OrganizationModel } from '../../models/OrganizationModel';
+import type { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import type { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
 import type { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -280,6 +281,12 @@ const getMockedAsyncQueryService = (
             fileStorageClient: {} as FileStorageClient,
             downloadFileModel: {} as DownloadFileModel,
             persistentDownloadFileService: {} as PersistentDownloadFileService,
+            organizationSettingsModel: {
+                get: jest.fn(async () => ({
+                    queryMaxLimit: null,
+                    csvCellsLimit: null,
+                })),
+            } as unknown as OrganizationSettingsModel,
         }),
         permissionsService: {} as PermissionsService,
         persistentDownloadFileService: {} as PersistentDownloadFileService,
@@ -287,6 +294,12 @@ const getMockedAsyncQueryService = (
         projectCompileLogModel: {} as ProjectCompileLogModel,
         adminNotificationService: {} as AdminNotificationService,
         spacePermissionService: {} as SpacePermissionService,
+        organizationSettingsModel: {
+            get: jest.fn(async () => ({
+                queryMaxLimit: null,
+                csvCellsLimit: null,
+            })),
+        } as unknown as OrganizationSettingsModel,
         ...overrides,
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3839,8 +3839,27 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
+        // Cap the interactive query at the org's effective max rows (org
+        // override, else the instance LIGHTDASH_QUERY_MAX_LIMIT). With no
+        // override this is the instance max, so normal queries are unaffected.
+        const { maxLimit } = await resolveOrganizationExportLimits(
+            this.organizationSettingsModel,
+            this.lightdashConfig.query,
+            organizationUuid,
+        );
+        const cappedArgs: ExecuteAsyncMetricQueryArgs =
+            inputMetricQuery.limit > maxLimit
+                ? {
+                      ...args,
+                      metricQuery: {
+                          ...inputMetricQuery,
+                          limit: maxLimit,
+                      },
+                  }
+                : args;
+
         return this.runAsyncMetricQueryWithoutPermissionCheck(
-            args,
+            cappedArgs,
             organizationUuid,
         );
     }

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -153,6 +153,7 @@ import type { ICacheService } from '../CacheService/ICacheService';
 import { CreateCacheResult } from '../CacheService/types';
 import { CsvService } from '../CsvService/CsvService';
 import { ExcelService } from '../ExcelService/ExcelService';
+import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
@@ -1416,6 +1417,13 @@ export class AsyncQueryService extends ProjectService {
                               resultsStorageClient,
                               exportsStorageClient: this.exportsStorageClient,
                               lightdashConfig: this.lightdashConfig,
+                              csvCellsLimit: (
+                                  await resolveOrganizationExportLimits(
+                                      this.organizationSettingsModel,
+                                      this.lightdashConfig.query,
+                                      organizationUuid,
+                                  )
+                              ).csvCellsLimit,
                               pivotDetails:
                                   AsyncQueryService.getPivotDetailsFromQueryHistory(
                                       queryHistory,
@@ -4123,6 +4131,12 @@ export class AsyncQueryService extends ProjectService {
 
         const context = QueryExecutionContext.FILTER_AUTOCOMPLETE;
 
+        const { maxLimit } = await resolveOrganizationExportLimits(
+            this.organizationSettingsModel,
+            this.lightdashConfig.query,
+            organizationUuid,
+        );
+
         const { metricQuery, explore, fieldId } =
             await getFieldValuesMetricQuery({
                 projectUuid,
@@ -4130,7 +4144,7 @@ export class AsyncQueryService extends ProjectService {
                 initialFieldId,
                 search,
                 limit,
-                maxLimit: this.lightdashConfig.query.maxLimit,
+                maxLimit,
                 filters,
                 exploreResolver: this.projectModel,
             });
@@ -4340,11 +4354,18 @@ export class AsyncQueryService extends ProjectService {
             limit,
         };
 
+        const { maxLimit, csvCellsLimit } =
+            await resolveOrganizationExportLimits(
+                this.organizationSettingsModel,
+                this.lightdashConfig.query,
+                savedChartOrganizationUuid,
+            );
+
         const metricQueryWithLimit = applyMetricQueryLimit(
             metricQuery,
             limit,
-            this.lightdashConfig.query?.csvCellsLimit,
-            this.lightdashConfig.query?.maxLimit,
+            csvCellsLimit,
+            maxLimit,
         );
 
         const queryTags: RunQueryTags = {
@@ -4618,11 +4639,18 @@ export class AsyncQueryService extends ProjectService {
                     : savedChart.metricQuery.sorts,
         };
 
+        const { maxLimit, csvCellsLimit } =
+            await resolveOrganizationExportLimits(
+                this.organizationSettingsModel,
+                this.lightdashConfig.query,
+                organizationUuid,
+            );
+
         const metricQueryWithLimit = applyMetricQueryLimit(
             metricQueryWithDashboardOverrides,
             limit,
-            this.lightdashConfig.query?.csvCellsLimit,
-            this.lightdashConfig.query?.maxLimit,
+            csvCellsLimit,
+            maxLimit,
         );
 
         const exploreDimensions = getDimensions(explore);
@@ -5057,11 +5085,18 @@ export class AsyncQueryService extends ProjectService {
             timezone: metricQuery.timezone,
         };
 
+        const { maxLimit, csvCellsLimit } =
+            await resolveOrganizationExportLimits(
+                this.organizationSettingsModel,
+                this.lightdashConfig.query,
+                organizationUuid,
+            );
+
         const underlyingDataMetricQueryWithLimit = applyMetricQueryLimit(
             underlyingDataMetricQuery,
             limit,
-            this.lightdashConfig.query?.csvCellsLimit,
-            this.lightdashConfig.query?.maxLimit,
+            csvCellsLimit,
+            maxLimit,
         );
 
         const {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3839,27 +3839,8 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        // Cap the interactive query at the org's effective max rows (org
-        // override, else the instance LIGHTDASH_QUERY_MAX_LIMIT). With no
-        // override this is the instance max, so normal queries are unaffected.
-        const { maxLimit } = await resolveOrganizationExportLimits(
-            this.organizationSettingsModel,
-            this.lightdashConfig.query,
-            organizationUuid,
-        );
-        const cappedArgs: ExecuteAsyncMetricQueryArgs =
-            inputMetricQuery.limit > maxLimit
-                ? {
-                      ...args,
-                      metricQuery: {
-                          ...inputMetricQuery,
-                          limit: maxLimit,
-                      },
-                  }
-                : args;
-
         return this.runAsyncMetricQueryWithoutPermissionCheck(
-            cappedArgs,
+            args,
             organizationUuid,
         );
     }

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -24,6 +24,7 @@ import { GroupsModel } from '../../models/GroupsModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
+import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
 import { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -91,6 +92,7 @@ describe('Csv service', () => {
             projectCompileLogModel: {} as ProjectCompileLogModel,
             adminNotificationService: {} as AdminNotificationService,
             spacePermissionService: {} as SpacePermissionService,
+            organizationSettingsModel: {} as OrganizationSettingsModel,
         }),
         fileStorageClient: {} as FileStorageClient,
         savedChartModel: {} as SavedChartModel,
@@ -104,6 +106,7 @@ describe('Csv service', () => {
             fileStorageClient: {} as FileStorageClient,
             downloadFileModel: {} as DownloadFileModel,
             persistentDownloadFileService: {} as PersistentDownloadFileService,
+            organizationSettingsModel: {} as OrganizationSettingsModel,
         }),
         persistentDownloadFileService: {} as PersistentDownloadFileService,
     });

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -514,15 +514,17 @@ export class CsvService extends BaseService {
         return fileId;
     }
 
-    couldBeTruncated(rows: Record<string, AnyType>[]) {
+    couldBeTruncated(
+        rows: Record<string, AnyType>[],
+        cellsLimit: number = this.lightdashConfig.query?.csvCellsLimit ??
+            100000,
+    ) {
         if (rows.length === 0) return false;
 
         const numberRows = rows.length;
         const numberColumns = Object.keys(rows[0]).length;
 
         // we use floor when limiting the rows, so the  need to make sure we got the last row valid
-        const cellsLimit = this.lightdashConfig.query?.csvCellsLimit || 100000;
-
         return numberRows * numberColumns >= cellsLimit - numberColumns;
     }
 

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -386,6 +386,7 @@ export class ExcelService {
         options,
         pivotDetails,
         timezone,
+        csvCellsLimit,
     }: {
         resultsFileName: string;
         fields: ItemsMap;
@@ -404,6 +405,9 @@ export class ExcelService {
             attachmentDownloadName?: string;
         };
         timezone?: string;
+        // Per-org export limit resolved by the caller; falls back to the
+        // instance default when not provided.
+        csvCellsLimit?: number;
     }): Promise<{ fileUrl: string; truncated: boolean; s3Key: string }> {
         const { onlyRaw, customLabels, pivotConfig, attachmentDownloadName } =
             options;
@@ -414,7 +418,8 @@ export class ExcelService {
             await resultsStorageClient.getDownloadStream(resultsFileName);
 
         const fieldCount = Object.keys(fields).length;
-        const cellsLimit = lightdashConfig.query?.csvCellsLimit || 100000;
+        const cellsLimit =
+            csvCellsLimit ?? lightdashConfig.query?.csvCellsLimit ?? 100000;
 
         // Use standard csvCellsLimit calculation - same as original downloadPivotTableCsv
         const maxRows = Math.floor(cellsLimit / fieldCount);

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -77,6 +77,7 @@ export const BaseResponse: HealthState = {
     },
     query: {
         csvCellsLimit: 100000,
+        csvMaxLimit: 5000000,
         maxLimit: 5000,
         maxPageSize: 2500,
         defaultLimit: 500,

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -77,8 +77,9 @@ export const BaseResponse: HealthState = {
     },
     query: {
         csvCellsLimit: 100000,
-        csvMaxLimit: 5000000,
+        csvCellsMaxLimit: 5000000,
         maxLimit: 5000,
+        queryMaxLimit: 5000,
         maxPageSize: 2500,
         defaultLimit: 500,
         retryQueryOnTransientErrors: true,

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -77,7 +77,7 @@ export const BaseResponse: HealthState = {
     },
     query: {
         csvCellsLimit: 100000,
-        csvCellsMaxLimit: 5000000,
+        csvMaxLimit: 5000000,
         maxLimit: 5000,
         queryMaxLimit: 5000,
         maxPageSize: 2500,

--- a/packages/backend/src/services/HealthService/HealthService.test.ts
+++ b/packages/backend/src/services/HealthService/HealthService.test.ts
@@ -4,6 +4,7 @@ import { getDockerHubVersion } from '../../clients/DockerHub/DockerHub';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { MigrationModel } from '../../models/MigrationModel/MigrationModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
+import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import { HealthService } from './HealthService';
 import { BaseResponse, userMock } from './HealthService.mock';
 
@@ -25,11 +26,18 @@ const migrationModel = {
     })),
 };
 
+// No per-org overrides — effective limits fall back to the instance defaults.
+const organizationSettingsModel = {
+    get: jest.fn(async () => ({ queryLimit: null, csvCellsLimit: null })),
+};
+
 describe('health', () => {
     const healthService = new HealthService({
         organizationModel: organizationModel as unknown as OrganizationModel,
         lightdashConfig: lightdashConfigMock,
         migrationModel: migrationModel as unknown as MigrationModel,
+        organizationSettingsModel:
+            organizationSettingsModel as unknown as OrganizationSettingsModel,
     });
 
     afterEach(() => {
@@ -73,6 +81,8 @@ describe('health', () => {
                 mode: LightdashMode.CLOUD_BETA,
             },
             migrationModel: migrationModel as unknown as MigrationModel,
+            organizationSettingsModel:
+                organizationSettingsModel as unknown as OrganizationSettingsModel,
         });
         expect(await service.getHealthState(undefined)).toEqual({
             ...BaseResponse,
@@ -122,6 +132,8 @@ describe('health', () => {
                     },
                 },
                 migrationModel: migrationModel as unknown as MigrationModel,
+                organizationSettingsModel:
+                    organizationSettingsModel as unknown as OrganizationSettingsModel,
             });
 
             const result = await service.getHealthState(userMock);
@@ -140,6 +152,8 @@ describe('health', () => {
                     },
                 },
                 migrationModel: migrationModel as unknown as MigrationModel,
+                organizationSettingsModel:
+                    organizationSettingsModel as unknown as OrganizationSettingsModel,
             });
 
             const userWithEmail = { ...userMock, email: testEmail };

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -145,8 +145,8 @@ export class HealthService extends BaseService {
                 maxLimit: effectiveMaxLimit,
                 // The instance ceilings an org admin can set the per-org limits
                 // to (the env values) — used by the admin panel's "Up to" hints.
-                csvCellsMaxLimit: Math.max(
-                    this.lightdashConfig.query.csvCellsMaxLimit,
+                csvMaxLimit: Math.max(
+                    this.lightdashConfig.query.csvMaxLimit,
                     this.lightdashConfig.query.csvCellsLimit,
                 ),
                 queryMaxLimit: this.lightdashConfig.query.maxLimit,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -10,13 +10,16 @@ import { getDockerHubVersion } from '../../clients/DockerHub/DockerHub';
 import { LightdashConfig } from '../../config/parseConfig';
 import { MigrationModel } from '../../models/MigrationModel/MigrationModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
+import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import { VERSION } from '../../version';
 import { BaseService } from '../BaseService';
+import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
 
 type HealthServiceArguments = {
     lightdashConfig: LightdashConfig;
     organizationModel: OrganizationModel;
     migrationModel: MigrationModel;
+    organizationSettingsModel: OrganizationSettingsModel;
 };
 
 export class HealthService extends BaseService {
@@ -26,15 +29,19 @@ export class HealthService extends BaseService {
 
     private readonly migrationModel: MigrationModel;
 
+    private readonly organizationSettingsModel: OrganizationSettingsModel;
+
     constructor({
         organizationModel,
         migrationModel,
         lightdashConfig,
+        organizationSettingsModel,
     }: HealthServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
         this.organizationModel = organizationModel;
         this.migrationModel = migrationModel;
+        this.organizationSettingsModel = organizationSettingsModel;
     }
 
     private isEnterpriseEnabled(): boolean {
@@ -43,6 +50,23 @@ export class HealthService extends BaseService {
 
     async getHealthState(user: SessionUser | undefined): Promise<HealthState> {
         const isAuthenticated: boolean = !!user?.userUuid;
+
+        // Resolve the query/CSV limits for the requesting org (override ?? the
+        // instance env default). Unauthenticated callers (e.g. the login page)
+        // have no org, so they see the instance defaults — unchanged behavior.
+        const {
+            maxLimit: effectiveMaxLimit,
+            csvCellsLimit: effectiveCsvCellsLimit,
+        } = user?.organizationUuid
+            ? await resolveOrganizationExportLimits(
+                  this.organizationSettingsModel,
+                  this.lightdashConfig.query,
+                  user.organizationUuid,
+              )
+            : {
+                  maxLimit: this.lightdashConfig.query.maxLimit,
+                  csvCellsLimit: this.lightdashConfig.query.csvCellsLimit,
+              };
 
         const migrationStartTime = performance.now();
         const { status: migrationStatus, currentVersion } =
@@ -116,14 +140,22 @@ export class HealthService extends BaseService {
             signupUrl: this.lightdashConfig.signupUrl,
             helpMenuUrl: this.lightdashConfig.helpMenuUrl,
             query: {
-                csvCellsLimit: this.lightdashConfig.query.csvCellsLimit,
-                csvMaxLimit: Math.max(
-                    this.lightdashConfig.query.csvMaxLimit,
+                // Effective for this org (override ?? env default).
+                csvCellsLimit: effectiveCsvCellsLimit,
+                maxLimit: effectiveMaxLimit,
+                // The instance ceilings an org admin can set the per-org limits
+                // to (the env values) — used by the admin panel's "Up to" hints.
+                csvCellsMaxLimit: Math.max(
+                    this.lightdashConfig.query.csvCellsMaxLimit,
                     this.lightdashConfig.query.csvCellsLimit,
                 ),
-                maxLimit: this.lightdashConfig.query.maxLimit,
+                queryMaxLimit: this.lightdashConfig.query.maxLimit,
                 maxPageSize: this.lightdashConfig.query.maxPageSize,
-                defaultLimit: this.lightdashConfig.query.defaultLimit,
+                // The new-query default, never above this org's effective max.
+                defaultLimit: Math.min(
+                    this.lightdashConfig.query.defaultLimit,
+                    effectiveMaxLimit,
+                ),
                 retryQueryOnTransientErrors:
                     this.lightdashConfig.query.retryQueryOnTransientErrors,
             },

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -117,6 +117,10 @@ export class HealthService extends BaseService {
             helpMenuUrl: this.lightdashConfig.helpMenuUrl,
             query: {
                 csvCellsLimit: this.lightdashConfig.query.csvCellsLimit,
+                csvMaxLimit: Math.max(
+                    this.lightdashConfig.query.csvMaxLimit,
+                    this.lightdashConfig.query.csvCellsLimit,
+                ),
                 maxLimit: this.lightdashConfig.query.maxLimit,
                 maxPageSize: this.lightdashConfig.query.maxPageSize,
                 defaultLimit: this.lightdashConfig.query.defaultLimit,

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.test.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.test.ts
@@ -1,0 +1,83 @@
+import { Ability } from '@casl/ability';
+import {
+    FeatureFlags,
+    ForbiddenError,
+    type PossibleAbilities,
+    type RegisteredAccount,
+} from '@lightdash/common';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { type FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
+import { type OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
+import { OrganizationSettingsService } from './OrganizationSettingsService';
+
+const account = {
+    organization: { organizationUuid: 'org-uuid', name: 'Acme' },
+    user: {
+        id: 'user-uuid',
+        userUuid: 'user-uuid',
+        ability: new Ability<PossibleAbilities>([
+            { subject: 'Organization', action: 'manage' },
+        ]),
+    },
+    authentication: { type: 'session' },
+    isAnonymousUser: () => false,
+    isServiceAccount: () => false,
+} as unknown as RegisteredAccount;
+
+// Raw row with no overrides — the resolver fills the rest with instance defaults.
+const rawSettings = { queryLimit: null, csvCellsLimit: null };
+
+const buildService = (proLimitsEnabled: boolean) => {
+    const featureFlagModel = {
+        get: jest.fn(async ({ featureFlagId }: { featureFlagId: string }) => ({
+            id: featureFlagId,
+            enabled:
+                proLimitsEnabled && featureFlagId === FeatureFlags.ProLimits,
+        })),
+    } as unknown as FeatureFlagModel;
+
+    const organizationSettingsModel = {
+        get: jest.fn(async () => rawSettings),
+        update: jest.fn(async () => rawSettings),
+    } as unknown as OrganizationSettingsModel;
+
+    const service = new OrganizationSettingsService({
+        lightdashConfig: lightdashConfigMock,
+        organizationSettingsModel,
+        featureFlagModel,
+    });
+    return { service, organizationSettingsModel };
+};
+
+describe('OrganizationSettingsService — pro-limits gate', () => {
+    it('rejects a csvCellsLimit update when pro-limits is disabled', async () => {
+        const { service, organizationSettingsModel } = buildService(false);
+        await expect(
+            service.updateOrganizationSettings(account, { csvCellsLimit: 50 }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(organizationSettingsModel.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a queryLimit update when pro-limits is disabled', async () => {
+        const { service } = buildService(false);
+        await expect(
+            service.updateOrganizationSettings(account, { queryLimit: 50 }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('allows a non-limit update (scheduled delivery) when pro-limits is disabled', async () => {
+        const { service, organizationSettingsModel } = buildService(false);
+        await service.updateOrganizationSettings(account, {
+            scheduledDeliveryExpirationSeconds: 3600,
+        });
+        expect(organizationSettingsModel.update).toHaveBeenCalled();
+    });
+
+    it('allows a limit update when pro-limits is enabled', async () => {
+        const { service, organizationSettingsModel } = buildService(true);
+        await service.updateOrganizationSettings(account, {
+            csvCellsLimit: 50,
+        });
+        expect(organizationSettingsModel.update).toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -88,11 +88,11 @@ export class OrganizationSettingsService extends BaseService {
                 `Scheduled delivery expiry and export limits must be whole numbers between 1 and ${POSTGRES_INTEGER_MAX}.`,
             );
         }
-        // The CSV cells limit is capped at LIGHTDASH_CSV_CELLS_MAX_LIMIT — but
+        // The CSV cells limit is capped at LIGHTDASH_CSV_MAX_LIMIT — but
         // never below the instance's own default, so an instance whose env
         // default already exceeds the cap is never forced to lower its limit.
         const csvCellsCap = Math.max(
-            this.lightdashConfig.query.csvCellsMaxLimit,
+            this.lightdashConfig.query.csvMaxLimit,
             this.lightdashConfig.query.csvCellsLimit,
         );
         if (

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import {
     ForbiddenError,
-    MAX_CSV_CELLS_LIMIT,
     OrganizationSettings,
     ParameterError,
     resolveEffectiveOrganizationSettings,
@@ -64,7 +63,7 @@ export class OrganizationSettingsService extends BaseService {
      * persistent URLs; limits match what instance admins set uncapped via env) —
      * we only reject nonsense (non-integers, zero, negatives).
      */
-    private static assertValidPatch(data: UpdateOrganizationSettings): void {
+    private assertValidPatch(data: UpdateOrganizationSettings): void {
         const positiveIntegerFields: Array<keyof UpdateOrganizationSettings> = [
             'scheduledDeliveryExpirationSeconds',
             'scheduledDeliveryExpirationSecondsEmail',
@@ -85,14 +84,20 @@ export class OrganizationSettingsService extends BaseService {
                 'Scheduled delivery expiry and export limits must be positive whole numbers.',
             );
         }
-        // The CSV cells limit is capped — beyond this exports risk OOM-scale work.
+        // The CSV cells limit is capped at LIGHTDASH_CSV_MAX_LIMIT — but never
+        // below the instance's own default, so an instance whose env default
+        // already exceeds the cap is never forced to lower its limit.
+        const csvCellsCap = Math.max(
+            this.lightdashConfig.query.csvMaxLimit,
+            this.lightdashConfig.query.csvCellsLimit,
+        );
         if (
             data.csvCellsLimit !== undefined &&
             data.csvCellsLimit !== null &&
-            data.csvCellsLimit > MAX_CSV_CELLS_LIMIT
+            data.csvCellsLimit > csvCellsCap
         ) {
             throw new ParameterError(
-                `CSV cells limit cannot exceed ${MAX_CSV_CELLS_LIMIT}.`,
+                `CSV cells limit cannot exceed ${csvCellsCap}.`,
             );
         }
     }
@@ -113,7 +118,7 @@ export class OrganizationSettingsService extends BaseService {
         data: UpdateOrganizationSettings,
     ): Promise<OrganizationSettings> {
         const organizationUuid = this.assertCanManageOrganization(account);
-        OrganizationSettingsService.assertValidPatch(data);
+        this.assertValidPatch(data);
         const raw = await this.organizationSettingsModel.update(
             organizationUuid,
             data,

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    FeatureFlags,
     ForbiddenError,
     OrganizationSettings,
     ParameterError,
@@ -9,6 +10,7 @@ import {
     type RegisteredAccount,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import { BaseService } from '../BaseService';
 import { getOrganizationSettingsInstanceDefaults } from './getInstanceDefaults';
@@ -16,6 +18,7 @@ import { getOrganizationSettingsInstanceDefaults } from './getInstanceDefaults';
 type OrganizationSettingsServiceArguments = {
     lightdashConfig: LightdashConfig;
     organizationSettingsModel: OrganizationSettingsModel;
+    featureFlagModel: FeatureFlagModel;
 };
 
 /**
@@ -30,13 +33,46 @@ export class OrganizationSettingsService extends BaseService {
 
     private readonly organizationSettingsModel: OrganizationSettingsModel;
 
+    private readonly featureFlagModel: FeatureFlagModel;
+
     constructor({
         lightdashConfig,
         organizationSettingsModel,
+        featureFlagModel,
     }: OrganizationSettingsServiceArguments) {
         super({ serviceName: 'OrganizationSettingsService' });
         this.lightdashConfig = lightdashConfig;
         this.organizationSettingsModel = organizationSettingsModel;
+        this.featureFlagModel = featureFlagModel;
+    }
+
+    /**
+     * The export limits (query rows / CSV cells) are a Pro capability gated by
+     * the `pro-limits` flag. The panel is hidden without it, but the update API
+     * must enforce it too so the gate can't be bypassed via a direct call.
+     */
+    private async assertCanManageLimits(
+        account: RegisteredAccount,
+        data: UpdateOrganizationSettings,
+    ): Promise<void> {
+        const touchesLimits =
+            data.queryLimit !== undefined || data.csvCellsLimit !== undefined;
+        if (!touchesLimits) {
+            return;
+        }
+        const flag = await this.featureFlagModel.get({
+            user: {
+                userUuid: account.user.userUuid,
+                organizationUuid: account.organization?.organizationUuid,
+                organizationName: account.organization?.name,
+            },
+            featureFlagId: FeatureFlags.ProLimits,
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError(
+                'Organization limits are not enabled for this organization.',
+            );
+        }
     }
 
     private assertCanManageOrganization(account: RegisteredAccount): string {
@@ -132,6 +168,7 @@ export class OrganizationSettingsService extends BaseService {
         data: UpdateOrganizationSettings,
     ): Promise<OrganizationSettings> {
         const organizationUuid = this.assertCanManageOrganization(account);
+        await this.assertCanManageLimits(account, data);
         this.assertValidPatch(data);
         const raw = await this.organizationSettingsModel.update(
             organizationUuid,

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -57,12 +57,10 @@ export class OrganizationSettingsService extends BaseService {
     }
 
     /**
-     * Sanity-checks the numeric overrides (scheduled-delivery expiries and
-     * export limits) before they're persisted. A `null` clears an override
-     * (back to inheriting the env default). We don't cap the values — they feed
-     * the existing mechanisms as-is (expiries over 7 days transparently use
-     * persistent URLs; limits match what instance admins set uncapped via env) —
-     * we only reject nonsense (non-integers, zero, negatives).
+     * Validates the numeric overrides before they're persisted: each must be a
+     * positive integer within the Postgres column ceiling, and the two export
+     * limits additionally cannot exceed their instance env ceilings. A `null`
+     * clears an override (back to inheriting the env default).
      */
     private assertValidPatch(data: UpdateOrganizationSettings): void {
         const positiveIntegerFields: Array<keyof UpdateOrganizationSettings> = [

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -71,7 +71,7 @@ export class OrganizationSettingsService extends BaseService {
             'scheduledDeliveryExpirationSecondsSlack',
             'scheduledDeliveryExpirationSecondsMsTeams',
             'scheduledDeliveryExpirationSecondsGoogleChat',
-            'queryMaxLimit',
+            'queryLimit',
             'csvCellsLimit',
         ];
         // Bounded by the integer column ceiling — above it the DB insert throws
@@ -88,11 +88,11 @@ export class OrganizationSettingsService extends BaseService {
                 `Scheduled delivery expiry and export limits must be whole numbers between 1 and ${POSTGRES_INTEGER_MAX}.`,
             );
         }
-        // The CSV cells limit is capped at LIGHTDASH_CSV_MAX_LIMIT — but never
-        // below the instance's own default, so an instance whose env default
-        // already exceeds the cap is never forced to lower its limit.
+        // The CSV cells limit is capped at LIGHTDASH_CSV_CELLS_MAX_LIMIT — but
+        // never below the instance's own default, so an instance whose env
+        // default already exceeds the cap is never forced to lower its limit.
         const csvCellsCap = Math.max(
-            this.lightdashConfig.query.csvMaxLimit,
+            this.lightdashConfig.query.csvCellsMaxLimit,
             this.lightdashConfig.query.csvCellsLimit,
         );
         if (
@@ -104,16 +104,16 @@ export class OrganizationSettingsService extends BaseService {
                 `CSV cells limit cannot exceed ${csvCellsCap}.`,
             );
         }
-        // The query row limit can only be restricted below the instance max
-        // (LIGHTDASH_QUERY_MAX_LIMIT) — the instance's hard ceiling.
-        const queryRowsCap = this.lightdashConfig.query.maxLimit;
+        // The query row limit can only be restricted below the instance ceiling
+        // (LIGHTDASH_QUERY_MAX_LIMIT).
+        const queryLimitCap = this.lightdashConfig.query.maxLimit;
         if (
-            data.queryMaxLimit !== undefined &&
-            data.queryMaxLimit !== null &&
-            data.queryMaxLimit > queryRowsCap
+            data.queryLimit !== undefined &&
+            data.queryLimit !== null &&
+            data.queryLimit > queryLimitCap
         ) {
             throw new ParameterError(
-                `Maximum query rows cannot exceed ${queryRowsCap}.`,
+                `Maximum query rows cannot exceed ${queryLimitCap}.`,
             );
         }
     }

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -104,6 +104,18 @@ export class OrganizationSettingsService extends BaseService {
                 `CSV cells limit cannot exceed ${csvCellsCap}.`,
             );
         }
+        // The query row limit can only be restricted below the instance max
+        // (LIGHTDASH_QUERY_MAX_LIMIT) — the instance's hard ceiling.
+        const queryRowsCap = this.lightdashConfig.query.maxLimit;
+        if (
+            data.queryMaxLimit !== undefined &&
+            data.queryMaxLimit !== null &&
+            data.queryMaxLimit > queryRowsCap
+        ) {
+            throw new ParameterError(
+                `Maximum query rows cannot exceed ${queryRowsCap}.`,
+            );
+        }
     }
 
     async getOrganizationSettings(

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ForbiddenError,
+    MAX_CSV_CELLS_LIMIT,
     OrganizationSettings,
     ParameterError,
     resolveEffectiveOrganizationSettings,
@@ -56,18 +57,22 @@ export class OrganizationSettingsService extends BaseService {
     }
 
     /**
-     * Sanity-checks the scheduled-delivery expiry overrides (base + per-channel)
-     * before they're persisted. A `null` clears an override (back to inheriting
-     * the base / env). We don't cap the value — it feeds the existing expiry
-     * mechanism as-is (links over 7 days transparently use persistent download
-     * URLs) — we only reject nonsense that would store an already-expired link.
+     * Sanity-checks the numeric overrides (scheduled-delivery expiries and
+     * export limits) before they're persisted. A `null` clears an override
+     * (back to inheriting the env default). We don't cap the values — they feed
+     * the existing mechanisms as-is (expiries over 7 days transparently use
+     * persistent URLs; limits match what instance admins set uncapped via env) —
+     * we only reject nonsense (non-integers, zero, negatives).
      */
     private static assertValidPatch(data: UpdateOrganizationSettings): void {
-        const expiryFields: Array<keyof UpdateOrganizationSettings> = [
+        const positiveIntegerFields: Array<keyof UpdateOrganizationSettings> = [
             'scheduledDeliveryExpirationSeconds',
             'scheduledDeliveryExpirationSecondsEmail',
             'scheduledDeliveryExpirationSecondsSlack',
             'scheduledDeliveryExpirationSecondsMsTeams',
+            'scheduledDeliveryExpirationSecondsGoogleChat',
+            'queryMaxLimit',
+            'csvCellsLimit',
         ];
         const isInvalid = (value: number | boolean | null | undefined) =>
             value !== undefined &&
@@ -75,9 +80,19 @@ export class OrganizationSettingsService extends BaseService {
             (typeof value !== 'number' ||
                 !Number.isInteger(value) ||
                 value <= 0);
-        if (expiryFields.some((field) => isInvalid(data[field]))) {
+        if (positiveIntegerFields.some((field) => isInvalid(data[field]))) {
             throw new ParameterError(
-                'Scheduled delivery link expiry must be a positive whole number of seconds.',
+                'Scheduled delivery expiry and export limits must be positive whole numbers.',
+            );
+        }
+        // The CSV cells limit is capped — beyond this exports risk OOM-scale work.
+        if (
+            data.csvCellsLimit !== undefined &&
+            data.csvCellsLimit !== null &&
+            data.csvCellsLimit > MAX_CSV_CELLS_LIMIT
+        ) {
+            throw new ParameterError(
+                `CSV cells limit cannot exceed ${MAX_CSV_CELLS_LIMIT}.`,
             );
         }
     }

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -3,6 +3,7 @@ import {
     ForbiddenError,
     OrganizationSettings,
     ParameterError,
+    POSTGRES_INTEGER_MAX,
     resolveEffectiveOrganizationSettings,
     UpdateOrganizationSettings,
     type RegisteredAccount,
@@ -73,15 +74,18 @@ export class OrganizationSettingsService extends BaseService {
             'queryMaxLimit',
             'csvCellsLimit',
         ];
+        // Bounded by the integer column ceiling — above it the DB insert throws
+        // an out-of-range error (a 500) instead of a clean validation failure.
         const isInvalid = (value: number | boolean | null | undefined) =>
             value !== undefined &&
             value !== null &&
             (typeof value !== 'number' ||
                 !Number.isInteger(value) ||
-                value <= 0);
+                value <= 0 ||
+                value > POSTGRES_INTEGER_MAX);
         if (positiveIntegerFields.some((field) => isInvalid(data[field]))) {
             throw new ParameterError(
-                'Scheduled delivery expiry and export limits must be positive whole numbers.',
+                `Scheduled delivery expiry and export limits must be whole numbers between 1 and ${POSTGRES_INTEGER_MAX}.`,
             );
         }
         // The CSV cells limit is capped at LIGHTDASH_CSV_MAX_LIMIT — but never

--- a/packages/backend/src/services/OrganizationSettingsService/getInstanceDefaults.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/getInstanceDefaults.ts
@@ -14,6 +14,6 @@ export const getOrganizationSettingsInstanceDefaults = (
     enableOidcToEmailLinking: lightdashConfig.auth.enableOidcToEmailLinking,
     scheduledDeliveryExpirationSeconds:
         lightdashConfig.persistentDownloadUrls.expirationSeconds,
-    queryMaxLimit: lightdashConfig.query.maxLimit,
+    queryLimit: lightdashConfig.query.maxLimit,
     csvCellsLimit: lightdashConfig.query.csvCellsLimit,
 });

--- a/packages/backend/src/services/OrganizationSettingsService/getInstanceDefaults.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/getInstanceDefaults.ts
@@ -14,4 +14,6 @@ export const getOrganizationSettingsInstanceDefaults = (
     enableOidcToEmailLinking: lightdashConfig.auth.enableOidcToEmailLinking,
     scheduledDeliveryExpirationSeconds:
         lightdashConfig.persistentDownloadUrls.expirationSeconds,
+    queryMaxLimit: lightdashConfig.query.maxLimit,
+    csvCellsLimit: lightdashConfig.query.csvCellsLimit,
 });

--- a/packages/backend/src/services/OrganizationSettingsService/resolveExportLimits.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/resolveExportLimits.ts
@@ -22,7 +22,7 @@ export const resolveOrganizationExportLimits = async (
 ): Promise<OrganizationExportLimits> => {
     const settings = await organizationSettingsModel.get(organizationUuid);
     return {
-        maxLimit: settings.queryMaxLimit ?? query.maxLimit,
+        maxLimit: settings.queryLimit ?? query.maxLimit,
         csvCellsLimit: settings.csvCellsLimit ?? query.csvCellsLimit,
     };
 };

--- a/packages/backend/src/services/OrganizationSettingsService/resolveExportLimits.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/resolveExportLimits.ts
@@ -1,0 +1,28 @@
+import { type LightdashConfig } from '../../config/parseConfig';
+import { type OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
+
+export type OrganizationExportLimits = {
+    /** Max rows a query/export may return (LIGHTDASH_QUERY_MAX_LIMIT override). */
+    maxLimit: number;
+    /** Max cells (rows × columns) a CSV/Excel export may contain
+     *  (LIGHTDASH_CSV_CELLS_LIMIT override). */
+    csvCellsLimit: number;
+};
+
+/**
+ * Resolves an org's effective export limits: the per-org override from
+ * `organization_settings` when set, otherwise the instance env default. Used at
+ * query/export enforcement points so each org's limits apply without changing
+ * behavior for orgs that haven't overridden anything.
+ */
+export const resolveOrganizationExportLimits = async (
+    organizationSettingsModel: OrganizationSettingsModel,
+    query: Pick<LightdashConfig['query'], 'maxLimit' | 'csvCellsLimit'>,
+    organizationUuid: string,
+): Promise<OrganizationExportLimits> => {
+    const settings = await organizationSettingsModel.get(organizationUuid);
+    return {
+        maxLimit: settings.queryMaxLimit ?? query.maxLimit,
+        csvCellsLimit: settings.csvCellsLimit ?? query.csvCellsLimit,
+    };
+};

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -19,11 +19,13 @@ import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClie
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { DownloadFileModel } from '../../models/DownloadFileModel';
+import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import {
     generateGenericFileId,
     streamJsonlData,
 } from '../../utils/FileDownloadUtils/FileDownloadUtils';
 import { BaseService } from '../BaseService';
+import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 
 type PivotTableServiceArguments = {
@@ -31,6 +33,7 @@ type PivotTableServiceArguments = {
     fileStorageClient: FileStorageClient;
     downloadFileModel: DownloadFileModel;
     persistentDownloadFileService: PersistentDownloadFileService;
+    organizationSettingsModel: OrganizationSettingsModel;
 };
 
 export class PivotTableService extends BaseService {
@@ -42,17 +45,21 @@ export class PivotTableService extends BaseService {
 
     persistentDownloadFileService: PersistentDownloadFileService;
 
+    organizationSettingsModel: OrganizationSettingsModel;
+
     constructor({
         lightdashConfig,
         fileStorageClient,
         downloadFileModel,
         persistentDownloadFileService,
+        organizationSettingsModel,
     }: PivotTableServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
         this.fileStorageClient = fileStorageClient;
         this.downloadFileModel = downloadFileModel;
         this.persistentDownloadFileService = persistentDownloadFileService;
+        this.organizationSettingsModel = organizationSettingsModel;
     }
 
     /**
@@ -74,15 +81,16 @@ export class PivotTableService extends BaseService {
     /**
      * Checks if the rows could be truncated based on cell limit
      */
-    private couldBeTruncated(rows: Record<string, AnyType>[]) {
+    private static couldBeTruncated(
+        rows: Record<string, AnyType>[],
+        cellsLimit: number,
+    ) {
         if (rows.length === 0) return false;
 
         const numberRows = rows.length;
         const numberColumns = Object.keys(rows[0]).length;
 
         // we use floor when limiting the rows, so the need to make sure we got the last row valid
-        const cellsLimit = this.lightdashConfig.query?.csvCellsLimit || 100000;
-
         return numberRows * numberColumns >= cellsLimit - numberColumns;
     }
 
@@ -132,7 +140,12 @@ export class PivotTableService extends BaseService {
             await storageClient.getDownloadStream(resultsFileName);
 
         const fieldCount = Object.keys(fields).length;
-        const cellsLimit = this.lightdashConfig.query?.csvCellsLimit || 100000;
+        const { csvCellsLimit: cellsLimit } =
+            await resolveOrganizationExportLimits(
+                this.organizationSettingsModel,
+                this.lightdashConfig.query,
+                organizationUuid,
+            );
 
         // Use standard csvCellsLimit calculation - same as original downloadPivotTableCsv
         const maxRows = Math.floor(cellsLimit / fieldCount);
@@ -150,7 +163,8 @@ export class PivotTableService extends BaseService {
         }
 
         // Use same truncation logic as original downloadPivotTableCsv
-        const finalTruncated = truncated || this.couldBeTruncated(rows);
+        const finalTruncated =
+            truncated || PivotTableService.couldBeTruncated(rows, cellsLimit);
 
         if (finalTruncated) {
             Logger.warn(

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -488,6 +488,7 @@ export const lightdashConfigWithNoSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
+        csvMaxLimit: 5000000,
         timezone: undefined,
         retryQueryOnTransientErrors: false,
         enableTimezoneSupport: undefined,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -488,7 +488,7 @@ export const lightdashConfigWithNoSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
-        csvMaxLimit: 5000000,
+        csvCellsMaxLimit: 5000000,
         timezone: undefined,
         retryQueryOnTransientErrors: false,
         enableTimezoneSupport: undefined,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -488,7 +488,7 @@ export const lightdashConfigWithNoSMTP: Pick<
         maxLimit: 100,
         defaultLimit: 500,
         csvCellsLimit: 100,
-        csvCellsMaxLimit: 5000000,
+        csvMaxLimit: 5000000,
         timezone: undefined,
         retryQueryOnTransientErrors: false,
         enableTimezoneSupport: undefined,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -34,6 +34,7 @@ import { GroupsModel } from '../../models/GroupsModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
+import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
 import { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -278,6 +279,12 @@ const getMockedProjectService = (
         } as unknown as AdminNotificationService,
         spacePermissionService:
             overrides.spacePermissionService ?? ({} as SpacePermissionService),
+        organizationSettingsModel: {
+            get: jest.fn(async () => ({
+                queryMaxLimit: null,
+                csvCellsLimit: null,
+            })),
+        } as unknown as OrganizationSettingsModel,
     });
 
 const account = buildAccount({

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -281,7 +281,7 @@ const getMockedProjectService = (
             overrides.spacePermissionService ?? ({} as SpacePermissionService),
         organizationSettingsModel: {
             get: jest.fn(async () => ({
-                queryMaxLimit: null,
+                queryLimit: null,
                 csvCellsLimit: null,
             })),
         } as unknown as OrganizationSettingsModel,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -230,6 +230,7 @@ import { GroupsModel } from '../../models/GroupsModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
+import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
 import { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -264,6 +265,7 @@ import { applyLimitToSqlQuery } from '../../utils/QueryBuilder/utils';
 import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import { BaseService } from '../BaseService';
+import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import {
     doesExploreMatchRequiredAttributes,
@@ -318,6 +320,7 @@ export type ProjectServiceArguments = {
     spacePermissionService: SpacePermissionService;
     natsClient?: INatsClient;
     contentVerificationModel?: ContentVerificationModel;
+    organizationSettingsModel: OrganizationSettingsModel;
 };
 
 export class ProjectService extends BaseService {
@@ -391,6 +394,8 @@ export class ProjectService extends BaseService {
 
     contentVerificationModel: ContentVerificationModel | undefined;
 
+    organizationSettingsModel: OrganizationSettingsModel;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -426,6 +431,7 @@ export class ProjectService extends BaseService {
         adminNotificationService,
         spacePermissionService,
         contentVerificationModel,
+        organizationSettingsModel,
     }: ProjectServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -464,6 +470,7 @@ export class ProjectService extends BaseService {
         this.adminNotificationService = adminNotificationService;
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
+        this.organizationSettingsModel = organizationSettingsModel;
     }
 
     static getMetricQueryExecutionProperties({
@@ -4604,11 +4611,18 @@ export class ProjectService extends BaseService {
                         throw new ForbiddenError();
                     }
 
+                    const { maxLimit, csvCellsLimit } =
+                        await resolveOrganizationExportLimits(
+                            this.organizationSettingsModel,
+                            this.lightdashConfig.query,
+                            organizationUuid,
+                        );
+
                     const metricQueryWithLimit = applyMetricQueryLimit(
                         metricQuery,
                         csvLimit,
-                        this.lightdashConfig.query?.csvCellsLimit,
-                        this.lightdashConfig.query?.maxLimit,
+                        csvCellsLimit,
+                        maxLimit,
                     );
 
                     const explore =
@@ -4828,10 +4842,16 @@ export class ProjectService extends BaseService {
             query_context: QueryExecutionContext.SQL_RUNNER,
         };
 
+        const { maxLimit } = await resolveOrganizationExportLimits(
+            this.organizationSettingsModel,
+            this.lightdashConfig.query,
+            organizationUuid,
+        );
+
         // enforce limit for current SQL queries as it may crash server. We are working on a new SQL runner that supports streaming
         const cteWithLimit = applyLimitToSqlQuery({
             sqlQuery: sql,
-            limit: this.lightdashConfig.query.maxLimit,
+            limit: maxLimit,
         });
 
         const results = await warehouseClient.runQuery(cteWithLimit, queryTags);
@@ -5160,13 +5180,20 @@ export class ProjectService extends BaseService {
         limit: number;
         filters: AndFilterGroup | undefined;
     }) {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const { maxLimit } = await resolveOrganizationExportLimits(
+            this.organizationSettingsModel,
+            this.lightdashConfig.query,
+            organizationUuid,
+        );
         return getFieldValuesMetricQuery({
             projectUuid,
             table,
             initialFieldId,
             search,
             limit,
-            maxLimit: this.lightdashConfig.query.maxLimit,
+            maxLimit,
             filters,
             exploreResolver: this.projectModel,
         });

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -620,6 +620,7 @@ export class ServiceRepository
                     lightdashConfig: this.context.lightdashConfig,
                     organizationSettingsModel:
                         this.models.getOrganizationSettingsModel(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
                 }),
         );
     }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -702,6 +702,8 @@ export class ServiceRepository
                     downloadFileModel: this.models.getDownloadFileModel(),
                     persistentDownloadFileService:
                         this.getPersistentDownloadFileService(),
+                    organizationSettingsModel:
+                        this.models.getOrganizationSettingsModel(),
                 }),
         );
     }
@@ -753,6 +755,8 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
+                    organizationSettingsModel:
+                        this.models.getOrganizationSettingsModel(),
                 }),
         );
     }
@@ -812,6 +816,8 @@ export class ServiceRepository
                     adminNotificationService:
                         this.getAdminNotificationService(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    organizationSettingsModel:
+                        this.models.getOrganizationSettingsModel(),
                 }),
         );
     }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -510,6 +510,8 @@ export class ServiceRepository
                     lightdashConfig: this.context.lightdashConfig,
                     organizationModel: this.models.getOrganizationModel(),
                     migrationModel: this.models.getMigrationModel(),
+                    organizationSettingsModel:
+                        this.models.getOrganizationSettingsModel(),
                 }),
         );
     }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -473,6 +473,9 @@ export type HealthState = {
         maxLimit: number;
         defaultLimit: number;
         csvCellsLimit: number;
+        /** Effective ceiling an org admin can set the per-org CSV cells limit
+         *  to: max(LIGHTDASH_CSV_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT). */
+        csvMaxLimit: number;
         maxPageSize: number;
         retryQueryOnTransientErrors: boolean;
     };

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -482,8 +482,8 @@ export type HealthState = {
          *  to: LIGHTDASH_QUERY_MAX_LIMIT. */
         queryMaxLimit: number;
         /** Instance ceiling an org admin can set the per-org CSV cells limit
-         *  to: max(LIGHTDASH_CSV_CELLS_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT). */
-        csvCellsMaxLimit: number;
+         *  to: max(LIGHTDASH_CSV_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT). */
+        csvMaxLimit: number;
         maxPageSize: number;
         retryQueryOnTransientErrors: boolean;
     };

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -470,12 +470,20 @@ export type HealthState = {
     signupUrl: string | undefined;
     helpMenuUrl: string | undefined;
     query: {
+        /** Effective max query rows for the requesting org (the org's
+         *  `query_limit` override, else LIGHTDASH_QUERY_MAX_LIMIT). Drives the
+         *  explorer/SQL-runner row-limit clamp. */
         maxLimit: number;
+        /** Effective new-query default for the org, never above `maxLimit`. */
         defaultLimit: number;
+        /** Effective CSV/Excel cells limit for the requesting org. */
         csvCellsLimit: number;
-        /** Effective ceiling an org admin can set the per-org CSV cells limit
-         *  to: max(LIGHTDASH_CSV_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT). */
-        csvMaxLimit: number;
+        /** Instance ceiling an org admin can set the per-org query rows limit
+         *  to: LIGHTDASH_QUERY_MAX_LIMIT. */
+        queryMaxLimit: number;
+        /** Instance ceiling an org admin can set the per-org CSV cells limit
+         *  to: max(LIGHTDASH_CSV_CELLS_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT). */
+        csvCellsMaxLimit: number;
         maxPageSize: number;
         retryQueryOnTransientErrors: boolean;
     };

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -227,6 +227,13 @@ export enum FeatureFlags {
      * MCP using the org's existing installation token — no manual URL/auth.
      */
     GithubMcpOneClick = 'github-mcp-one-click',
+
+    /**
+     * Gate the org-level export Limits settings panel (per-org query max rows
+     * and CSV cells limit). Backend enforcement of any stored overrides is
+     * always on; this flag only controls who can see/configure the panel.
+     */
+    ProLimits = 'pro-limits',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/organizationSettings.test.ts
+++ b/packages/common/src/types/organizationSettings.test.ts
@@ -7,7 +7,7 @@ const INSTANCE_DEFAULTS: OrganizationSettingsInstanceDefaults = {
     enableOidcLinking: false,
     enableOidcToEmailLinking: true,
     scheduledDeliveryExpirationSeconds: 259200, // 3 days (env default)
-    queryMaxLimit: 5000,
+    queryLimit: 5000,
     csvCellsLimit: 100000,
 };
 
@@ -24,7 +24,7 @@ describe('resolveEffectiveOrganizationSettings', () => {
             scheduledDeliveryExpirationSecondsSlack: null,
             scheduledDeliveryExpirationSecondsMsTeams: null,
             scheduledDeliveryExpirationSecondsGoogleChat: null,
-            queryMaxLimit: 5000,
+            queryLimit: 5000,
             csvCellsLimit: 100000,
         });
     });
@@ -34,13 +34,13 @@ describe('resolveEffectiveOrganizationSettings', () => {
             {},
             INSTANCE_DEFAULTS,
         );
-        expect(inherited.queryMaxLimit).toBe(5000);
+        expect(inherited.queryLimit).toBe(5000);
         expect(inherited.csvCellsLimit).toBe(100000);
         const overridden = resolveEffectiveOrganizationSettings(
-            { queryMaxLimit: 250000, csvCellsLimit: 50000000 },
+            { queryLimit: 250000, csvCellsLimit: 50000000 },
             INSTANCE_DEFAULTS,
         );
-        expect(overridden.queryMaxLimit).toBe(250000);
+        expect(overridden.queryLimit).toBe(250000);
         expect(overridden.csvCellsLimit).toBe(50000000);
     });
 

--- a/packages/common/src/types/organizationSettings.test.ts
+++ b/packages/common/src/types/organizationSettings.test.ts
@@ -7,6 +7,8 @@ const INSTANCE_DEFAULTS: OrganizationSettingsInstanceDefaults = {
     enableOidcLinking: false,
     enableOidcToEmailLinking: true,
     scheduledDeliveryExpirationSeconds: 259200, // 3 days (env default)
+    queryMaxLimit: 5000,
+    csvCellsLimit: 100000,
 };
 
 describe('resolveEffectiveOrganizationSettings', () => {
@@ -22,7 +24,24 @@ describe('resolveEffectiveOrganizationSettings', () => {
             scheduledDeliveryExpirationSecondsSlack: null,
             scheduledDeliveryExpirationSecondsMsTeams: null,
             scheduledDeliveryExpirationSecondsGoogleChat: null,
+            queryMaxLimit: 5000,
+            csvCellsLimit: 100000,
         });
+    });
+
+    test('export limits resolve to an effective number, inheriting the env when unset', () => {
+        const inherited = resolveEffectiveOrganizationSettings(
+            {},
+            INSTANCE_DEFAULTS,
+        );
+        expect(inherited.queryMaxLimit).toBe(5000);
+        expect(inherited.csvCellsLimit).toBe(100000);
+        const overridden = resolveEffectiveOrganizationSettings(
+            { queryMaxLimit: 250000, csvCellsLimit: 50000000 },
+            INSTANCE_DEFAULTS,
+        );
+        expect(overridden.queryMaxLimit).toBe(250000);
+        expect(overridden.csvCellsLimit).toBe(50000000);
     });
 
     test('the base expiry resolves to an effective number, inheriting the env when unset', () => {

--- a/packages/common/src/types/organizationSettings.ts
+++ b/packages/common/src/types/organizationSettings.ts
@@ -63,16 +63,17 @@ export type OrganizationSettings = {
      */
     scheduledDeliveryExpirationSecondsGoogleChat: number | null;
     /**
-     * Max number of rows a query/export may return for this org (overrides the
-     * instance-wide `LIGHTDASH_QUERY_MAX_LIMIT`; `null` inherits it). Always
-     * resolved to an effective number in API responses so the frontend can
-     * display it directly.
+     * Max number of rows a query may return for this org. Inherits and is
+     * capped by the instance-wide `LIGHTDASH_QUERY_MAX_LIMIT` (the ceiling);
+     * `null` inherits it. Always resolved to an effective number in API
+     * responses so the frontend can display it directly.
      */
-    queryMaxLimit: number | null;
+    queryLimit: number | null;
     /**
      * Max number of cells (rows × columns) a CSV/Excel export may contain for
-     * this org (overrides `LIGHTDASH_CSV_CELLS_LIMIT`; `null` inherits it).
-     * Always resolved to an effective number in API responses.
+     * this org. Inherits `LIGHTDASH_CSV_CELLS_LIMIT` and is capped by
+     * `LIGHTDASH_CSV_CELLS_MAX_LIMIT` (the ceiling); `null` inherits the
+     * default. Always resolved to an effective number in API responses.
      */
     csvCellsLimit: number | null;
 };
@@ -108,7 +109,7 @@ export type OrganizationSettingsInstanceDefaults = {
     enableOidcLinking: boolean;
     enableOidcToEmailLinking: boolean;
     scheduledDeliveryExpirationSeconds: number;
-    queryMaxLimit: number;
+    queryLimit: number;
     csvCellsLimit: number;
 };
 
@@ -147,6 +148,6 @@ export const resolveEffectiveOrganizationSettings = (
     scheduledDeliveryExpirationSecondsGoogleChat:
         raw.scheduledDeliveryExpirationSecondsGoogleChat ?? null,
     // Limits resolve to an effective number (fall back to the env default).
-    queryMaxLimit: raw.queryMaxLimit ?? instanceDefaults.queryMaxLimit,
+    queryLimit: raw.queryLimit ?? instanceDefaults.queryLimit,
     csvCellsLimit: raw.csvCellsLimit ?? instanceDefaults.csvCellsLimit,
 });

--- a/packages/common/src/types/organizationSettings.ts
+++ b/packages/common/src/types/organizationSettings.ts
@@ -84,6 +84,13 @@ export type OrganizationSettings = {
  */
 export const S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS = 604800;
 
+/**
+ * Postgres `integer` column ceiling. Every numeric org setting is stored in an
+ * `integer` column, so a value above this overflows the column (a DB error, not
+ * a clean validation failure). Used as the hard upper bound for all of them.
+ */
+export const POSTGRES_INTEGER_MAX = 2147483647;
+
 export type UpdateOrganizationSettings = Partial<OrganizationSettings>;
 
 export type ApiOrganizationSettingsResponse = {

--- a/packages/common/src/types/organizationSettings.ts
+++ b/packages/common/src/types/organizationSettings.ts
@@ -62,6 +62,19 @@ export type OrganizationSettings = {
      * override (it still falls back to the base / env base).
      */
     scheduledDeliveryExpirationSecondsGoogleChat: number | null;
+    /**
+     * Max number of rows a query/export may return for this org (overrides the
+     * instance-wide `LIGHTDASH_QUERY_MAX_LIMIT`; `null` inherits it). Always
+     * resolved to an effective number in API responses so the frontend can
+     * display it directly.
+     */
+    queryMaxLimit: number | null;
+    /**
+     * Max number of cells (rows × columns) a CSV/Excel export may contain for
+     * this org (overrides `LIGHTDASH_CSV_CELLS_LIMIT`; `null` inherits it).
+     * Always resolved to an effective number in API responses.
+     */
+    csvCellsLimit: number | null;
 };
 
 /**
@@ -70,6 +83,13 @@ export type OrganizationSettings = {
  * delivery transparently falls back to the persistent-download-URL system.
  */
 export const S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS = 604800;
+
+/**
+ * Upper bound for {@link OrganizationSettings.csvCellsLimit} — 50 million cells.
+ * Matches the highest value set across Cloud customers today; a sane ceiling
+ * that still keeps wide exports feasible without inviting OOM-scale requests.
+ */
+export const MAX_CSV_CELLS_LIMIT = 50000000; // 50 million
 
 export type UpdateOrganizationSettings = Partial<OrganizationSettings>;
 
@@ -88,6 +108,8 @@ export type OrganizationSettingsInstanceDefaults = {
     enableOidcLinking: boolean;
     enableOidcToEmailLinking: boolean;
     scheduledDeliveryExpirationSeconds: number;
+    queryMaxLimit: number;
+    csvCellsLimit: number;
 };
 
 /**
@@ -124,4 +146,7 @@ export const resolveEffectiveOrganizationSettings = (
         raw.scheduledDeliveryExpirationSecondsMsTeams ?? null,
     scheduledDeliveryExpirationSecondsGoogleChat:
         raw.scheduledDeliveryExpirationSecondsGoogleChat ?? null,
+    // Limits resolve to an effective number (fall back to the env default).
+    queryMaxLimit: raw.queryMaxLimit ?? instanceDefaults.queryMaxLimit,
+    csvCellsLimit: raw.csvCellsLimit ?? instanceDefaults.csvCellsLimit,
 });

--- a/packages/common/src/types/organizationSettings.ts
+++ b/packages/common/src/types/organizationSettings.ts
@@ -72,7 +72,7 @@ export type OrganizationSettings = {
     /**
      * Max number of cells (rows × columns) a CSV/Excel export may contain for
      * this org. Inherits `LIGHTDASH_CSV_CELLS_LIMIT` and is capped by
-     * `LIGHTDASH_CSV_CELLS_MAX_LIMIT` (the ceiling); `null` inherits the
+     * `LIGHTDASH_CSV_MAX_LIMIT` (the ceiling); `null` inherits the
      * default. Always resolved to an effective number in API responses.
      */
     csvCellsLimit: number | null;

--- a/packages/common/src/types/organizationSettings.ts
+++ b/packages/common/src/types/organizationSettings.ts
@@ -84,13 +84,6 @@ export type OrganizationSettings = {
  */
 export const S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS = 604800;
 
-/**
- * Upper bound for {@link OrganizationSettings.csvCellsLimit} — 50 million cells.
- * Matches the highest value set across Cloud customers today; a sane ceiling
- * that still keeps wide exports feasible without inviting OOM-scale requests.
- */
-export const MAX_CSV_CELLS_LIMIT = 50000000; // 50 million
-
 export type UpdateOrganizationSettings = Partial<OrganizationSettings>;
 
 export type ApiOrganizationSettingsResponse = {

--- a/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
@@ -18,8 +18,8 @@ import {
  *
  * The caps are the instance ceilings from /health: `queryRowsCap` is
  * LIGHTDASH_QUERY_MAX_LIMIT (`query.queryMaxLimit`) and `csvCellsCap` is
- * max(LIGHTDASH_CSV_CELLS_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT)
- * (`query.csvCellsMaxLimit`). Both are always ≥ the org's current value, so
+ * max(LIGHTDASH_CSV_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT)
+ * (`query.csvMaxLimit`). Both are always ≥ the org's current value, so
  * they can be used directly as the input max.
  */
 const LimitsForm: FC<{
@@ -103,7 +103,7 @@ const LimitsPanel: FC = () => {
             key={`${data.queryLimit}-${data.csvCellsLimit}`}
             settings={data}
             queryRowsCap={health.data.query.queryMaxLimit}
-            csvCellsCap={health.data.query.csvCellsMaxLimit}
+            csvCellsCap={health.data.query.csvMaxLimit}
         />
     );
 };

--- a/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
@@ -1,0 +1,102 @@
+import {
+    MAX_CSV_CELLS_LIMIT,
+    type OrganizationSettings,
+    type UpdateOrganizationSettings,
+} from '@lightdash/common';
+import { Button, Group, Loader, NumberInput, Stack } from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { type FC } from 'react';
+import {
+    useOrganizationSettings,
+    useUpdateOrganizationSettings,
+} from '../../../hooks/organization/useOrganizationSettings';
+
+// Generous UI guardrail for the row limit — there's no backend cap on it (only
+// the CSV cells limit is capped, at MAX_CSV_CELLS_LIMIT).
+const MAX_QUERY_ROWS = 10000000;
+
+/**
+ * Editable form for the org's export limits. Split out from the panel so the
+ * form's initial values are captured from the loaded settings exactly once
+ * (keyed remount on the effective values), never clobbered by a refetch.
+ */
+const LimitsForm: FC<{ settings: OrganizationSettings }> = ({ settings }) => {
+    const update = useUpdateOrganizationSettings();
+
+    // The API returns effective numbers (org override resolved against the env),
+    // so these are always set; the shared type is nullable for the raw row.
+    const initial = {
+        queryMaxLimit: settings.queryMaxLimit ?? 5000,
+        csvCellsLimit: settings.csvCellsLimit ?? 100000,
+    };
+    const form = useForm({ initialValues: initial });
+
+    const handleSubmit = form.onSubmit((values) => {
+        const patch: UpdateOrganizationSettings = {
+            queryMaxLimit: values.queryMaxLimit,
+            csvCellsLimit: values.csvCellsLimit,
+        };
+        update.mutate(patch);
+    });
+
+    const isUnchanged =
+        form.values.queryMaxLimit === initial.queryMaxLimit &&
+        form.values.csvCellsLimit === initial.csvCellsLimit;
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <Stack gap="lg">
+                <NumberInput
+                    label="Maximum query rows"
+                    description="The most rows a single query or export can return for your organization."
+                    min={1}
+                    max={MAX_QUERY_ROWS}
+                    clampBehavior="strict"
+                    allowDecimal={false}
+                    allowNegative={false}
+                    thousandSeparator=","
+                    {...form.getInputProps('queryMaxLimit')}
+                />
+                <NumberInput
+                    label="Maximum CSV / Excel cells"
+                    description={`The most cells (rows × columns) a CSV or Excel export can contain. Up to ${MAX_CSV_CELLS_LIMIT.toLocaleString()}.`}
+                    min={1}
+                    max={MAX_CSV_CELLS_LIMIT}
+                    clampBehavior="strict"
+                    allowDecimal={false}
+                    allowNegative={false}
+                    thousandSeparator=","
+                    {...form.getInputProps('csvCellsLimit')}
+                />
+                <Group justify="flex-end">
+                    <Button
+                        type="submit"
+                        loading={update.isLoading}
+                        disabled={isUnchanged}
+                    >
+                        Save
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    );
+};
+
+const LimitsPanel: FC = () => {
+    const { data, isInitialLoading } = useOrganizationSettings();
+
+    if (isInitialLoading || !data) {
+        return <Loader />;
+    }
+
+    // Remount when the effective values change so the form re-seeds from server
+    // state without a clobbering useEffect.
+    return (
+        <LimitsForm
+            key={`${data.queryMaxLimit}-${data.csvCellsLimit}`}
+            settings={data}
+        />
+    );
+};
+
+export default LimitsPanel;

--- a/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
@@ -16,10 +16,11 @@ import {
  * form's initial values are captured from the loaded settings exactly once
  * (keyed remount on the effective values), never clobbered by a refetch.
  *
- * The caps come from /health (instance env): `queryRowsCap` is
- * LIGHTDASH_QUERY_MAX_LIMIT and `csvCellsCap` is
- * max(LIGHTDASH_CSV_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT). Both are always ≥ the
- * org's current value, so they can be used directly as the input max.
+ * The caps are the instance ceilings from /health: `queryRowsCap` is
+ * LIGHTDASH_QUERY_MAX_LIMIT (`query.queryMaxLimit`) and `csvCellsCap` is
+ * max(LIGHTDASH_CSV_CELLS_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT)
+ * (`query.csvCellsMaxLimit`). Both are always ≥ the org's current value, so
+ * they can be used directly as the input max.
  */
 const LimitsForm: FC<{
     settings: OrganizationSettings;
@@ -31,21 +32,21 @@ const LimitsForm: FC<{
     // The API returns effective numbers (org override resolved against the env),
     // so these are always set; the shared type is nullable for the raw row.
     const initial = {
-        queryMaxLimit: settings.queryMaxLimit ?? 5000,
+        queryLimit: settings.queryLimit ?? 5000,
         csvCellsLimit: settings.csvCellsLimit ?? 100000,
     };
     const form = useForm({ initialValues: initial });
 
     const handleSubmit = form.onSubmit((values) => {
         const patch: UpdateOrganizationSettings = {
-            queryMaxLimit: values.queryMaxLimit,
+            queryLimit: values.queryLimit,
             csvCellsLimit: values.csvCellsLimit,
         };
         update.mutate(patch);
     });
 
     const isUnchanged =
-        form.values.queryMaxLimit === initial.queryMaxLimit &&
+        form.values.queryLimit === initial.queryLimit &&
         form.values.csvCellsLimit === initial.csvCellsLimit;
 
     return (
@@ -60,7 +61,7 @@ const LimitsForm: FC<{
                     allowDecimal={false}
                     allowNegative={false}
                     thousandSeparator=","
-                    {...form.getInputProps('queryMaxLimit')}
+                    {...form.getInputProps('queryLimit')}
                 />
                 <NumberInput
                     label="Maximum CSV / Excel cells"
@@ -99,10 +100,10 @@ const LimitsPanel: FC = () => {
     // state without a clobbering useEffect.
     return (
         <LimitsForm
-            key={`${data.queryMaxLimit}-${data.csvCellsLimit}`}
+            key={`${data.queryLimit}-${data.csvCellsLimit}`}
             settings={data}
-            queryRowsCap={health.data.query.maxLimit}
-            csvCellsCap={health.data.query.csvMaxLimit}
+            queryRowsCap={health.data.query.queryMaxLimit}
+            csvCellsCap={health.data.query.csvCellsMaxLimit}
         />
     );
 };

--- a/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
@@ -1,4 +1,5 @@
 import {
+    POSTGRES_INTEGER_MAX,
     type OrganizationSettings,
     type UpdateOrganizationSettings,
 } from '@lightdash/common';
@@ -53,6 +54,8 @@ const LimitsForm: FC<{
                     label="Maximum query rows"
                     description="The most rows a single query or export can return for your organization."
                     min={1}
+                    max={POSTGRES_INTEGER_MAX}
+                    clampBehavior="strict"
                     allowDecimal={false}
                     allowNegative={false}
                     thousandSeparator=","

--- a/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
@@ -1,5 +1,4 @@
 import {
-    POSTGRES_INTEGER_MAX,
     type OrganizationSettings,
     type UpdateOrganizationSettings,
 } from '@lightdash/common';
@@ -17,14 +16,16 @@ import {
  * form's initial values are captured from the loaded settings exactly once
  * (keyed remount on the effective values), never clobbered by a refetch.
  *
- * `csvCellsCap` is the instance's effective ceiling for the CSV cells limit
- * (from /health: max(LIGHTDASH_CSV_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT)); it's
- * always ≥ the org's current value, so it can be used directly as the input max.
+ * The caps come from /health (instance env): `queryRowsCap` is
+ * LIGHTDASH_QUERY_MAX_LIMIT and `csvCellsCap` is
+ * max(LIGHTDASH_CSV_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT). Both are always ≥ the
+ * org's current value, so they can be used directly as the input max.
  */
 const LimitsForm: FC<{
     settings: OrganizationSettings;
+    queryRowsCap: number;
     csvCellsCap: number;
-}> = ({ settings, csvCellsCap }) => {
+}> = ({ settings, queryRowsCap, csvCellsCap }) => {
     const update = useUpdateOrganizationSettings();
 
     // The API returns effective numbers (org override resolved against the env),
@@ -52,9 +53,9 @@ const LimitsForm: FC<{
             <Stack gap="lg">
                 <NumberInput
                     label="Maximum query rows"
-                    description="The most rows a single query or export can return for your organization."
+                    description={`The most rows a single query or export can return for your organization. Up to ${queryRowsCap.toLocaleString()}.`}
                     min={1}
-                    max={POSTGRES_INTEGER_MAX}
+                    max={queryRowsCap}
                     clampBehavior="strict"
                     allowDecimal={false}
                     allowNegative={false}
@@ -100,6 +101,7 @@ const LimitsPanel: FC = () => {
         <LimitsForm
             key={`${data.queryMaxLimit}-${data.csvCellsLimit}`}
             settings={data}
+            queryRowsCap={health.data.query.maxLimit}
             csvCellsCap={health.data.query.csvMaxLimit}
         />
     );

--- a/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
@@ -1,26 +1,29 @@
 import {
-    MAX_CSV_CELLS_LIMIT,
     type OrganizationSettings,
     type UpdateOrganizationSettings,
 } from '@lightdash/common';
 import { Button, Group, Loader, NumberInput, Stack } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { type FC } from 'react';
+import useHealth from '../../../hooks/health/useHealth';
 import {
     useOrganizationSettings,
     useUpdateOrganizationSettings,
 } from '../../../hooks/organization/useOrganizationSettings';
 
-// Generous UI guardrail for the row limit — there's no backend cap on it (only
-// the CSV cells limit is capped, at MAX_CSV_CELLS_LIMIT).
-const MAX_QUERY_ROWS = 10000000;
-
 /**
  * Editable form for the org's export limits. Split out from the panel so the
  * form's initial values are captured from the loaded settings exactly once
  * (keyed remount on the effective values), never clobbered by a refetch.
+ *
+ * `csvCellsCap` is the instance's effective ceiling for the CSV cells limit
+ * (from /health: max(LIGHTDASH_CSV_MAX_LIMIT, LIGHTDASH_CSV_CELLS_LIMIT)); it's
+ * always ≥ the org's current value, so it can be used directly as the input max.
  */
-const LimitsForm: FC<{ settings: OrganizationSettings }> = ({ settings }) => {
+const LimitsForm: FC<{
+    settings: OrganizationSettings;
+    csvCellsCap: number;
+}> = ({ settings, csvCellsCap }) => {
     const update = useUpdateOrganizationSettings();
 
     // The API returns effective numbers (org override resolved against the env),
@@ -50,8 +53,6 @@ const LimitsForm: FC<{ settings: OrganizationSettings }> = ({ settings }) => {
                     label="Maximum query rows"
                     description="The most rows a single query or export can return for your organization."
                     min={1}
-                    max={MAX_QUERY_ROWS}
-                    clampBehavior="strict"
                     allowDecimal={false}
                     allowNegative={false}
                     thousandSeparator=","
@@ -59,9 +60,9 @@ const LimitsForm: FC<{ settings: OrganizationSettings }> = ({ settings }) => {
                 />
                 <NumberInput
                     label="Maximum CSV / Excel cells"
-                    description={`The most cells (rows × columns) a CSV or Excel export can contain. Up to ${MAX_CSV_CELLS_LIMIT.toLocaleString()}.`}
+                    description={`The most cells (rows × columns) a CSV or Excel export can contain. Up to ${csvCellsCap.toLocaleString()}.`}
                     min={1}
-                    max={MAX_CSV_CELLS_LIMIT}
+                    max={csvCellsCap}
                     clampBehavior="strict"
                     allowDecimal={false}
                     allowNegative={false}
@@ -84,8 +85,9 @@ const LimitsForm: FC<{ settings: OrganizationSettings }> = ({ settings }) => {
 
 const LimitsPanel: FC = () => {
     const { data, isInitialLoading } = useOrganizationSettings();
+    const health = useHealth();
 
-    if (isInitialLoading || !data) {
+    if (isInitialLoading || !data || !health.data) {
         return <Loader />;
     }
 
@@ -95,6 +97,7 @@ const LimitsPanel: FC = () => {
         <LimitsForm
             key={`${data.queryMaxLimit}-${data.csvCellsLimit}`}
             settings={data}
+            csvCellsCap={health.data.query.csvMaxLimit}
         />
     );
 };

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -28,6 +28,7 @@ import {
     IconFileExport,
     IconFolders,
     IconGitPullRequest,
+    IconGauge,
     IconHistory,
     IconIdBadge2,
     IconKey,
@@ -79,6 +80,7 @@ import GithubSettingsPanel from '../components/UserSettings/GithubSettingsPanel'
 import GitlabSettingsPanel from '../components/UserSettings/GitlabSettingsPanel';
 import ImpersonationPanel from '../components/UserSettings/ImpersonationPanel';
 import { LeaveOrganizationPanel } from '../components/UserSettings/LeaveOrganizationPanel';
+import LimitsPanel from '../components/UserSettings/LimitsPanel';
 import MyAppsPanel from '../components/UserSettings/MyAppsPanel';
 import { MyWarehouseConnectionsPanel } from '../components/UserSettings/MyWarehouseConnectionsPanel';
 import OAuthClientsPanel from '../components/UserSettings/OAuthClientsPanel';
@@ -186,6 +188,11 @@ const Settings: FC = () => {
     const { data: dataAppsFlag } = useServerFeatureFlag(
         FeatureFlags.EnableDataApps,
     );
+
+    const { data: proLimitsFlag } = useServerFeatureFlag(
+        FeatureFlags.ProLimits,
+    );
+    const isProLimitsEnabled = proLimitsFlag?.enabled ?? false;
 
     const { data: ssoOrganizationSettingsFlag } = useServerFeatureFlag(
         FeatureFlags.SsoOrganizationSettings,
@@ -434,6 +441,26 @@ const Settings: FC = () => {
                                 </Text>
                             </div>
                             <ExportingPanel />
+                        </SettingsGridCard>
+                    </Stack>
+                ),
+            });
+        }
+        if (isProLimitsEnabled && user?.ability.can('manage', 'Organization')) {
+            allowedRoutes.push({
+                path: '/limits',
+                element: (
+                    <Stack gap="xl">
+                        <SettingsGridCard>
+                            <div>
+                                <Title order={4}>Limits</Title>
+                                <Text c="ldGray.6" fz="xs">
+                                    Limit how many rows a query can return and
+                                    how many cells a CSV or Excel export can
+                                    contain for your organization.
+                                </Text>
+                            </div>
+                            <LimitsPanel />
                         </SettingsGridCard>
                     </Stack>
                 ),
@@ -692,6 +719,7 @@ const Settings: FC = () => {
         health?.hasGitlab,
         health?.auth.google.enabled,
         dataAppsFlag?.enabled,
+        isProLimitsEnabled,
         isSsoOrganizationSettingsEnabled,
         isLeaveOrganizationEnabled,
         isAiCopilotEnabledOrTrial,
@@ -1007,6 +1035,20 @@ const Settings: FC = () => {
                                         }
                                     />
                                 )}
+                                {isProLimitsEnabled &&
+                                    user.ability.can(
+                                        'manage',
+                                        'Organization',
+                                    ) && (
+                                        <RouterNavLink
+                                            label="Limits"
+                                            to="/generalSettings/limits"
+                                            exact
+                                            leftSection={
+                                                <MantineIcon icon={IconGauge} />
+                                            }
+                                        />
+                                    )}
                                 {isCustomRolesEnabled && (
                                     <Can I="manage" a="Organization">
                                         <RouterNavLink

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -46,7 +46,7 @@ export default function mockHealthResponse(
             queryMaxLimit: 1000000,
             defaultLimit: 500,
             csvCellsLimit: 100,
-            csvCellsMaxLimit: 5000000,
+            csvMaxLimit: 5000000,
             retryQueryOnTransientErrors: true,
         },
         dashboard: {

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -43,9 +43,10 @@ export default function mockHealthResponse(
         query: {
             maxPageSize: 2500,
             maxLimit: 1000000,
+            queryMaxLimit: 1000000,
             defaultLimit: 500,
             csvCellsLimit: 100,
-            csvMaxLimit: 5000000,
+            csvCellsMaxLimit: 5000000,
             retryQueryOnTransientErrors: true,
         },
         dashboard: {

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -45,6 +45,7 @@ export default function mockHealthResponse(
             maxLimit: 1000000,
             defaultLimit: 500,
             csvCellsLimit: 100,
+            csvMaxLimit: 5000000,
             retryQueryOnTransientErrors: true,
         },
         dashboard: {


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-7214/add-organization-level-csv-and-export-limits](https://linear.app/lightdash/issue/PROD-7214/add-organization-level-csv-and-export-limits)



![CleanShot 2026-06-01 at 14.14.50.png](https://app.graphite.com/user-attachments/assets/c68341c6-e9b4-46e8-af58-e6bda8c24cc4.png)



### Description:

Adds per-organization export limits, allowing admins to override the instance-wide `LIGHTDASH_QUERY_MAX_LIMIT` (max rows per query/export) and `LIGHTDASH_CSV_CELLS_LIMIT` (max cells per CSV/Excel export) on a per-org basis. When no override is set, behavior is identical to before — the env defaults are used as fallback.

Two nullable columns (`query_max_limit`, `csv_cells_limit`) are added to `organization_settings` via migration. The `OrganizationSettingsModel` reads and writes these, and a new `resolveOrganizationExportLimits` helper resolves the effective limit (org override → env default) at each enforcement point. Enforcement is updated in `ProjectService`, `AsyncQueryService`, `PivotTableService`, `CsvService`, and `ExcelService` to use the resolved org limits rather than reading directly from `lightdashConfig`.

`csvCellsLimit` is capped at 50,000,000 cells server-side. There is no cap on `queryMaxLimit`.

The configuration UI is a new **Export limits** panel in org settings, gated behind the `pro-limits` feature flag (`FeatureFlags.ProLimits`). The flag only controls panel visibility — backend enforcement of any stored override is always active. The panel can be enabled via `LIGHTDASH_ENABLE_FEATURE_FLAGS=pro-limits`, a `feature_flags` row, or a per-org `feature_flag_overrides` row.