### PR TITLE
feat(ai-router): add analytics tracking for router config, instructions, and message routing events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -26,6 +26,8 @@ import {
     TableSelectionType,
     ValidateProjectPayload,
     WarehouseTypes,
+    type AiRouterDecisionConfidence,
+    type AiRouterRouteNextAction,
     type DataAppClaudeModel,
 } from '@lightdash/common';
 import Analytics, {
@@ -2120,6 +2122,39 @@ export type AiAgentPullRequestViewedEvent = BaseTrack & {
     };
 };
 
+export type AiRouterConfigUpdatedEvent = BaseTrack & {
+    event: 'ai_router.config_updated';
+    userId: string;
+    properties: {
+        organizationId: string;
+        enabled: boolean;
+        projectsCount: number;
+    };
+};
+
+export type AiRouterInstructionsUpdatedEvent = BaseTrack & {
+    event: 'ai_router.instructions_updated';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        instructionLength: number;
+        taggedAgentsCount: number;
+    };
+};
+
+export type AiRouterMessageRoutedEvent = BaseTrack & {
+    event: 'ai_router.message_routed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        confidence: AiRouterDecisionConfidence;
+        nextAction: AiRouterRouteNextAction;
+        candidatesCount: number;
+    };
+};
+
 export type SchedulerOwnershipReassignedEvent = BaseTrack & {
     event: 'scheduler.ownership_reassigned';
     properties: {
@@ -2267,6 +2302,9 @@ type TypedEvent =
     | AiAgentSuggestionClickEvent
     | AiAgentSuggestionSubmitEvent
     | AiAgentPullRequestViewedEvent
+    | AiRouterConfigUpdatedEvent
+    | AiRouterInstructionsUpdatedEvent
+    | AiRouterMessageRoutedEvent
     | ContentVerificationEvent
     | SchedulerOwnershipReassignedEvent
     | ImpersonationEvent;

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -213,6 +213,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 }),
             aiRouterService: ({ models, repository, context }) =>
                 new AiRouterService({
+                    analytics: context.lightdashAnalytics,
                     lightdashConfig: context.lightdashConfig,
                     aiRouterModel: models.getAiRouterModel<AiRouterModel>(),
                     aiAgentService:

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -13,6 +13,12 @@ import {
     type UpsertAiRouterInstructionRequest,
     type UpsertAiRouterRequest,
 } from '@lightdash/common';
+import {
+    type AiRouterConfigUpdatedEvent,
+    type AiRouterInstructionsUpdatedEvent,
+    type AiRouterMessageRoutedEvent,
+    type LightdashAnalytics,
+} from '../../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../../config/parseConfig';
 import { BaseService } from '../../../services/BaseService';
 import { type AiRouterModel } from '../../models/AiRouterModel';
@@ -21,20 +27,29 @@ import { getModel } from '../ai/models';
 import { type AiAgentService } from '../AiAgentService/AiAgentService';
 
 type Deps = {
+    analytics: LightdashAnalytics;
     lightdashConfig: LightdashConfig;
     aiRouterModel: AiRouterModel;
     aiAgentService: AiAgentService;
 };
 
 export class AiRouterService extends BaseService {
+    private readonly analytics: LightdashAnalytics;
+
     private readonly lightdashConfig: LightdashConfig;
 
     private readonly aiRouterModel: AiRouterModel;
 
     private readonly aiAgentService: AiAgentService;
 
-    constructor({ lightdashConfig, aiRouterModel, aiAgentService }: Deps) {
+    constructor({
+        analytics,
+        lightdashConfig,
+        aiRouterModel,
+        aiAgentService,
+    }: Deps) {
         super({ serviceName: 'AiRouterService' });
+        this.analytics = analytics;
         this.lightdashConfig = lightdashConfig;
         this.aiRouterModel = aiRouterModel;
         this.aiAgentService = aiAgentService;
@@ -98,11 +113,23 @@ export class AiRouterService extends BaseService {
     ): Promise<AiRouter> {
         const organizationUuid = AiRouterService.organizationUuidOf(account);
         this.assertManageAiAgent(account, organizationUuid);
-        return this.aiRouterModel.upsert({
+        const router = await this.aiRouterModel.upsert({
             organizationUuid,
             enabled: body.enabled,
             projectUuids: body.projectUuids,
         });
+
+        this.analytics.track<AiRouterConfigUpdatedEvent>({
+            event: 'ai_router.config_updated',
+            userId: account.user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                enabled: router.enabled,
+                projectsCount: router.projectUuids.length,
+            },
+        });
+
+        return router;
     }
 
     async getInstruction(
@@ -160,12 +187,25 @@ export class AiRouterService extends BaseService {
 
         const router = await this.aiRouterModel.upsert({ organizationUuid });
 
-        return this.aiRouterModel.createInstructionVersion({
+        const instruction = await this.aiRouterModel.createInstructionVersion({
             routerUuid: router.routerUuid,
             projectUuid,
             instruction: body.instruction,
             taggedAgentUuids: body.taggedAgentUuids,
         });
+
+        this.analytics.track<AiRouterInstructionsUpdatedEvent>({
+            event: 'ai_router.instructions_updated',
+            userId: account.user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                instructionLength: body.instruction.length,
+                taggedAgentsCount: body.taggedAgentUuids.length,
+            },
+        });
+
+        return instruction;
     }
 
     async listDecisions(
@@ -240,6 +280,18 @@ export class AiRouterService extends BaseService {
             confidence: brain.confidence,
             reasoning: brain.reasoning,
             candidateAgentUuids: candidates.map((c) => c.uuid),
+        });
+
+        this.analytics.track<AiRouterMessageRoutedEvent>({
+            event: 'ai_router.message_routed',
+            userId: account.user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                confidence: brain.confidence,
+                nextAction,
+                candidatesCount: candidates.length,
+            },
         });
 
         return {


### PR DESCRIPTION
Closes: ZAP-463

### Description:

Adds backend analytics tracking for the AI Router feature, which previously shipped with no observability. Follows the existing `ai_agent.*` event conventions in `LightdashAnalytics`.

Three new events:

- **`ai_router.config_updated`** — emitted when the router is enabled/disabled or its project scope changes (`enabled`, `projectsCount`).
- **`ai_router.instructions_updated`** — emitted when per-project routing instructions are saved (`projectId`, `instructionLength`, `taggedAgentsCount`).
- **`ai_router.message_routed`** — emitted when a prompt is routed (`projectId`, `confidence`, `nextAction`, `candidatesCount`). `confidence` + `nextAction` together show how often high-confidence auto-routing actually fires vs. falling back to the picker.

### Changes

- `LightdashAnalytics.ts` — define the three event types and register them in the `TypedEvent` union.
- `ee/index.ts` — inject `lightdashAnalytics` into the `AiRouterService` provider (it wasn't receiving analytics before).
- `AiRouterService.ts` — emit the events from `upsertConfig`, `upsertInstruction`, and `route`.

No API regeneration needed — controller signatures and return types are unchanged.
