### PR TITLE
docs(data-apps): warn against contradictory sign+direction phrasing

### DIFF
--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -1083,3 +1083,4 @@ function DrillResults({ query: q }) {
 | Building drill query inside render | Infinite re-fetching | Build in onClick handler, store in state |
 | Drilling by a dimension already in the source query | Pointless — same grouping | Pick a different, more granular dimension |
 | Using `e.chartX`/`e.chartY` for menu position | Chart-relative coords — menu appears at wrong position | Recharts `onClick` has no native event; capture `clientX`/`clientY` from a wrapper `<div onPointerDown>` via `useRef` — pointerdown fires before onClick so the ref is ready (see action menu example) |
+| Combining a direction word with a contradictory sign in narrative copy (`down +12%`, `up -4%`) | Sign and verb disagree → reads as a self-contradiction, looks like a platform bug | Pick one convention per report and stick to it: either signed deltas with no direction word (`+12%`, `−4%`), or direction word with unsigned magnitude (`up 12%`, `down 4%`). Never mix. |


### PR DESCRIPTION
## Summary

- Adds a Common Pitfalls row to `sandboxes/data-apps/template/skill.md` telling the agent not to combine a direction word with a contradictory sign in narrative copy (e.g. `down +12%`, `up -4%`).
- Came out of a customer report where a PDF report contained "Revenue is down +12%" — the agent had the delta and the verb in context but produced self-contradicting prose. Sample data was off and the prompt had a large number of attached charts, both of which exacerbate the issue, but the phrasing rule itself is missing from the skill.
- Lightest-weight fix that fits the existing "Common Pitfalls" table pattern.

## Test plan

- [ ] No app code changes — table-only doc edit in the data-apps skill.
- [ ] Verify the skill renders correctly when picked up by the next data-app build (no broken markdown table).