### PR TITLE
fix(validation): treat table calc filters as usage

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -589,12 +589,13 @@ export class ValidationService extends BaseService {
                             chartType,
                             chartConfig,
                             queryTableCalculations: tableCalculations,
+                            tableCalculationFilters: filters.tableCalculations,
                         });
 
                     const unusedTableCalculationErrors: CreateChartValidation[] =
                         unusedTableCalculations.map((tc) => ({
                             ...commonValidation,
-                            error: `table calculation is not used in the chart configuration (x-axis or y-axis). This can cause incorrect rendering. We recommend removing unused fields.`,
+                            error: `table calculation is not used in the chart configuration (x-axis, y-axis, or table calculation filters). This can cause incorrect rendering. We recommend removing unused fields.`,
                             errorType: ValidationErrorType.ChartConfiguration,
                             fieldName: tc,
                         }));

--- a/packages/common/src/utils/chartValidation.test.ts
+++ b/packages/common/src/utils/chartValidation.test.ts
@@ -1,0 +1,48 @@
+import { FilterOperator } from '../types/filter';
+import { ChartType } from '../types/savedCharts';
+import { getUnusedTableCalculations } from './chartValidation';
+
+describe('getUnusedTableCalculations', () => {
+    it('does not mark table calculations used by table calculation filters as unused', () => {
+        const result = getUnusedTableCalculations({
+            chartType: ChartType.CARTESIAN,
+            chartConfig: {
+                layout: {
+                    xField: 'orders_created_week',
+                    yField: ['running_total'],
+                },
+                eChartsConfig: {},
+            },
+            queryTableCalculations: ['running_total', 'after_date'],
+            tableCalculationFilters: {
+                id: 'table-calculation-filters',
+                and: [
+                    {
+                        id: 'after-date-filter',
+                        target: { fieldId: 'after_date' },
+                        operator: FilterOperator.EQUALS,
+                        values: [true],
+                    },
+                ],
+            },
+        });
+
+        expect(result.unusedTableCalculations).toEqual([]);
+    });
+
+    it('marks table calculations unused when they are not on axes or in filters', () => {
+        const result = getUnusedTableCalculations({
+            chartType: ChartType.CARTESIAN,
+            chartConfig: {
+                layout: {
+                    xField: 'orders_created_week',
+                    yField: ['running_total'],
+                },
+                eChartsConfig: {},
+            },
+            queryTableCalculations: ['running_total', 'helper_calc'],
+        });
+
+        expect(result.unusedTableCalculations).toEqual(['helper_calc']);
+    });
+});

--- a/packages/common/src/utils/chartValidation.ts
+++ b/packages/common/src/utils/chartValidation.ts
@@ -1,3 +1,4 @@
+import { flattenFilterGroup, type FilterGroup } from '../types/filter';
 import {
     ChartType,
     type CartesianChart,
@@ -96,6 +97,8 @@ export type UnusedTableCalculationsInput = {
     chartConfig: ChartConfig['config'] | undefined;
     /** All table calculation names in the metric query */
     queryTableCalculations: string[];
+    /** Table calculation filters that can reference helper table calculations */
+    tableCalculationFilters?: FilterGroup;
 };
 
 /**
@@ -104,6 +107,7 @@ export type UnusedTableCalculationsInput = {
  * For cartesian charts, table calculations should be used in one of:
  * - x-axis (xField)
  * - y-axis (yField)
+ * - table calculation filters
  *
  * If a table calculation is in the query but not used in any of these places,
  * it may cause incorrect results (extra rows that don't aggregate properly).
@@ -115,7 +119,12 @@ export function getUnusedTableCalculations(
 ): {
     unusedTableCalculations: string[];
 } {
-    const { chartType, chartConfig, queryTableCalculations } = input;
+    const {
+        chartType,
+        chartConfig,
+        queryTableCalculations,
+        tableCalculationFilters,
+    } = input;
 
     if (chartType !== ChartType.CARTESIAN) {
         return { unusedTableCalculations: [] };
@@ -142,6 +151,16 @@ export function getUnusedTableCalculations(
             if (queryTableCalculations.includes(field)) {
                 usedTableCalculations.add(field);
             }
+        }
+    }
+
+    const tableCalculationFilterRules = tableCalculationFilters
+        ? flattenFilterGroup(tableCalculationFilters)
+        : [];
+    for (const filter of tableCalculationFilterRules) {
+        const fieldId = filter.target?.fieldId;
+        if (fieldId && queryTableCalculations.includes(fieldId)) {
+            usedTableCalculations.add(fieldId);
         }
     }
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
@@ -97,8 +97,11 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
             chartType: chartConfig.type,
             chartConfig: chartConfig.config,
             queryTableCalculations: tableCalcNames,
+            tableCalculationFilters:
+                resultsData?.metricQuery?.filters?.tableCalculations,
         });
     }, [
+        resultsData?.metricQuery?.filters?.tableCalculations,
         resultsData?.metricQuery?.tableCalculations,
         chartConfig?.type,
         chartConfig.config,
@@ -117,7 +120,7 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
         }
         if (shouldShowUnusedTableCalcs) {
             _messages.push(
-                'Your query includes table calculations that are not used in the chart configuration (x-axis or y-axis). Remove them from the query to avoid incorrect results unless you are using them intentionally.',
+                'Your query includes table calculations that are not used in the chart configuration (x-axis, y-axis, or table calculation filters). Remove them from the query to avoid incorrect results unless you are using them intentionally.',
             );
         }
         if (shouldShowPivotMismatch) {


### PR DESCRIPTION
## Summary

- Treat table calculations referenced by `metricQuery.filters.tableCalculations` as used by cartesian charts.
- Pass table calculation filters into backend validation and frontend visualization warnings.
- Add a regression test covering filter-only table calculation helpers.

## Root cause

The unused table calculation validator only checked cartesian chart axes. A table calculation used only as a table calculation filter could be reported as unused, even though it affects post-table-calculation filtering semantics.

## Validation

- `corepack pnpm -F common test -- chartValidation.test.ts --runInBand`
- `corepack pnpm -F common typecheck`
- `corepack pnpm -F common build`
- `corepack pnpm -F backend typecheck`
- `corepack pnpm -F frontend typecheck`
- targeted lint/format checks for touched files
- `git diff --check`