### PR TITLE
fix(data-apps): truncate long names instead of overflowing into next column

### DIFF
--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -178,6 +178,7 @@ const MyAppsPanel: FC = () => {
                             c="inherit"
                             underline="hover"
                             truncate="end"
+                            display="block"
                         >
                             {displayName}
                         </Anchor>
@@ -232,6 +233,7 @@ const MyAppsPanel: FC = () => {
                             c="inherit"
                             underline="hover"
                             truncate="end"
+                            display="block"
                         >
                             {spaceName}
                         </Anchor>


### PR DESCRIPTION
### Description:
Mantine's truncate="end" only sets overflow/text-overflow/white-space — not display. Since <Anchor component={Link}> renders inline, max-width: 100% from .bodyCell > * was ignored and long names ran past the cell. Add display="block" so the existing max-width applies and the ellipsis kicks in.

<img width="2102" height="334" alt="image" src="https://github.com/user-attachments/assets/69e5b559-8d55-4984-bb02-2fb31b19942e" />
