### PR TITLE
feat(ai-writeback): show "View preview" next to "View pull request" in chat (PROD-8055)

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -572,6 +572,46 @@ export const getPullRequest = async ({
     }
 };
 
+/**
+ * Return the bodies of every issue comment on a pull request (PRs are issues in
+ * the GitHub API). Used to discover the Lightdash preview-environment URL that
+ * the dbt repo's CI posts after publishing a preview. Empty bodies are dropped.
+ */
+export const getPullRequestComments = async ({
+    owner,
+    repo,
+    pullNumber,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    pullNumber: number;
+    installationId?: string;
+    token?: string;
+}): Promise<string[]> => {
+    const { octokit, headers } = getOctokit(installationId, token);
+
+    try {
+        const comments = await octokit.paginate(
+            octokit.rest.issues.listComments,
+            {
+                owner,
+                repo,
+                issue_number: pullNumber,
+                per_page: 100,
+                headers,
+            },
+        );
+
+        return comments
+            .map((comment) => comment.body ?? '')
+            .filter((body) => body.length > 0);
+    } catch (e) {
+        throw new UnexpectedGitError(getErrorMessage(e));
+    }
+};
+
 export type PullRequestMetadata = {
     title: string;
     state: PullRequestState;

--- a/packages/backend/src/controllers/pullRequestsController.ts
+++ b/packages/backend/src/controllers/pullRequestsController.ts
@@ -1,5 +1,6 @@
 import {
     ApiErrorPayload,
+    ApiPullRequestPreviewResponse,
     ApiPullRequestsResponse,
     assertRegisteredAccount,
     KnexPaginateArgs,
@@ -55,6 +56,36 @@ export class PullRequestsController extends BaseController {
                     toSessionUser(req.account),
                     projectUuid,
                     paginateArgs,
+                ),
+        };
+    }
+
+    /**
+     * Resolve the Lightdash preview environment URL for a write-back pull
+     * request. Returns `{ previewUrl: null }` until the preview is published,
+     * so the client can poll.
+     * @summary Get pull request preview
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/preview')
+    @OperationId('getPullRequestPreview')
+    async getPullRequestPreview(
+        @Path() projectUuid: string,
+        @Query() prUrl: string,
+        @Request() req: express.Request,
+    ): Promise<ApiPullRequestPreviewResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        return {
+            status: 'ok',
+            results: await this.services
+                .getPullRequestsService()
+                .getPullRequestPreview(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    prUrl,
                 ),
         };
     }

--- a/packages/backend/src/controllers/pullRequestsController.ts
+++ b/packages/backend/src/controllers/pullRequestsController.ts
@@ -4,6 +4,7 @@ import {
     ApiPullRequestsResponse,
     assertRegisteredAccount,
     KnexPaginateArgs,
+    ParameterError,
 } from '@lightdash/common';
 import {
     Get,
@@ -18,6 +19,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { z } from 'zod';
 import { toSessionUser } from '../auth/account';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
@@ -76,6 +78,12 @@ export class PullRequestsController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiPullRequestPreviewResponse> {
         assertRegisteredAccount(req.account);
+
+        const parsedPrUrl = z.string().url().safeParse(prUrl);
+        if (!parsedPrUrl.success) {
+            throw new ParameterError('prUrl must be a valid URL');
+        }
+
         this.setStatus(200);
 
         return {
@@ -85,7 +93,7 @@ export class PullRequestsController extends BaseController {
                 .getPullRequestPreview(
                     toSessionUser(req.account),
                     projectUuid,
-                    prUrl,
+                    parsedPrUrl.data,
                 ),
         };
     }

--- a/packages/backend/src/ee/controllers/AiWritebackController.ts
+++ b/packages/backend/src/ee/controllers/AiWritebackController.ts
@@ -4,9 +4,11 @@ import {
     type AiWritebackRequestBody,
     type ApiAiWritebackResponse,
     type ApiErrorPayload,
+    type ApiProjectCiStatusResponse,
 } from '@lightdash/common';
 import {
     Body,
+    Get,
     Hidden,
     Middlewares,
     OperationId,
@@ -78,6 +80,32 @@ export class AiWritebackController extends BaseController {
         return {
             status: 'ok',
             results: result,
+        };
+    }
+
+    /**
+     * Get the project's CI status — whether its repo has a Lightdash
+     * preview-deploy workflow. Lets the chat UI decide whether a write-back PR
+     * will produce a preview deployment. Returns null when never scanned.
+     * @summary Get project CI status
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/ci-status')
+    @OperationId('getProjectCiStatus')
+    async getProjectCiStatus(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiProjectCiStatusResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results = await this.getAiWritebackService().getProjectCiStatus(
+            toSessionUser(req.account),
+            projectUuid,
+        );
+        return {
+            status: 'ok',
+            results,
         };
     }
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -343,6 +343,32 @@ export class AiWritebackService extends BaseService {
      *   branch (updates the existing PR), pause the sandbox again.
      */
     /**
+     * Read the recorded CI status for a project (whether its repo has a
+     * Lightdash preview-deploy workflow). Returns null when the project has
+     * never been scanned. Used by the chat UI to decide whether a write-back
+     * PR will get a preview deployment, so it only waits for a preview URL when
+     * one is actually expected.
+     */
+    async getProjectCiStatus(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ProjectCiStatus | null> {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('SourceCode', {
+                    organizationUuid: user.organizationUuid!,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        return this.projectCiStatusModel.findByProjectUuid(projectUuid);
+    }
+
+    /**
      * Secondary task of the writeback agent: while the repo is cloned in the
      * sandbox, detect whether it already deploys Lightdash preview projects via
      * GitHub Actions and persist the result. A project already recorded as set

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -353,12 +353,15 @@ export class AiWritebackService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<ProjectCiStatus | null> {
+        // Authorize against the project's own organization (resource-derived),
+        // not the caller's org.
+        const project = await this.projectModel.get(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
-                    organizationUuid: user.organizationUuid!,
+                    organizationUuid: project.organizationUuid,
                     projectUuid,
                 }),
             )

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12332,11 +12332,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12394,11 +12394,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12435,11 +12435,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13510,11 +13510,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13575,11 +13575,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13756,11 +13756,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13775,11 +13775,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13794,11 +13794,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -18941,6 +18941,57 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 prompt: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ProjectCiStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                checkedAt: { dataType: 'datetime', required: true },
+                detectedCommitSha: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                workflowPath: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                hasPreviewDeployWorkflow: {
+                    dataType: 'boolean',
+                    required: true,
+                },
+                projectUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiProjectCiStatusResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ProjectCiStatus' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
         },
@@ -48886,6 +48937,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'runAiWriteback',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiWritebackController_getProjectCiStatus: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/ai-writeback/ci-status',
+        ...fetchMiddlewares<RequestHandler>(AiWritebackController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiWritebackController.prototype.getProjectCiStatus,
+        ),
+
+        async function AiWritebackController_getProjectCiStatus(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiWritebackController_getProjectCiStatus,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiWritebackController>(
+                        AiWritebackController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getProjectCiStatus',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12435,11 +12435,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13510,11 +13510,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13756,11 +13756,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13775,11 +13775,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13794,11 +13794,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -19708,6 +19708,51 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentJudgeProjectContextEntry: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                objects: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                terms: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                content: { dataType: 'string', required: true },
+                kind: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['definition'] },
+                        { dataType: 'enum', enums: ['context'] },
+                    ],
+                    required: true,
+                },
+                id: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                op: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['create'] },
+                        { dataType: 'enum', enums: ['update'] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentReviewItemSummary: {
         dataType: 'refAlias',
         type: {
@@ -19725,6 +19770,19 @@ const models: TsoaRoute.Models = {
                                     nestedProperties: {
                                         createdAt: {
                                             dataType: 'datetime',
+                                            required: true,
+                                        },
+                                        projectContextEntry: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    ref: 'AiAgentJudgeProjectContextEntry',
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: [null],
+                                                },
+                                            ],
                                             required: true,
                                         },
                                         recommendation: {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12282,6 +12282,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['listContent'] },
                 { dataType: 'enum', enums: ['findExplores'] },
                 { dataType: 'enum', enums: ['findFields'] },
+                { dataType: 'enum', enums: ['searchSemanticLayer'] },
                 { dataType: 'enum', enums: ['discoverFields'] },
                 { dataType: 'enum', enums: ['searchFieldValues'] },
                 { dataType: 'enum', enums: ['findDashboards'] },
@@ -12453,11 +12454,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12472,11 +12473,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12491,11 +12492,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12595,24 +12596,24 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                tableName:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
-                                                                                                name: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 fieldType:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                tableName:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -12640,6 +12641,29 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
                                                                                                 joinedTables:
                                                                                                     {
                                                                                                         dataType:
@@ -12667,35 +12691,12 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -12727,11 +12728,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12876,24 +12877,24 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    tableName:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
-                                                                                                        },
-                                                                                                    name: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     fieldType:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    tableName:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
+                                                                                                    name: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
@@ -12924,11 +12925,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12943,11 +12944,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12961,13 +12962,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -12990,11 +12991,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13106,51 +13107,6 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -13171,6 +13127,51 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -13370,25 +13371,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -13427,11 +13409,30 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13486,10 +13487,6 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13499,6 +13496,10 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                             },
                                         },
                                         {
@@ -13528,11 +13529,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13547,11 +13548,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13569,6 +13570,168 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                ranking: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType:
+                                                                'nestedObjectLiteral',
+                                                            nestedProperties: {
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                chartUsage:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'double',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'undefined',
+                                                                                                },
+                                                                                            ],
+                                                                                    },
+                                                                                searchRank:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'double',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'undefined',
+                                                                                                },
+                                                                                            ],
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                tableName:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
+                                                                type: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    'metric',
+                                                                                ],
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    'dimension',
+                                                                                ],
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 status: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -25284,6 +25447,36 @@ const models: TsoaRoute.Models = {
                     ref: 'KnexPaginatedData_PullRequestWithStatus-Array_',
                     required: true,
                 },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PullRequestPreview: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                previewUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiPullRequestPreviewResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'PullRequestPreview', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
@@ -56522,6 +56715,73 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'listPullRequests',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsPullRequestsController_getPullRequestPreview: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        prUrl: {
+            in: 'query',
+            name: 'prUrl',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/pull-requests/preview',
+        ...fetchMiddlewares<RequestHandler>(PullRequestsController),
+        ...fetchMiddlewares<RequestHandler>(
+            PullRequestsController.prototype.getPullRequestPreview,
+        ),
+
+        async function PullRequestsController_getPullRequestPreview(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsPullRequestsController_getPullRequestPreview,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<PullRequestsController>(
+                        PullRequestsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getPullRequestPreview',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13893,8 +13893,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13952,8 +13952,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13977,19 +13977,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -14486,6 +14473,19 @@
                                                     "name",
                                                     "status"
                                                 ],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
                                                 "type": "object"
                                             },
                                             {
@@ -19586,6 +19586,59 @@
                 "required": ["prompt"],
                 "type": "object",
                 "description": "Body for kicking off an AI writeback run. The target repository is\ncloned into a sandbox, the prompt is executed by the Claude Code CLI, and a\npull request is opened against the repo if the agent changes any files.\n\nThe target repository (owner, repo) and the dbt project sub-folder are\nresolved server-side from the Lightdash project's dbt connection — identified\nby the `projectUuid` path parameter — so the caller only supplies the prompt."
+            },
+            "ProjectCiStatus": {
+                "properties": {
+                    "checkedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "detectedCommitSha": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Repo HEAD commit the scan ran against, for debugging staleness."
+                    },
+                    "workflowPath": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Path of the detected workflow file, or null when none was found."
+                    },
+                    "hasPreviewDeployWorkflow": {
+                        "type": "boolean"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "checkedAt",
+                    "detectedCommitSha",
+                    "workflowPath",
+                    "hasPreviewDeployWorkflow",
+                    "projectUuid"
+                ],
+                "type": "object",
+                "description": "Per-project record of whether a project's git repo has Lightdash CI/CD set\nup. Populated as a secondary task of the AI writeback sandbox agent: while it\nhas the repo cloned it scans `.github/workflows/` for a Lightdash\npreview-deploy workflow and persists the result so we don't re-scan a project\nthat already has it set up."
+            },
+            "ApiProjectCiStatusResponse": {
+                "properties": {
+                    "results": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ProjectCiStatus"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object",
+                "description": "CI status for a project, or null when the project has never been scanned\n(e.g. no AI writeback has run yet). A null result means \"unknown\", which is\ndistinct from a record with `hasPreviewDeployWorkflow: false` (\"scanned, no\npreview workflow\")."
             },
             "Pick_AiAgentThreadSummary_AiAgentUser-and-_slackUserId-string-or-null--email-string-or-null__.user-or-createdAt-or-createdFrom-or-title-or-uuid_": {
                 "properties": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13852,6 +13852,7 @@
                     "listContent",
                     "findExplores",
                     "findFields",
+                    "searchSemanticLayer",
                     "discoverFields",
                     "searchFieldValues",
                     "findDashboards",
@@ -13996,6 +13997,19 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "error",
+                                                            "success"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
@@ -14016,24 +14030,24 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "tableName": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "name": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "fieldType": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
                                                                             "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "tableName",
-                                                                        "name",
                                                                         "fieldType",
-                                                                        "label"
+                                                                        "tableName",
+                                                                        "label",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -14042,6 +14056,11 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
@@ -14049,21 +14068,16 @@
                                                                             "type": "array",
                                                                             "nullable": true
                                                                         },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "name",
-                                                                        "label"
+                                                                        "label",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -14081,8 +14095,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -14141,24 +14155,24 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "name": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "fieldType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "label": {
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    "name": {
+                                                                                        "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "tableName",
-                                                                                    "name",
                                                                                     "fieldType",
-                                                                                    "label"
+                                                                                    "tableName",
+                                                                                    "label",
+                                                                                    "name"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -14185,8 +14199,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -14199,19 +14213,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14220,8 +14234,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
+                                                            "success",
                                                             "not_found"
                                                         ]
                                                     }
@@ -14287,28 +14301,28 @@
                                                                                 "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
+                                                                                "description": {
                                                                                     "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
+                                                                                    "nullable": true
                                                                                 },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
+                                                                                "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "description": {
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
                                                                                     "type": "string",
-                                                                                    "nullable": true
+                                                                                    "enum": [
+                                                                                        "metric",
+                                                                                        "dimension"
+                                                                                    ]
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "name": {
                                                                                     "type": "string"
@@ -14317,12 +14331,12 @@
                                                                             "required": [
                                                                                 "isFromJoinedTable",
                                                                                 "fieldValueType",
-                                                                                "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "table",
-                                                                                "label",
-                                                                                "fieldId",
                                                                                 "description",
+                                                                                "fieldFilterType",
+                                                                                "fieldId",
+                                                                                "table",
+                                                                                "fieldType",
+                                                                                "label",
                                                                                 "name"
                                                                             ],
                                                                             "type": "object"
@@ -14476,19 +14490,6 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "error",
-                                                            "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -14507,9 +14508,6 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
@@ -14517,13 +14515,16 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "name",
                                                     "slug",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14532,10 +14533,82 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
                                                             "success",
+                                                            "error",
                                                             "rejected",
                                                             "timeout"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "ranking": {
+                                                        "properties": {
+                                                            "fields": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "fieldType": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "tableName": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "label": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "fieldType",
+                                                                        "tableName",
+                                                                        "label",
+                                                                        "name"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "metric",
+                                                                    "dimension",
+                                                                    null
+                                                                ],
+                                                                "nullable": true
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fields",
+                                                            "searchQuery",
+                                                            "type"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -26161,6 +26234,31 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "PullRequestPreview": {
+                "properties": {
+                    "previewUrl": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["previewUrl"],
+                "type": "object",
+                "description": "The Lightdash preview environment for a pull request. `previewUrl` is null\nuntil a preview has been published: the dbt repo's CI creates the preview\nproject asynchronously and comments its URL on the PR, so the URL can only be\ndiscovered after the fact (it is not predictable from the PR itself)."
+            },
+            "ApiPullRequestPreviewResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/PullRequestPreview"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "DbtProjectType.DBT": {
                 "enum": ["dbt"],
                 "type": "string"
@@ -37494,7 +37592,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3078.0",
+        "version": "0.3080.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -50214,6 +50312,55 @@
                         "schema": {
                             "format": "double",
                             "type": "number"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/pull-requests/preview": {
+            "get": {
+                "operationId": "getPullRequestPreview",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiPullRequestPreviewResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Resolve the Lightdash preview environment URL for a write-back pull\nrequest. Returns `{ previewUrl: null }` until the preview is published,\nso the client can poll.",
+                "summary": "Get pull request preview",
+                "tags": ["Pull Requests"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "prUrl",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 ]

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13987,6 +13987,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -14473,19 +14486,6 @@
                                                     "name",
                                                     "status"
                                                 ],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
                                                 "type": "object"
                                             },
                                             {
@@ -20347,6 +20347,39 @@
                 "required": ["targetRefs", "rationale", "title", "actionType"],
                 "type": "object"
             },
+            "AiAgentJudgeProjectContextEntry": {
+                "properties": {
+                    "objects": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "terms": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "content": {
+                        "type": "string"
+                    },
+                    "kind": {
+                        "type": "string",
+                        "enum": ["definition", "context"]
+                    },
+                    "id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "op": {
+                        "type": "string",
+                        "enum": ["create", "update"]
+                    }
+                },
+                "required": ["objects", "terms", "content", "kind", "id", "op"],
+                "type": "object"
+            },
             "AiAgentReviewItemSummary": {
                 "allOf": [
                     {
@@ -20359,6 +20392,14 @@
                                     "createdAt": {
                                         "type": "string",
                                         "format": "date-time"
+                                    },
+                                    "projectContextEntry": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/AiAgentJudgeProjectContextEntry"
+                                            }
+                                        ],
+                                        "nullable": true
                                     },
                                     "recommendation": {
                                         "allOf": [
@@ -20410,6 +20451,7 @@
                                 },
                                 "required": [
                                     "createdAt",
+                                    "projectContextEntry",
                                     "recommendation",
                                     "evidenceExcerpts",
                                     "targetRefs",
@@ -37645,7 +37687,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3080.0",
+        "version": "0.3081.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/PullRequestsModel.ts
+++ b/packages/backend/src/models/PullRequestsModel.ts
@@ -225,6 +225,32 @@ export class PullRequestsModel {
         return mapDbPullRequest(row, threadInfo.get(pullRequestUuid) ?? null);
     }
 
+    /**
+     * Look up a recorded pull request by its URL, scoped to a project. Used to
+     * resolve a PR the frontend only knows by URL (e.g. from an AI write-back
+     * tool result) back to its stored owner/repo/number before reaching out to
+     * the provider.
+     */
+    async findByProjectAndUrl(
+        projectUuid: string,
+        prUrl: string,
+    ): Promise<PullRequest | null> {
+        const row = await this.database(PullRequestsTableName)
+            .where('project_uuid', projectUuid)
+            .andWhere('pr_url', prUrl)
+            .first();
+
+        if (!row) {
+            return null;
+        }
+
+        const threadInfo = await this.getAiThreadInfo([row.pull_request_uuid]);
+        return mapDbPullRequest(
+            row,
+            threadInfo.get(row.pull_request_uuid) ?? null,
+        );
+    }
+
     async delete(pullRequestUuid: string): Promise<void> {
         await this.database(PullRequestsTableName)
             .where('pull_request_uuid', pullRequestUuid)

--- a/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
+++ b/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
@@ -1,11 +1,13 @@
 import { subject } from '@casl/ability';
 import {
     DbtProjectType,
+    extractPreviewUrlFromComments,
     ForbiddenError,
     getErrorMessage,
     KnexPaginateArgs,
     KnexPaginatedData,
     PullRequest,
+    PullRequestPreview,
     PullRequestProvider,
     PullRequestState,
     PullRequestWithStatus,
@@ -186,5 +188,79 @@ export class PullRequestsService extends BaseService {
             }),
             pagination,
         };
+    }
+
+    /**
+     * Resolve the Lightdash preview-environment URL for a write-back pull
+     * request, identified by its URL within a project. The preview is created
+     * asynchronously by the dbt repo's CI, which comments the URL on the PR, so
+     * this reads the PR's comments and extracts the link.
+     *
+     * Returns `{ previewUrl: null }` (rather than throwing) whenever a preview
+     * isn't available yet — an unknown PR, a non-GitHub provider, missing git
+     * credentials, or a transient provider error — so the caller can poll until
+     * the preview appears without surfacing errors.
+     */
+    async getPullRequestPreview(
+        user: SessionUser,
+        projectUuid: string,
+        prUrl: string,
+    ): Promise<PullRequestPreview> {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('SourceCode', {
+                    organizationUuid: user.organizationUuid!,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const pullRequest = await this.pullRequestsModel.findByProjectAndUrl(
+            projectUuid,
+            prUrl,
+        );
+        // Only surface previews for PRs we recorded for this project, and only
+        // for GitHub (the single provider we read comments from today).
+        if (
+            !pullRequest ||
+            pullRequest.provider !== PullRequestProvider.GITHUB
+        ) {
+            return { previewUrl: null };
+        }
+
+        try {
+            const credentials =
+                await this.gitIntegrationService.getGitCredentials(
+                    user,
+                    projectUuid,
+                );
+            if (credentials.type !== DbtProjectType.GITHUB) {
+                return { previewUrl: null };
+            }
+            const comments = await GithubClient.getPullRequestComments({
+                owner: pullRequest.owner,
+                repo: pullRequest.repo,
+                pullNumber: pullRequest.prNumber,
+                installationId: credentials.installationId,
+                token: credentials.token,
+            });
+            return {
+                previewUrl: extractPreviewUrlFromComments(
+                    comments,
+                    this.lightdashConfig.siteUrl,
+                ),
+            };
+        } catch (error) {
+            this.logger.warn('Failed to resolve pull request preview URL', {
+                projectUuid,
+                prUrl,
+                error: getErrorMessage(error),
+            });
+            return { previewUrl: null };
+        }
     }
 }

--- a/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
+++ b/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
@@ -233,20 +233,34 @@ export class PullRequestsService extends BaseService {
         }
 
         try {
-            const credentials =
-                await this.gitIntegrationService.getGitCredentials(
-                    user,
-                    projectUuid,
-                );
-            if (credentials.type !== DbtProjectType.GITHUB) {
-                return { previewUrl: null };
+            // Read the PR's comments using the GitHub App installation — the
+            // same identity the write-back used to open the PR — so a stale
+            // OAuth user token can't block the lookup. Fall back to the
+            // project's stored credentials (e.g. a personal access token) only
+            // when there is no installation.
+            let installationId: string | undefined;
+            let token: string | undefined;
+            try {
+                installationId =
+                    await this.gitIntegrationService.getInstallationId(user);
+            } catch {
+                const credentials =
+                    await this.gitIntegrationService.getGitCredentials(
+                        user,
+                        projectUuid,
+                    );
+                if (credentials.type !== DbtProjectType.GITHUB) {
+                    return { previewUrl: null };
+                }
+                installationId = credentials.installationId;
+                token = credentials.token;
             }
             const comments = await GithubClient.getPullRequestComments({
                 owner: pullRequest.owner,
                 repo: pullRequest.repo,
                 pullNumber: pullRequest.prNumber,
-                installationId: credentials.installationId,
-                token: credentials.token,
+                installationId,
+                token,
             });
             return {
                 previewUrl: extractPreviewUrlFromComments(

--- a/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
+++ b/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
@@ -206,12 +206,24 @@ export class PullRequestsService extends BaseService {
         projectUuid: string,
         prUrl: string,
     ): Promise<PullRequestPreview> {
+        const pullRequest = await this.pullRequestsModel.findByProjectAndUrl(
+            projectUuid,
+            prUrl,
+        );
+        // Nothing recorded for this project + URL — no preview to surface.
+        if (!pullRequest) {
+            return { previewUrl: null };
+        }
+
+        // Authorize against the project's own organization (taken from the
+        // recorded PR), not the caller's org — so an org admin cannot probe a
+        // project that belongs to a different organization.
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
-                    organizationUuid: user.organizationUuid!,
+                    organizationUuid: pullRequest.organizationUuid,
                     projectUuid,
                 }),
             )
@@ -219,16 +231,8 @@ export class PullRequestsService extends BaseService {
             throw new ForbiddenError();
         }
 
-        const pullRequest = await this.pullRequestsModel.findByProjectAndUrl(
-            projectUuid,
-            prUrl,
-        );
-        // Only surface previews for PRs we recorded for this project, and only
-        // for GitHub (the single provider we read comments from today).
-        if (
-            !pullRequest ||
-            pullRequest.provider !== PullRequestProvider.GITHUB
-        ) {
+        // Only GitHub is supported for reading preview comments today.
+        if (pullRequest.provider !== PullRequestProvider.GITHUB) {
             return { previewUrl: null };
         }
 

--- a/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
+++ b/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
@@ -16,6 +16,7 @@ import {
 import * as GithubClient from '../../clients/github/Github';
 import * as GitlabClient from '../../clients/gitlab/Gitlab';
 import type { LightdashConfig } from '../../config/parseConfig';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { PullRequestsModel } from '../../models/PullRequestsModel';
 import { BaseService } from '../BaseService';
 import { GitIntegrationService } from '../GitIntegrationService/GitIntegrationService';
@@ -24,6 +25,7 @@ type PullRequestsServiceArguments = {
     lightdashConfig: LightdashConfig;
     pullRequestsModel: PullRequestsModel;
     gitIntegrationService: GitIntegrationService;
+    projectModel: ProjectModel;
 };
 
 type PullRequestMetadata = { title: string; state: PullRequestState };
@@ -35,11 +37,14 @@ export class PullRequestsService extends BaseService {
 
     private readonly gitIntegrationService: GitIntegrationService;
 
+    private readonly projectModel: ProjectModel;
+
     constructor(args: PullRequestsServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
         this.pullRequestsModel = args.pullRequestsModel;
         this.gitIntegrationService = args.gitIntegrationService;
+        this.projectModel = args.projectModel;
     }
 
     /**
@@ -101,12 +106,16 @@ export class PullRequestsService extends BaseService {
         projectUuid: string,
         paginateArgs?: KnexPaginateArgs,
     ): Promise<KnexPaginatedData<PullRequestWithStatus[]>> {
+        // Authorize against the project's own organization (resource-derived),
+        // not the caller's org.
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
-                    organizationUuid: user.organizationUuid!,
+                    organizationUuid,
                     projectUuid,
                 }),
             )

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -441,6 +441,7 @@ export class ServiceRepository
                     lightdashConfig: this.context.lightdashConfig,
                     pullRequestsModel: this.models.getPullRequestsModel(),
                     gitIntegrationService: this.getGitIntegrationService(),
+                    projectModel: this.models.getProjectModel(),
                 }),
         );
     }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -185,6 +185,7 @@ import type {
     PreAggregateMatchMiss,
 } from './preAggregate';
 import { type ApiPreviewExpirationProjectSettingsResponse } from './previewExpirationProjectSettings';
+import { type ProjectCiStatus } from './projectCiStatus';
 import {
     type ApiProjectCompileLogResponse,
     type ApiProjectCompileLogsResponse,
@@ -988,6 +989,7 @@ type ApiResults =
     | Array<GitRepo>
     | PullRequestCreated
     | PullRequestPreview
+    | ProjectCiStatus
     | ApiGitFileContent
     | GitIntegrationConfiguration
     | GitBranch

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -128,6 +128,7 @@ import {
     type GitIntegrationConfiguration,
     type GitRepo,
     type PullRequestCreated,
+    type PullRequestPreview,
 } from './gitIntegration';
 import type { ApiGroupListResponse } from './groups';
 import { type ApiImpersonationOrganizationSettingsResponse } from './impersonationOrganizationSettings';
@@ -986,6 +987,7 @@ type ApiResults =
     | DecodedEmbed
     | Array<GitRepo>
     | PullRequestCreated
+    | PullRequestPreview
     | ApiGitFileContent
     | GitIntegrationConfiguration
     | GitBranch

--- a/packages/common/src/types/gitIntegration.test.ts
+++ b/packages/common/src/types/gitIntegration.test.ts
@@ -1,0 +1,80 @@
+import { extractPreviewUrlFromComments } from './gitIntegration';
+
+const SITE_URL = 'https://app.lightdash.cloud';
+const PREVIEW_UUID = '3c9a1b2d-4e5f-6071-8293-a4b5c6d7e8f9';
+const PREVIEW_URL = `${SITE_URL}/projects/${PREVIEW_UUID}/tables`;
+
+describe('extractPreviewUrlFromComments', () => {
+    it('returns null when there are no comments', () => {
+        expect(extractPreviewUrlFromComments([], SITE_URL)).toBeNull();
+    });
+
+    it('returns null when no comment contains a preview URL', () => {
+        expect(
+            extractPreviewUrlFromComments(
+                ['Looks good to me', 'Please add a test'],
+                SITE_URL,
+            ),
+        ).toBeNull();
+    });
+
+    it('extracts a bare preview URL', () => {
+        expect(
+            extractPreviewUrlFromComments(
+                [`Preview environment ready: ${PREVIEW_URL}`],
+                SITE_URL,
+            ),
+        ).toBe(PREVIEW_URL);
+    });
+
+    it('extracts a preview URL from a markdown link without trailing punctuation', () => {
+        expect(
+            extractPreviewUrlFromComments(
+                [`Your [preview](${PREVIEW_URL}) is ready.`],
+                SITE_URL,
+            ),
+        ).toBe(PREVIEW_URL);
+    });
+
+    it('ignores project URLs on other hosts', () => {
+        expect(
+            extractPreviewUrlFromComments(
+                [
+                    `https://github.com/lightdash/jaffle/pull/29`,
+                    `https://evil.example.com/projects/${PREVIEW_UUID}/tables`,
+                ],
+                SITE_URL,
+            ),
+        ).toBeNull();
+    });
+
+    it('returns the most recently posted preview URL', () => {
+        const newerUuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+        const newerUrl = `${SITE_URL}/projects/${newerUuid}/tables`;
+        expect(
+            extractPreviewUrlFromComments(
+                [
+                    `Preview ready: ${PREVIEW_URL}`,
+                    `Preview updated: ${newerUrl}`,
+                ],
+                SITE_URL,
+            ),
+        ).toBe(newerUrl);
+    });
+
+    it('matches the project root when there is no trailing path', () => {
+        const rootUrl = `${SITE_URL}/projects/${PREVIEW_UUID}`;
+        expect(
+            extractPreviewUrlFromComments([`Preview: ${rootUrl}`], SITE_URL),
+        ).toBe(rootUrl);
+    });
+
+    it('returns null for an invalid site URL', () => {
+        expect(
+            extractPreviewUrlFromComments(
+                [`Preview: ${PREVIEW_URL}`],
+                'not a url',
+            ),
+        ).toBeNull();
+    });
+});

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -145,3 +145,55 @@ export type ApiPullRequestsResponse = {
     status: 'ok';
     results: KnexPaginatedData<PullRequestWithStatus[]>;
 };
+
+/**
+ * The Lightdash preview environment for a pull request. `previewUrl` is null
+ * until a preview has been published: the dbt repo's CI creates the preview
+ * project asynchronously and comments its URL on the PR, so the URL can only be
+ * discovered after the fact (it is not predictable from the PR itself).
+ */
+export type PullRequestPreview = {
+    previewUrl: string | null;
+};
+
+export type ApiPullRequestPreviewResponse = {
+    status: 'ok';
+    results: PullRequestPreview;
+};
+
+const PREVIEW_PROJECT_UUID =
+    '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+/**
+ * Find the Lightdash preview-environment URL inside a pull request's comments.
+ *
+ * When the AI write-back opens a PR against a dbt repo, that repo's CI runs
+ * `lightdash preview`, which publishes a PREVIEW-type project and posts its URL
+ * (`{siteUrl}/projects/{previewProjectUuid}/...`) as a PR comment. Only URLs on
+ * this instance's own host are considered, so a link to github.com or an
+ * unrelated site is never mistaken for a preview. Comments are scanned
+ * newest-first, so a re-published preview wins. Returns null when none match.
+ */
+export const extractPreviewUrlFromComments = (
+    commentBodies: string[],
+    siteUrl: string,
+): string | null => {
+    let host: string;
+    try {
+        host = new URL(siteUrl).host;
+    } catch {
+        return null;
+    }
+    const escapedHost = host.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const previewUrlRegex = new RegExp(
+        `https?://${escapedHost}/projects/${PREVIEW_PROJECT_UUID}(?:/[\\w-]+)*`,
+        'i',
+    );
+    for (let i = commentBodies.length - 1; i >= 0; i -= 1) {
+        const match = commentBodies[i].match(previewUrlRegex);
+        if (match) {
+            return match[0];
+        }
+    }
+    return null;
+};

--- a/packages/common/src/types/projectCiStatus.ts
+++ b/packages/common/src/types/projectCiStatus.ts
@@ -14,3 +14,14 @@ export type ProjectCiStatus = {
     detectedCommitSha: string | null;
     checkedAt: Date;
 };
+
+/**
+ * CI status for a project, or null when the project has never been scanned
+ * (e.g. no AI writeback has run yet). A null result means "unknown", which is
+ * distinct from a record with `hasPreviewDeployWorkflow: false` ("scanned, no
+ * preview workflow").
+ */
+export type ApiProjectCiStatusResponse = {
+    status: 'ok';
+    results: ProjectCiStatus | null;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -905,6 +905,7 @@ const AssistantBubbleContent: FC<{
             {proposeWritebackMetadata && (
                 <AiProposeWritebackToolCall
                     metadata={proposeWritebackMetadata}
+                    projectUuid={projectUuid}
                 />
             )}
         </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -906,6 +906,7 @@ const AssistantBubbleContent: FC<{
                 <AiProposeWritebackToolCall
                     metadata={proposeWritebackMetadata}
                     projectUuid={projectUuid}
+                    prCreatedAt={message.createdAt}
                 />
             )}
         </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
@@ -3,13 +3,16 @@ import { Button, Group, Paper, Stack, Text, ThemeIcon } from '@mantine-8/core';
 import {
     IconAlertTriangle,
     IconExternalLink,
+    IconEye,
     IconGitPullRequest,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
+import { usePullRequestPreview } from '../../../hooks/usePullRequestPreview';
 
 type Props = {
     metadata: ToolProposeWritebackOutput['metadata'];
+    projectUuid: string;
 };
 
 // Parses "https://github.com/lightdash/jaffle/pull/29" into "lightdash/jaffle #29"
@@ -40,7 +43,15 @@ const summarisePrUrl = (prUrl: string): string | null => {
  * it instead — matching the Slack experience where the user's mention gets
  * a green-tick reaction plus the PR link in the agent message body.
  */
-export const AiProposeWritebackToolCall: FC<Props> = ({ metadata }) => {
+export const AiProposeWritebackToolCall: FC<Props> = ({
+    metadata,
+    projectUuid,
+}) => {
+    // Poll for the preview environment once a PR exists. The hook is disabled
+    // until there's a PR URL, so it's a no-op for the error / no-PR branches.
+    const prUrl = metadata.status === 'success' ? metadata.prUrl : null;
+    const { data: preview } = usePullRequestPreview(projectUuid, prUrl);
+
     if (metadata.status === 'error') {
         return (
             <Paper withBorder p="sm" radius="md" bg="red.0">
@@ -120,19 +131,36 @@ export const AiProposeWritebackToolCall: FC<Props> = ({ metadata }) => {
                         )}
                     </Stack>
                 </Group>
-                <Button
-                    component="a"
-                    href={metadata.prUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    variant="filled"
-                    size="compact-sm"
-                    rightSection={
-                        <MantineIcon icon={IconExternalLink} size={14} />
-                    }
-                >
-                    View pull request
-                </Button>
+                <Group gap="xs" wrap="nowrap">
+                    {preview?.previewUrl && (
+                        <Button
+                            component="a"
+                            href={preview.previewUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            variant="default"
+                            size="compact-sm"
+                            leftSection={
+                                <MantineIcon icon={IconEye} size={14} />
+                            }
+                        >
+                            View preview
+                        </Button>
+                    )}
+                    <Button
+                        component="a"
+                        href={metadata.prUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        variant="filled"
+                        size="compact-sm"
+                        rightSection={
+                            <MantineIcon icon={IconExternalLink} size={14} />
+                        }
+                    >
+                        View pull request
+                    </Button>
+                </Group>
             </Group>
         </Paper>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
@@ -7,21 +7,28 @@ import {
     Stack,
     Text,
     ThemeIcon,
+    Tooltip,
 } from '@mantine-8/core';
 import {
     IconAlertTriangle,
     IconExternalLink,
     IconEye,
     IconGitPullRequest,
+    IconInfoCircle,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { useProjectCiStatus } from '../../../hooks/useProjectCiStatus';
-import { usePullRequestPreview } from '../../../hooks/usePullRequestPreview';
+import {
+    isPreviewWaitTimedOut,
+    usePullRequestPreview,
+} from '../../../hooks/usePullRequestPreview';
 
 type Props = {
     metadata: ToolProposeWritebackOutput['metadata'];
     projectUuid: string;
+    /** When the write-back PR was opened — anchors the ~10 min preview wait. */
+    prCreatedAt: string;
 };
 
 // Parses "https://github.com/lightdash/jaffle/pull/29" into "lightdash/jaffle #29"
@@ -55,6 +62,7 @@ const summarisePrUrl = (prUrl: string): string | null => {
 export const AiProposeWritebackToolCall: FC<Props> = ({
     metadata,
     projectUuid,
+    prCreatedAt,
 }) => {
     const prUrl = metadata.status === 'success' ? metadata.prUrl : null;
 
@@ -65,11 +73,14 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
 
     // Only wait for a preview URL when one is actually expected — poll unless we
     // positively know the repo has no preview workflow (avoids polling forever
-    // on repos that never produce a preview).
+    // on repos that never produce a preview). The poll also stops ~10 min after
+    // the PR was opened.
     const { data: preview } = usePullRequestPreview(
         projectUuid,
         previewDeployConfigured === false ? null : prUrl,
+        prCreatedAt,
     );
+    const previewTimedOut = isPreviewWaitTimedOut(prCreatedAt);
 
     if (metadata.status === 'error') {
         return (
@@ -165,7 +176,7 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
                         >
                             View preview
                         </Button>
-                    ) : previewDeployConfigured ? (
+                    ) : previewDeployConfigured && !previewTimedOut ? (
                         // A preview deploy is configured but its URL hasn't been
                         // posted yet — surface that it's on the way rather than
                         // showing nothing.
@@ -177,6 +188,23 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
                         >
                             Preparing preview…
                         </Button>
+                    ) : previewDeployConfigured && previewTimedOut ? (
+                        // Configured but no preview URL after ~10 min — the
+                        // deploy likely failed or was skipped. Tell the user
+                        // rather than spinning forever.
+                        <Tooltip
+                            withinPortal
+                            multiline
+                            w={220}
+                            label="The preview deploy didn't post a URL within 10 minutes. It may have failed or been skipped — check the pull request."
+                        >
+                            <Group gap={4} wrap="nowrap" c="ldGray.6">
+                                <MantineIcon icon={IconInfoCircle} size={14} />
+                                <Text size="xs" c="ldGray.6">
+                                    Preview didn't appear
+                                </Text>
+                            </Group>
+                        </Tooltip>
                     ) : null}
                     <Button
                         component="a"

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
@@ -1,5 +1,13 @@
 import { type ToolProposeWritebackOutput } from '@lightdash/common';
-import { Button, Group, Paper, Stack, Text, ThemeIcon } from '@mantine-8/core';
+import {
+    Button,
+    Group,
+    Loader,
+    Paper,
+    Stack,
+    Text,
+    ThemeIcon,
+} from '@mantine-8/core';
 import {
     IconAlertTriangle,
     IconExternalLink,
@@ -8,6 +16,7 @@ import {
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
+import { useProjectCiStatus } from '../../../hooks/useProjectCiStatus';
 import { usePullRequestPreview } from '../../../hooks/usePullRequestPreview';
 
 type Props = {
@@ -47,10 +56,20 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
     metadata,
     projectUuid,
 }) => {
-    // Poll for the preview environment once a PR exists. The hook is disabled
-    // until there's a PR URL, so it's a no-op for the error / no-PR branches.
     const prUrl = metadata.status === 'success' ? metadata.prUrl : null;
-    const { data: preview } = usePullRequestPreview(projectUuid, prUrl);
+
+    // Does this project's repo deploy Lightdash previews? `false` means it was
+    // scanned and has no preview workflow; `undefined`/null means unknown.
+    const { data: ciStatus } = useProjectCiStatus(projectUuid);
+    const previewDeployConfigured = ciStatus?.hasPreviewDeployWorkflow;
+
+    // Only wait for a preview URL when one is actually expected — poll unless we
+    // positively know the repo has no preview workflow (avoids polling forever
+    // on repos that never produce a preview).
+    const { data: preview } = usePullRequestPreview(
+        projectUuid,
+        previewDeployConfigured === false ? null : prUrl,
+    );
 
     if (metadata.status === 'error') {
         return (
@@ -132,7 +151,7 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
                     </Stack>
                 </Group>
                 <Group gap="xs" wrap="nowrap">
-                    {preview?.previewUrl && (
+                    {preview?.previewUrl ? (
                         <Button
                             component="a"
                             href={preview.previewUrl}
@@ -146,7 +165,19 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
                         >
                             View preview
                         </Button>
-                    )}
+                    ) : previewDeployConfigured ? (
+                        // A preview deploy is configured but its URL hasn't been
+                        // posted yet — surface that it's on the way rather than
+                        // showing nothing.
+                        <Button
+                            variant="default"
+                            size="compact-sm"
+                            disabled
+                            leftSection={<Loader size={14} />}
+                        >
+                            Preparing preview…
+                        </Button>
+                    ) : null}
                     <Button
                         component="a"
                         href={metadata.prUrl}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectCiStatus.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectCiStatus.ts
@@ -1,0 +1,28 @@
+import type { ApiError, ProjectCiStatus } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+
+const getProjectCiStatus = (
+    projectUuid: string,
+): Promise<ProjectCiStatus | null> =>
+    lightdashApi<ProjectCiStatus | null>({
+        version: 'v1',
+        url: `/ee/projects/${projectUuid}/ai-writeback/ci-status`,
+        method: 'GET',
+        body: undefined,
+    });
+
+/**
+ * Whether a project's repo deploys Lightdash previews (the pipeline-detection
+ * signal recorded by AI write-back). `null` results mean "never scanned".
+ * CI status changes rarely, so this is cached and not polled.
+ */
+export const useProjectCiStatus = (projectUuid: string | undefined) =>
+    useQuery<ProjectCiStatus | null, ApiError>({
+        queryKey: ['projectCiStatus', projectUuid],
+        queryFn: () => getProjectCiStatus(projectUuid!),
+        enabled: !!projectUuid,
+        refetchOnWindowFocus: false,
+        retry: false,
+        staleTime: 5 * 60 * 1000,
+    });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePullRequestPreview.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePullRequestPreview.ts
@@ -1,0 +1,39 @@
+import type { ApiError, PullRequestPreview } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+
+const getPullRequestPreview = async (
+    projectUuid: string,
+    prUrl: string,
+): Promise<PullRequestPreview> =>
+    lightdashApi<PullRequestPreview>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/pull-requests/preview?prUrl=${encodeURIComponent(
+            prUrl,
+        )}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+// The dbt repo's CI publishes the preview asynchronously and comments its URL
+// on the PR, so we poll until a URL appears, then stop.
+const PREVIEW_POLL_INTERVAL_MS = 20_000;
+
+/**
+ * Resolve (and poll for) the Lightdash preview-environment URL of a write-back
+ * pull request. Disabled until both a project and a PR URL are known; stops
+ * polling as soon as a preview URL is found.
+ */
+export const usePullRequestPreview = (
+    projectUuid: string | undefined,
+    prUrl: string | null | undefined,
+) =>
+    useQuery<PullRequestPreview, ApiError>({
+        queryKey: ['pullRequestPreview', projectUuid, prUrl],
+        queryFn: () => getPullRequestPreview(projectUuid!, prUrl!),
+        enabled: !!projectUuid && !!prUrl,
+        refetchInterval: (data) =>
+            data?.previewUrl ? false : PREVIEW_POLL_INTERVAL_MS,
+        refetchOnWindowFocus: false,
+        retry: false,
+    });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePullRequestPreview.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePullRequestPreview.ts
@@ -19,21 +19,42 @@ const getPullRequestPreview = async (
 // on the PR, so we poll until a URL appears, then stop.
 const PREVIEW_POLL_INTERVAL_MS = 20_000;
 
+// Give up waiting ~10 min after the PR was opened. If the CI hasn't published a
+// preview URL by then it most likely failed, was skipped, or the PR was closed.
+const PREVIEW_WAIT_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * Whether the preview wait window (~10 min from when the PR was opened) has
+ * elapsed. Drives both stopping the poll and the timed-out UI.
+ */
+export const isPreviewWaitTimedOut = (
+    prCreatedAt: string | null | undefined,
+): boolean => {
+    if (!prCreatedAt) return false;
+    const openedAt = new Date(prCreatedAt).getTime();
+    if (Number.isNaN(openedAt)) return false;
+    return Date.now() - openedAt > PREVIEW_WAIT_TIMEOUT_MS;
+};
+
 /**
  * Resolve (and poll for) the Lightdash preview-environment URL of a write-back
  * pull request. Disabled until both a project and a PR URL are known; stops
- * polling as soon as a preview URL is found.
+ * polling once a preview URL is found OR the ~10 min wait window from
+ * `prCreatedAt` elapses.
  */
 export const usePullRequestPreview = (
     projectUuid: string | undefined,
     prUrl: string | null | undefined,
+    prCreatedAt?: string | null,
 ) =>
     useQuery<PullRequestPreview, ApiError>({
         queryKey: ['pullRequestPreview', projectUuid, prUrl],
         queryFn: () => getPullRequestPreview(projectUuid!, prUrl!),
         enabled: !!projectUuid && !!prUrl,
         refetchInterval: (data) =>
-            data?.previewUrl ? false : PREVIEW_POLL_INTERVAL_MS,
+            data?.previewUrl || isPreviewWaitTimedOut(prCreatedAt)
+                ? false
+                : PREVIEW_POLL_INTERVAL_MS,
         refetchOnWindowFocus: false,
         retry: false,
     });


### PR DESCRIPTION
## What & why

When the AI write-back agent opens a pull request, the chat shows a **View pull request** button. This adds a **View preview** button beside it that links to the Lightdash preview environment for that PR — appearing only once the preview is actually ready, so the user can jump straight from the chat into the preview.

Closes PROD-8055 (https://linear.app/lightdash/issue/PROD-8055).

## Approach — discover, don't predict

The write-back PR targets the **dbt repo**, whose CI runs `lightdash preview` to publish a Lightdash *preview project* (`{siteUrl}/projects/{previewProjectUuid}/…`) and comments the URL on the PR. That URL has a freshly-generated UUID and is created asynchronously, so it can't be computed up front — it can only be **discovered** from the PR comments.

(The `lightdash-preview-pr-{N}.okteto.dev` URL is unrelated — that's this repo's own dev preview, not a dbt-repo preview.)

## Changes

**common**
- `extractPreviewUrlFromComments(bodies, siteUrl)` — pure helper that matches only `/projects/{uuid}` URLs on this instance's own host (newest comment wins). 8 unit tests.
- `PullRequestPreview` / `ApiPullRequestPreviewResponse` types.

**backend**
- `Github.getPullRequestComments()` — paginated `issues.listComments`.
- `PullRequestsModel.findByProjectAndUrl()` — resolve a recorded PR by URL within a project.
- `PullRequestsService.getPullRequestPreview()` — perm-checks `view SourceCode`, reads the PR's comments via the GitHub App installation, extracts the preview URL. Returns `{ previewUrl: null }` (HTTP 200) on any not-ready state — unknown PR, non-GitHub provider, missing credentials, transient error — so the client can poll without surfacing errors.
- `GET /api/v1/projects/{projectUuid}/pull-requests/preview?prUrl=…`.

**frontend**
- `usePullRequestPreview()` — polls every 20s, stops as soon as a URL appears.
- `AiProposeWritebackToolCall` renders **View preview** beside **View pull request** when ready (absent until then → no dead links).

The agent tool contract (`toolProposeWritebackOutputSchema`) is intentionally untouched — the frontend keys the lookup off the `prUrl` it already has, isolating this to a read-only side-channel endpoint.

## Testing

- 8 common unit tests for the URL extraction pass.
- Endpoint smoke-tested locally: returns `{previewUrl:null}` + HTTP 200 for a non-existent PR.
- Lint + typecheck green across common / backend / frontend.
- Generated OpenAPI is additive (1 new path, 0 removed).

## Not in this PR

- Full green-path UI verification needs a real write-back PR against a dbt repo whose CI publishes a preview comment.
- GitLab is not yet supported (returns null); gentler poll/backoff for large fan-out is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)