### PR TITLE
feat(ai-writeback): record pull request rows for the AI write-back path

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -70,15 +70,16 @@ export type DbAiWritebackThread = {
     ai_writeback_thread_uuid: string;
     ai_thread_uuid: string;
     sandbox_id: string;
-    pr_url: string;
     pull_request_uuid: string | null;
     created_at: Date;
 };
 
 export type AiWritebackThreadTable = Knex.CompositeTableType<
     DbAiWritebackThread,
-    Pick<DbAiWritebackThread, 'ai_thread_uuid' | 'sandbox_id' | 'pr_url'> &
-        Partial<Pick<DbAiWritebackThread, 'pull_request_uuid'>>,
+    Pick<
+        DbAiWritebackThread,
+        'ai_thread_uuid' | 'sandbox_id' | 'pull_request_uuid'
+    >,
     Pick<DbAiWritebackThread, 'sandbox_id' | 'pull_request_uuid'>
 >;
 

--- a/packages/backend/src/ee/database/migrations/20260601130000_backfill_pull_requests_from_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260601130000_backfill_pull_requests_from_ai_writeback_thread.ts
@@ -1,0 +1,203 @@
+import { Knex } from 'knex';
+
+const AiWritebackThreadTableName = 'ai_writeback_thread';
+const AiThreadTableName = 'ai_thread';
+const AiPromptTableName = 'ai_prompt';
+const PullRequestsTableName = 'pull_requests';
+
+// Backfill source for AI write-back PRs — must match PullRequestSource.AI_AGENT.
+const AI_AGENT_SOURCE = 'ai_agent';
+
+// Local row shapes so the query builders don't resolve to the registered
+// `knex/types/tables` composite types — keeping this migration decoupled from
+// the live entity definitions (which enforce enum columns and restrict the
+// insert/update shape) so it can't break when those types evolve.
+type PullRequestRow = {
+    pull_request_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    created_by_user_uuid: string | null;
+    provider: string;
+    source: string;
+    owner: string;
+    repo: string;
+    pr_number: number;
+    pr_url: string;
+    created_at: Date;
+};
+
+type WritebackRow = {
+    ai_writeback_thread_uuid: string;
+    ai_thread_uuid: string;
+    pr_url: string;
+    created_at: Date;
+    pull_request_uuid: string | null;
+};
+
+type ParsedPrUrl = {
+    provider: 'github' | 'gitlab';
+    owner: string;
+    repo: string;
+    prNumber: number;
+};
+
+/**
+ * Parse owner/repo/number out of a GitHub PR or GitLab merge-request URL.
+ * GitLab nests the project under a group path and uses `/-/merge_requests/`;
+ * we collapse the group/subgroup path into `owner` and keep the final segment
+ * as `repo`. Returns null for anything we can't confidently parse.
+ */
+const parsePrUrl = (prUrl: string): ParsedPrUrl | null => {
+    const github = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+    if (github) {
+        return {
+            provider: 'github',
+            owner: github[1],
+            repo: github[2],
+            prNumber: Number(github[3]),
+        };
+    }
+
+    const gitlab = prUrl.match(
+        /gitlab\.com\/(.+)\/([^/]+)\/-\/merge_requests\/(\d+)/,
+    );
+    if (gitlab) {
+        return {
+            provider: 'gitlab',
+            owner: gitlab[1],
+            repo: gitlab[2],
+            prNumber: Number(gitlab[3]),
+        };
+    }
+
+    return null;
+};
+
+export async function up(knex: Knex): Promise<void> {
+    const hasWriteback = await knex.schema.hasTable(AiWritebackThreadTableName);
+    const hasPullRequests = await knex.schema.hasTable(PullRequestsTableName);
+    if (!hasWriteback || !hasPullRequests) {
+        return;
+    }
+
+    // Only threads that produced a PR but aren't linked to a pull_requests row
+    // yet. Re-running the migration is therefore a no-op for already-linked rows.
+    const rows = await knex<WritebackRow>(AiWritebackThreadTableName)
+        .innerJoin(
+            AiThreadTableName,
+            `${AiThreadTableName}.ai_thread_uuid`,
+            `${AiWritebackThreadTableName}.ai_thread_uuid`,
+        )
+        .whereNull(`${AiWritebackThreadTableName}.pull_request_uuid`)
+        .select<
+            {
+                ai_writeback_thread_uuid: string;
+                ai_thread_uuid: string;
+                organization_uuid: string;
+                project_uuid: string;
+                pr_url: string;
+                created_at: Date;
+            }[]
+        >(
+            `${AiWritebackThreadTableName}.ai_writeback_thread_uuid`,
+            `${AiWritebackThreadTableName}.ai_thread_uuid`,
+            `${AiThreadTableName}.organization_uuid`,
+            `${AiThreadTableName}.project_uuid`,
+            `${AiWritebackThreadTableName}.pr_url`,
+            `${AiWritebackThreadTableName}.created_at`,
+        );
+
+    let linked = 0;
+    let skipped = 0;
+
+    for (const row of rows) {
+        const parsed = parsePrUrl(row.pr_url);
+        if (!parsed) {
+            skipped += 1;
+            console.log(
+                `Skipping ai_writeback_thread ${row.ai_writeback_thread_uuid}: unparseable PR URL "${row.pr_url}"`,
+            );
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+
+        // The correct attribution is the user who drove the AI thread. The
+        // thread itself has no user column, so we take the earliest prompt's
+        // author (every thread has exactly one prompt author in practice).
+        // eslint-disable-next-line no-await-in-loop
+        const promptUser = await knex(AiPromptTableName)
+            .where('ai_thread_uuid', row.ai_thread_uuid)
+            .whereNotNull('created_by_user_uuid')
+            .orderBy('created_at', 'asc')
+            .first('created_by_user_uuid');
+        const createdByUserUuid: string | null =
+            promptUser?.created_by_user_uuid ?? null;
+
+        // Reuse an existing pull_requests row (e.g. recorded by the live
+        // code path) instead of hitting the unique (provider, owner, repo,
+        // pr_number) constraint.
+        // eslint-disable-next-line no-await-in-loop
+        const existing = await knex<PullRequestRow>(PullRequestsTableName)
+            .where({
+                provider: parsed.provider,
+                owner: parsed.owner,
+                repo: parsed.repo,
+                pr_number: parsed.prNumber,
+            })
+            .first('pull_request_uuid');
+
+        let pullRequestUuid: string;
+        if (existing) {
+            pullRequestUuid = existing.pull_request_uuid;
+        } else {
+            // eslint-disable-next-line no-await-in-loop
+            const [inserted] = await knex<PullRequestRow>(PullRequestsTableName)
+                .insert({
+                    organization_uuid: row.organization_uuid,
+                    project_uuid: row.project_uuid,
+                    created_by_user_uuid: createdByUserUuid,
+                    provider: parsed.provider,
+                    source: AI_AGENT_SOURCE,
+                    owner: parsed.owner,
+                    repo: parsed.repo,
+                    pr_number: parsed.prNumber,
+                    pr_url: row.pr_url,
+                    // Preserve the original write-back time so the PR list
+                    // orders by when the work actually happened.
+                    created_at: row.created_at,
+                })
+                .returning('pull_request_uuid');
+            pullRequestUuid = inserted.pull_request_uuid;
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        await knex<WritebackRow>(AiWritebackThreadTableName)
+            .where('ai_writeback_thread_uuid', row.ai_writeback_thread_uuid)
+            .update({ pull_request_uuid: pullRequestUuid });
+
+        linked += 1;
+    }
+
+    console.log(
+        `Backfilled pull_requests from ai_writeback_thread: ${linked} linked, ${skipped} skipped`,
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    const hasWriteback = await knex.schema.hasTable(AiWritebackThreadTableName);
+    const hasPullRequests = await knex.schema.hasTable(PullRequestsTableName);
+    if (!hasWriteback || !hasPullRequests) {
+        return;
+    }
+
+    // Drop the links first (FK is ON DELETE SET NULL, but we clear them
+    // explicitly so the intent is obvious), then remove the AI-agent rows
+    // this backfill produced.
+    await knex<WritebackRow>(AiWritebackThreadTableName)
+        .whereNotNull('pull_request_uuid')
+        .update({ pull_request_uuid: null });
+
+    await knex<PullRequestRow>(PullRequestsTableName)
+        .where('source', AI_AGENT_SOURCE)
+        .delete();
+}

--- a/packages/backend/src/ee/database/migrations/20260601140000_drop_pr_url_from_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260601140000_drop_pr_url_from_ai_writeback_thread.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+const AiWritebackThreadTableName = 'ai_writeback_thread';
+const ColumnName = 'pr_url';
+
+export async function up(knex: Knex): Promise<void> {
+    const hasColumn = await knex.schema.hasColumn(
+        AiWritebackThreadTableName,
+        ColumnName,
+    );
+    if (hasColumn) {
+        await knex.schema.alterTable(AiWritebackThreadTableName, (table) => {
+            table.dropColumn(ColumnName);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    const hasColumn = await knex.schema.hasColumn(
+        AiWritebackThreadTableName,
+        ColumnName,
+    );
+    if (!hasColumn) {
+        // Re-added as nullable — the original values lived in the column we
+        // dropped and are now sourced from the linked pull_requests row, so
+        // they can't be reconstructed here.
+        await knex.schema.alterTable(AiWritebackThreadTableName, (table) => {
+            table.text(ColumnName).nullable();
+        });
+    }
+}

--- a/packages/backend/src/ee/database/migrations/20260601150000_index_ai_writeback_thread_pull_request_uuid.ts
+++ b/packages/backend/src/ee/database/migrations/20260601150000_index_ai_writeback_thread_pull_request_uuid.ts
@@ -1,0 +1,25 @@
+import { Knex } from 'knex';
+
+const AiWritebackThreadTableName = 'ai_writeback_thread';
+const IndexName = 'ai_writeback_thread_pull_request_uuid_index';
+
+// CREATE INDEX CONCURRENTLY can't run inside a transaction.
+export const config = { transaction: false };
+
+export async function up(knex: Knex): Promise<void> {
+    const hasTable = await knex.schema.hasTable(AiWritebackThreadTableName);
+    if (!hasTable) {
+        return;
+    }
+    // Index the FK column so the ON DELETE SET NULL cascade from pull_requests
+    // and the parent→child join in PullRequestsModel.getAiThreadInfo don't
+    // seq-scan. CONCURRENTLY + IF NOT EXISTS keeps it lock-light and idempotent.
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS ?? ON ?? (pull_request_uuid)`,
+        [IndexName, AiWritebackThreadTableName],
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [IndexName]);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -96,6 +96,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getGithubAppInstallationsModel(),
                     aiWritebackThreadModel:
                         models.getAiWritebackThreadModel<AiWritebackThreadModel>(),
+                    pullRequestsModel: models.getPullRequestsModel(),
                 }),
             appGenerateService: ({ context, models, clients, repository }) =>
                 new AppGenerateService({

--- a/packages/backend/src/ee/models/AiWritebackThreadModel.ts
+++ b/packages/backend/src/ee/models/AiWritebackThreadModel.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex';
+import { PullRequestsTableName } from '../../database/entities/pullRequests';
 import {
     AiWritebackThreadTable,
     AiWritebackThreadTableName,
@@ -7,6 +8,15 @@ import {
 
 type Dependencies = {
     database: Knex;
+};
+
+/**
+ * A writeback thread row enriched with the PR URL resolved from the linked
+ * `pull_requests` row. `pr_url` is null only when the link was cleared (the
+ * FK is ON DELETE SET NULL).
+ */
+export type AiWritebackThreadWithPrUrl = DbAiWritebackThread & {
+    pr_url: string | null;
 };
 
 export class AiWritebackThreadModel {
@@ -18,11 +28,18 @@ export class AiWritebackThreadModel {
 
     async findByAiThreadUuid(
         aiThreadUuid: string,
-    ): Promise<DbAiWritebackThread | null> {
-        const row = await this.database<AiWritebackThreadTable>(
-            AiWritebackThreadTableName,
-        )
-            .where('ai_thread_uuid', aiThreadUuid)
+    ): Promise<AiWritebackThreadWithPrUrl | null> {
+        const row = await this.database(AiWritebackThreadTableName)
+            .leftJoin(
+                PullRequestsTableName,
+                `${PullRequestsTableName}.pull_request_uuid`,
+                `${AiWritebackThreadTableName}.pull_request_uuid`,
+            )
+            .where(`${AiWritebackThreadTableName}.ai_thread_uuid`, aiThreadUuid)
+            .select<AiWritebackThreadWithPrUrl>(
+                `${AiWritebackThreadTableName}.*`,
+                `${PullRequestsTableName}.pr_url`,
+            )
             .first();
         return row ?? null;
     }
@@ -30,7 +47,7 @@ export class AiWritebackThreadModel {
     async create(data: {
         aiThreadUuid: string;
         sandboxId: string;
-        prUrl: string;
+        pullRequestUuid: string;
     }): Promise<DbAiWritebackThread> {
         const [row] = await this.database<AiWritebackThreadTable>(
             AiWritebackThreadTableName,
@@ -38,7 +55,7 @@ export class AiWritebackThreadModel {
             .insert({
                 ai_thread_uuid: data.aiThreadUuid,
                 sandbox_id: data.sandboxId,
-                pr_url: data.prUrl,
+                pull_request_uuid: data.pullRequestUuid,
             })
             .returning('*');
         return row;

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -8,6 +8,8 @@ import {
     isUserWithOrg,
     MissingConfigError,
     ParameterError,
+    PullRequestProvider,
+    PullRequestSource,
     WarehouseTypes,
     type AiWritebackRunResult,
     type DbtProjectConfig,
@@ -29,9 +31,12 @@ import type { LightdashConfig } from '../../../config/parseConfig';
 import type { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import type { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import type { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import type { PullRequestsModel } from '../../../models/PullRequestsModel';
 import { BaseService } from '../../../services/BaseService';
-import type { DbAiWritebackThread } from '../../database/entities/ai';
-import type { AiWritebackThreadModel } from '../../models/AiWritebackThreadModel';
+import type {
+    AiWritebackThreadModel,
+    AiWritebackThreadWithPrUrl,
+} from '../../models/AiWritebackThreadModel';
 import {
     ALLOWED_TOOLS,
     CLAUDE_MODEL,
@@ -82,6 +87,7 @@ type AiWritebackServiceDeps = {
     featureFlagModel: FeatureFlagModel;
     githubAppInstallationsModel: GithubAppInstallationsModel;
     aiWritebackThreadModel: AiWritebackThreadModel;
+    pullRequestsModel: PullRequestsModel;
 };
 
 export class AiWritebackService extends BaseService {
@@ -97,6 +103,8 @@ export class AiWritebackService extends BaseService {
 
     private readonly aiWritebackThreadModel: AiWritebackThreadModel;
 
+    private readonly pullRequestsModel: PullRequestsModel;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -104,6 +112,7 @@ export class AiWritebackService extends BaseService {
         featureFlagModel,
         githubAppInstallationsModel,
         aiWritebackThreadModel,
+        pullRequestsModel,
     }: AiWritebackServiceDeps) {
         super({ serviceName: 'AiWritebackService' });
         this.lightdashConfig = lightdashConfig;
@@ -112,6 +121,7 @@ export class AiWritebackService extends BaseService {
         this.featureFlagModel = featureFlagModel;
         this.githubAppInstallationsModel = githubAppInstallationsModel;
         this.aiWritebackThreadModel = aiWritebackThreadModel;
+        this.pullRequestsModel = pullRequestsModel;
     }
 
     private async assertEnabled(user: SessionUser): Promise<void> {
@@ -616,6 +626,8 @@ export class AiWritebackService extends BaseService {
                 github,
                 hasChanges,
                 turn,
+                user,
+                projectUuid,
                 aiThreadUuid,
                 setStage,
                 prTitle,
@@ -815,7 +827,7 @@ export class AiWritebackService extends BaseService {
         projectUuid: string;
         githubConnection: GithubConnection;
         token: string;
-        existingRow: DbAiWritebackThread | null;
+        existingRow: AiWritebackThreadWithPrUrl | null;
         setStage: SetStage;
     }): Promise<Sandbox> {
         setStage('sandbox');
@@ -1234,6 +1246,8 @@ export class AiWritebackService extends BaseService {
         github,
         hasChanges,
         turn,
+        user,
+        projectUuid,
         aiThreadUuid,
         setStage,
         prTitle,
@@ -1243,6 +1257,8 @@ export class AiWritebackService extends BaseService {
         github: GithubInstallation;
         hasChanges: boolean;
         turn: TurnContext;
+        user: SessionUser;
+        projectUuid: string;
         aiThreadUuid: string | undefined;
         setStage: SetStage;
         prTitle: string | null;
@@ -1293,11 +1309,27 @@ export class AiWritebackService extends BaseService {
             `AiWriteback: opened PR ${prUrl} (sandboxId=${sandbox.sandboxId})`,
         );
 
+        // Record the PR so it shows up in the project's "Pull requests" view,
+        // attributed to the user who drove the writeback. The thread row links
+        // to it via pull_request_uuid (the PR URL is no longer stored on the
+        // thread itself).
+        const pullRequest = await this.pullRequestsModel.findOrCreate({
+            organizationUuid: turn.organizationUuid,
+            projectUuid,
+            createdByUserUuid: user.userUuid,
+            provider: PullRequestProvider.GITHUB,
+            source: PullRequestSource.AI_AGENT,
+            owner: turn.githubConnection.owner,
+            repo: turn.githubConnection.repo,
+            prNumber: AiWritebackService.parsePullNumber(prUrl),
+            prUrl,
+        });
+
         if (aiThreadUuid) {
             await this.aiWritebackThreadModel.create({
                 aiThreadUuid,
                 sandboxId: sandbox.sandboxId,
-                prUrl,
+                pullRequestUuid: pullRequest.pullRequestUuid,
             });
         }
 
@@ -1403,7 +1435,7 @@ export class AiWritebackService extends BaseService {
         prDescription,
     }: {
         sandbox: Sandbox;
-        existingRow: DbAiWritebackThread;
+        existingRow: AiWritebackThreadWithPrUrl;
         githubConnection: GithubConnection;
         installationId: string;
         token: string;
@@ -1439,6 +1471,12 @@ export class AiWritebackService extends BaseService {
             username: GIT_USERNAME,
             password: token,
         });
+
+        if (!existingRow.pr_url) {
+            throw new ParameterError(
+                'Cannot update pull request: the writeback thread is not linked to a pull request',
+            );
+        }
 
         setStage('pull_request');
         await updatePullRequest({

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -1,6 +1,6 @@
 import type { SessionUser, WarehouseTypes } from '@lightdash/common';
 import type { AiWritebackFailureStage } from '../../../analytics/LightdashAnalytics';
-import type { DbAiWritebackThread } from '../../database/entities/ai';
+import type { AiWritebackThreadWithPrUrl } from '../../models/AiWritebackThreadModel';
 
 /**
  * The canonical warehouse keys we ship a skill file for. Several
@@ -33,7 +33,7 @@ export type TurnContext = {
     organizationUuid: string;
     projectName: string;
     githubConnection: GithubConnection;
-    existingRow: DbAiWritebackThread | null;
+    existingRow: AiWritebackThreadWithPrUrl | null;
     isResume: boolean;
     /**
      * The project's warehouse dialect, used to pick the warehouse skill file

--- a/packages/backend/src/models/PullRequestsModel.ts
+++ b/packages/backend/src/models/PullRequestsModel.ts
@@ -4,6 +4,7 @@ import {
     PullRequest,
     PullRequestProvider,
     PullRequestSource,
+    UnexpectedDatabaseError,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import {
@@ -131,6 +132,55 @@ export class PullRequestsModel {
 
         // A newly created PR has no ai_writeback_thread link yet.
         return mapDbPullRequest(row, null);
+    }
+
+    /**
+     * Record a PR, tolerating an existing row for the same
+     * (provider, owner, repo, pr_number). Callers that record a PR *after* it
+     * has already been opened on the provider (e.g. AI write-back) must not
+     * fail the whole run on a duplicate — a retry, or the same PR already
+     * recorded by another path, would otherwise throw on the unique
+     * constraint. The insert-or-ignore is atomic, so concurrent callers are
+     * safe; the existing row's attribution (source/user) is preserved rather
+     * than overwritten.
+     */
+    async findOrCreate(data: CreatePullRequest): Promise<PullRequest> {
+        const inserted = await this.database(PullRequestsTableName)
+            .insert({
+                organization_uuid: data.organizationUuid,
+                project_uuid: data.projectUuid,
+                created_by_user_uuid: data.createdByUserUuid,
+                provider: data.provider,
+                source: data.source,
+                owner: data.owner,
+                repo: data.repo,
+                pr_number: data.prNumber,
+                pr_url: data.prUrl,
+            })
+            .onConflict(['provider', 'owner', 'repo', 'pr_number'])
+            .ignore()
+            .returning('*');
+
+        if (inserted.length > 0) {
+            return mapDbPullRequest(inserted[0], null);
+        }
+
+        // The insert was ignored because a row already exists — return it.
+        const existing = await this.database(PullRequestsTableName)
+            .where({
+                provider: data.provider,
+                owner: data.owner,
+                repo: data.repo,
+                pr_number: data.prNumber,
+            })
+            .first();
+        if (!existing) {
+            // Shouldn't happen: a conflict implies a row exists.
+            throw new UnexpectedDatabaseError(
+                'Failed to record pull request: row neither inserted nor found',
+            );
+        }
+        return mapDbPullRequest(existing, null);
     }
 
     async getByProject(


### PR DESCRIPTION
## Summary

Closes: [PROD-8033](https://linear.app/lightdash/issue/PROD-8033/create-pull-request-records-for-ai-path)

Write-backs from the AI agent (Slack-triggered) opened a GitHub PR but recorded nothing in Lightdash, so they never appeared in the project's "Pull requests" view that the in-app/dbt-runner path already populates. This wires the AI path into the same `pull_requests` table — attributed to the user who triggered the write-back — and removes the now-redundant `pr_url` column from `ai_writeback_thread`, which becomes a link to the canonical PR row.

## How it works

When the agent opens its initial PR, the service records the PR and links the thread to it:

```
AiWritebackService.applyAgentChanges
  └─ openInitialPullRequest ──► GitHub PR opened
       └─ pullRequestsModel.findOrCreate({ source: ai_agent, createdByUserUuid: user })
            └─ aiWritebackThreadModel.create({ pullRequestUuid })   # links the thread

ai_writeback_thread                 pull_requests
  pull_request_uuid ───────────────► pull_request_uuid (PK)
  (pr_url column dropped)            pr_url, owner, repo, pr_number, source, created_by_user_uuid
```

- `AiWritebackService.ts` — injects `PullRequestsModel`; on opening a PR it records a `pull_requests` row (`source: ai_agent`, `provider: github`, attributed to `user.userUuid`) and links the thread via `pull_request_uuid`. Resume turns now read `pr_url` from the linked row, with a fast-fail guard when the link is absent.
- `PullRequestsModel.findOrCreate()` — new method. Records a PR tolerant of an existing row for the same `(provider, owner, repo, pr_number)` via an atomic insert-or-ignore, so a retry (the PR is already open on GitHub) can't fail the run on the unique constraint. Preserves the existing row's attribution.
- `AiWritebackThreadModel` — `create()` takes `pullRequestUuid` instead of `prUrl`; `findByAiThreadUuid()` left-joins `pull_requests` to keep exposing `pr_url`.
- `entities/ai.ts` / `index.ts` — drop `pr_url` from the entity; DI wiring.

## Regression analysis

| Group | Effect |
|---|---|
| AI write-backs (new PRs) | Now recorded in `pull_requests`, attributed to the triggering user, visible in project settings. |
| AI write-back resume turns | `pr_url` resolved via the thread→PR join; PR update/no-change paths unchanged. |
| In-app / dbt-runner write-backs | No change — already recorded; `findOrCreate` only added, `create` untouched. |
| Deployments without an EE license | No change — `ai_writeback_thread` and the EE migrations don't exist there (all guarded by `hasTable`/`hasColumn`). |

No API surface change, no new dependencies.

## Migration

```bash
pnpm -F backend migrate
```

Three EE migrations, in order:
- `20260601130000` — backfill `pull_requests` from existing `ai_writeback_thread` rows (parses `pr_url`, attributes to the thread's prompt author, links each thread). Idempotent: re-runs skip already-linked rows and reuse existing PR rows.
- `20260601140000` — drop `pr_url` from `ai_writeback_thread`.
- `20260601150000` — add the missing index on the `ai_writeback_thread.pull_request_uuid` FK (`CREATE INDEX CONCURRENTLY`, `transaction: false`).

## Test plan

- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend lint` — clean
- [x] `pnpm -F backend test:dev:nowatch` — 73/73 passing (11 suites incl. `GitIntegrationService`)
- [x] Migrations applied locally; backfill linked 43/43 threads, all attributed to the correct prompt author, all resolve `pr_url` via the join
- [x] FK index present in `\d ai_writeback_thread`
- [ ] Reviewer: exercise a live Slack AI write-back end-to-end and confirm the PR shows in project settings

## Follow-ups (separate PRs)

- Live path is GitHub-only (hard-coded provider); the backfill already parses GitLab URLs for any historical data.
- Add unit tests for `parsePrUrl` and a model test for `findByAiThreadUuid` join + null `pr_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)