### PR TITLE
fix(ai-agents): when agent modifies a dashboard, properly refresh the tiles/tabs

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -33,11 +33,6 @@ type ContentLinkProps = {
     onDashboardLinkClick?: (url: string) => void;
 };
 
-const getDashboardRouteKey = (pathname: string) => {
-    const match = pathname.match(/^\/projects\/([^/]+)\/dashboards\/([^/]+)/);
-    return match ? `${match[1]}/${match[2]}` : null;
-};
-
 export const ContentLink: FC<ContentLinkProps> = ({
     contentType,
     props,
@@ -80,11 +75,6 @@ export const ContentLink: FC<ContentLinkProps> = ({
             pathname: targetUrl.pathname,
             search: targetUrl.search,
         });
-        const isCurrentDashboard =
-            getDashboardRouteKey(location.pathname) ===
-            getDashboardRouteKey(targetUrl.pathname);
-
-        if (isCurrentDashboard) return;
 
         if (onDashboardLinkClick) {
             onDashboardLinkClick(targetPath);

--- a/packages/frontend/src/ee/features/aiCopilot/utils/contentToolResultNavigation.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/contentToolResultNavigation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { type AiAgentToolResult } from '../types';
+import { getDashboardNavigationUrlFromContentToolResult } from './contentToolResultNavigation';
+
+const dashboardEditResult = {
+    toolName: 'editContent',
+    toolArgs: {
+        type: 'dashboard',
+        slug: 'jaffle-dashboard',
+        patch: [],
+    },
+    toolResult: {
+        result: '{}',
+        metadata: {
+            status: 'success',
+            slug: 'jaffle-dashboard',
+            name: 'Jaffle dashboard',
+            uuid: '2ba751c1-521f-4af5-a910-e40917f2c24e',
+            href: '/projects/project-uuid/dashboards/jaffle-dashboard',
+        },
+    },
+} as AiAgentToolResult;
+
+describe('getDashboardNavigationUrlFromContentToolResult', () => {
+    it('does not navigate when already on the same dashboard tab by uuid', () => {
+        expect(
+            getDashboardNavigationUrlFromContentToolResult(
+                'project-uuid',
+                dashboardEditResult,
+                {
+                    pathname:
+                        '/projects/project-uuid/dashboards/2ba751c1-521f-4af5-a910-e40917f2c24e/view/tabs/9dc8ea5c-c8a8-45f3-bc3c-192452b2cd72',
+                    search: '',
+                },
+            ),
+        ).toBeNull();
+    });
+
+    it('navigates when on a different dashboard', () => {
+        expect(
+            getDashboardNavigationUrlFromContentToolResult(
+                'project-uuid',
+                dashboardEditResult,
+                {
+                    pathname: '/projects/project-uuid/dashboards/other',
+                    search: '',
+                },
+            ),
+        ).toBe('/projects/project-uuid/dashboards/jaffle-dashboard');
+    });
+
+    it('navigates when on the same dashboard identifier in a different project', () => {
+        expect(
+            getDashboardNavigationUrlFromContentToolResult(
+                'project-uuid',
+                dashboardEditResult,
+                {
+                    pathname:
+                        '/projects/other-project-uuid/dashboards/2ba751c1-521f-4af5-a910-e40917f2c24e/view/tabs/9dc8ea5c-c8a8-45f3-bc3c-192452b2cd72',
+                    search: '',
+                },
+            ),
+        ).toBe('/projects/project-uuid/dashboards/jaffle-dashboard');
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/utils/contentToolResultNavigation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/contentToolResultNavigation.ts
@@ -1,43 +1,36 @@
+import {
+    isSameDashboardRoute,
+    isSameLocation,
+} from '../../../../utils/dashboardRoutes';
 import { type AiAgentToolResult } from '../types';
 
-type LocationLike = {
-    pathname: string;
-    search: string;
-};
+type LocationLike = Parameters<typeof isSameLocation>[1];
 
-const normalizePathname = (pathname: string): string =>
-    pathname.replace(/\/$/, '');
-
-const isSameLocation = (targetUrl: string, location: LocationLike): boolean => {
-    const target = new URL(targetUrl, window.location.origin);
-
-    return (
-        normalizePathname(target.pathname) ===
-            normalizePathname(location.pathname) &&
-        target.search === location.search
-    );
-};
-
-const getDashboardUrlFromContentToolResult = (
+const getDashboardNavigationTargetFromContentToolResult = (
     toolResult: AiAgentToolResult,
-): string | null => {
-    if (toolResult.isPreliminary) return null;
+):
+    | {
+          dashboardUrl: string;
+          dashboardUuid: string;
+          dashboardSlug: string;
+      }
+    | undefined => {
+    if (toolResult.isPreliminary) return undefined;
 
-    if (toolResult.toolName === 'createContent') {
-        if (toolResult.toolArgs.type !== 'dashboard') return null;
-        if (toolResult.toolResult.metadata.status !== 'success') return null;
-
-        return toolResult.toolResult.metadata.href;
+    if (
+        toolResult.toolName !== 'createContent' &&
+        toolResult.toolName !== 'editContent'
+    ) {
+        return undefined;
     }
+    if (toolResult.toolArgs.type !== 'dashboard') return undefined;
+    if (toolResult.toolResult.metadata.status !== 'success') return undefined;
 
-    if (toolResult.toolName === 'editContent') {
-        if (toolResult.toolArgs.type !== 'dashboard') return null;
-        if (toolResult.toolResult.metadata.status !== 'success') return null;
-
-        return toolResult.toolResult.metadata.href;
-    }
-
-    return null;
+    return {
+        dashboardUrl: toolResult.toolResult.metadata.href,
+        dashboardUuid: toolResult.toolResult.metadata.uuid,
+        dashboardSlug: toolResult.toolResult.metadata.slug,
+    };
 };
 
 export const getDashboardNavigationUrlFromContentToolResult = (
@@ -45,8 +38,19 @@ export const getDashboardNavigationUrlFromContentToolResult = (
     toolResult: AiAgentToolResult,
     location: LocationLike = window.location,
 ): string | null => {
-    const dashboardUrl = getDashboardUrlFromContentToolResult(toolResult);
-    if (!dashboardUrl || isSameLocation(dashboardUrl, location)) return null;
+    const target =
+        getDashboardNavigationTargetFromContentToolResult(toolResult);
+    if (
+        !target ||
+        isSameLocation(target.dashboardUrl, location) ||
+        isSameDashboardRoute({
+            location,
+            projectUuid,
+            dashboardUuid: target.dashboardUuid,
+            dashboardSlug: target.dashboardSlug,
+        })
+    )
+        return null;
 
-    return dashboardUrl;
+    return target.dashboardUrl;
 };

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -1,5 +1,4 @@
 import {
-    type Dashboard,
     type DashboardChartTile,
     type DashboardFilters,
     type DashboardTile,
@@ -12,6 +11,7 @@ import { scrollToDashboardTile } from '../../components/common/Dashboard/scrollT
 import { useAiAgentStoreSelector } from '../../ee/features/aiCopilot/store/hooks';
 import { getDashboard } from '../../hooks/dashboard/useDashboard';
 import { getSavedQuery } from '../../hooks/useSavedQuery';
+import { planDashboardAiAgentChanges } from './dashboardAiAgentChangePlanner';
 import useDashboardContext from './useDashboardContext';
 
 const emptyFilters: DashboardFilters = {
@@ -29,9 +29,7 @@ const DashboardAiAgentContextBridge = () => {
     const dashboard = useDashboardContext((c) => c.dashboard);
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
-    const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
-    const setActiveTab = useDashboardContext((c) => c.setActiveTab);
     const setDashboardFilters = useDashboardContext(
         (c) => c.setDashboardFilters,
     );
@@ -61,39 +59,16 @@ const DashboardAiAgentContextBridge = () => {
         [dashboardUuid, projectUuid],
     );
 
-    const scrollToChartTile = useCallback(
-        (tile: DashboardChartTile, tabs: Dashboard['tabs']) => {
-            const focusRequestId = (focusRequestIdRef.current += 1);
-            const tab = tile.tabUuid
-                ? tabs.find(
-                      (dashboardTab) => dashboardTab.uuid === tile.tabUuid,
-                  )
-                : undefined;
-            if (tab) setActiveTab(tab);
+    const scrollToChartTile = useCallback((tile: DashboardChartTile) => {
+        const focusRequestId = (focusRequestIdRef.current += 1);
 
+        window.requestAnimationFrame(() => {
             window.requestAnimationFrame(() => {
-                window.requestAnimationFrame(() => {
-                    if (focusRequestId !== focusRequestIdRef.current) return;
-                    scrollToDashboardTile(tile.uuid);
-                });
+                if (focusRequestId !== focusRequestIdRef.current) return;
+                scrollToDashboardTile(tile.uuid);
             });
-        },
-        [setActiveTab],
-    );
-
-    const successfulContentResults = useMemo(
-        () =>
-            activeThreadParts.flatMap((part) =>
-                part.type === 'toolCall' &&
-                (part.toolName === 'createContent' ||
-                    part.toolName === 'editContent') &&
-                part.isPreliminary === false &&
-                part.toolResult?.metadata.status === 'success'
-                    ? [part]
-                    : [],
-            ),
-        [activeThreadParts],
-    );
+        });
+    }, []);
 
     const refreshChartTilesFromTiles = useCallback(
         async (
@@ -154,16 +129,10 @@ const DashboardAiAgentContextBridge = () => {
             });
 
             if (options?.focusTile) {
-                scrollToChartTile(matchingTiles[0], dashboardTabs);
+                scrollToChartTile(matchingTiles[0]);
             }
         },
-        [
-            dashboardTabs,
-            dashboardUuid,
-            projectUuid,
-            queryClient,
-            scrollToChartTile,
-        ],
+        [dashboardUuid, projectUuid, queryClient, scrollToChartTile],
     );
 
     const refreshDashboard = useCallback(
@@ -207,7 +176,7 @@ const DashboardAiAgentContextBridge = () => {
                     (tile) => tile.properties.chartSlug === chartSlugToFocus,
                 );
                 if (tileToFocus) {
-                    scrollToChartTile(tileToFocus, freshDashboard.tabs);
+                    scrollToChartTile(tileToFocus);
                     return true;
                 }
             }
@@ -238,62 +207,47 @@ const DashboardAiAgentContextBridge = () => {
     useEffect(() => {
         if (!currentDashboardSlug || !projectUuid || !dashboardUuid) return;
 
-        for (const part of successfulContentResults) {
-            const contentSlug =
-                part.toolResult?.metadata.status === 'success'
-                    ? part.toolResult.metadata.slug
-                    : part.toolName === 'createContent'
-                      ? part.toolArgs.content.slug
-                      : part.toolArgs.slug;
-            const targetDashboardSlug =
-                part.toolName === 'createContent'
-                    ? 'dashboardSlug' in part.toolArgs.content
-                        ? part.toolArgs.content.dashboardSlug
-                        : undefined
-                    : undefined;
+        const plan = planDashboardAiAgentChanges({
+            parts: activeThreadParts,
+            handledToolCallIds: handledToolCallIdsRef.current,
+            currentDashboardSlug,
+            pendingChartSlugToFocus: pendingChartSlugToFocusRef.current,
+        });
 
-            if (handledToolCallIdsRef.current.has(part.toolCallId)) continue;
+        for (const toolCallId of plan.handledToolCallIds) {
+            handledToolCallIdsRef.current.add(toolCallId);
+        }
+        pendingChartSlugToFocusRef.current = plan.pendingChartSlugToFocus;
 
-            handledToolCallIdsRef.current.add(part.toolCallId);
-
-            switch (part.toolArgs.type) {
-                case 'chart':
-                    if (
-                        part.toolName === 'createContent' &&
-                        targetDashboardSlug === currentDashboardSlug
-                    ) {
-                        pendingChartSlugToFocusRef.current = contentSlug;
-                        void refreshDashboard(contentSlug).then((focused) => {
+        for (const action of plan.actions) {
+            switch (action.type) {
+                case 'refreshChart':
+                    void refreshChartTiles(action.chartSlug, {
+                        focusTile: action.focusTile,
+                    });
+                    break;
+                case 'refreshDashboard':
+                    void refreshDashboard(action.focusChartSlug).then(
+                        (focused) => {
                             if (
                                 focused &&
                                 pendingChartSlugToFocusRef.current ===
-                                    contentSlug
+                                    action.focusChartSlug
                             ) {
                                 pendingChartSlugToFocusRef.current = null;
                             }
-                        });
-                        continue;
-                    }
-
-                    void refreshChartTiles(contentSlug, { focusTile: true });
-                    continue;
-                case 'dashboard':
-                    if (contentSlug !== currentDashboardSlug) continue;
-                    void refreshDashboard(
-                        pendingChartSlugToFocusRef.current ?? undefined,
-                    ).then((focused) => {
-                        if (focused) pendingChartSlugToFocusRef.current = null;
-                    });
-                    continue;
+                        },
+                    );
+                    break;
             }
         }
     }, [
+        activeThreadParts,
         currentDashboardSlug,
         dashboardUuid,
         projectUuid,
         refreshChartTiles,
         refreshDashboard,
-        successfulContentResults,
     ]);
 
     return null;

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -65,6 +65,7 @@ import {
 } from '../../hooks/useSavedDashboardFiltersOverrides';
 import DashboardContext from './context';
 import DashboardTileStatusProvider from './DashboardTileStatusProvider';
+import { getActiveTabForTabs } from './getActiveTabForTabs';
 import useDashboardContext from './useDashboardContext';
 import useDashboardTileStatusContext from './useDashboardTileStatusContext';
 
@@ -332,13 +333,14 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     // visible tab if the URL points at a hidden tab. In edit mode all tabs are selectable.
     useEffect(() => {
         if (dashboardTabs && dashboardTabs.length > 0) {
-            const selectableTabs = isEditMode
-                ? dashboardTabs
-                : dashboardTabs.filter((tab) => !tab.hidden);
-            const tabsForFallback =
-                selectableTabs.length > 0 ? selectableTabs : dashboardTabs;
-            const urlMatch = selectableTabs.find((tab) => tab.uuid === tabUuid);
-            setActiveTab(urlMatch ?? tabsForFallback[0]);
+            setActiveTab((currentActiveTab) =>
+                getActiveTabForTabs(
+                    dashboardTabs,
+                    tabUuid,
+                    isEditMode,
+                    currentActiveTab,
+                ),
+            );
         }
     }, [dashboardTabs, tabUuid, isEditMode]);
 

--- a/packages/frontend/src/providers/Dashboard/dashboardAiAgentChangePlanner.test.ts
+++ b/packages/frontend/src/providers/Dashboard/dashboardAiAgentChangePlanner.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import { type StreamPart } from '../../ee/features/aiCopilot/store/aiAgentThreadStreamSlice';
+import { planDashboardAiAgentChanges } from './dashboardAiAgentChangePlanner';
+
+const dashboardEditPart = {
+    type: 'toolCall',
+    toolCallId: 'dashboard-edit',
+    toolName: 'editContent',
+    isPreliminary: false,
+    toolArgs: {
+        type: 'dashboard',
+        slug: 'jaffle-dashboard',
+        patch: [],
+    },
+    toolResult: {
+        result: '{}',
+        metadata: {
+            status: 'success',
+            slug: 'jaffle-dashboard',
+            name: 'Jaffle dashboard',
+            uuid: 'dashboard-uuid',
+            url: '/projects/project-uuid/dashboards/jaffle-dashboard',
+        },
+    },
+} as StreamPart;
+
+const chartEditPart = {
+    type: 'toolCall',
+    toolCallId: 'chart-edit',
+    toolName: 'editContent',
+    isPreliminary: false,
+    toolArgs: {
+        type: 'chart',
+        slug: 'orders-over-time',
+        patch: [],
+    },
+    toolResult: {
+        result: '{}',
+        metadata: {
+            status: 'success',
+            slug: 'orders-over-time',
+            name: 'Orders over time',
+            uuid: 'chart-uuid',
+            url: '/projects/project-uuid/saved/chart-uuid',
+        },
+    },
+} as StreamPart;
+
+const chartCreatePart = {
+    type: 'toolCall',
+    toolCallId: 'chart-create',
+    toolName: 'createContent',
+    isPreliminary: false,
+    toolArgs: {
+        type: 'chart',
+        content: {
+            slug: 'new-orders-chart',
+            dashboardSlug: 'jaffle-dashboard',
+        },
+    },
+    toolResult: {
+        result: '{}',
+        metadata: {
+            status: 'success',
+            slug: 'new-orders-chart',
+            name: 'New orders chart',
+            uuid: 'chart-uuid',
+            url: '/projects/project-uuid/saved/chart-uuid',
+        },
+    },
+} as StreamPart;
+
+describe('planDashboardAiAgentChanges', () => {
+    it('plans a dashboard refresh for current dashboard edits', () => {
+        expect(
+            planDashboardAiAgentChanges({
+                parts: [dashboardEditPart],
+                handledToolCallIds: new Set(),
+                currentDashboardSlug: 'jaffle-dashboard',
+                pendingChartSlugToFocus: null,
+            }),
+        ).toEqual({
+            handledToolCallIds: ['dashboard-edit'],
+            actions: [{ type: 'refreshDashboard', focusChartSlug: undefined }],
+            pendingChartSlugToFocus: null,
+        });
+    });
+
+    it('plans focused chart refreshes for chart edits', () => {
+        expect(
+            planDashboardAiAgentChanges({
+                parts: [chartEditPart],
+                handledToolCallIds: new Set(),
+                currentDashboardSlug: 'jaffle-dashboard',
+                pendingChartSlugToFocus: null,
+            }),
+        ).toEqual({
+            handledToolCallIds: ['chart-edit'],
+            actions: [
+                {
+                    type: 'refreshChart',
+                    chartSlug: 'orders-over-time',
+                    focusTile: true,
+                },
+            ],
+            pendingChartSlugToFocus: null,
+        });
+    });
+
+    it('plans a dashboard refresh when a chart is created on the current dashboard', () => {
+        expect(
+            planDashboardAiAgentChanges({
+                parts: [chartCreatePart],
+                handledToolCallIds: new Set(),
+                currentDashboardSlug: 'jaffle-dashboard',
+                pendingChartSlugToFocus: null,
+            }),
+        ).toEqual({
+            handledToolCallIds: ['chart-create'],
+            actions: [
+                {
+                    type: 'refreshDashboard',
+                    focusChartSlug: 'new-orders-chart',
+                },
+            ],
+            pendingChartSlugToFocus: 'new-orders-chart',
+        });
+    });
+
+    it('uses the pending chart focus when the current dashboard is refreshed', () => {
+        expect(
+            planDashboardAiAgentChanges({
+                parts: [dashboardEditPart],
+                handledToolCallIds: new Set(),
+                currentDashboardSlug: 'jaffle-dashboard',
+                pendingChartSlugToFocus: 'new-orders-chart',
+            }),
+        ).toEqual({
+            handledToolCallIds: ['dashboard-edit'],
+            actions: [
+                {
+                    type: 'refreshDashboard',
+                    focusChartSlug: 'new-orders-chart',
+                },
+            ],
+            pendingChartSlugToFocus: 'new-orders-chart',
+        });
+    });
+
+    it('does not refresh when a different dashboard is edited', () => {
+        expect(
+            planDashboardAiAgentChanges({
+                parts: [dashboardEditPart],
+                handledToolCallIds: new Set(),
+                currentDashboardSlug: 'other-dashboard',
+                pendingChartSlugToFocus: null,
+            }),
+        ).toEqual({
+            handledToolCallIds: ['dashboard-edit'],
+            actions: [],
+            pendingChartSlugToFocus: null,
+        });
+    });
+
+    it('ignores already handled tool calls', () => {
+        expect(
+            planDashboardAiAgentChanges({
+                parts: [dashboardEditPart],
+                handledToolCallIds: new Set(['dashboard-edit']),
+                currentDashboardSlug: 'jaffle-dashboard',
+                pendingChartSlugToFocus: null,
+            }),
+        ).toEqual({
+            handledToolCallIds: [],
+            actions: [],
+            pendingChartSlugToFocus: null,
+        });
+    });
+});

--- a/packages/frontend/src/providers/Dashboard/dashboardAiAgentChangePlanner.ts
+++ b/packages/frontend/src/providers/Dashboard/dashboardAiAgentChangePlanner.ts
@@ -1,0 +1,110 @@
+import { type StreamPart } from '../../ee/features/aiCopilot/store/aiAgentThreadStreamSlice';
+
+type SuccessfulContentToolCall = Extract<StreamPart, { type: 'toolCall' }> & {
+    toolName: 'createContent' | 'editContent';
+    isPreliminary: false;
+    toolResult: {
+        metadata: {
+            status: 'success';
+            slug: string;
+        };
+    };
+};
+
+export type DashboardAiAgentChangeAction =
+    | {
+          type: 'refreshDashboard';
+          focusChartSlug?: string;
+      }
+    | {
+          type: 'refreshChart';
+          chartSlug: string;
+          focusTile: boolean;
+      };
+
+export type DashboardAiAgentChangePlan = {
+    handledToolCallIds: string[];
+    actions: DashboardAiAgentChangeAction[];
+    pendingChartSlugToFocus: string | null;
+};
+
+const isSuccessfulContentToolCall = (
+    part: StreamPart,
+): part is SuccessfulContentToolCall =>
+    part.type === 'toolCall' &&
+    (part.toolName === 'createContent' || part.toolName === 'editContent') &&
+    part.isPreliminary === false &&
+    part.toolResult?.metadata.status === 'success';
+
+const getContentSlug = (part: SuccessfulContentToolCall) =>
+    part.toolResult.metadata.slug;
+
+const getTargetDashboardSlug = (part: SuccessfulContentToolCall) =>
+    part.toolName === 'createContent' &&
+    'dashboardSlug' in part.toolArgs.content
+        ? part.toolArgs.content.dashboardSlug
+        : undefined;
+
+export const planDashboardAiAgentChanges = ({
+    parts,
+    handledToolCallIds,
+    currentDashboardSlug,
+    pendingChartSlugToFocus,
+}: {
+    parts: StreamPart[];
+    handledToolCallIds: Set<string>;
+    currentDashboardSlug: string;
+    pendingChartSlugToFocus: string | null;
+}): DashboardAiAgentChangePlan => {
+    const actions: DashboardAiAgentChangeAction[] = [];
+    const nextHandledToolCallIds: string[] = [];
+    let nextPendingChartSlugToFocus = pendingChartSlugToFocus;
+
+    for (const part of parts) {
+        if (!isSuccessfulContentToolCall(part)) continue;
+        if (handledToolCallIds.has(part.toolCallId)) continue;
+
+        nextHandledToolCallIds.push(part.toolCallId);
+
+        const contentSlug = getContentSlug(part);
+
+        switch (part.toolArgs.type) {
+            case 'chart': {
+                const targetDashboardSlug = getTargetDashboardSlug(part);
+                if (
+                    part.toolName === 'createContent' &&
+                    targetDashboardSlug === currentDashboardSlug
+                ) {
+                    nextPendingChartSlugToFocus = contentSlug;
+                    actions.push({
+                        type: 'refreshDashboard',
+                        focusChartSlug: contentSlug,
+                    });
+                    break;
+                }
+
+                actions.push({
+                    type: 'refreshChart',
+                    chartSlug: contentSlug,
+                    focusTile: true,
+                });
+                break;
+            }
+            case 'dashboard': {
+                if (contentSlug !== currentDashboardSlug) break;
+
+                actions.push({
+                    type: 'refreshDashboard',
+                    focusChartSlug: nextPendingChartSlugToFocus ?? undefined,
+                });
+                break;
+            }
+        }
+    }
+
+    return {
+        handledToolCallIds: nextHandledToolCallIds,
+        actions,
+        pendingChartSlugToFocus: nextPendingChartSlugToFocus,
+    };
+};

--- a/packages/frontend/src/providers/Dashboard/getActiveTabForTabs.test.ts
+++ b/packages/frontend/src/providers/Dashboard/getActiveTabForTabs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { getActiveTabForTabs } from './getActiveTabForTabs';
+
+const tabs = [
+    { uuid: 'overview', name: 'Overview', order: 0, hidden: false },
+    { uuid: 'revenue', name: 'Revenue', order: 1, hidden: false },
+    { uuid: 'orders', name: 'Orders', order: 2, hidden: false },
+];
+
+describe('getActiveTabForTabs', () => {
+    it('uses the tab from the url when it exists', () => {
+        expect(getActiveTabForTabs(tabs, 'orders', false, tabs[1])?.uuid).toBe(
+            'orders',
+        );
+    });
+
+    it('preserves current tab when no url tab exists', () => {
+        expect(getActiveTabForTabs(tabs, undefined, false, tabs[1])?.uuid).toBe(
+            'revenue',
+        );
+    });
+
+    it('falls back only when there is no current tab', () => {
+        expect(
+            getActiveTabForTabs(tabs, undefined, false, undefined)?.uuid,
+        ).toBe('overview');
+    });
+});

--- a/packages/frontend/src/providers/Dashboard/getActiveTabForTabs.ts
+++ b/packages/frontend/src/providers/Dashboard/getActiveTabForTabs.ts
@@ -1,0 +1,27 @@
+import { type Dashboard } from '@lightdash/common';
+
+export const getActiveTabForTabs = (
+    dashboardTabs: Dashboard['tabs'],
+    tabUuid: string | undefined,
+    isEditMode: boolean,
+    currentActiveTab: Dashboard['tabs'][number] | undefined,
+) => {
+    if (dashboardTabs.length === 0) return undefined;
+
+    const selectableTabs = isEditMode
+        ? dashboardTabs
+        : dashboardTabs.filter((tab) => !tab.hidden);
+    const tabsForFallback =
+        selectableTabs.length > 0 ? selectableTabs : dashboardTabs;
+    const urlMatch = selectableTabs.find((tab) => tab.uuid === tabUuid);
+    if (urlMatch) return urlMatch;
+
+    const currentMatch =
+        tabUuid === undefined
+            ? selectableTabs.find((tab) => tab.uuid === currentActiveTab?.uuid)
+            : undefined;
+    if (currentMatch) return currentMatch;
+    if (currentActiveTab) return currentActiveTab;
+
+    return tabsForFallback[0];
+};

--- a/packages/frontend/src/utils/dashboardRoutes.ts
+++ b/packages/frontend/src/utils/dashboardRoutes.ts
@@ -1,0 +1,64 @@
+import { matchPath } from 'react-router';
+
+type LocationLike = {
+    pathname: string;
+    search?: string;
+};
+
+const normalizePathname = (pathname: string): string =>
+    pathname.replace(/\/$/, '');
+
+const getDashboardIdentifierFromPathname = (pathname: string) => {
+    const match =
+        matchPath(
+            '/projects/:projectUuid/dashboards/:dashboardIdentifier/*',
+            pathname,
+        ) ??
+        matchPath(
+            '/projects/:projectUuid/dashboards/:dashboardIdentifier',
+            pathname,
+        );
+
+    return match?.params.dashboardIdentifier ?? null;
+};
+
+const getProjectUuidFromPathname = (pathname: string) => {
+    const match = matchPath('/projects/:projectUuid/*', pathname);
+
+    return match?.params.projectUuid ?? null;
+};
+
+export const isSameLocation = (
+    targetUrl: string,
+    location: LocationLike,
+): boolean => {
+    const target = new URL(targetUrl, window.location.origin);
+
+    return (
+        normalizePathname(target.pathname) ===
+            normalizePathname(location.pathname) &&
+        target.search === (location.search ?? '')
+    );
+};
+
+export const isSameDashboardRoute = ({
+    location,
+    projectUuid,
+    dashboardUuid,
+    dashboardSlug,
+}: {
+    location: LocationLike;
+    projectUuid: string;
+    dashboardUuid?: string;
+    dashboardSlug?: string;
+}) => {
+    const currentProjectUuid = getProjectUuidFromPathname(location.pathname);
+    if (currentProjectUuid !== projectUuid) return false;
+
+    const currentDashboardIdentifier = getDashboardIdentifierFromPathname(
+        location.pathname,
+    );
+    if (!currentDashboardIdentifier) return false;
+
+    return [dashboardUuid, dashboardSlug].includes(currentDashboardIdentifier);
+};


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Fixes a bug where navigating to a dashboard via an AI Copilot content link was being incorrectly suppressed when the current URL contained the dashboard's UUID, even though the link used the dashboard's slug (or vice versa). The check now uses both UUID and slug to determine whether the user is already on the target dashboard, and also validates that the project matches.

The dashboard tab selection logic has been updated so that switching between tabs no longer resets the active tab to the first tab when the URL doesn't specify one — the current tab is now preserved in that case.

The AI agent change handling logic in `DashboardAiAgentContextBridge` has been extracted into a pure `planDashboardAiAgentChanges` function, making it independently testable. The `scrollToChartTile` helper no longer attempts to switch tabs itself, since tab switching is now handled separately via the URL-driven tab selection.

A shared `dashboardRoutes` utility has been introduced with `isSameLocation` and `isSameDashboardRoute` helpers, replacing ad-hoc pathname matching logic that existed in multiple places.