### PR TITLE
refactor(ai-agents): rename `url` to `href` and add canonical content links to tool results

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4954,6 +4954,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 projectUuid,
             });
 
+        const getContentUrl = (type: 'dashboard' | 'chart', slug: string) => {
+            switch (type) {
+                case 'dashboard':
+                    return `/projects/${projectUuid}/dashboards/${slug}/view`;
+                case 'chart':
+                    return `/projects/${projectUuid}/saved/${slug}/view`;
+                default:
+                    return assertUnreachable(type, 'Invalid content type');
+            }
+        };
+
         const readContent: ReadContentFn = ({ slug, type }) =>
             wrapSentryTransaction(
                 'AiAgent.readContent',
@@ -4978,6 +4989,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             return {
                                 type: 'dashboard',
                                 content: dashboard,
+                                href: getContentUrl(
+                                    'dashboard',
+                                    dashboard.slug,
+                                ),
                             };
                         }
                         case 'chart': {
@@ -4998,6 +5013,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             return {
                                 type: 'chart',
                                 content: chart,
+                                href: getContentUrl('chart', chart.slug),
                             };
                         }
                         default:
@@ -5090,13 +5106,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             return {
                                 ...editedContent,
                                 uuid,
-                                url: `/projects/${projectUuid}/dashboards/${editedContent.content.slug}`,
+                                href: getContentUrl(
+                                    'dashboard',
+                                    editedContent.content.slug,
+                                ),
                             };
                         case 'chart':
                             return {
                                 ...editedContent,
                                 uuid,
-                                url: `/projects/${projectUuid}/saved/${editedContent.content.slug}`,
+                                href: getContentUrl(
+                                    'chart',
+                                    editedContent.content.slug,
+                                ),
                             };
                         default:
                             return assertUnreachable(
@@ -5145,7 +5167,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             return {
                                 ...createdContent,
                                 uuid,
-                                url: `/projects/${projectUuid}/dashboards/${finalSlug}`,
+                                href: getContentUrl('dashboard', finalSlug),
                             };
                         }
                         case 'chart': {
@@ -5177,7 +5199,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             return {
                                 ...createdContent,
                                 uuid,
-                                url: `/projects/${projectUuid}/saved/${finalSlug}`,
+                                href: getContentUrl('chart', finalSlug),
                             };
                         }
                         default:

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -545,6 +545,9 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
             {
               "additionalProperties": false,
               "properties": {
+                "href": {
+                  "type": "string",
+                },
                 "name": {
                   "type": "string",
                 },
@@ -553,9 +556,6 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                 },
                 "status": {
                   "const": "success",
-                  "type": "string",
-                },
-                "url": {
                   "type": "string",
                 },
                 "uuid": {
@@ -567,7 +567,7 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                 "slug",
                 "name",
                 "uuid",
-                "url",
+                "href",
               ],
               "type": "object",
             },
@@ -636,6 +636,9 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
             {
               "additionalProperties": false,
               "properties": {
+                "href": {
+                  "type": "string",
+                },
                 "name": {
                   "type": "string",
                 },
@@ -644,9 +647,6 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                 },
                 "status": {
                   "const": "success",
-                  "type": "string",
-                },
-                "url": {
                   "type": "string",
                 },
                 "uuid": {
@@ -658,7 +658,7 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                 "slug",
                 "name",
                 "uuid",
-                "url",
+                "href",
               ],
               "type": "object",
             },
