### PR TITLE
feat(pull-requests): polish pull requests table UX

### DIFF
--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
@@ -23,7 +23,7 @@
 /* Created (relative time) */
 .table th:nth-of-type(2),
 .table td:nth-of-type(2) {
-    width: 120px;
+    width: 150px;
     white-space: nowrap;
 }
 

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
@@ -7,6 +7,14 @@
     );
 }
 
+/* Vertical scroll container for infinite scroll; the sticky header stays
+   pinned while rows scroll under it. */
+.scrollArea {
+    max-height: calc(100dvh - 230px);
+    min-height: 200px;
+    overflow: auto;
+}
+
 .table {
     /* Fixed layout + full width: columns honour their widths exactly, so the
        Source/State tags never collapse and the Title absorbs the remainder. */
@@ -87,13 +95,6 @@
         var(--mantine-color-ldGray-0),
         var(--mantine-color-ldDark-6)
     );
-}
-
-/* Dim the body while paging so the table doesn't jump between pages */
-.tbodyFetching {
-    opacity: 0.55;
-    transition: opacity 150ms ease;
-    pointer-events: none;
 }
 
 /* Artsy pull-request medallion: a soft shadow gives it a little lift */

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -3,9 +3,10 @@ import {
     ActionIcon,
     Alert,
     Badge,
+    Box,
     Center,
     Group,
-    Pagination,
+    Loader,
     Paper,
     Skeleton,
     Stack,
@@ -24,13 +25,12 @@ import {
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { useState, type FC } from 'react';
+import { useCallback, useEffect, useRef, type FC, type UIEvent } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { usePullRequestsTable } from '../hooks/usePullRequestsTable';
 import { type PullRequestRow } from '../types';
 import {
-    DEFAULT_PULL_REQUESTS_PAGE_SIZE,
     EMPTY_VALUE,
     getProviderLabel,
     getSourceColor,
@@ -209,15 +209,20 @@ const PullRequestSkeletonRow: FC = () => (
 
 const PullRequestsTableShell: FC<{
     children: React.ReactNode;
-    dimmed: boolean;
-}> = ({ children, dimmed }) => (
+    containerRef?: React.Ref<HTMLDivElement>;
+    onScroll?: (event: UIEvent<HTMLDivElement>) => void;
+}> = ({ children, containerRef, onScroll }) => (
     <Paper
         withBorder
         shadow="subtle"
         radius="md"
         className={classes.tablePaper}
     >
-        <Table.ScrollContainer minWidth={720}>
+        <Box
+            ref={containerRef}
+            onScroll={onScroll}
+            className={classes.scrollArea}
+        >
             <Table
                 verticalSpacing="sm"
                 horizontalSpacing="sm"
@@ -237,35 +242,49 @@ const PullRequestsTableShell: FC<{
                         <Table.Th className={classes.th}>PR</Table.Th>
                     </Table.Tr>
                 </Table.Thead>
-                <Table.Tbody
-                    className={dimmed ? classes.tbodyFetching : undefined}
-                >
-                    {children}
-                </Table.Tbody>
+                <Table.Tbody>{children}</Table.Tbody>
             </Table>
-        </Table.ScrollContainer>
+        </Box>
     </Paper>
 );
 
 const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
-    const [page, setPage] = useState(1);
-    const { rows, pagination, isLoading, isFetching, error } =
-        usePullRequestsTable(projectUuid, {
-            page,
-            pageSize: DEFAULT_PULL_REQUESTS_PAGE_SIZE,
-        });
+    const {
+        rows,
+        totalResults,
+        isLoading,
+        isFetchingNextPage,
+        hasNextPage,
+        fetchNextPage,
+        error,
+    } = usePullRequestsTable(projectUuid);
 
-    const totalResults = pagination?.totalResults ?? rows.length;
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+
+    // Fetch the next page once the user scrolls near the bottom of the table.
+    const fetchMoreOnBottomReached = useCallback(
+        (container?: HTMLDivElement | null) => {
+            if (!container) return;
+            const { scrollHeight, scrollTop, clientHeight } = container;
+            if (
+                scrollHeight - scrollTop - clientHeight < 400 &&
+                !isFetchingNextPage &&
+                hasNextPage
+            ) {
+                void fetchNextPage();
+            }
+        },
+        [fetchNextPage, isFetchingNextPage, hasNextPage],
+    );
+
+    // The first page may not fill the viewport — fetch more on mount if so.
+    useEffect(() => {
+        fetchMoreOnBottomReached(tableContainerRef.current);
+    }, [fetchMoreOnBottomReached]);
 
     return (
         <Stack gap="md">
-            <Stack gap="two">
-                <Title order={5}>Pull requests</Title>
-                <Text size="sm" c="dimmed">
-                    Pull requests opened from this project, including changes
-                    proposed by AI agents and the in-app editors.
-                </Text>
-            </Stack>
+            <Title order={5}>Pull requests</Title>
 
             {error ? (
                 <Alert
@@ -276,7 +295,7 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                     {error.error.message}
                 </Alert>
             ) : isLoading ? (
-                <PullRequestsTableShell dimmed={false}>
+                <PullRequestsTableShell>
                     {SKELETON_ROW_KEYS.map((key) => (
                         <PullRequestSkeletonRow key={key} />
                     ))}
@@ -300,12 +319,12 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                 </Center>
             ) : (
                 <Stack gap="sm">
-                    <Text size="xs" c="dimmed">
-                        {totalResults} pull request
-                        {totalResults === 1 ? '' : 's'}
-                    </Text>
-
-                    <PullRequestsTableShell dimmed={isFetching}>
+                    <PullRequestsTableShell
+                        containerRef={tableContainerRef}
+                        onScroll={(event) =>
+                            fetchMoreOnBottomReached(event.currentTarget)
+                        }
+                    >
                         {rows.map((row) => (
                             <PullRequestRowItem
                                 key={row.pullRequestUuid}
@@ -314,16 +333,22 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                         ))}
                     </PullRequestsTableShell>
 
-                    {(pagination?.totalPageCount ?? 1) > 1 ? (
-                        <Group justify="flex-end">
-                            <Pagination
-                                size="sm"
-                                total={pagination?.totalPageCount ?? 1}
-                                value={page}
-                                onChange={setPage}
-                            />
-                        </Group>
-                    ) : null}
+                    <Group justify="center" gap="xs" h={20}>
+                        {isFetchingNextPage ? (
+                            <>
+                                <Loader size="xs" />
+                                <Text size="xs" c="dimmed">
+                                    Loading more...
+                                </Text>
+                            </>
+                        ) : (
+                            <Text size="xs" c="dimmed">
+                                {hasNextPage
+                                    ? 'Scroll for more'
+                                    : `All ${totalResults} loaded`}
+                            </Text>
+                        )}
+                    </Group>
                 </Stack>
             )}
         </Stack>

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -151,11 +151,7 @@ const PullRequestRowItem: FC<{ row: PullRequestRow }> = ({ row }) => {
                             <MantineIcon icon={IconMessageCircle} />
                         </ActionIcon>
                     </Tooltip>
-                ) : (
-                    <Text size="sm" c="dimmed">
-                        {EMPTY_VALUE}
-                    </Text>
-                )}
+                ) : null}
             </Table.Td>
             <Table.Td>
                 <Tooltip
@@ -234,7 +230,7 @@ const PullRequestsTableShell: FC<{
                             aria-label="Pull request"
                         />
                         <Table.Th className={classes.th}>Created</Table.Th>
-                        <Table.Th className={classes.th}>Author</Table.Th>
+                        <Table.Th className={classes.th}>User</Table.Th>
                         <Table.Th className={classes.th}>Title</Table.Th>
                         <Table.Th className={classes.th}>State</Table.Th>
                         <Table.Th className={classes.th}>Thread</Table.Th>

--- a/packages/frontend/src/features/pullRequests/hooks/usePullRequestsTable.ts
+++ b/packages/frontend/src/features/pullRequests/hooks/usePullRequestsTable.ts
@@ -3,11 +3,12 @@ import {
     type ApiPullRequestsResponse,
     type KnexPaginateArgs,
 } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { lightdashApi } from '../../../api';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { type PullRequestAuthor, type PullRequestRow } from '../types';
+import { DEFAULT_PULL_REQUESTS_PAGE_SIZE } from '../utils';
 
 const getPullRequests = async (
     projectUuid: string,
@@ -20,26 +21,29 @@ const getPullRequests = async (
     });
 
 /**
- * Shared data hook for every Pull Requests table version. Fetches the paginated
- * pull requests for the current page and resolves each author from the org
- * members list. Returns render-ready rows plus pagination metadata.
+ * Infinite-scroll data hook for the Pull Requests table. Fetches pages, flattens
+ * them into render-ready rows, and resolves each author from the org members
+ * list. Returns the rows plus the controls the page needs to fetch more on
+ * scroll.
  */
-export const usePullRequestsTable = (
-    projectUuid: string,
-    paginateArgs: KnexPaginateArgs,
-) => {
-    const pullRequestsQuery = useQuery<
+export const usePullRequestsTable = (projectUuid: string) => {
+    const query = useInfiniteQuery<
         ApiPullRequestsResponse['results'],
         ApiError
     >({
-        queryKey: [
-            'pull-requests',
-            projectUuid,
-            paginateArgs.page,
-            paginateArgs.pageSize,
-        ],
-        queryFn: () => getPullRequests(projectUuid, paginateArgs),
+        queryKey: ['pull-requests', projectUuid],
+        queryFn: ({ pageParam = 1 }) =>
+            getPullRequests(projectUuid, {
+                page: pageParam as number,
+                pageSize: DEFAULT_PULL_REQUESTS_PAGE_SIZE,
+            }),
+        getNextPageParam: (lastPage, pages) => {
+            const currentPage = pages.length;
+            const totalPages = lastPage.pagination?.totalPageCount ?? 0;
+            return currentPage < totalPages ? currentPage + 1 : undefined;
+        },
         keepPreviousData: true,
+        refetchOnWindowFocus: false,
     });
 
     const usersQuery = useOrganizationUsers();
@@ -61,20 +65,28 @@ export const usePullRequestsTable = (
 
     const rows = useMemo<PullRequestRow[]>(
         () =>
-            (pullRequestsQuery.data?.data ?? []).map((pullRequest) => ({
-                ...pullRequest,
-                author: pullRequest.createdByUserUuid
-                    ? (authorsByUuid.get(pullRequest.createdByUserUuid) ?? null)
-                    : null,
-            })),
-        [pullRequestsQuery.data, authorsByUuid],
+            (query.data?.pages ?? [])
+                .flatMap((page) => page.data)
+                .map((pullRequest) => ({
+                    ...pullRequest,
+                    author: pullRequest.createdByUserUuid
+                        ? (authorsByUuid.get(pullRequest.createdByUserUuid) ??
+                          null)
+                        : null,
+                })),
+        [query.data, authorsByUuid],
     );
+
+    const totalResults =
+        query.data?.pages?.[0]?.pagination?.totalResults ?? rows.length;
 
     return {
         rows,
-        pagination: pullRequestsQuery.data?.pagination,
-        isLoading: pullRequestsQuery.isInitialLoading,
-        isFetching: pullRequestsQuery.isFetching,
-        error: pullRequestsQuery.error,
+        totalResults,
+        isLoading: query.isInitialLoading,
+        isFetchingNextPage: query.isFetchingNextPage,
+        hasNextPage: query.hasNextPage ?? false,
+        fetchNextPage: query.fetchNextPage,
+        error: query.error,
     };
 };

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -8,6 +8,7 @@ import SuboptimalState from '../components/common/SuboptimalState/SuboptimalStat
 import CompilationHistory from '../components/CompilationHistory';
 import { DataOps } from '../components/DataOps';
 import { DefaultUserSpaces } from '../components/DefaultUserSpaces';
+import { useIsGitProject } from '../components/Explorer/WriteBackModal/hooks';
 import PreAggregateAudit from '../components/PreAggregateAudit';
 import PreAggregateMaterializations from '../components/PreAggregateMaterializations';
 import ProjectUserAccess from '../components/ProjectAccess';
@@ -39,6 +40,9 @@ const ProjectSettings: FC = () => {
 
     const isSoftDeleteEnabled = health.data?.softDelete?.enabled ?? false;
     const isPullRequestsEnabled = useIsPullRequestsEnabled();
+    // Only relevant when the project's code lives in a Git provider, since the
+    // section lists PRs opened against that repo.
+    const isGitProject = useIsGitProject(projectUuid ?? '');
 
     const routes = useMemo<RouteObject[]>(() => {
         if (!projectUuid) {
@@ -117,7 +121,7 @@ const ProjectSettings: FC = () => {
                 path: `/compilationHistory`,
                 element: <CompilationHistory projectUuid={projectUuid} />,
             },
-            ...(isPullRequestsEnabled
+            ...(isPullRequestsEnabled && isGitProject
                 ? [
                       {
                           path: `/pullRequests`,
@@ -164,7 +168,7 @@ const ProjectSettings: FC = () => {
                 element: <SettingsEmbed projectUuid={projectUuid} />,
             },
         ];
-    }, [projectUuid, isSoftDeleteEnabled, isPullRequestsEnabled]);
+    }, [projectUuid, isSoftDeleteEnabled, isPullRequestsEnabled, isGitProject]);
     const routesElements = useRoutes(routes);
 
     if (error) {

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -55,6 +55,7 @@ import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import RouterNavLink from '../components/common/RouterNavLink';
 import { SettingsGridCard } from '../components/common/Settings/SettingsCard';
+import { useIsGitProject } from '../components/Explorer/WriteBackModal/hooks';
 import PageSpinner from '../components/PageSpinner';
 import AccessTokensPanel from '../components/UserSettings/AccessTokensPanel';
 import AllowedDomainsPanel from '../components/UserSettings/AllowedDomainsPanel';
@@ -196,6 +197,8 @@ const Settings: FC = () => {
         isInitialLoading: isProjectLoading,
         error: projectError,
     } = useProject(activeProjectUuid);
+
+    const isGitProject = useIsGitProject(activeProjectUuid ?? '');
 
     const allowPasswordAuthentication =
         !health?.auth.disablePasswordAuthentication;
@@ -1502,6 +1505,7 @@ const Settings: FC = () => {
                                     ) : null}
 
                                     {isPullRequestsEnabled &&
+                                    isGitProject &&
                                     user.ability?.can(
                                         'view',
                                         subject('SourceCode', {


### PR DESCRIPTION
## Summary

Closes: [PROD-8031](https://linear.app/lightdash/issue/PROD-8031/improve-ux)

<img width="3024" height="1724" alt="CleanShot 2026-06-01 at 16 18 59@2x" src="https://github.com/user-attachments/assets/86270625-bfad-4b31-bbc7-b4d8d3804e18" />


A UX punchlist for the project-settings "Pull requests" table, taking the **Ask AI → Threads** table as the reference. The table now only appears for Git-connected projects, scrolls infinitely instead of paging, fills the viewport, and has tidier columns.

### Changes

- **Gated on Git integration** — the section (route + sidebar link) only shows when the project's dbt connection is GitHub/GitLab, reusing the existing `useIsGitProject` hook. Non-Git projects no longer see an empty/irrelevant section.
- **Infinite scroll** replaces the paginator — `usePullRequestsTable` now uses `useInfiniteQuery`; the table body fetches the next page on scroll (`fetchMoreOnBottomReached`), matching the Threads table pattern, with a "Loading more… / All N loaded" footer.
- **Taller table** — the scroll container fills most of the viewport (`max-height: calc(100dvh - 230px)`) instead of a short fixed block.
- **Tidier columns** — `Author` → `User`, `Created` widened `120px → 150px`.
- **Empty Thread cell** — PRs with no linked AI thread render a blank cell instead of a `—` placeholder.
- **Removed** the descriptive caption under the "Pull requests" heading.

## Visual

Table, before → after:

```
Before:                                  After:
  columns: … Author … Created(120px)       columns: … User … Created(150px)
  Thread cell (no thread):  —              Thread cell (no thread):  (blank)
  paging:  [ 1 2 3 … ] pager              paging:  infinite scroll + "All N loaded"
  height:  short fixed block              height:  fills viewport (100dvh - 230px)
  visible: always (flag only)            visible: only when GitHub/GitLab connected
```

## Regression analysis

- **Git gating** — both the `/pullRequests` route (`ProjectSettings`) and the sidebar link (`Settings`) now require `isGitProject` in addition to the existing feature flag + `view SourceCode` permission. Non-Git projects lose access to a section that had nothing to show.
- **Data hook** — `usePullRequestsTable` switched from `useQuery` (page arg) to `useInfiniteQuery`; author resolution from org members is unchanged.
- No backend/API surface touched (all changes are frontend).

## Test plan

- [x] `pnpm -F frontend typecheck` — clean
- [x] `pnpm -F frontend lint` — clean
- [ ] GitHub/GitLab project: "Pull requests" appears in settings; non-Git project: it's hidden.
- [ ] Scroll the list past one page — next page loads; footer shows "All N loaded" at the end.
- [ ] Table fills the viewport without a double scrollbar; sticky header stays pinned.
- [ ] A PR with no AI thread shows a blank Thread cell; a GitLab PR shows the GitLab icon.

> Screenshots pending — couldn't capture locally (unrelated migration-state issue on this branch blocks running the app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)