### PR TITLE
feat(ai-writeback): raise PR as the connecting GitHub user with signed commits (PROD-8050)

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -109,10 +109,7 @@ export const getOrRefreshToken = async (
         });
         if (tokenResponse.status === 200) return { token, refreshToken };
     } catch {
-        console.debug(
-            'Refreshing expired or invalid github token',
-            refreshToken,
-        );
+        console.debug('Refreshing expired or invalid github token');
     }
 
     const auth = await getGithubApp().oauth.refreshToken({

--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -10,6 +10,7 @@ import {
 } from '@lightdash/common';
 import { App } from '@octokit/app';
 import { Octokit as OctokitRest } from '@octokit/rest';
+import Logger from '../../logging/logger';
 
 const { createAppAuth } = require('@octokit/auth-app');
 
@@ -132,7 +133,7 @@ export const getOrRefreshToken = async (
         });
         if (tokenResponse.status === 200) return { token, refreshToken };
     } catch {
-        console.debug('Refreshing expired or invalid github token');
+        Logger.debug('Refreshing expired or invalid github token');
     }
 
     const auth = await getGithubApp().oauth.refreshToken({
@@ -708,7 +709,7 @@ export const getBranches = async ({
         });
         return branches;
     } catch (e) {
-        console.error(e);
+        Logger.error(`Failed to list GitHub branches: ${getErrorMessage(e)}`);
         throw new UnexpectedGitError(getErrorMessage(e));
     }
 };

--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -235,6 +235,99 @@ export const createBranch = async ({
         throw new UnexpectedGitError(getErrorMessage(error));
     }
 };
+export const getBranchHeadSha = async ({
+    owner,
+    repo,
+    branch,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    branch: string;
+    installationId?: string;
+    token?: string;
+}): Promise<string> => {
+    const { octokit, headers } = getOctokit(installationId, token);
+    try {
+        const { data } = await octokit.rest.git.getRef({
+            owner,
+            repo,
+            ref: `heads/${branch}`,
+            headers,
+        });
+        return data.object.sha;
+    } catch (e) {
+        throw new UnexpectedGitError(getErrorMessage(e));
+    }
+};
+
+export type GithubFileChanges = {
+    /** `contents` is the base64-encoded file content, as required by the API. */
+    additions: { path: string; contents: string }[];
+    deletions: { path: string }[];
+};
+
+/**
+ * Create a commit on a branch via the GitHub GraphQL `createCommitOnBranch`
+ * mutation. Unlike a pushed git commit, an API commit is signed by GitHub
+ * server-side (shows as "Verified") and authored by the credential's identity —
+ * the committer cannot be spoofed, which is exactly what makes it verifiable.
+ * Pass a user `token` to attribute (and sign) the commit as that user, or an
+ * `installationId` to attribute it to the app. `expectedHeadOid` must be the
+ * current tip of `branch` (optimistic concurrency).
+ */
+export const createSignedCommitOnBranch = async ({
+    owner,
+    repo,
+    branch,
+    expectedHeadOid,
+    headline,
+    body,
+    fileChanges,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    branch: string;
+    expectedHeadOid: string;
+    headline: string;
+    body: string;
+    fileChanges: GithubFileChanges;
+    installationId?: string;
+    token?: string;
+}): Promise<{ oid: string; url: string }> => {
+    const { octokit, headers } = getOctokit(installationId, token);
+    const mutation = `mutation($input: CreateCommitOnBranchInput!) {
+        createCommitOnBranch(input: $input) {
+            commit {
+                oid
+                url
+            }
+        }
+    }`;
+    try {
+        const response = await octokit.graphql<{
+            createCommitOnBranch: { commit: { oid: string; url: string } };
+        }>(mutation, {
+            input: {
+                branch: {
+                    repositoryNameWithOwner: `${owner}/${repo}`,
+                    branchName: branch,
+                },
+                message: { headline, body },
+                expectedHeadOid,
+                fileChanges,
+            },
+            headers,
+        });
+        return response.createCommitOnBranch.commit;
+    } catch (e) {
+        throw new UnexpectedGitError(getErrorMessage(e));
+    }
+};
+
 export const getInstallationToken = async (
     installationId: string,
 ): Promise<string> => {

--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -80,6 +80,29 @@ export const getOctokitRestForApp = (installationId: string): OctokitRest => {
     });
 };
 
