### PR TITLE
fix(explorer): keep field-picker state on background refetch [PROD-8043]

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -99,7 +99,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
 
     const {
         data: explore,
-        isFetching,
+        isInitialLoading,
         status,
         error,
     } = useExplore(activeTableName);
@@ -173,7 +173,10 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
         return items;
     }, [onBack, explore]);
 
-    if (isFetching) {
+    // Only show the skeleton on the initial load (no data yet) — not on
+    // background refetches, which would unmount ExploreTree and wipe its
+    // local search/expanded state (PROD-8043).
+    if (isInitialLoading) {
         return <LoadingSkeleton />;
     }
 

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -173,9 +173,6 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
         return items;
     }, [onBack, explore]);
 
-    // Only show the skeleton on the initial load (no data yet) — not on
-    // background refetches, which would unmount ExploreTree and wipe its
-    // local search/expanded state (PROD-8043).
     if (isInitialLoading) {
         return <LoadingSkeleton />;
     }


### PR DESCRIPTION
## Problem

The explore field-picker (left sidebar) intermittently reset its UI state while working in an explore — the search term cleared and all field categories collapsed, preceded by a brief skeleton flash. It mostly showed up on large explores and was hard to reproduce on smaller ones.

## Root cause

`ExplorePanel` rendered `<LoadingSkeleton/>` whenever the explore query was `isFetching`, which is true on **every** background refetch — not just the initial load. Swapping in the skeleton unmounts `ExploreTree`, whose search term and expanded-category state live in local `useState`, so they reset on remount.

Background refetches fire when the cached explore goes stale (30s default `staleTime`) and a new `useExplore` observer mounts — e.g. as new field nodes mount while the user types in search. Larger/slower explores keep the skeleton on screen long enough to be disruptive, which is why it correlated with explore size.

This was an unintended change in #17612, which flipped the gate from `status === 'loading'` to `isFetching` while extracting the `LoadingSkeleton` component.

## Fix

Gate the skeleton on `isInitialLoading` (no data yet) instead of `isFetching`. Background refetches now update the tree in place without unmounting it, preserving the search term + expanded categories. Switching tables still shows the skeleton, and dbt refresh still surfaces new fields (it has its own progress UI via the Refresh dbt button/job toast).

A regression test follows in the stacked PR.

Closes: PROD-8043
Closes: #23722
