### PR TITLE
fix(scheduler): enforce create:ScheduledDeliveries on send-now path

### DIFF
--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1437,7 +1437,37 @@ export class SchedulerService extends BaseService {
             }
         }
 
+        const { organizationUuid, projectUuid } =
+            await this.getSchedulerProjectContext(scheduler);
+
         await this.checkViewResource(user, scheduler);
+
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'create',
+                subject('ScheduledDeliveries', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: getSchedulerResourceTypeAndId(scheduler),
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        if (
+            scheduler.format === SchedulerFormat.GSHEETS &&
+            auditedAbility.cannot(
+                'create',
+                subject('GoogleSheets', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
 
         const slackChannels = scheduler.targets
             .filter(isCreateSchedulerSlackTarget)
@@ -1446,9 +1476,6 @@ export class SchedulerService extends BaseService {
             user.organizationUuid,
             slackChannels,
         );
-
-        const { organizationUuid, projectUuid } =
-            await this.getSchedulerProjectContext(scheduler);
 
         return this.schedulerClient.addScheduledDeliveryJob(
             new Date(),


### PR DESCRIPTION
Closes: PROD-8036

### Description:

The unsaved "send now" scheduler path (`SchedulerService.sendScheduler`) only checked **view** access on the underlying resource, so a viewer could `POST /api/v1/schedulers/send` with attacker-chosen delivery targets and enqueue an export job — a permission bypass / data-exfiltration risk. This change resolves the project context before authorization, then enforces `create:ScheduledDeliveries` (scoped to the resolved org/project) plus the `GoogleSheets` guard for GSHEETS syncs, matching every other create/send path. The "Send now" UI is only reachable behind `create:ScheduledDeliveries`, so no legitimate flow regresses.