### PR TITLE
feat(ai-router): respect user's default agent

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -20,7 +20,12 @@ import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useAiRouterConfig } from '../../hooks/useAiRouter';
 import styles from './AgentSelector.module.css';
-import { getAgentOptions, type Agent } from './AgentSelectorUtils';
+import {
+    AI_ROUTING_AUTO_VALUE,
+    AI_ROUTING_SEARCH_PARAM,
+    getAgentOptions,
+    type Agent,
+} from './AgentSelectorUtils';
 
 type Props = {
     agents: Agent[];
@@ -65,15 +70,22 @@ export const AgentSelector = ({
                 viewTransition: true,
             });
         } else if (value === AUTO_VALUE) {
+            const autoSearch = new URLSearchParams(search);
+            autoSearch.set(AI_ROUTING_SEARCH_PARAM, AI_ROUTING_AUTO_VALUE);
             void navigate(
-                { pathname: `/projects/${projectUuid}/ai-agents`, search },
+                {
+                    pathname: `/projects/${projectUuid}/ai-agents`,
+                    search: autoSearch.toString(),
+                },
                 { viewTransition: true },
             );
         } else {
+            const agentSearch = new URLSearchParams(search);
+            agentSearch.delete(AI_ROUTING_SEARCH_PARAM);
             void navigate(
                 {
                     pathname: `/projects/${projectUuid}/ai-agents/${value}/threads`,
-                    search,
+                    search: agentSearch.toString(),
                 },
                 {
                     viewTransition: true,

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelectorUtils.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelectorUtils.tsx
@@ -6,6 +6,14 @@ import MantineIcon from '../../../../../components/common/MantineIcon';
 
 export type Agent = Pick<AiAgent, 'name' | 'uuid' | 'imageUrl'>;
 
+/**
+ * Marks an explicit "Auto" selection on the `/ai-agents` index URL so it shows
+ * the router even when the user has a default agent preference (which would
+ * otherwise take precedence on an implicit landing).
+ */
+export const AI_ROUTING_SEARCH_PARAM = 'routing';
+export const AI_ROUTING_AUTO_VALUE = 'auto';
+
 export interface AgentSelectOption extends ComboboxItem {
     imageUrl?: AiAgent['imageUrl'];
 }

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
@@ -18,8 +18,12 @@ import {
     IconPlus,
     IconRobot,
 } from '@tabler/icons-react';
-import { Link, Navigate, useParams } from 'react-router';
+import { Link, Navigate, useParams, useSearchParams } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
+import {
+    AI_ROUTING_AUTO_VALUE,
+    AI_ROUTING_SEARCH_PARAM,
+} from '../../features/aiCopilot/components/AgentSelector/AgentSelectorUtils';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiOrganizationSettings } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
@@ -67,8 +71,22 @@ const AiPageLoading = () => (
     </AiAgentPageLayout>
 );
 
+/**
+ * Index of `/ai-agents`. Decides where to start, in priority order:
+ *
+ * 1. No agents — render the welcome / empty state.
+ * 2. Exactly one agent — open it; there's no routing decision to make.
+ * 3. A valid default agent preference — open it, unless the user explicitly
+ *    asked for Auto (`?routing=auto`, set by the agent selector). A preference
+ *    pointing at a deleted agent is ignored.
+ * 4. Router enabled — show the auto-router (`AgentsRouterPage`).
+ * 5. Otherwise — open the first agent in the list.
+ */
 const AgentsWelcome = () => {
     const { projectUuid } = useParams();
+    const [searchParams] = useSearchParams();
+    const forceRouter =
+        searchParams.get(AI_ROUTING_SEARCH_PARAM) === AI_ROUTING_AUTO_VALUE;
     const canCreateAgent = useAiAgentPermission({
         action: 'manage',
         projectUuid,
@@ -113,27 +131,34 @@ const AgentsWelcome = () => {
         return <AiPageLoading />;
     }
 
+    const userDefaultAgentUuid =
+        userAgentPreferencesQuery.data?.defaultAgentUuid;
+    const hasValidUserDefault =
+        userDefaultAgentUuid !== undefined &&
+        agentsQuery.data.some((agent) => agent.uuid === userDefaultAgentUuid);
+
     if (agentsQuery.data.length === 0) {
         // Fall through to the empty state below.
     } else if (agentsQuery.data.length === 1) {
-        // Only one agent — no routing decision to make.
         return (
             <Navigate
                 to={`/projects/${projectUuid}/ai-agents/${agentsQuery.data[0].uuid}`}
                 replace
             />
         );
+    } else if (hasValidUserDefault && !forceRouter) {
+        return (
+            <Navigate
+                to={`/projects/${projectUuid}/ai-agents/${userDefaultAgentUuid}`}
+                replace
+            />
+        );
     } else if (aiRouterConfigQuery.data?.enabled) {
         return <AgentsRouterPage />;
     } else {
-        // Router disabled or not configured: prior behaviour — prefer the
-        // user's default agent, otherwise the first agent in the list.
-        const defaultAgentUuid =
-            userAgentPreferencesQuery.data?.defaultAgentUuid ??
-            agentsQuery.data[0].uuid;
         return (
             <Navigate
-                to={`/projects/${projectUuid}/ai-agents/${defaultAgentUuid}`}
+                to={`/projects/${projectUuid}/ai-agents/${agentsQuery.data[0].uuid}`}
                 replace
             />
         );


### PR DESCRIPTION
Closes: [PROD-8027](https://linear.app/lightdash/issue/PROD-8027/respect-users-default-agent-over-the-ai-router-on-the-agents-page)

### Description

The AI router auto-selects the best-fit agent based on the user's prompt, and it had become the default landing experience on `/ai-agents` — overriding a user's explicitly chosen default agent. This PR makes the default agent preference take precedence over the router's auto-selection, while keeping the router reachable on demand.

### What changed

The `/ai-agents` index (`AgentsWelcome`) now decides where to start in this priority order:

1. **No agents** — welcome / empty state.
2. **Exactly one agent** — open it.
3. **Valid default agent preference** — open it, _unless_ the user explicitly asked for Auto. A preference pointing at a deleted agent is ignored.
4. **Router enabled** — show the auto-router (`AgentsRouterPage`).
5. **Otherwise** — open the first agent.

Previously the router was checked before the preference, so an enabled router always won.

### Keeping "Auto" reachable

The agent selector's **Auto** option navigates to the bare `/ai-agents` index, so the new precedence would have made Auto unreachable for anyone with a default agent (it'd bounce straight back to their agent). To fix this:

- Picking **Auto** now sets a `?routing=auto` search param, which `AgentsWelcome` reads to force the router even when a default preference exists.
- Navigating to a specific agent strips the param so it doesn't leak into thread URLs.
- A search param (rather than transient router state) is used so the router survives a page refresh.

### Files

- `AgentsWelcome.tsx` — preference-before-router precedence; `forceRouter` override; ignores stale preferences.
- `AgentSelector.tsx` — sets `routing=auto` on explicit Auto; strips it for agent navigation.
- `AgentSelectorUtils.tsx` — shared `AI_ROUTING_SEARCH_PARAM` / `AI_ROUTING_AUTO_VALUE` constants.