+/** Resolve the GitHub App's bot account (login + numeric id) for an
+ * installation, so it can be referenced as a co-author with its avatar. */
+export const getAppBotIdentity = async (
+    installationId: string,
+): Promise<{ login: string; id: number }> => {
+    const octokit = getOctokitRestForApp(installationId);
+    try {
+        const { data: installation } = await octokit.rest.apps.getInstallation({
+            installation_id: parseInt(installationId, 10),
+        });
+        const slug = installation.app_slug;
+        if (!slug) {
+            throw new ParameterError('GitHub installation has no app_slug');
+        }
+        const { data: bot } = await octokit.rest.users.getByUsername({
+            username: `${slug}[bot]`,
+        });
+        return { login: bot.login, id: bot.id };
+    } catch (e) {
+        throw new UnexpectedGitError(getErrorMessage(e));
+    }
+};
+
 /** Wrapper to get the right octokit client for the authentication provided
  * If available, use the installation id as a bot
  * otherwise use the token as a user

--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -52,6 +52,20 @@ export const getOctokitRestForUser = (
     };
 };
 
+/** Resolve the GitHub account behind a user OAuth token. Used to attribute
+ * writeback PRs and commits to the user rather than the app. */
+export const getAuthenticatedUser = async (
+    token: string,
+): Promise<{ login: string; id: number }> => {
+    const { octokit, headers } = getOctokitRestForUser(token);
+    try {
+        const { data } = await octokit.rest.users.getAuthenticated({ headers });
+        return { login: data.login, id: data.id };
+    } catch (e) {
+        throw new UnexpectedGitError(getErrorMessage(e));
+    }
+};
+
 export const getOctokitRestForApp = (installationId: string): OctokitRest => {
     if (appId === undefined)
         throw new Error('Github integration not configured');

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -46,6 +46,7 @@ import type {
 import {
     ALLOWED_TOOLS,
     CLAUDE_MODEL,
+    CO_AUTHOR_TRAILER,
     COMMIT_AUTHOR_EMAIL,
     COMMIT_AUTHOR_NAME,
     COMPILE_STRIPPED_ENV_VARS,
@@ -579,13 +580,16 @@ export class AiWritebackService extends BaseService {
         });
 
         setStage('push');
+        const body = description
+            ? `${description}\n\n${CO_AUTHOR_TRAILER}`
+            : CO_AUTHOR_TRAILER;
         await createSignedCommitOnBranch({
             owner: githubConnection.owner,
             repo: githubConnection.repo,
             branch,
             expectedHeadOid,
             headline: title,
-            body: description,
+            body,
             fileChanges,
             ...(prToken ? { token: prToken } : { installationId }),
         });

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -26,6 +26,7 @@ import {
     createBranch,
     createPullRequest,
     createSignedCommitOnBranch,
+    getAppBotIdentity,
     getAuthenticatedUser,
     getBranchHeadSha,
     getInstallationToken,
@@ -260,7 +261,25 @@ export class AiWritebackService extends BaseService {
             );
         }
 
-        return { installationId, token, prToken, commitAuthor };
+        let coAuthorTrailer = CO_AUTHOR_TRAILER;
+        try {
+            const bot = await getAppBotIdentity(installationId);
+            coAuthorTrailer = `Co-authored-by: ${bot.login} <${bot.id}+${bot.login}@users.noreply.github.com>`;
+        } catch (error) {
+            this.logger.warn(
+                `AiWriteback: could not resolve GitHub app bot identity for the co-author trailer; using the default. ${getErrorMessage(
+                    error,
+                )}`,
+            );
+        }
+
+        return {
+            installationId,
+            token,
+            prToken,
+            commitAuthor,
+            coAuthorTrailer,
+        };
     }
 
     private static elapsed(start: number): number {
@@ -555,6 +574,7 @@ export class AiWritebackService extends BaseService {
         title,
         description,
         commitAuthor,
+        coAuthorTrailer,
         prToken,
         installationId,
         setStage,
@@ -566,6 +586,7 @@ export class AiWritebackService extends BaseService {
         title: string;
         description: string;
         commitAuthor: GithubCommitAuthor;
+        coAuthorTrailer: string;
         prToken: string | null;
         installationId: string;
         setStage: SetStage;
@@ -581,8 +602,8 @@ export class AiWritebackService extends BaseService {
 
         setStage('push');
         const body = description
-            ? `${description}\n\n${CO_AUTHOR_TRAILER}`
-            : CO_AUTHOR_TRAILER;
+            ? `${description}\n\n${coAuthorTrailer}`
+            : coAuthorTrailer;
         await createSignedCommitOnBranch({
             owner: githubConnection.owner,
             repo: githubConnection.repo,
@@ -1422,6 +1443,7 @@ export class AiWritebackService extends BaseService {
                 installationId: github.installationId,
                 prToken: github.prToken,
                 commitAuthor: github.commitAuthor,
+                coAuthorTrailer: github.coAuthorTrailer,
                 setStage,
                 prTitle,
                 prDescription,
@@ -1442,6 +1464,7 @@ export class AiWritebackService extends BaseService {
             installationId: github.installationId,
             prToken: github.prToken,
             commitAuthor: github.commitAuthor,
+            coAuthorTrailer: github.coAuthorTrailer,
             setStage,
             prTitle,
             prDescription,
@@ -1492,6 +1515,7 @@ export class AiWritebackService extends BaseService {
         installationId,
         prToken,
         commitAuthor,
+        coAuthorTrailer,
         setStage,
         prTitle,
         prDescription,
@@ -1501,6 +1525,7 @@ export class AiWritebackService extends BaseService {
         installationId: string;
         prToken: string | null;
         commitAuthor: GithubCommitAuthor;
+        coAuthorTrailer: string;
         setStage: SetStage;
         prTitle: string | null;
         prDescription: string | null;
@@ -1557,6 +1582,7 @@ export class AiWritebackService extends BaseService {
             title,
             description,
             commitAuthor,
+            coAuthorTrailer,
             prToken,
             installationId,
             setStage,
@@ -1592,6 +1618,7 @@ export class AiWritebackService extends BaseService {
         installationId,
         prToken,
         commitAuthor,
+        coAuthorTrailer,
         setStage,
         prTitle,
         prDescription,
@@ -1602,6 +1629,7 @@ export class AiWritebackService extends BaseService {
         installationId: string;
         prToken: string | null;
         commitAuthor: GithubCommitAuthor;
+        coAuthorTrailer: string;
         setStage: SetStage;
         prTitle: string | null;
         prDescription: string | null;
@@ -1653,6 +1681,7 @@ export class AiWritebackService extends BaseService {
             title,
             description,
             commitAuthor,
+            coAuthorTrailer,
             prToken,
             installationId,
             setStage,

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -24,7 +24,9 @@ import type {
 } from '../../../analytics/LightdashAnalytics';
 import {
     createPullRequest,
+    getAuthenticatedUser,
     getInstallationToken,
+    getOrRefreshToken,
     updatePullRequest,
 } from '../../../clients/github/Github';
 import type { LightdashConfig } from '../../../config/parseConfig';
@@ -69,6 +71,7 @@ import type {
     AiWritebackRunArgs,
     AiWritebackSource,
     AppliedChanges,
+    GithubCommitAuthor,
     GithubConnection,
     GithubInstallation,
     SetStage,
@@ -194,9 +197,13 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
-     * Resolve a GitHub App installation access token for the organization.
-     * The token authenticates the in-sandbox clone/push and the pull request
-     * creation. Throws if no installation exists.
+     * Resolve GitHub auth for the organization. The installation access token
+     * authenticates the in-sandbox clone/push. We additionally resolve the
+     * OAuth user identity (the user who connected the GitHub App for the org)
+     * so the pull request is opened — and the commits authored — as a real
+     * user instead of the Lightdash app. Best-effort: any failure resolving the
+     * user identity falls back to the app installation + bot author. Throws only
+     * when no installation exists at all.
      */
     private async getGithubInstallation(
         organizationUuid: string,
@@ -213,7 +220,42 @@ export class AiWritebackService extends BaseService {
             );
         }
         const token = await getInstallationToken(installationId);
-        return { installationId, token };
+
+        let prToken: string | null = null;
+        let commitAuthor: GithubCommitAuthor = {
+            name: COMMIT_AUTHOR_NAME,
+            email: COMMIT_AUTHOR_EMAIL,
+        };
+        try {
+            const { token: oauthToken, refreshToken } =
+                await this.githubAppInstallationsModel.getAuth(
+                    organizationUuid,
+                );
+            const refreshed = await getOrRefreshToken(oauthToken, refreshToken);
+            if (refreshed.token !== oauthToken) {
+                await this.githubAppInstallationsModel.updateAuth(
+                    organizationUuid,
+                    refreshed.token,
+                    refreshed.refreshToken,
+                );
+            }
+            const githubUser = await getAuthenticatedUser(refreshed.token);
+            prToken = refreshed.token;
+            // Use the GitHub-provided noreply email so we never need the user's
+            // real address and the commit still links to their profile.
+            commitAuthor = {
+                name: githubUser.login,
+                email: `${githubUser.id}+${githubUser.login}@users.noreply.github.com`,
+            };
+        } catch (error) {
+            this.logger.warn(
+                `AiWriteback: could not resolve GitHub user identity for org ${organizationUuid}; the PR will be opened by the app. ${getErrorMessage(
+                    error,
+                )}`,
+            );
+        }
+
+        return { installationId, token, prToken, commitAuthor };
     }
 
     private static elapsed(start: number): number {
@@ -1282,6 +1324,8 @@ export class AiWritebackService extends BaseService {
                 githubConnection: turn.githubConnection,
                 installationId: github.installationId,
                 token: github.token,
+                prToken: github.prToken,
+                commitAuthor: github.commitAuthor,
                 setStage,
                 prTitle,
                 prDescription,
@@ -1301,6 +1345,8 @@ export class AiWritebackService extends BaseService {
             githubConnection: turn.githubConnection,
             token: github.token,
             installationId: github.installationId,
+            prToken: github.prToken,
+            commitAuthor: github.commitAuthor,
             setStage,
             prTitle,
             prDescription,
@@ -1350,6 +1396,8 @@ export class AiWritebackService extends BaseService {
         githubConnection,
         token,
         installationId,
+        prToken,
+        commitAuthor,
         setStage,
         prTitle,
         prDescription,
@@ -1358,6 +1406,8 @@ export class AiWritebackService extends BaseService {
         githubConnection: GithubConnection;
         token: string;
         installationId: string;
+        prToken: string | null;
+        commitAuthor: GithubCommitAuthor;
         setStage: SetStage;
         prTitle: string | null;
         prDescription: string | null;
@@ -1391,8 +1441,8 @@ export class AiWritebackService extends BaseService {
         await sandbox.git.createBranch(CWD, branch);
         await this.stageChanges(sandbox, githubConnection.projectSubPath);
         await sandbox.git.commit(CWD, title, {
-            authorName: COMMIT_AUTHOR_NAME,
-            authorEmail: COMMIT_AUTHOR_EMAIL,
+            authorName: commitAuthor.name,
+            authorEmail: commitAuthor.email,
         });
 
         setStage('push');
@@ -1405,6 +1455,9 @@ export class AiWritebackService extends BaseService {
         });
 
         setStage('pull_request');
+        // Open the PR as the user when we resolved their OAuth token (passing a
+        // user token and omitting installationId makes getOctokit auth as the
+        // user); otherwise fall back to the app installation.
         const pr = await createPullRequest({
             owner: githubConnection.owner,
             repo: githubConnection.repo,
@@ -1412,7 +1465,7 @@ export class AiWritebackService extends BaseService {
             body: description,
             head: branch,
             base: baseBranch,
-            installationId,
+            ...(prToken ? { token: prToken } : { installationId }),
         });
         return pr.html_url;
     }
@@ -1430,6 +1483,8 @@ export class AiWritebackService extends BaseService {
         githubConnection,
         installationId,
         token,
+        prToken,
+        commitAuthor,
         setStage,
         prTitle,
         prDescription,
@@ -1439,6 +1494,8 @@ export class AiWritebackService extends BaseService {
         githubConnection: GithubConnection;
         installationId: string;
         token: string;
+        prToken: string | null;
+        commitAuthor: GithubCommitAuthor;
         setStage: SetStage;
         prTitle: string | null;
         prDescription: string | null;
@@ -1461,8 +1518,8 @@ export class AiWritebackService extends BaseService {
         setStage('commit');
         await this.stageChanges(sandbox, githubConnection.projectSubPath);
         await sandbox.git.commit(CWD, title, {
-            authorName: COMMIT_AUTHOR_NAME,
-            authorEmail: COMMIT_AUTHOR_EMAIL,
+            authorName: commitAuthor.name,
+            authorEmail: commitAuthor.email,
         });
 
         setStage('push');
@@ -1479,13 +1536,15 @@ export class AiWritebackService extends BaseService {
         }
 
         setStage('pull_request');
+        // Patch the PR as the user when their OAuth token is available; fall
+        // back to the app installation otherwise.
         await updatePullRequest({
             owner: githubConnection.owner,
             repo: githubConnection.repo,
             pullNumber: AiWritebackService.parsePullNumber(existingRow.pr_url),
             title,
             body: description,
-            installationId,
+            ...(prToken ? { token: prToken } : { installationId }),
         });
     }
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -23,12 +23,16 @@ import type {
     LightdashAnalytics,
 } from '../../../analytics/LightdashAnalytics';
 import {
+    createBranch,
     createPullRequest,
+    createSignedCommitOnBranch,
     getAuthenticatedUser,
+    getBranchHeadSha,
     getInstallationToken,
     getOrRefreshToken,
     updatePullRequest,
 } from '../../../clients/github/Github';
+import type { GithubFileChanges } from '../../../clients/github/Github';
 import type { LightdashConfig } from '../../../config/parseConfig';
 import type { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import type { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
@@ -198,12 +202,12 @@ export class AiWritebackService extends BaseService {
 
     /**
      * Resolve GitHub auth for the organization. The installation access token
-     * authenticates the in-sandbox clone/push. We additionally resolve the
-     * OAuth user identity (the user who connected the GitHub App for the org)
-     * so the pull request is opened — and the commits authored — as a real
-     * user instead of the Lightdash app. Best-effort: any failure resolving the
-     * user identity falls back to the app installation + bot author. Throws only
-     * when no installation exists at all.
+     * authenticates the in-sandbox clone. We additionally resolve the OAuth user
+     * identity (the user who connected the GitHub App for the org) so the pull
+     * request is opened — and the signed commits authored — as a real user
+     * instead of the Lightdash app. Best-effort: any failure resolving the user
+     * identity falls back to the app installation + bot author. Throws only when
+     * no installation exists at all.
      */
     private async getGithubInstallation(
         organizationUuid: string,
@@ -496,6 +500,95 @@ export class AiWritebackService extends BaseService {
             CWD,
             scopedToProject ? { files: [projectSubPath] } : { all: true },
         );
+    }
+
+    /**
+     * Read the staged changes out of the sandbox as a set of file additions and
+     * deletions for a GitHub API commit. `-z` keeps paths NUL-separated so paths
+     * with spaces survive; `--no-renames` collapses renames into delete + add so
+     * each record is a simple (status, path) pair. Paths are repo-root-relative,
+     * which is what `createCommitOnBranch` expects.
+     */
+    private static async collectFileChanges(
+        sandbox: Sandbox,
+    ): Promise<GithubFileChanges> {
+        const { stdout } = await sandbox.commands.run(
+            `git -C ${CWD} diff --cached --name-status --no-renames -z`,
+        );
+        const parts = stdout.split('\0').filter((p) => p.length > 0);
+        const addPaths: string[] = [];
+        const deletions: { path: string }[] = [];
+        for (let i = 0; i + 1 < parts.length; i += 2) {
+            const status = parts[i];
+            const path = parts[i + 1];
+            if (status.startsWith('D')) {
+                deletions.push({ path });
+            } else {
+                addPaths.push(path);
+            }
+        }
+        const additions = await Promise.all(
+            addPaths.map(async (path) => ({
+                path,
+                contents: Buffer.from(
+                    await sandbox.files.read(`${CWD}/${path}`),
+                    'utf-8',
+                ).toString('base64'),
+            })),
+        );
+        return { additions, deletions };
+    }
+
+    /**
+     * Stage the agent's edits and commit them to `branch` via the GitHub API so
+     * the commit is signed/verified and authored by the user (or the app, when
+     * no user token is available). A local commit is also made — never pushed —
+     * purely to advance the sandbox HEAD so a subsequent resume turn's staged
+     * diff contains only that turn's edits.
+     */
+    private async commitChangesToBranch({
+        sandbox,
+        githubConnection,
+        branch,
+        expectedHeadOid,
+        title,
+        description,
+        commitAuthor,
+        prToken,
+        installationId,
+        setStage,
+    }: {
+        sandbox: Sandbox;
+        githubConnection: GithubConnection;
+        branch: string;
+        expectedHeadOid: string;
+        title: string;
+        description: string;
+        commitAuthor: GithubCommitAuthor;
+        prToken: string | null;
+        installationId: string;
+        setStage: SetStage;
+    }): Promise<void> {
+        setStage('commit');
+        await this.stageChanges(sandbox, githubConnection.projectSubPath);
+        const fileChanges =
+            await AiWritebackService.collectFileChanges(sandbox);
+        await sandbox.git.commit(CWD, title, {
+            authorName: commitAuthor.name,
+            authorEmail: commitAuthor.email,
+        });
+
+        setStage('push');
+        await createSignedCommitOnBranch({
+            owner: githubConnection.owner,
+            repo: githubConnection.repo,
+            branch,
+            expectedHeadOid,
+            headline: title,
+            body: description,
+            fileChanges,
+            ...(prToken ? { token: prToken } : { installationId }),
+        });
     }
 
     /**
@@ -1323,7 +1416,6 @@ export class AiWritebackService extends BaseService {
                 existingRow: turn.existingRow,
                 githubConnection: turn.githubConnection,
                 installationId: github.installationId,
-                token: github.token,
                 prToken: github.prToken,
                 commitAuthor: github.commitAuthor,
                 setStage,
@@ -1343,7 +1435,6 @@ export class AiWritebackService extends BaseService {
         const prUrl = await this.openInitialPullRequest({
             sandbox,
             githubConnection: turn.githubConnection,
-            token: github.token,
             installationId: github.installationId,
             prToken: github.prToken,
             commitAuthor: github.commitAuthor,
@@ -1394,7 +1485,6 @@ export class AiWritebackService extends BaseService {
     private async openInitialPullRequest({
         sandbox,
         githubConnection,
-        token,
         installationId,
         prToken,
         commitAuthor,
@@ -1404,7 +1494,6 @@ export class AiWritebackService extends BaseService {
     }: {
         sandbox: Sandbox;
         githubConnection: GithubConnection;
-        token: string;
         installationId: string;
         prToken: string | null;
         commitAuthor: GithubCommitAuthor;
@@ -1436,22 +1525,37 @@ export class AiWritebackService extends BaseService {
             ));
 
         const branch = `lightdash-ai-writeback/${randomUUID()}`;
+        const auth = prToken ? { token: prToken } : { installationId };
 
-        setStage('commit');
-        await sandbox.git.createBranch(CWD, branch);
-        await this.stageChanges(sandbox, githubConnection.projectSubPath);
-        await sandbox.git.commit(CWD, title, {
-            authorName: commitAuthor.name,
-            authorEmail: commitAuthor.email,
+        // Create the feature branch on the remote at the base tip, then commit
+        // onto it via the API so the commit is signed/verified. expectedHeadOid
+        // is the base tip we just branched from.
+        const baseOid = await getBranchHeadSha({
+            owner: githubConnection.owner,
+            repo: githubConnection.repo,
+            branch: baseBranch,
+            ...auth,
         });
-
-        setStage('push');
-        await sandbox.git.push(CWD, {
-            remote: 'origin',
+        await createBranch({
+            owner: githubConnection.owner,
+            repo: githubConnection.repo,
+            sha: baseOid,
             branch,
-            setUpstream: true,
-            username: GIT_USERNAME,
-            password: token,
+            ...auth,
+        });
+        await sandbox.git.createBranch(CWD, branch);
+
+        await this.commitChangesToBranch({
+            sandbox,
+            githubConnection,
+            branch,
+            expectedHeadOid: baseOid,
+            title,
+            description,
+            commitAuthor,
+            prToken,
+            installationId,
+            setStage,
         });
 
         setStage('pull_request');
@@ -1465,7 +1569,7 @@ export class AiWritebackService extends BaseService {
             body: description,
             head: branch,
             base: baseBranch,
-            ...(prToken ? { token: prToken } : { installationId }),
+            ...auth,
         });
         return pr.html_url;
     }
@@ -1482,7 +1586,6 @@ export class AiWritebackService extends BaseService {
         existingRow,
         githubConnection,
         installationId,
-        token,
         prToken,
         commitAuthor,
         setStage,
@@ -1493,7 +1596,6 @@ export class AiWritebackService extends BaseService {
         existingRow: AiWritebackThreadWithPrUrl;
         githubConnection: GithubConnection;
         installationId: string;
-        token: string;
         prToken: string | null;
         commitAuthor: GithubCommitAuthor;
         setStage: SetStage;
@@ -1515,25 +1617,42 @@ export class AiWritebackService extends BaseService {
                 'Follow-up changes from the Lightdash AI writeback agent.',
             ));
 
-        setStage('commit');
-        await this.stageChanges(sandbox, githubConnection.projectSubPath);
-        await sandbox.git.commit(CWD, title, {
-            authorName: commitAuthor.name,
-            authorEmail: commitAuthor.email,
-        });
-
-        setStage('push');
-        await sandbox.git.push(CWD, {
-            remote: 'origin',
-            username: GIT_USERNAME,
-            password: token,
-        });
-
         if (!existingRow.pr_url) {
             throw new ParameterError(
                 'Cannot update pull request: the writeback thread is not linked to a pull request',
             );
         }
+
+        const auth = prToken ? { token: prToken } : { installationId };
+
+        // The resumed sandbox is still on the feature branch from the prior
+        // turn. Commit this turn's edits onto it via the API (signed) using the
+        // branch's current remote tip as expectedHeadOid.
+        const featureBranch = (await sandbox.git.status(CWD)).currentBranch;
+        if (!featureBranch) {
+            throw new ParameterError(
+                'Cannot update pull request: the sandbox is not on a feature branch',
+            );
+        }
+        const expectedHeadOid = await getBranchHeadSha({
+            owner: githubConnection.owner,
+            repo: githubConnection.repo,
+            branch: featureBranch,
+            ...auth,
+        });
+
+        await this.commitChangesToBranch({
+            sandbox,
+            githubConnection,
+            branch: featureBranch,
+            expectedHeadOid,
+            title,
+            description,
+            commitAuthor,
+            prToken,
+            installationId,
+            setStage,
+        });
 
         setStage('pull_request');
         // Patch the PR as the user when their OAuth token is available; fall
@@ -1544,7 +1663,7 @@ export class AiWritebackService extends BaseService {
             pullNumber: AiWritebackService.parsePullNumber(existingRow.pr_url),
             title,
             body: description,
-            ...(prToken ? { token: prToken } : { installationId }),
+            ...auth,
         });
     }
 

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -35,6 +35,8 @@ export const GIT_USERNAME = 'x-access-token';
 export const COMMIT_AUTHOR_NAME = 'Lightdash';
 export const COMMIT_AUTHOR_EMAIL = 'developers@lightdash.com';
 
+export const CO_AUTHOR_TRAILER = `Co-authored-by: ${COMMIT_AUTHOR_NAME} <${COMMIT_AUTHOR_EMAIL}>`;
+
 // Hard ceiling on a single synchronous run. The HTTP request is held open for
 // the duration, so keep this well under typical load-balancer/proxy timeouts.
 export const RUN_TIMEOUT_MS = 20 * 60 * 1000;

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -22,9 +22,24 @@ export type GithubConnection = {
     projectSubPath: string;
 };
 
+export type GithubCommitAuthor = {
+    name: string;
+    email: string;
+};
+
 export type GithubInstallation = {
     installationId: string;
+    /** Installation access token — authenticates the in-sandbox clone/push. */
     token: string;
+    /**
+     * OAuth user token used to open/update the pull request so it is attributed
+     * to the GitHub user who connected the app for the org, not the Lightdash
+     * app itself. `null` when no user identity could be resolved, in which case
+     * the PR falls back to being opened by the app installation.
+     */
+    prToken: string | null;
+    /** Author stamped on the writeback commits — the GitHub user, or the bot fallback. */
+    commitAuthor: GithubCommitAuthor;
 };
 
 export type SetStage = (stage: AiWritebackFailureStage) => void;

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -40,6 +40,13 @@ export type GithubInstallation = {
     prToken: string | null;
     /** Author stamped on the writeback commits — the GitHub user, or the bot fallback. */
     commitAuthor: GithubCommitAuthor;
+    /**
+     * `Co-authored-by:` trailer appended to the commit message to credit the
+     * Lightdash app bot (resolved to its avatar-backed GitHub identity), so the
+     * agent's involvement is visible even though the commit is authored as the
+     * user.
+     */
+    coAuthorTrailer: string;
 };
 
 export type SetStage = (stage: AiWritebackFailureStage) => void;


### PR DESCRIPTION
## What & why

AI writeback opened its pull request with the GitHub App **installation token** and hardcoded the commit author to the Lightdash bot, so every writeback PR showed up as opened by `lightdash-app[bot]` with commits authored by `Lightdash <developers@lightdash.com>` — no trace of who requested the change, and the commits were unsigned/Unverified.

This PR makes writeback PRs **opened by, authored by, and signed on behalf of the connecting GitHub user**.

Relates to PROD-8050.

## Changes

**1. Raise the PR & author commits as the user**
- `getGithubInstallation` now also resolves the org's GitHub OAuth user identity (`getAuth` → `getOrRefreshToken` → `getAuthenticatedUser`).
- The PR is opened/updated with the user OAuth token (omitting `installationId` so `getOctokit` authenticates as the user).
- Falls back to the app installation + bot author when no user identity can be resolved.

**2. Signed / Verified commits via the GitHub API**
- Replaces the in-sandbox `git push` with a GraphQL `createCommitOnBranch` call. GitHub builds and **signs the commit server-side** (web-flow GPG key) and stamps the author from the authenticated token, so the commit is **Verified** and attributed to the user — the committer cannot be spoofed, which is what makes it verifiable.
- Adds `getBranchHeadSha` + `createSignedCommitOnBranch` helpers; the feature branch is created on the remote via the API and `expectedHeadOid` is resolved from the branch tip (base for the initial PR, feature branch on resume).
- Per-turn file changes are collected from the staged diff (`git diff --cached -z`) and sent as base64 additions/deletions. A local commit (never pushed) keeps the sandbox HEAD advancing so resume turns stay per-turn clean.
- The clone still uses the installation token; only the commit/push step changed.

**3. Dev tooling fix**
- `scripts/dev-fast-start.sh` always runs the idempotent core+EE migrate instead of false-skipping when one EE table already exists, so restoring a snapshot that's behind HEAD no longer leaves `/health` returning 500.

## How the signing works

`createCommitOnBranch` produces a commit whose `committer` is `GitHub <noreply@github.com>` and whose signature validates against GitHub's web-flow key, while the `author` is the OAuth token's user. The signature attests "GitHub created this commit on behalf of the authenticated user" — which is why a user OAuth token (not the app token) is required.

## Verification

Tested end-to-end through the AI agent chat against a GitHub-backed dbt project:
- PR opened by the user (`is_bot: false`).
- Commit `verified: true` / reason `valid`, authored by the user.

## Remaining scope

The identity used is the **GitHub connector** for the org (the user who connected the GitHub App), not yet the specific Slack/web requester. True per-requester attribution needs a per-user GitHub OAuth linkage (tracked in PROD-8050) — no per-user GitHub identity is stored today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
