### PR TITLE
fix: skip service account lookup when feature is disabled

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -165,14 +165,17 @@ describe('UserService', () => {
             expect(userModel.findSessionUserByUUID).toHaveBeenCalledWith(
                 'userUuid',
             );
-            expect(userModel.findServiceAccountByUserUuid).toHaveBeenCalledWith(
-                'userUuid',
-            );
             expect(account.isSessionUser()).toBe(true);
             expect(account.isServiceAccount()).toBe(false);
         });
 
         test('should return a service account when the user backs a service account', async () => {
+            const service = createUserService({
+                ...lightdashConfigMock,
+                serviceAccount: {
+                    enabled: true,
+                },
+            });
             (
                 userModel.findServiceAccountByUserUuid as jest.Mock
             ).mockResolvedValueOnce({
@@ -182,7 +185,7 @@ describe('UserService', () => {
                 organizationUuid: sessionUser.organizationUuid,
             });
 
-            const account = await userService.getAccountByUserUuid('userUuid');
+            const account = await service.getAccountByUserUuid('userUuid');
 
             expect(account.isServiceAccount()).toBe(true);
             expect(account.authentication).toMatchObject({

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1689,6 +1689,11 @@ export class UserService extends BaseService {
 
     async getAccountByUserUuid(userUuid: string): Promise<RegisteredAccount> {
         const sessionUser = await this.getSessionByUserUuid(userUuid);
+
+        if (!this.lightdashConfig.serviceAccount.enabled) {
+            return AccountFactory.fromSession(sessionUser);
+        }
+
         const serviceAccount =
             await this.userModel.findServiceAccountByUserUuid(userUuid);
 


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/23724

### Description:

When service accounts are disabled in the Lightdash config, `getAccountByUserUuid` now returns early with a session-based account, skipping the unnecessary `findServiceAccountByUserUuid` database lookup. Tests have been updated to reflect this behavior, ensuring the service account lookup is only triggered when the feature is explicitly enabled.