### PR TITLE
docs(permissions): document CASL actor resource scoping

### DIFF
--- a/.claude/skills/ld-permissions/SKILL.md
+++ b/.claude/skills/ld-permissions/SKILL.md
@@ -40,6 +40,34 @@ if (user.ability.cannot('manage', subject('Dashboard', { projectUuid }))) {
 }
 ```
 
+### CASL Subject Scoping: Resource, Not Actor
+
+CASL actor is passed before the check:
+
+```typescript
+getUserAbilityBuilder({
+    user: lightdashUser, // actor
+    projectProfiles,
+    permissionsConfig,
+});
+
+const ability = this.createAuditedAbility(accountOrUser); // actor
+```
+
+`subject(...)` must describe only the target resource:
+
+```typescript
+ability.can(
+    'manage',
+    subject('X', {
+        organizationUuid: target.organizationUuid,
+        projectUuid: target.projectUuid,
+    }),
+);
+```
+
+Never fill `subject(...)` from actor fields like `user.organizationUuid`. Org-level grants may only check `organizationUuid`, so actor-sourced subject fields can become cross-org access on multi-org instances. Single-org dev hides it.
+
 **Frontend permission check:**
 ```typescript
 const { user } = useUser();


### PR DESCRIPTION
## Summary

- Adds guidance to the `ld-permissions` skill for CASL actor-vs-resource scoping.
- Shows where the actor is passed (`getUserAbilityBuilder`, `createAuditedAbility`) and where the resource is passed (`subject(...)`).
- Documents the actor-sourced `organizationUuid` anti-pattern and why it can hide in single-org dev setups.

## Validation

- `git diff --check -- .claude/skills/ld-permissions/SKILL.md`