### PR TITLE
feat(data-apps): show on-chart value labels by default in PDF reports

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -23,6 +23,7 @@ Build a print-optimized report:
 - Set \`@page { margin: 0; size: A4 }\` so the design fills the sheet edge-to-edge — apply your own padding inside each page (e.g. \`p-12\`) instead of relying on the browser's default page margin (which is ugly and shrinks the canvas).
 - Use a clean, document-style typography hierarchy (title, section headings, body).
 - Render charts at fixed widths so they reflow across pages cleanly.
+- The app itself stays fully interactive (hover tooltips, the "Filter by <value>" action menu, etc.) — keep all of it. But the *exported* PDF is static: readers of the printed page can't hover, so any value only available via tooltip is lost. So **in addition to** the normal interactivity, draw the numbers on the chart: \`<LabelList>\` on bars, and labeled or end-of-line point labels on lines. Keep them legible — compact-format the numbers (e.g. \`1.2K\`, \`$1.3M\`) and avoid overlap on dense series.
 - Include a title page header (title, subtitle, generated-on date) and section dividers.
 - Apply CSS \`@media print\` rules and \`page-break-inside: avoid\` on cards and figures.
 - Note: browsers may inject their own header/footer on printed pages (URL, page number, date), controlled by the user's print dialog — not removable via CSS. Keep critical content away from the very top and bottom edges so it doesn't sit underneath.

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -495,6 +495,23 @@ const dateCol = getColumn(columns, 'order_date_month');
 
 **Self-check before declaring done:** grep the generated app for `<XAxis` and `<YAxis`. Every match must have a `tickFormatter` prop. If any axis is missing one, fix it before reporting the build complete — claiming "all axes formatted" without verifying is the most common way this lands broken.
 
+#### Chart value labels
+
+By default the value behind a bar or point is read by hovering for the tooltip, so leave labels off to avoid clutter — the chart stays interactive either way. The exception is when the chart's output will be read **statically**, e.g. exported or printed to PDF: there's no hover on a printed page, so any tooltip-only value is lost. In that case draw the numbers on the chart with `<LabelList>` **in addition to** the tooltip and any "Filter by &lt;value&gt;" interactions — labels are additive, they don't replace interactivity. Use a `formatter` so labels match the axis/tooltip formatting, and keep them compact to avoid overlap on dense series.
+
+```tsx
+import { Bar, LabelList } from 'recharts';
+import { formatNumber } from '@/lib/format';
+
+<Bar dataKey="total_revenue" fill={CHART_COLORS[0]}>
+    <LabelList
+        dataKey="total_revenue"
+        position="top"
+        formatter={(v) => formatNumber(v, 'axis')}
+    />
+</Bar>
+```
+
 #### Tables
 
 Use `formatField` for cells so dates render `Jun 16, 2025` instead of `2025-06-16`, while currency/percent metrics still flow through the SDK's server format:


### PR DESCRIPTION
Closes #23714

### Description:
PDF/print output is static — readers can't hover for tooltips, so any value only available via tooltip is lost on the exported page. Instruct the PDF-report template (and add a generic LabelList example to the skill) to draw value labels on charts in addition to the existing interactivity (tooltips, "Filter by <value>" action menu), which is preserved.

<img width="771" height="541" alt="Screenshot 2026-06-01 at 15 36 14" src="https://github.com/user-attachments/assets/0506aeae-9a9d-4b56-9ab7-4b78b079cdec" />