@@ -4562,20 +4562,46 @@ Even if only the part is being changed, make sure to pass the entire value with 
       "additionalProperties": false,
       "properties": {
         "metadata": {
-          "additionalProperties": false,
-          "properties": {
-            "status": {
-              "enum": [
-                "success",
-                "error",
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "const": "error",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
               ],
-              "type": "string",
+              "type": "object",
             },
-          },
-          "required": [
-            "status",
+            {
+              "additionalProperties": false,
+              "properties": {
+                "href": {
+                  "type": "string",
+                },
+                "name": {
+                  "type": "string",
+                },
+                "slug": {
+                  "type": "string",
+                },
+                "status": {
+                  "const": "success",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+                "slug",
+                "name",
+                "href",
+              ],
+              "type": "object",
+            },
           ],
-          "type": "object",
         },
         "result": {
           "type": "string",

--- a/packages/backend/src/ee/services/ai/tools/createContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/createContent.ts
@@ -10,6 +10,16 @@ type Dependencies = {
 
 const toolDefinition = createContentToolDefinition.for('agent');
 
+const contentResult = ({
+    content,
+    href,
+    type,
+}: {
+    content: unknown;
+    href: string;
+    type: 'dashboard' | 'chart';
+}) => `<${type} href="${href}" />\n---\n${JSON.stringify(content, null, 2)}`;
+
 export const getCreateContent = ({ createContent }: Dependencies) =>
     tool({
         ...toolDefinition,
@@ -19,16 +29,21 @@ export const getCreateContent = ({ createContent }: Dependencies) =>
                     type,
                     content,
                 } as Parameters<CreateContentFn>[0]);
+                const metadata = {
+                    status: 'success' as const,
+                    slug: result.content.slug,
+                    name: result.content.name,
+                    uuid: result.uuid,
+                    href: result.href,
+                };
 
                 return {
-                    result: JSON.stringify(result.content, null, 2),
-                    metadata: {
-                        status: 'success' as const,
-                        slug: result.content.slug,
-                        name: result.content.name,
-                        uuid: result.uuid,
-                        url: result.url,
-                    },
+                    result: contentResult({
+                        content: result.content,
+                        href: metadata.href,
+                        type: result.type,
+                    }),
+                    metadata,
                 };
             } catch (error) {
                 return {

--- a/packages/backend/src/ee/services/ai/tools/editContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/editContent.ts
@@ -10,22 +10,37 @@ type Dependencies = {
 
 const toolDefinition = editContentToolDefinition.for('agent');
 
+const contentResult = ({
+    content,
+    href,
+    type,
+}: {
+    content: unknown;
+    href: string;
+    type: 'dashboard' | 'chart';
+}) => `<${type} href="${href}" />\n---\n${JSON.stringify(content, null, 2)}`;
+
 export const getEditContent = ({ editContent }: Dependencies) =>
     tool({
         ...toolDefinition,
         execute: async ({ slug, type, patch }) => {
             try {
                 const result = await editContent({ slug, type, patch });
+                const metadata = {
+                    status: 'success' as const,
+                    slug: result.content.slug,
+                    name: result.content.name,
+                    uuid: result.uuid,
+                    href: result.href,
+                };
 
                 return {
-                    result: JSON.stringify(result.content, null, 2),
-                    metadata: {
-                        status: 'success' as const,
-                        slug: result.content.slug,
-                        name: result.content.name,
-                        uuid: result.uuid,
-                        url: result.url,
-                    },
+                    result: contentResult({
+                        content: result.content,
+                        href: metadata.href,
+                        type: result.type,
+                    }),
+                    metadata,
                 };
             } catch (error) {
                 return {

--- a/packages/backend/src/ee/services/ai/tools/readContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/readContent.ts
@@ -10,18 +10,36 @@ type Dependencies = {
 
 const toolDefinition = readContentToolDefinition.for('agent');
 
+const contentResult = ({
+    content,
+    href,
+    type,
+}: {
+    content: unknown;
+    href: string;
+    type: 'dashboard' | 'chart';
+}) => `<${type} href="${href}" />\n---\n${JSON.stringify(content, null, 2)}`;
+
 export const getReadContent = ({ readContent }: Dependencies) =>
     tool({
         ...toolDefinition,
         execute: async ({ slug, type }) => {
             try {
                 const result = await readContent({ slug, type });
+                const metadata = {
+                    status: 'success' as const,
+                    slug: result.content.slug,
+                    name: result.content.name,
+                    href: result.href,
+                };
 
                 return {
-                    result: JSON.stringify(result.content, null, 2),
-                    metadata: {
-                        status: 'success' as const,
-                    },
+                    result: contentResult({
+                        content: result.content,
+                        href: metadata.href,
+                        type: result.type,
+                    }),
+                    metadata,
                 };
             } catch (error) {
                 return {

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -144,10 +144,12 @@ export type ReadContentFn = (args: {
     | {
           type: 'dashboard';
           content: DashboardAsCode;
+          href: string;
       }
     | {
           type: 'chart';
           content: ChartAsCode;
+          href: string;
       }
 >;
 
@@ -160,13 +162,13 @@ export type EditContentFn = (args: {
           type: 'dashboard';
           content: DashboardAsCode;
           uuid: string;
-          url: string;
+          href: string;
       }
     | {
           type: 'chart';
           content: ChartAsCode;
           uuid: string;
-          url: string;
+          href: string;
       }
 >;
 
@@ -185,13 +187,13 @@ export type CreateContentFn = (args: CreateContentArgs) => Promise<
           type: 'dashboard';
           content: DashboardAsCode;
           uuid: string;
-          url: string;
+          href: string;
       }
     | {
           type: 'chart';
           content: ChartAsCode;
           uuid: string;
-          url: string;
+          href: string;
       }
 >;
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolCreateContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolCreateContentArgs.ts
@@ -60,7 +60,7 @@ const toolCreateContentMetadataSchema = z.discriminatedUnion('status', [
         slug: z.string(),
         name: z.string(),
         uuid: z.string(),
-        url: z.string(),
+        href: z.string(),
     }),
 ]);
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditContentArgs.ts
@@ -22,7 +22,7 @@ const toolEditContentMetadataSchema = z.discriminatedUnion('status', [
         slug: z.string(),
         name: z.string(),
         uuid: z.string(),
-        url: z.string(),
+        href: z.string(),
     }),
 ]);
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolReadContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolReadContentArgs.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { baseOutputMetadataSchema } from '../outputMetadata';
 
 export const TOOL_READ_CONTENT_DESCRIPTION =
     'Read a dashboard or chart as JSON using its slug. Call this before editing.';
@@ -11,9 +10,19 @@ export const toolReadContentArgsSchema = z.object({
         .describe('Type of Lightdash content to read.'),
 });
 
+const toolReadContentMetadataSchema = z.discriminatedUnion('status', [
+    z.object({ status: z.literal('error') }),
+    z.object({
+        status: z.literal('success'),
+        slug: z.string(),
+        name: z.string(),
+        href: z.string(),
+    }),
+]);
+
 export const toolReadContentOutputSchema = z.object({
     result: z.string(),
-    metadata: baseOutputMetadataSchema,
+    metadata: toolReadContentMetadataSchema,
 });
 
 export type ToolReadContentArgs = z.infer<typeof toolReadContentArgsSchema>;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.test.ts
@@ -1,0 +1,55 @@
+import { type Element, type Root } from 'hast';
+import { describe, expect, it } from 'vitest';
+import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
+
+const linkTree = (href: string): Root => ({
+    type: 'root',
+    children: [
+        {
+            type: 'element',
+            tagName: 'a',
+            properties: { href },
+            children: [],
+        },
+    ],
+});
+
+const processHref = (href: string) => {
+    const tree = linkTree(href);
+    rehypeAiAgentContentLinks()(tree);
+    return (tree.children[0] as Element).properties;
+};
+
+describe('rehypeAiAgentContentLinks', () => {
+    it('marks canonical dashboard links', () => {
+        expect(
+            processHref(
+                '/projects/project-uuid/dashboards/dashboard-slug/view?tab=1',
+            ),
+        ).toMatchObject({
+            href: '/projects/project-uuid/dashboards/dashboard-slug/view?tab=1',
+            'data-content-type': 'dashboard-link',
+            'data-dashboard-uuid': 'dashboard-slug',
+        });
+    });
+
+    it('marks canonical saved chart links', () => {
+        expect(
+            processHref('/projects/project-uuid/saved/chart-slug/view#section'),
+        ).toMatchObject({
+            href: '/projects/project-uuid/saved/chart-slug/view#section',
+            'data-content-type': 'chart-link',
+            'data-chart-uuid': 'chart-slug',
+        });
+    });
+
+    it('marks canonical sql runner links', () => {
+        expect(
+            processHref('/projects/project-uuid/sql-runner/sql-chart-slug'),
+        ).toMatchObject({
+            href: '/projects/project-uuid/sql-runner/sql-chart-slug',
+            'data-content-type': 'chart-link',
+            'data-chart-uuid': 'sql-chart-slug',
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.ts
@@ -69,7 +69,42 @@ const LINK_PROCESSORS: LinkProcessor[] = [
 
 const processLink = (node: Element, href: string): void => {
     const processor = LINK_PROCESSORS.find((p) => href.includes(p.fragment));
-    if (!processor) return;
+    if (!processor) {
+        const dashboardMatch = href.match(
+            /\/projects\/[^/]+\/dashboards\/([^/]+)\/view/,
+        );
+        const chartMatch = href.match(
+            /\/projects\/[^/]+\/saved\/([^/]+)\/view/,
+        );
+        const sqlRunnerMatch = href.match(
+            /\/projects\/[^/]+\/sql-runner\/([^/#?]+)/,
+        );
+
+        if (dashboardMatch) {
+            node.properties = {
+                ...node.properties,
+                'data-content-type': 'dashboard-link',
+                'data-dashboard-uuid': dashboardMatch[1],
+                href,
+            };
+        } else if (chartMatch) {
+            node.properties = {
+                ...node.properties,
+                'data-content-type': 'chart-link',
+                'data-chart-uuid': chartMatch[1],
+                href,
+            };
+        } else if (sqlRunnerMatch) {
+            node.properties = {
+                ...node.properties,
+                'data-content-type': 'chart-link',
+                'data-chart-uuid': sqlRunnerMatch[1],
+                href,
+            };
+        }
+
+        return;
+    }
 
     node.properties = {
         ...node.properties,

--- a/packages/frontend/src/ee/features/aiCopilot/utils/contentToolResultNavigation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/contentToolResultNavigation.ts
@@ -18,51 +18,26 @@ const isSameLocation = (targetUrl: string, location: LocationLike): boolean => {
     );
 };
 
-const getDashboardSlugFromContentToolResult = (
+const getDashboardUrlFromContentToolResult = (
     toolResult: AiAgentToolResult,
 ): string | null => {
     if (toolResult.isPreliminary) return null;
 
-    switch (toolResult.toolName) {
-        case 'createContent':
-            if (toolResult.toolArgs.type !== 'dashboard') return null;
-            if (toolResult.toolResult.metadata.status !== 'success')
-                return null;
+    if (toolResult.toolName === 'createContent') {
+        if (toolResult.toolArgs.type !== 'dashboard') return null;
+        if (toolResult.toolResult.metadata.status !== 'success') return null;
 
-            return (
-                toolResult.toolResult.metadata.slug ??
-                toolResult.toolArgs.content.slug
-            );
-        case 'editContent':
-            if (toolResult.toolArgs.type !== 'dashboard') return null;
-            if (toolResult.toolResult.metadata.status !== 'success')
-                return null;
-
-            return (
-                toolResult.toolResult.metadata.slug ?? toolResult.toolArgs.slug
-            );
-        default:
-            return null;
-    }
-};
-
-const getDashboardUrlFromContentToolResult = (
-    projectUuid: string,
-    toolResult: AiAgentToolResult,
-): string | null => {
-    if (
-        (toolResult.toolName === 'createContent' ||
-            toolResult.toolName === 'editContent') &&
-        toolResult.toolArgs.type === 'dashboard' &&
-        toolResult.toolResult.metadata.status === 'success'
-    ) {
-        return toolResult.toolResult.metadata.url;
+        return toolResult.toolResult.metadata.href;
     }
 
-    const dashboardSlug = getDashboardSlugFromContentToolResult(toolResult);
-    return dashboardSlug
-        ? `/projects/${projectUuid}/dashboards/${dashboardSlug}`
-        : null;
+    if (toolResult.toolName === 'editContent') {
+        if (toolResult.toolArgs.type !== 'dashboard') return null;
+        if (toolResult.toolResult.metadata.status !== 'success') return null;
+
+        return toolResult.toolResult.metadata.href;
+    }
+
+    return null;
 };
 
 export const getDashboardNavigationUrlFromContentToolResult = (
@@ -70,10 +45,7 @@ export const getDashboardNavigationUrlFromContentToolResult = (
     toolResult: AiAgentToolResult,
     location: LocationLike = window.location,
 ): string | null => {
-    const dashboardUrl = getDashboardUrlFromContentToolResult(
-        projectUuid,
-        toolResult,
-    );
+    const dashboardUrl = getDashboardUrlFromContentToolResult(toolResult);
     if (!dashboardUrl || isSameLocation(dashboardUrl, location)) return null;
 
     return dashboardUrl;


### PR DESCRIPTION
## Summary
- Return canonical project-scoped `href` metadata from `readContent`, `editContent`, and `createContent`.
- Include a `href` XML header in content tool result text so agents can link without inventing routes.
- Update AI chat content-link parsing/navigation to handle canonical dashboard, saved chart, and SQL runner paths.

## Testing
- `pnpm -F common build`
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- `pnpm -F backend test -- agentToolContracts.snapshot.test.ts --runInBand`
- `pnpm exec vitest run src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.test.ts`

Closes: ZAP-461