### PR TITLE
fix: support Athena FLOAT type, export conversion helper, and add tests

### DIFF
--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
@@ -1,6 +1,7 @@
 import {
     AthenaAuthenticationType,
     CreateAthenaCredentials,
+    DimensionType,
     WarehouseConnectionError,
     WarehouseQueryError,
     WarehouseTypes,
@@ -19,7 +20,11 @@ jest.mock('@aws-sdk/credential-providers', () => ({
 }));
 
 // eslint-disable-next-line import/first -- Must import after mocks are set up
-import { AthenaWarehouseClient } from './AthenaWarehouseClient';
+import {
+    AthenaTypes,
+    AthenaWarehouseClient,
+    convertDataTypeToDimensionType,
+} from './AthenaWarehouseClient';
 
 const baseCredentials: CreateAthenaCredentials = {
     type: WarehouseTypes.ATHENA,
@@ -31,6 +36,18 @@ const baseCredentials: CreateAthenaCredentials = {
     accessKeyId: 'AKID',
     secretAccessKey: 'SECRET',
 };
+
+describe('convertDataTypeToDimensionType', () => {
+    test.each([
+        [AthenaTypes.FLOAT, DimensionType.NUMBER],
+        ['FLOAT', DimensionType.NUMBER],
+        [AthenaTypes.DOUBLE, DimensionType.NUMBER],
+        [AthenaTypes.BIGINT, DimensionType.NUMBER],
+        ['decimal(10, 2)', DimensionType.NUMBER],
+    ])('maps Athena %s columns to %s dimensions', (input, expected) => {
+        expect(convertDataTypeToDimensionType(input)).toBe(expected);
+    });
+});
 
 describe('AthenaWarehouseClient', () => {
     beforeEach(() => {

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
@@ -39,6 +39,7 @@ export enum AthenaTypes {
     INTEGER = 'integer',
     BIGINT = 'bigint',
     REAL = 'real',
+    FLOAT = 'float',
     DOUBLE = 'double',
     DECIMAL = 'decimal',
     VARCHAR = 'varchar',
@@ -57,7 +58,7 @@ export enum AthenaTypes {
     UUID = 'uuid',
 }
 
-const convertDataTypeToDimensionType = (
+export const convertDataTypeToDimensionType = (
     type: AthenaTypes | string,
 ): DimensionType => {
     const normalizedType = type.toLowerCase().replace(/\(\d+(,\s*\d+)?\)/, '');
@@ -69,6 +70,7 @@ const convertDataTypeToDimensionType = (
         case AthenaTypes.INTEGER:
         case AthenaTypes.BIGINT:
         case AthenaTypes.REAL:
+        case AthenaTypes.FLOAT:
         case AthenaTypes.DOUBLE:
         case AthenaTypes.DECIMAL:
             return DimensionType.NUMBER;
@@ -375,6 +377,7 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
             case AthenaTypes.BIGINT:
                 return parseInt(value, 10);
             case AthenaTypes.REAL:
+            case AthenaTypes.FLOAT:
             case AthenaTypes.DOUBLE:
             case AthenaTypes.DECIMAL:
                 return parseFloat(value);


### PR DESCRIPTION
### Motivation
- Ensure Athena `FLOAT` columns are correctly interpreted as numeric dimensions and parsed as numbers, and make the data-type-to-dimension conversion reusable and testable.

### Description
- Add `FLOAT` to the `AthenaTypes` enum and handle it in the value parsing logic in `parseValue` so floats are parsed with `parseFloat`.
- Export the `convertDataTypeToDimensionType` function and update imports to expose `AthenaTypes`, `AthenaWarehouseClient`, and `convertDataTypeToDimensionType` for testing and reuse.
- Add unit tests in `AthenaWarehouseClient.test.ts` for `convertDataTypeToDimensionType` that assert mapping of `FLOAT`, `DOUBLE`, `BIGINT`, and `decimal(10, 2)` to `DimensionType.NUMBER`, and adjust test imports to include `DimensionType`.

### Testing
- Ran the package unit tests for the warehouses package with `yarn test packages/warehouses`, including the new `convertDataTypeToDimensionType` test and existing authentication tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e0f99e2d0832e896c0f00d876a0c6)