### PR TITLE
feat: add project-level default agent setting

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -35,6 +35,7 @@ import {
     SqlChartAsCode,
     UpdateDefaultUserSpaces,
     UpdateMetadata,
+    UpdateProjectDefaultAgent,
     UpdateProjectMember,
     UserWarehouseCredentials,
     type ApiCalculateSubtotalsResponse,
@@ -774,6 +775,34 @@ export class ProjectController extends BaseController {
                 projectUuid,
                 body.colorPaletteUuid,
             );
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * Set the default AI agent for a project.
+     * Users without a personal preference will use this agent.
+     * @summary Update project default AI agent
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('{projectUuid}/defaultAiAgent')
+    @OperationId('updateProjectDefaultAgent')
+    async updateProjectDefaultAgent(
+        @Path() projectUuid: string,
+        @Body() body: UpdateProjectDefaultAgent,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+        await this.services
+            .getProjectService()
+            .updateProjectDefaultAgent(req.user!, projectUuid, body);
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -41,6 +41,7 @@ export type DbProject = {
     expires_at: Date | null;
     default_preview_expiration_hours: number;
     max_preview_expiration_hours: number;
+    default_ai_agent_uuid: string | null;
 };
 
 type CreateDbProject = Pick<
@@ -82,6 +83,7 @@ type UpdateDbProject = Partial<
         | 'table_groups'
         | 'default_preview_expiration_hours'
         | 'max_preview_expiration_hours'
+        | 'default_ai_agent_uuid'
     >
 >;
 

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -45,6 +45,7 @@ import {
     ApiCreateEvaluationResponse,
     ApiErrorPayload,
     ApiGetUserAgentPreferencesResponse,
+    ApiGetUserAgentPreferencesWithDefaultsResponse,
     ApiRevertChangeRequest,
     ApiRevertChangeResponse,
     ApiStartAiMcpOAuthResponse,
@@ -126,6 +127,27 @@ export class AiAgentController extends BaseController {
         return {
             status: 'ok',
             results: userPreferences ?? undefined,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/preferences/with-defaults')
+    @OperationId('getUserAgentPreferencesWithDefaults')
+    async getUserAgentPreferencesWithDefaults(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiGetUserAgentPreferencesWithDefaultsResponse> {
+        this.setStatus(200);
+
+        const preferences =
+            await this.getAiAgentService().getUserAgentPreferencesWithDefaults(
+                req.user!,
+                projectUuid,
+            );
+        return {
+            status: 'ok',
+            results: preferences,
         };
     }
 

--- a/packages/backend/src/ee/database/migrations/20260505101254_add_default_ai_agent_to_projects.ts
+++ b/packages/backend/src/ee/database/migrations/20260505101254_add_default_ai_agent_to_projects.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+const PROJECTS_TABLE = 'projects';
+const AI_AGENT_TABLE = 'ai_agent';
+const DEFAULT_AI_AGENT_COLUMN = 'default_ai_agent_uuid';
+
+export async function up(knex: Knex): Promise<void> {
+    // Add default_ai_agent_uuid column to projects table
+    await knex.schema.alterTable(PROJECTS_TABLE, (table) => {
+        table
+            .uuid(DEFAULT_AI_AGENT_COLUMN)
+            .nullable()
+            .references('ai_agent_uuid')
+            .inTable(AI_AGENT_TABLE)
+            .onDelete('SET NULL');
+
+        table.index(DEFAULT_AI_AGENT_COLUMN);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // Remove the default_ai_agent_uuid column
+    await knex.schema.alterTable(PROJECTS_TABLE, (table) => {
+        table.dropIndex(DEFAULT_AI_AGENT_COLUMN);
+        table.dropColumn(DEFAULT_AI_AGENT_COLUMN);
+    });
+}

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.effectiveDefault.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.effectiveDefault.integration.test.ts
@@ -1,0 +1,494 @@
+import { AiAgent, SEED_PROJECT } from '@lightdash/common';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+    getServices,
+    getTestContext,
+    IntegrationTestContext,
+} from '../../../vitest.setup.integration';
+
+describe('AiAgentService - Project Default Agent Integration Tests', () => {
+    let context: IntegrationTestContext;
+    let agent1: AiAgent;
+    let agent2: AiAgent;
+    let agent3RestrictedToOtherUser: AiAgent;
+    const projectUuid = SEED_PROJECT.project_uuid;
+
+    beforeAll(async () => {
+        context = getTestContext();
+        const services = getServices(context.app);
+
+        // Create agent 1: Open access
+        agent1 = await services.aiAgentService.createAgent(context.testUser, {
+            name: 'Test Agent 1 - Open',
+            description: null,
+            projectUuid,
+            tags: [],
+            integrations: [],
+            instruction: '',
+            groupAccess: [],
+            userAccess: [],
+            spaceAccess: [],
+            imageUrl: null,
+            enableDataAccess: false,
+            enableSelfImprovement: false,
+            version: 2,
+        });
+
+        // Create agent 2: Open access
+        agent2 = await services.aiAgentService.createAgent(context.testUser, {
+            name: 'Test Agent 2 - Open',
+            description: null,
+            projectUuid,
+            tags: [],
+            integrations: [],
+            instruction: '',
+            groupAccess: [],
+            userAccess: [],
+            spaceAccess: [],
+            imageUrl: null,
+            enableDataAccess: false,
+            enableSelfImprovement: false,
+            version: 2,
+        });
+
+        // Create agent 3: Restricted to a different user
+        agent3RestrictedToOtherUser = await services.aiAgentService.createAgent(
+            context.testUser,
+            {
+                name: 'Test Agent 3 - Restricted',
+                description: null,
+                projectUuid,
+                tags: [],
+                integrations: [],
+                instruction: '',
+                groupAccess: [],
+                userAccess: ['some-other-user-uuid'],
+                spaceAccess: [],
+                imageUrl: null,
+                enableDataAccess: false,
+                enableSelfImprovement: false,
+                version: 2,
+            },
+        );
+    });
+
+    const resetDefaultPreferences = async () => {
+        const services = getServices(context.app);
+
+        await services.aiAgentService.deleteUserAgentPreferences(
+            context.testUser,
+            projectUuid,
+        );
+        await services.projectService.updateProjectDefaultAgent(
+            context.testUser,
+            projectUuid,
+            { defaultAiAgentUuid: null },
+        );
+    };
+
+    describe('getEffectiveDefaultAgentUuid', () => {
+        it('returns user preference when set and accessible', async () => {
+            const services = getServices(context.app);
+
+            // Set user preference to agent2
+            await services.aiAgentService.updateUserAgentPreferences(
+                context.testUser,
+                projectUuid,
+                { defaultAgentUuid: agent2.uuid },
+            );
+
+            const effectiveDefault =
+                await services.aiAgentService.getEffectiveDefaultAgentUuid(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(effectiveDefault).toBe(agent2.uuid);
+        });
+
+        it('uses project default when user preference is not set', async () => {
+            const services = getServices(context.app);
+
+            await resetDefaultPreferences();
+
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: agent1.uuid },
+            );
+
+            const effectiveDefault =
+                await services.aiAgentService.getEffectiveDefaultAgentUuid(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(effectiveDefault).toBe(agent1.uuid);
+        });
+
+        it('user preference takes precedence over project default when both are set', async () => {
+            const services = getServices(context.app);
+
+            // Set user preference to agent2 first
+            await services.aiAgentService.updateUserAgentPreferences(
+                context.testUser,
+                projectUuid,
+                { defaultAgentUuid: agent2.uuid },
+            );
+
+            // Set project default to agent1
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: agent1.uuid },
+            );
+
+            // Even with user pref set to agent2, project default is agent1
+            // This test verifies project default is readable
+            const projectModel = context.app.getModels().getProjectModel();
+            const projectSummary = await projectModel.getSummary(projectUuid);
+
+            expect(projectSummary.defaultAiAgentUuid).toBe(agent1.uuid);
+
+            // Effective default should still be user preference (agent2)
+            const effectiveDefault =
+                await services.aiAgentService.getEffectiveDefaultAgentUuid(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(effectiveDefault).toBe(agent2.uuid);
+        });
+
+        it('uses project default when user preference is inaccessible', async () => {
+            const services = getServices(context.app);
+
+            await resetDefaultPreferences();
+
+            await services.aiAgentService.updateUserAgentPreferences(
+                context.testUser,
+                projectUuid,
+                { defaultAgentUuid: agent3RestrictedToOtherUser.uuid },
+            );
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: agent1.uuid },
+            );
+
+            const effectiveDefault =
+                await services.aiAgentService.getEffectiveDefaultAgentUuid(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(effectiveDefault).toBe(agent1.uuid);
+        });
+
+        it('uses first accessible agent when no defaults are configured', async () => {
+            const services = getServices(context.app);
+
+            await resetDefaultPreferences();
+
+            const accessibleAgents = await services.aiAgentService.listAgents(
+                context.testUser,
+                projectUuid,
+            );
+
+            const effectiveDefault =
+                await services.aiAgentService.getEffectiveDefaultAgentUuid(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(accessibleAgents.length).toBeGreaterThan(0);
+            expect(effectiveDefault).toBe(accessibleAgents[0].uuid);
+        });
+
+        it('uses first accessible agent when both defaults are inaccessible', async () => {
+            const services = getServices(context.app);
+
+            await resetDefaultPreferences();
+
+            await services.aiAgentService.updateUserAgentPreferences(
+                context.testUser,
+                projectUuid,
+                { defaultAgentUuid: agent3RestrictedToOtherUser.uuid },
+            );
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: agent3RestrictedToOtherUser.uuid },
+            );
+
+            const accessibleAgents = await services.aiAgentService.listAgents(
+                context.testUser,
+                projectUuid,
+            );
+
+            const effectiveDefault =
+                await services.aiAgentService.getEffectiveDefaultAgentUuid(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(effectiveDefault).not.toBe(agent3RestrictedToOtherUser.uuid);
+            expect(effectiveDefault).toBe(accessibleAgents[0].uuid);
+        });
+
+        it('uses accessible user preference when project default is inaccessible', async () => {
+            const services = getServices(context.app);
+
+            // Set user preference to agent1 (accessible)
+            await services.aiAgentService.updateUserAgentPreferences(
+                context.testUser,
+                projectUuid,
+                { defaultAgentUuid: agent1.uuid },
+            );
+
+            // Set project default to restricted agent (not accessible to testUser)
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: agent3RestrictedToOtherUser.uuid },
+            );
+
+            const effectiveDefault =
+                await services.aiAgentService.getEffectiveDefaultAgentUuid(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(effectiveDefault).toBe(agent1.uuid);
+        });
+
+        it('can clear project default by setting to null', async () => {
+            const services = getServices(context.app);
+
+            // Set project default
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: agent1.uuid },
+            );
+
+            // Clear project default
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: null },
+            );
+
+            const projectModel = context.app.getModels().getProjectModel();
+            const projectSummary = await projectModel.getSummary(projectUuid);
+
+            expect(projectSummary.defaultAiAgentUuid).toBeUndefined();
+        });
+
+        it('clears project default and falls back when project default agent is deleted', async () => {
+            const services = getServices(context.app);
+
+            await resetDefaultPreferences();
+
+            const tempAgent = await services.aiAgentService.createAgent(
+                context.testUser,
+                {
+                    name: 'Temp Project Default Agent',
+                    description: null,
+                    projectUuid,
+                    tags: [],
+                    integrations: [],
+                    instruction: '',
+                    groupAccess: [],
+                    userAccess: [],
+                    spaceAccess: [],
+                    imageUrl: null,
+                    enableDataAccess: false,
+                    enableSelfImprovement: false,
+                    version: 2,
+                },
+            );
+
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: tempAgent.uuid },
+            );
+
+            await services.aiAgentService.deleteAgent(
+                context.testUser,
+                tempAgent.uuid,
+            );
+
+            const projectModel = context.app.getModels().getProjectModel();
+            const projectSummary = await projectModel.getSummary(projectUuid);
+
+            expect(projectSummary.defaultAiAgentUuid).toBeUndefined();
+
+            const effectiveDefault =
+                await services.aiAgentService.getEffectiveDefaultAgentUuid(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(effectiveDefault).not.toBe(tempAgent.uuid);
+            expect([agent1.uuid, agent2.uuid]).toContain(effectiveDefault);
+
+            const preferences =
+                await services.aiAgentService.getUserAgentPreferencesWithDefaults(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(preferences.projectDefault).toBeNull();
+            expect(preferences.effectiveDefault).toBe(effectiveDefault);
+        });
+
+        it('removes user preference and falls back to project default when user default agent is deleted', async () => {
+            const services = getServices(context.app);
+
+            await resetDefaultPreferences();
+
+            const tempAgent = await services.aiAgentService.createAgent(
+                context.testUser,
+                {
+                    name: 'Temp User Default Agent',
+                    description: null,
+                    projectUuid,
+                    tags: [],
+                    integrations: [],
+                    instruction: '',
+                    groupAccess: [],
+                    userAccess: [],
+                    spaceAccess: [],
+                    imageUrl: null,
+                    enableDataAccess: false,
+                    enableSelfImprovement: false,
+                    version: 2,
+                },
+            );
+
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: agent1.uuid },
+            );
+            await services.aiAgentService.updateUserAgentPreferences(
+                context.testUser,
+                projectUuid,
+                { defaultAgentUuid: tempAgent.uuid },
+            );
+
+            await services.aiAgentService.deleteAgent(
+                context.testUser,
+                tempAgent.uuid,
+            );
+
+            const userPreferences =
+                await services.aiAgentService.getUserAgentPreferences(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(userPreferences).toBeNull();
+
+            const effectiveDefault =
+                await services.aiAgentService.getEffectiveDefaultAgentUuid(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(effectiveDefault).toBe(agent1.uuid);
+
+            const preferences =
+                await services.aiAgentService.getUserAgentPreferencesWithDefaults(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(preferences.userDefault).toBeNull();
+            expect(preferences.projectDefault).toBe(agent1.uuid);
+            expect(preferences.effectiveDefault).toBe(agent1.uuid);
+        });
+    });
+
+    describe('getUserAgentPreferencesWithDefaults', () => {
+        it('returns all three layers when preferences are set', async () => {
+            const services = getServices(context.app);
+
+            // Set user default to agent1
+            await services.aiAgentService.updateUserAgentPreferences(
+                context.testUser,
+                projectUuid,
+                { defaultAgentUuid: agent1.uuid },
+            );
+
+            // Set project default to agent2
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: agent2.uuid },
+            );
+
+            const result =
+                await services.aiAgentService.getUserAgentPreferencesWithDefaults(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(result.userDefault).toBe(agent1.uuid);
+            expect(result.projectDefault).toBe(agent2.uuid);
+            expect(result.effectiveDefault).toBe(agent1.uuid); // User pref wins
+        });
+
+        it('returns project default when it differs from user default', async () => {
+            const services = getServices(context.app);
+
+            // Set user default to agent2
+            await services.aiAgentService.updateUserAgentPreferences(
+                context.testUser,
+                projectUuid,
+                { defaultAgentUuid: agent2.uuid },
+            );
+
+            // Set project default to agent1
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: agent1.uuid },
+            );
+
+            const result =
+                await services.aiAgentService.getUserAgentPreferencesWithDefaults(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(result.userDefault).toBe(agent2.uuid);
+            expect(result.projectDefault).toBe(agent1.uuid);
+            expect(result.effectiveDefault).toBe(agent2.uuid); // User pref wins
+        });
+
+        it('returns project default as effective when user preference is unset', async () => {
+            const services = getServices(context.app);
+
+            await resetDefaultPreferences();
+
+            await services.projectService.updateProjectDefaultAgent(
+                context.testUser,
+                projectUuid,
+                { defaultAiAgentUuid: agent1.uuid },
+            );
+
+            const result =
+                await services.aiAgentService.getUserAgentPreferencesWithDefaults(
+                    context.testUser,
+                    projectUuid,
+                );
+
+            expect(result.userDefault).toBeNull();
+            expect(result.projectDefault).toBe(agent1.uuid);
+            expect(result.effectiveDefault).toBe(agent1.uuid);
+        });
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -16,6 +16,7 @@ import {
     AiAgentThreadSummary,
     AiAgentUser,
     AiAgentUserPreferences,
+    AiAgentUserPreferencesWithDefaults,
     AiAgentWithContext,
     AiDuplicateSlackPromptError,
     AiMcpCredentialScope,
@@ -764,6 +765,93 @@ export class AiAgentService extends BaseService {
         }
 
         return false;
+    }
+
+    /**
+     * Returns the effective default agent UUID for a user in a project.
+     * Priority chain (first accessible agent wins):
+     * 1. User preference (if set and accessible)
+     * 2. Project default (if set and accessible)
+     * 3. First agent from listAgents (if any)
+     * 4. null (no agents available)
+     */
+    async getEffectiveDefaultAgentUuid(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<string | null> {
+        const { organizationUuid, userUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        // Step 1: Check user preference
+        const userPreferences = await this.aiAgentModel.getUserAgentPreferences(
+            {
+                userUuid,
+                projectUuid,
+            },
+        );
+
+        if (userPreferences?.defaultAgentUuid) {
+            try {
+                const userPrefAgent = await this.aiAgentModel.getAgent({
+                    organizationUuid,
+                    agentUuid: userPreferences.defaultAgentUuid,
+                    projectUuid,
+                });
+
+                if (userPrefAgent) {
+                    const hasAccess = await this.checkAgentAccess(
+                        user,
+                        userPrefAgent,
+                    );
+                    if (hasAccess) {
+                        return userPreferences.defaultAgentUuid;
+                    }
+                }
+            } catch (error) {
+                // User preference points to non-existent or deleted agent, continue to next fallback
+                Logger.debug(
+                    `User preference agent ${userPreferences.defaultAgentUuid} not accessible, falling back`,
+                );
+            }
+        }
+
+        // Step 2: Check project default
+        const project = await this.projectModel.getSummary(projectUuid);
+        if (project.defaultAiAgentUuid) {
+            try {
+                const projectDefaultAgent = await this.aiAgentModel.getAgent({
+                    organizationUuid,
+                    agentUuid: project.defaultAiAgentUuid,
+                    projectUuid,
+                });
+
+                if (projectDefaultAgent) {
+                    const hasAccess = await this.checkAgentAccess(
+                        user,
+                        projectDefaultAgent,
+                    );
+                    if (hasAccess) {
+                        return project.defaultAiAgentUuid;
+                    }
+                }
+            } catch (error) {
+                // Project default points to non-existent or deleted agent, continue to next fallback
+                Logger.debug(
+                    `Project default agent ${project.defaultAiAgentUuid} not accessible, falling back`,
+                );
+            }
+        }
+
+        // Step 3: Use first accessible agent from listAgents
+        const accessibleAgents = await this.listAgents(user, projectUuid);
+        if (accessibleAgents.length > 0) {
+            return accessibleAgents[0].uuid;
+        }
+
+        // Step 4: No agents available
+        return null;
     }
 
     async getAvailableExplores(
@@ -6930,6 +7018,54 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             projectUuid,
             defaultAgentUuid: body.defaultAgentUuid,
         });
+    }
+
+    async getUserAgentPreferencesWithDefaults(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<AiAgentUserPreferencesWithDefaults> {
+        const { organizationUuid, userUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        if (!isCopilotEnabled) {
+            throw new ForbiddenError('Copilot not enabled');
+        }
+
+        const project = await this.projectService.getProject(
+            projectUuid,
+            fromSession(user),
+        );
+        if (project.organizationUuid !== organizationUuid) {
+            throw new ForbiddenError(
+                'Project does not belong to this organization',
+            );
+        }
+
+        // Get user preference
+        const userPreferences = await this.aiAgentModel.getUserAgentPreferences(
+            {
+                userUuid,
+                projectUuid,
+            },
+        );
+
+        // Get project from model to access default_ai_agent_uuid
+        const projectSummary = await this.projectModel.getSummary(projectUuid);
+
+        // Get effective default
+        const effectiveDefault = await this.getEffectiveDefaultAgentUuid(
+            user,
+            projectUuid,
+        );
+
+        return {
+            userDefault: userPreferences?.defaultAgentUuid || null,
+            projectDefault: projectSummary.defaultAiAgentUuid || null,
+            effectiveDefault,
+        };
     }
 
     async deleteUserAgentPreferences(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -850,6 +850,7 @@ export class ProjectModel {
                   project_defaults: ProjectDefaults | null;
                   color_palette_uuid: string | null;
                   expires_at: Date | null;
+                  default_ai_agent_uuid: string | null;
               }
             | {
                   name: string;
@@ -873,6 +874,7 @@ export class ProjectModel {
                   project_defaults: ProjectDefaults | null;
                   color_palette_uuid: string | null;
                   expires_at: Date | null;
+                  default_ai_agent_uuid: string | null;
               }
         )[];
         return wrapSentryTransaction(
@@ -952,6 +954,9 @@ export class ProjectModel {
                             .ref('project_defaults')
                             .withSchema(ProjectTableName),
                         this.database
+                            .ref('default_ai_agent_uuid')
+                            .withSchema(ProjectTableName),
+                        this.database
                             .ref('color_palette_uuid')
                             .withSchema(ProjectTableName),
                         this.database
@@ -1009,6 +1014,8 @@ export class ProjectModel {
                     projectDefaults: project.project_defaults ?? undefined,
                     colorPaletteUuid: project.color_palette_uuid ?? null,
                     expiresAt: project.expires_at ?? null,
+                    defaultAiAgentUuid:
+                        project.default_ai_agent_uuid ?? undefined,
                 };
 
                 // If project uses organization warehouse credentials, load them
@@ -1064,6 +1071,7 @@ export class ProjectModel {
                     | 'project_uuid'
                     | 'project_type'
                     | 'copied_from_project_uuid'
+                    | 'default_ai_agent_uuid'
                 > &
                     Pick<DbOrganization, 'organization_uuid'>
             >([
@@ -1072,6 +1080,7 @@ export class ProjectModel {
                 `${OrganizationTableName}.organization_uuid`,
                 `${ProjectTableName}.copied_from_project_uuid`,
                 `${ProjectTableName}.project_type`,
+                `${ProjectTableName}.default_ai_agent_uuid`,
             ])
             .where('projects.project_uuid', projectUuid)
             .first();
@@ -1086,6 +1095,7 @@ export class ProjectModel {
             name: project.name,
             type: project.project_type,
             upstreamProjectUuid: project.copied_from_project_uuid || undefined,
+            defaultAiAgentUuid: project.default_ai_agent_uuid || undefined,
         };
     }
 
@@ -1234,6 +1244,7 @@ export class ProjectModel {
             hasDefaultUserSpaces: project.hasDefaultUserSpaces,
             colorPaletteUuid: project.colorPaletteUuid ?? null,
             expiresAt: project.expiresAt,
+            defaultAiAgentUuid: project.defaultAiAgentUuid,
         };
     }
 
@@ -1933,6 +1944,15 @@ export class ProjectModel {
             parentSpaceUuid: row.parent_space_uuid,
             parentPath: row.parent_path,
         }));
+    }
+
+    async updateProjectDefaultAgent(
+        projectUuid: string,
+        defaultAiAgentUuid: string | null,
+    ): Promise<void> {
+        await this.database(ProjectTableName)
+            .update({ default_ai_agent_uuid: defaultAiAgentUuid })
+            .where('project_uuid', projectUuid);
     }
 
     async ensureDefaultUserSpace(

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -158,6 +158,7 @@ const projectModel = {
     getCachedExploreNames: jest.fn(async () => []),
     saveExploresToCache: jest.fn(async () => ({ cachedExploreUuids: [] })),
     updateDefaultUserSpaces: jest.fn(async () => undefined),
+    updateProjectDefaultAgent: jest.fn(async () => undefined),
 };
 const preAggregateModel = {
     upsertPreAggregateDefinitions: jest.fn(),
@@ -2161,6 +2162,81 @@ describe('ProjectService', () => {
                     defaultProject.projectUuid,
                     exploreName,
                 ),
+            ).rejects.toThrow(ForbiddenError);
+        });
+    });
+
+    describe('updateProjectDefaultAgent', () => {
+        test('should update project default agent when user has manage permission', async () => {
+            const adminUser: SessionUser = {
+                ...user,
+                role: OrganizationMemberRole.ADMIN,
+                ability: defineUserAbility(
+                    {
+                        userUuid: user.userUuid,
+                        role: OrganizationMemberRole.ADMIN,
+                        organizationUuid: 'organizationUuid',
+                    },
+                    [],
+                ),
+            };
+
+            const agentUuid = 'agent-uuid-123';
+            const updateSpy = jest
+                .spyOn(projectModel, 'updateProjectDefaultAgent')
+                .mockResolvedValue(undefined);
+
+            await service.updateProjectDefaultAgent(adminUser, projectUuid, {
+                defaultAiAgentUuid: agentUuid,
+            });
+
+            expect(updateSpy).toHaveBeenCalledWith(projectUuid, agentUuid);
+        });
+
+        test('should allow setting default agent to null', async () => {
+            const adminUser: SessionUser = {
+                ...user,
+                role: OrganizationMemberRole.ADMIN,
+                ability: defineUserAbility(
+                    {
+                        userUuid: user.userUuid,
+                        role: OrganizationMemberRole.ADMIN,
+                        organizationUuid: 'organizationUuid',
+                    },
+                    [],
+                ),
+            };
+
+            const updateSpy = jest
+                .spyOn(projectModel, 'updateProjectDefaultAgent')
+                .mockResolvedValue(undefined);
+
+            await service.updateProjectDefaultAgent(adminUser, projectUuid, {
+                defaultAiAgentUuid: null,
+            });
+
+            expect(updateSpy).toHaveBeenCalledWith(projectUuid, null);
+        });
+
+        test('should throw ForbiddenError when user lacks manage permission', async () => {
+            const restrictedUser: SessionUser = {
+                ...user,
+                userUuid: 'restricted-uuid',
+                role: OrganizationMemberRole.VIEWER,
+                ability: defineUserAbility(
+                    {
+                        userUuid: 'restricted-uuid',
+                        role: OrganizationMemberRole.VIEWER,
+                        organizationUuid: 'organizationUuid',
+                    },
+                    [],
+                ),
+            };
+
+            await expect(
+                service.updateProjectDefaultAgent(restrictedUser, projectUuid, {
+                    defaultAiAgentUuid: 'agent-uuid',
+                }),
             ).rejects.toThrow(ForbiddenError);
         });
     });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -158,6 +158,7 @@ import {
     UpdateDefaultUserSpaces,
     UpdateMetadata,
     UpdateProject,
+    UpdateProjectDefaultAgent,
     UpdateProjectMember,
     UpdateQueryTimezoneSettings,
     UpdateSchedulerSettings,
@@ -7010,6 +7011,34 @@ export class ProjectService extends BaseService {
         await this.projectModel.updateDefaultUserSpaces(
             projectUuid,
             data.hasDefaultUserSpaces,
+        );
+    }
+
+    async updateProjectDefaultAgent(
+        user: SessionUser,
+        projectUuid: string,
+        data: UpdateProjectDefaultAgent,
+    ): Promise<void> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        // Note: Agent validation is done via FK constraint
+        // Setting invalid UUID will be rejected by database
+        await this.projectModel.updateProjectDefaultAgent(
+            projectUuid,
+            data.defaultAiAgentUuid,
         );
     }
 

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -520,9 +520,18 @@ export type AiAgentUserPreferences = {
     defaultAgentUuid: AiAgent['uuid'];
 };
 
+export type AiAgentUserPreferencesWithDefaults = {
+    userDefault: AiAgent['uuid'] | null;
+    projectDefault: AiAgent['uuid'] | null;
+    effectiveDefault: AiAgent['uuid'] | null;
+};
+
 export type ApiGetUserAgentPreferencesResponse =
     | ApiSuccess<AiAgentUserPreferences>
     | ApiSuccessEmpty;
+
+export type ApiGetUserAgentPreferencesWithDefaultsResponse =
+    ApiSuccess<AiAgentUserPreferencesWithDefaults>;
 
 export type ApiUpdateUserAgentPreferences = AiAgentUserPreferences;
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -292,6 +292,11 @@ export type UpdateMetadata = {
 export type UpdateDefaultUserSpaces = {
     hasDefaultUserSpaces: boolean;
 };
+
+export type UpdateProjectDefaultAgent = {
+    defaultAiAgentUuid: string | null;
+};
+
 export type ApiFormulaValidationResults =
     | { valid: true; compiledSql: string }
     | { valid: false; error: string };

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -824,11 +824,17 @@ export type Project = {
     projectDefaults?: ProjectDefaults;
     colorPaletteUuid: string | null;
     expiresAt: Date | null;
+    defaultAiAgentUuid?: string | null;
 };
 
 export type ProjectSummary = Pick<
     Project,
-    'name' | 'projectUuid' | 'organizationUuid' | 'type' | 'upstreamProjectUuid'
+    | 'name'
+    | 'projectUuid'
+    | 'organizationUuid'
+    | 'type'
+    | 'upstreamProjectUuid'
+    | 'defaultAiAgentUuid'
 >;
 
 export type ApiProjectResponse = {

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -28,7 +28,7 @@ import {
     useCreateAgentThreadMutation,
     useProjectAiAgents,
 } from '../../../features/aiCopilot/hooks/useProjectAiAgents';
-import { useGetUserAgentPreferences } from '../../../features/aiCopilot/hooks/useUserAgentPreferences';
+import { useGetUserAgentPreferencesWithDefaults } from '../../../features/aiCopilot/hooks/useUserAgentPreferences';
 import { store } from '../../../features/aiCopilot/store';
 import { AiAgentThreadStreamAbortControllerContextProvider } from '../../../features/aiCopilot/streaming/AiAgentThreadStreamAbortControllerContextProvider';
 import styles from './aiSearchBox.module.css';
@@ -49,10 +49,8 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
     const isTrial =
         aiOrganizationSettingsQuery.isSuccess &&
         aiOrganizationSettingsQuery.data.isTrial;
-    const {
-        data: userAgentPreferences,
-        isLoading: isLoadingUserAgentPreferences,
-    } = useGetUserAgentPreferences(projectUuid);
+    const { data: agentPreferences, isLoading: isLoadingAgentPreferences } =
+        useGetUserAgentPreferencesWithDefaults(projectUuid);
     const [selectedAgent, setSelectedAgent] = useState<AiAgentSummary>();
     const canManageAgents = useAiAgentPermission({
         action: 'manage',
@@ -65,13 +63,13 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
     useEffect(() => {
         if (!agents || agents.length === 0) return;
 
-        const preferredAgent =
+        // Use effective default from server-side resolver
+        const effectiveDefaultAgent =
             agents.find(
-                (agent) =>
-                    agent.uuid === userAgentPreferences?.defaultAgentUuid,
+                (agent) => agent.uuid === agentPreferences?.effectiveDefault,
             ) ?? agents[0];
-        setSelectedAgent(preferredAgent);
-    }, [agents, userAgentPreferences?.defaultAgentUuid]);
+        setSelectedAgent(effectiveDefaultAgent);
+    }, [agents, agentPreferences?.effectiveDefault]);
 
     const form = useForm({
         initialValues: {
@@ -105,7 +103,7 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
         );
     };
 
-    if (isLoadingAgents || isLoadingUserAgentPreferences) {
+    if (isLoadingAgents || isLoadingAgentPreferences) {
         return (
             <Paper style={{ overflow: 'hidden' }} p="md">
                 <Group wrap="nowrap" align="center">
@@ -134,6 +132,10 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                             agents={agents}
                             selectedAgent={selectedAgent ?? agents[0]}
                             onSelect={onSelect}
+                            projectDefaultUuid={
+                                agentPreferences?.projectDefault
+                            }
+                            userDefaultUuid={agentPreferences?.userDefault}
                         />
                         <Group gap="xs" flex={1}>
                             <SearchDropdown

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminProjectDefaultAgent.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminProjectDefaultAgent.tsx
@@ -1,0 +1,202 @@
+import {
+    Alert,
+    Box,
+    Group,
+    Paper,
+    Select,
+    Skeleton,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine-8/core';
+import { IconAlertCircle, IconBox, IconInfoCircle } from '@tabler/icons-react';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import useToaster from '../../../../../hooks/toaster/useToaster';
+import { useActiveProjectUuid } from '../../../../../hooks/useActiveProject';
+import { useProjects } from '../../../../../hooks/useProjects';
+import { useProjectAiAgents } from '../../hooks/useProjectAiAgents';
+import { useGetUserAgentPreferencesWithDefaults } from '../../hooks/useUserAgentPreferences';
+import { useUpdateProjectDefaultAgent } from './useUpdateProjectDefaultAgent';
+
+export const AiAgentsAdminProjectDefaultAgent: FC = () => {
+    const theme = useMantineTheme();
+    const { showToastSuccess } = useToaster();
+    const { activeProjectUuid } = useActiveProjectUuid();
+    const { data: projects, isLoading: isLoadingProjects } = useProjects();
+    const [selectedProjectUuid, setSelectedProjectUuid] = useState<
+        string | null
+    >(null);
+
+    useEffect(() => {
+        if (activeProjectUuid && selectedProjectUuid === null) {
+            setSelectedProjectUuid(activeProjectUuid);
+        }
+    }, [activeProjectUuid, selectedProjectUuid]);
+
+    const projectUuid = selectedProjectUuid ?? activeProjectUuid ?? null;
+
+    const { data: agents, isLoading: isLoadingAgents } = useProjectAiAgents({
+        projectUuid: projectUuid ?? undefined,
+        redirectOnUnauthorized: false,
+        options: { enabled: !!projectUuid },
+    });
+    const { data: agentPreferences, isLoading: isLoadingPreferences } =
+        useGetUserAgentPreferencesWithDefaults(projectUuid ?? undefined, {
+            enabled: !!projectUuid,
+        });
+    const { mutate: updateProjectDefaultAgent, isLoading: isUpdating } =
+        useUpdateProjectDefaultAgent(projectUuid ?? '');
+
+    const projectOptions = useMemo(
+        () =>
+            projects?.map((project) => ({
+                value: project.projectUuid,
+                label: project.name,
+            })) ?? [],
+        [projects],
+    );
+
+    const selectedAgent = agents?.find(
+        (agent) => agent.uuid === agentPreferences?.projectDefault,
+    );
+
+    const selectedAgentHasRestrictions =
+        selectedAgent &&
+        ((selectedAgent.groupAccess && selectedAgent.groupAccess.length > 0) ||
+            (selectedAgent.userAccess && selectedAgent.userAccess.length > 0));
+
+    const handleChange = (agentUuid: string | null) => {
+        if (!projectUuid) return;
+        updateProjectDefaultAgent(
+            { defaultAiAgentUuid: agentUuid },
+            {
+                onSuccess: () => {
+                    showToastSuccess({
+                        title: 'Project default agent updated',
+                    });
+                },
+            },
+        );
+    };
+
+    const isLoading =
+        isLoadingProjects ||
+        !projectUuid ||
+        isLoadingAgents ||
+        isLoadingPreferences;
+
+    return (
+        <Paper
+            p="md"
+            mb="sm"
+            style={{
+                border: `1px solid ${theme.colors.ldGray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+            }}
+        >
+            <Stack gap="sm">
+                <Group justify="space-between" align="flex-start">
+                    <Box>
+                        <Title order={6}>Project default agent</Title>
+                        <Text c="ldGray.6" size="xs">
+                            Users without a personal preference will use this
+                            agent by default.
+                        </Text>
+                    </Box>
+                    <Select
+                        w={220}
+                        size="xs"
+                        placeholder="Select project"
+                        leftSection={<MantineIcon icon={IconBox} size="sm" />}
+                        data={projectOptions}
+                        value={projectUuid}
+                        onChange={setSelectedProjectUuid}
+                        disabled={isLoadingProjects}
+                        searchable
+                    />
+                </Group>
+
+                {isLoading ? (
+                    <Skeleton height={36} />
+                ) : !agents || agents.length === 0 ? (
+                    <Text c="ldGray.6" size="sm">
+                        No AI agents in this project. Create an agent first to
+                        set a default.
+                    </Text>
+                ) : (
+                    <>
+                        <Group gap="xs" align="center">
+                            <Text fw={500} size="sm">
+                                Default agent
+                            </Text>
+                            <Tooltip
+                                label={
+                                    <Stack gap="xs">
+                                        <Text size="xs" fw={600}>
+                                            Fallback chain:
+                                        </Text>
+                                        <Text size="xs">
+                                            1. User preference (if set)
+                                            <br />
+                                            2. Project default (if set)
+                                            <br />
+                                            3. First accessible agent
+                                        </Text>
+                                    </Stack>
+                                }
+                                multiline
+                                w={250}
+                            >
+                                <Box>
+                                    <MantineIcon
+                                        icon={IconInfoCircle}
+                                        color="ldGray.6"
+                                        size="sm"
+                                    />
+                                </Box>
+                            </Tooltip>
+                        </Group>
+
+                        <Select
+                            placeholder="Select an agent (optional)"
+                            size="sm"
+                            data={[
+                                {
+                                    value: 'null',
+                                    label: 'No default (let users choose)',
+                                },
+                                ...agents.map((agent) => ({
+                                    value: agent.uuid,
+                                    label: agent.name,
+                                })),
+                            ]}
+                            value={agentPreferences?.projectDefault || 'null'}
+                            onChange={(value) =>
+                                handleChange(value === 'null' ? null : value)
+                            }
+                            disabled={isUpdating}
+                            clearable={false}
+                        />
+
+                        {selectedAgentHasRestrictions && (
+                            <Alert
+                                icon={<MantineIcon icon={IconAlertCircle} />}
+                                color="yellow"
+                                title="Limited access agent"
+                            >
+                                This agent has group or user access
+                                restrictions. Users who cannot access this agent
+                                will automatically fall back to the first
+                                available agent.
+                            </Alert>
+                        )}
+                    </>
+                )}
+            </Stack>
+        </Paper>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiAgentsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiAgentsSettingsPage.tsx
@@ -5,6 +5,7 @@ import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs
 import { useActiveProjectUuid } from '../../../../../../hooks/useActiveProject';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import AiAgentAdminAgentsTable from '../AiAgentAdminAgentsTable';
+import { AiAgentsAdminProjectDefaultAgent } from '../AiAgentsAdminProjectDefaultAgent';
 import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
 
 export const AiAgentsSettingsPage = () => {
@@ -32,6 +33,7 @@ export const AiAgentsSettingsPage = () => {
 
             {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
 
+            <AiAgentsAdminProjectDefaultAgent />
             <AiAgentAdminAgentsTable />
         </Stack>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/useUpdateProjectDefaultAgent.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/useUpdateProjectDefaultAgent.ts
@@ -1,0 +1,45 @@
+import {
+    type ApiError,
+    type ApiSuccessEmpty,
+    type UpdateProjectDefaultAgent,
+} from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../../api';
+import useToaster from '../../../../../hooks/toaster/useToaster';
+
+const updateProjectDefaultAgent = (
+    projectUuid: string,
+    data: UpdateProjectDefaultAgent,
+) =>
+    lightdashApi<ApiSuccessEmpty['results']>({
+        url: `/projects/${projectUuid}/defaultAiAgent`,
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+export const useUpdateProjectDefaultAgent = (projectUuid: string) => {
+    const { showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+
+    return useMutation<
+        ApiSuccessEmpty['results'],
+        ApiError,
+        UpdateProjectDefaultAgent
+    >({
+        mutationFn: (data) => updateProjectDefaultAgent(projectUuid, data),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({
+                queryKey: ['userAgentPreferencesWithDefaults', projectUuid],
+            });
+            void queryClient.invalidateQueries({
+                queryKey: ['project', projectUuid],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update project default agent',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -1,5 +1,6 @@
 import {
     Avatar,
+    Badge,
     Center,
     Combobox,
     Group,
@@ -24,6 +25,7 @@ import {
     AI_ROUTING_AUTO_VALUE,
     AI_ROUTING_SEARCH_PARAM,
     getAgentOptions,
+    shouldShowProjectDefaultBadge,
     type Agent,
 } from './AgentSelectorUtils';
 
@@ -37,6 +39,8 @@ type Props = {
      * tight (e.g. the chat input).
      */
     compact?: boolean;
+    projectDefaultUuid?: string | null;
+    userDefaultUuid?: string | null;
 };
 
 const AUTO_VALUE = '__auto__';
@@ -46,6 +50,8 @@ export const AgentSelector = ({
     selectedAgent,
     projectUuid,
     compact = false,
+    projectDefaultUuid,
+    userDefaultUuid,
 }: Props) => {
     const navigate = useNavigate();
     const { search } = useLocation();
@@ -55,7 +61,11 @@ export const AgentSelector = ({
         onDropdownClose: () => combobox.resetSelectedOption(),
     });
 
-    const agentOptions = getAgentOptions(agents);
+    const agentOptions = getAgentOptions(
+        agents,
+        projectDefaultUuid,
+        userDefaultUuid,
+    );
     const isAuto = selectedAgent === 'auto';
     // Auto is only meaningful when there's more than one agent AND the router
     // is enabled. Treat any non-`enabled: true` state (loading, error, disabled)
@@ -172,35 +182,50 @@ export const AgentSelector = ({
                     </Combobox.Header>
                 )}
                 <Combobox.Options>
-                    {agentOptions.map((item) => (
-                        <Combobox.Option
-                            value={item.value}
-                            key={item.value}
-                            p={2}
-                            pr={6}
-                        >
-                            <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
-                                <LightdashUserAvatar
-                                    size={22}
-                                    name={item.label}
-                                    src={item.imageUrl}
-                                />
+                    {agentOptions.map((item) => {
+                        const showProjectDefaultBadge =
+                            shouldShowProjectDefaultBadge(item);
 
-                                <Text size="xs" truncate="end" flex={1}>
-                                    {item.label}
-                                </Text>
+                        return (
+                            <Combobox.Option
+                                value={item.value}
+                                key={item.value}
+                                p={2}
+                                pr={6}
+                            >
+                                <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
+                                    <LightdashUserAvatar
+                                        size={22}
+                                        name={item.label}
+                                        src={item.imageUrl}
+                                    />
 
-                                {!isAuto &&
-                                    item.value === selectedAgent.uuid && (
-                                        <MantineIcon
-                                            icon={IconCheck}
-                                            size="sm"
-                                            color="ldGray.7"
-                                        />
+                                    <Text size="xs" truncate="end" flex={1}>
+                                        {item.label}
+                                    </Text>
+
+                                    {showProjectDefaultBadge && (
+                                        <Badge
+                                            size="xs"
+                                            variant="light"
+                                            color="blue"
+                                        >
+                                            Project default
+                                        </Badge>
                                     )}
-                            </Group>
-                        </Combobox.Option>
-                    ))}
+
+                                    {!isAuto &&
+                                        item.value === selectedAgent.uuid && (
+                                            <MantineIcon
+                                                icon={IconCheck}
+                                                size="sm"
+                                                color="ldGray.7"
+                                            />
+                                        )}
+                                </Group>
+                            </Combobox.Option>
+                        );
+                    })}
 
                     <Combobox.Footer p={4} pr={6}>
                         <Combobox.Option value="new" p={2}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelectorUtils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelectorUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getAgentOptions,
+    shouldShowProjectDefaultBadge,
+    type Agent,
+} from './AgentSelectorUtils';
+
+const agents: Agent[] = [
+    { uuid: 'agent-1', name: 'Agent One', imageUrl: null },
+    { uuid: 'agent-2', name: 'Agent Two', imageUrl: null },
+];
+
+describe('getAgentOptions', () => {
+    it('marks project and user defaults on the correct agents', () => {
+        const options = getAgentOptions(agents, 'agent-1', 'agent-2');
+
+        expect(options).toEqual([
+            expect.objectContaining({
+                value: 'agent-1',
+                isProjectDefault: true,
+                isUserDefault: false,
+            }),
+            expect.objectContaining({
+                value: 'agent-2',
+                isProjectDefault: false,
+                isUserDefault: true,
+            }),
+        ]);
+    });
+
+    it('leaves flags unset when no defaults are configured', () => {
+        const options = getAgentOptions(agents, null, null);
+
+        expect(options.every((option) => !option.isProjectDefault)).toBe(true);
+        expect(options.every((option) => !option.isUserDefault)).toBe(true);
+    });
+});
+
+describe('shouldShowProjectDefaultBadge', () => {
+    it('shows the badge for a project default that is not the user default', () => {
+        const [projectDefaultOption] = getAgentOptions(
+            agents,
+            'agent-1',
+            'agent-2',
+        );
+
+        expect(shouldShowProjectDefaultBadge(projectDefaultOption)).toBe(true);
+    });
+
+    it('hides the badge when the user default is the same agent', () => {
+        const [sameDefaultOption] = getAgentOptions(
+            agents,
+            'agent-1',
+            'agent-1',
+        );
+
+        expect(shouldShowProjectDefaultBadge(sameDefaultOption)).toBe(false);
+    });
+
+    it('hides the badge when no project default is set', () => {
+        const [option] = getAgentOptions(agents, null, 'agent-2');
+
+        expect(shouldShowProjectDefaultBadge(option)).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelectorUtils.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelectorUtils.tsx
@@ -1,5 +1,5 @@
 import { type AiAgent } from '@lightdash/common';
-import { Group, Text, type ComboboxItem } from '@mantine-8/core';
+import { Badge, Group, Text, type ComboboxItem } from '@mantine-8/core';
 import { IconCheck } from '@tabler/icons-react';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -16,6 +16,8 @@ export const AI_ROUTING_AUTO_VALUE = 'auto';
 
 export interface AgentSelectOption extends ComboboxItem {
     imageUrl?: AiAgent['imageUrl'];
+    isProjectDefault?: boolean;
+    isUserDefault?: boolean;
 }
 
 export const renderSelectOption = ({
@@ -24,27 +26,49 @@ export const renderSelectOption = ({
 }: {
     option: AgentSelectOption;
     checked?: boolean;
-}) => (
-    <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
-        <LightdashUserAvatar
-            size={22}
-            name={option.label}
-            src={option.imageUrl}
-        />
-        <Text size="xs" truncate="end" flex={1}>
-            {option.label}
-        </Text>
+}) => {
+    const showProjectDefaultBadge = shouldShowProjectDefaultBadge(option);
 
-        {checked && <MantineIcon icon={IconCheck} size="sm" color="violet" />}
-    </Group>
-);
+    return (
+        <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
+            <LightdashUserAvatar
+                size={22}
+                name={option.label}
+                src={option.imageUrl}
+            />
+            <Text size="xs" truncate="end" flex={1}>
+                {option.label}
+            </Text>
 
-export const getAgentOptions = (agents: Agent[]) =>
+            {showProjectDefaultBadge && (
+                <Badge size="xs" variant="light" color="blue">
+                    Project default
+                </Badge>
+            )}
+
+            {checked && (
+                <MantineIcon icon={IconCheck} size="sm" color="violet" />
+            )}
+        </Group>
+    );
+};
+
+export const shouldShowProjectDefaultBadge = (
+    option: Pick<AgentSelectOption, 'isProjectDefault' | 'isUserDefault'>,
+) => Boolean(option.isProjectDefault && !option.isUserDefault);
+
+export const getAgentOptions = (
+    agents: Agent[],
+    projectDefaultUuid?: string | null,
+    userDefaultUuid?: string | null,
+) =>
     agents.map(
         ({ name, uuid, imageUrl }) =>
             ({
                 label: name,
                 value: uuid,
                 imageUrl: imageUrl,
+                isProjectDefault: projectDefaultUuid === uuid,
+                isUserDefault: userDefaultUuid === uuid,
             }) satisfies AgentSelectOption,
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
@@ -21,18 +21,26 @@ type Props = ComboboxProps & {
     agents: Agent[];
     selectedAgent: Agent;
     onSelect: (val: string) => void;
+    projectDefaultUuid?: string | null;
+    userDefaultUuid?: string | null;
 };
 
 export const CompactAgentSelector = ({
     agents,
     selectedAgent,
     onSelect,
+    projectDefaultUuid,
+    userDefaultUuid,
     ...props
 }: Props) => {
     const combobox = useCombobox({
         onDropdownClose: () => combobox.resetSelectedOption(),
     });
-    const agentOptions = getAgentOptions(agents);
+    const agentOptions = getAgentOptions(
+        agents,
+        projectDefaultUuid,
+        userDefaultUuid,
+    );
     const hasOneAgent = agentOptions.length === 1;
     const hasAgents = agentOptions.length > 0;
 

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useUserAgentPreferences.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useUserAgentPreferences.ts
@@ -1,4 +1,5 @@
 import {
+    type AiAgentUserPreferencesWithDefaults,
     type ApiAiAgentExploreAccessSummaryResponse,
     type ApiError,
     type ApiGetUserAgentPreferencesResponse,
@@ -34,6 +35,29 @@ export const useGetUserAgentPreferences = (
     return useQuery<ApiGetUserAgentPreferencesResponse['results'], ApiError>({
         queryKey: [USER_AGENT_PREFERENCES, projectUuid],
         queryFn: () => getUserAgentPreferences(projectUuid!),
+        ...options,
+        enabled: !!projectUuid && options?.enabled !== false,
+    });
+};
+
+const getUserAgentPreferencesWithDefaults = async (
+    projectUuid: string,
+): Promise<AiAgentUserPreferencesWithDefaults> => {
+    const response = await lightdashApi<any>({
+        url: `/projects/${projectUuid}/aiAgents/preferences/with-defaults`,
+        method: 'GET',
+        body: undefined,
+    });
+    return response;
+};
+
+export const useGetUserAgentPreferencesWithDefaults = (
+    projectUuid?: string | null,
+    options?: UseQueryOptions<AiAgentUserPreferencesWithDefaults, ApiError>,
+) => {
+    return useQuery<AiAgentUserPreferencesWithDefaults, ApiError>({
+        queryKey: ['userAgentPreferencesWithDefaults', projectUuid],
+        queryFn: () => getUserAgentPreferencesWithDefaults(projectUuid!),
         ...options,
         enabled: !!projectUuid && options?.enabled !== false,
     });
@@ -80,6 +104,10 @@ export const useUpdateUserAgentPreferences = (projectUuid: string) => {
         onSuccess: () => {
             void queryClient.invalidateQueries({
                 queryKey: [USER_AGENT_PREFERENCES, projectUuid],
+            });
+            // Also invalidate preferences with defaults (used by homepage)
+            void queryClient.invalidateQueries({
+                queryKey: ['userAgentPreferencesWithDefaults', projectUuid],
             });
         },
         onError: ({ error }, _variables, context) => {
@@ -135,6 +163,10 @@ export const useDeleteUserAgentPreferences = (projectUuid: string) => {
         onSuccess: () => {
             void queryClient.invalidateQueries({
                 queryKey: [USER_AGENT_PREFERENCES, projectUuid],
+            });
+            // Also invalidate preferences with defaults (used by homepage)
+            void queryClient.invalidateQueries({
+                queryKey: ['userAgentPreferencesWithDefaults', projectUuid],
             });
         },
         onError: ({ error }, _variables, context) => {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -23,6 +23,7 @@ import {
     useAiAgentThread,
     useProjectAiAgents,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import { useGetUserAgentPreferencesWithDefaults } from '../../features/aiCopilot/hooks/useUserAgentPreferences';
 import { store as aiAgentStore } from '../../features/aiCopilot/store';
 import { openPanel } from '../../features/aiCopilot/store/aiAgentLauncherSlice';
 
@@ -44,6 +45,10 @@ const AgentPage = () => {
         projectUuid: projectUuid!,
         redirectOnUnauthorized: true,
     });
+
+    const { data: agentPreferences } = useGetUserAgentPreferencesWithDefaults(
+        projectUuid!,
+    );
 
     const [isAgentSidebarCollapsed, setIsAgentSidebarCollapsed] =
         useState(false);
@@ -173,6 +178,10 @@ const AgentPage = () => {
                                 projectUuid={projectUuid!}
                                 agents={agentsList}
                                 selectedAgent={agent}
+                                projectDefaultUuid={
+                                    agentPreferences?.projectDefault
+                                }
+                                userDefaultUuid={agentPreferences?.userDefault}
                             />
                         ) : undefined
                     }

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
@@ -29,7 +29,7 @@ import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentP
 import { useAiOrganizationSettings } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import { useAiRouterConfig } from '../../features/aiCopilot/hooks/useAiRouter';
 import { useProjectAiAgents } from '../../features/aiCopilot/hooks/useProjectAiAgents';
-import { useGetUserAgentPreferences } from '../../features/aiCopilot/hooks/useUserAgentPreferences';
+import { useGetUserAgentPreferencesWithDefaults } from '../../features/aiCopilot/hooks/useUserAgentPreferences';
 import AgentsRouterPage from './AgentsRouterPage';
 
 const AGENT_FEATURES = [
@@ -105,9 +105,12 @@ const AgentsWelcome = () => {
             enabled: isAiCopilotEnabledOrTrial,
         },
     });
-    const userAgentPreferencesQuery = useGetUserAgentPreferences(projectUuid, {
-        enabled: isAiCopilotEnabledOrTrial,
-    });
+    const userAgentPreferencesQuery = useGetUserAgentPreferencesWithDefaults(
+        projectUuid,
+        {
+            enabled: isAiCopilotEnabledOrTrial,
+        },
+    );
     const aiRouterConfigQuery = useAiRouterConfig();
 
     if (aiOrganizationSettingsQuery.isLoading) {
@@ -156,9 +159,12 @@ const AgentsWelcome = () => {
     } else if (aiRouterConfigQuery.data?.enabled) {
         return <AgentsRouterPage />;
     } else {
+        const defaultAgentUuid =
+            userAgentPreferencesQuery.data?.effectiveDefault ??
+            agentsQuery.data[0].uuid;
         return (
             <Navigate
-                to={`/projects/${projectUuid}/ai-agents/${agentsQuery.data[0].uuid}`}
+                to={`/projects/${projectUuid}/ai-agents/${defaultAgentUuid}`}
                 replace
             />
         );

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -1,5 +1,6 @@
 import {
     ActionIcon,
+    Badge,
     Center,
     Group,
     Pill,
@@ -36,6 +37,7 @@ import {
     useCreateAgentThreadMutation,
     useVerifiedQuestions,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import { useGetUserAgentPreferencesWithDefaults } from '../../features/aiCopilot/hooks/useUserAgentPreferences';
 import { setThreadSqlMode } from '../../features/aiCopilot/store/aiAgentThreadModeSlice';
 import { useAiAgentStoreDispatch } from '../../features/aiCopilot/store/hooks';
 import { type AiAgentToolResult } from '../../features/aiCopilot/types';
@@ -105,6 +107,9 @@ const AiAgentNewThreadPage: FC = () => {
             },
             onToolResult: handleToolResult,
         });
+    const { data: agentPreferences } = useGetUserAgentPreferencesWithDefaults(
+        projectUuid!,
+    );
     const { data: verifiedQuestions } = useVerifiedQuestions(
         projectUuid,
         agentUuid,
@@ -145,6 +150,9 @@ const AiAgentNewThreadPage: FC = () => {
         [modelOptions, selectedModelKey],
     );
     const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
+
+    const isProjectDefault = agentPreferences?.projectDefault === agent.uuid;
+    const showProjectDefaultBadge = isProjectDefault;
 
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
 
@@ -203,10 +211,20 @@ const AiAgentNewThreadPage: FC = () => {
                             name={agent.name || 'AI'}
                             src={agent.imageUrl}
                         />
-                        <Group justify="center" gap={2}>
+                        <Group justify="center" gap="xs">
                             <Title order={4} ta="center">
                                 {agent.name}
                             </Title>
+                            {showProjectDefaultBadge && (
+                                <Badge
+                                    size="sm"
+                                    variant="light"
+                                    color="blue"
+                                    styles={{ root: { textTransform: 'none' } }}
+                                >
+                                    Project default
+                                </Badge>
+                            )}
                             <DefaultAgentButton
                                 projectUuid={projectUuid}
                                 agentUuid={agent.uuid}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#21858](https://github.com/lightdash/lightdash/issues/21858)

### Description:

Adds a project-level default AI agent that admins configure under **Settings → Ask AI → Agents**. When a user has no personal default, the app uses the project default for agent selection, landing routes, and the home AI search box.

Resolution order: **user default → project default → first accessible agent**. Deleted or inaccessible defaults fall back automatically.


<img width="926" height="513" alt="Screenshot 2026-06-01 at 3 43 10 PM" src="https://github.com/user-attachments/assets/d811178f-2669-47f5-8c03-5f1fa37922fb" />
