### PR TITLE
feat(content-as-code): add `manage:ContentAsCode@self` scope restricting writes to own preview projects (PROD-8004)

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -27,6 +27,7 @@ import {
     NotFoundError,
     ParameterError,
     Project,
+    ProjectType,
     PromotionAction,
     PromotionChanges,
     SavedChartDAO,
@@ -1233,6 +1234,8 @@ export class CoderService extends BaseService {
                 subject('ContentAsCode', {
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    type: project.type,
+                    createdByUserUuid: project.createdByUserUuid,
                     metadata: { slug },
                 }),
             )
@@ -1460,6 +1463,8 @@ export class CoderService extends BaseService {
                 subject('ContentAsCode', {
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    type: project.type,
+                    createdByUserUuid: project.createdByUserUuid,
                     metadata: { slug },
                 }),
             )
@@ -1755,6 +1760,8 @@ export class CoderService extends BaseService {
                 subject('ContentAsCode', {
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    type: project.type,
+                    createdByUserUuid: project.createdByUserUuid,
                     metadata: { slug },
                 }),
             )

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -346,6 +346,14 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('manage', 'ContentAsCode', {
             organizationUuid: member.organizationUuid,
         });
+        // Redundant with the broad grant above, but kept so the system
+        // role mirrors the `manage:ContentAsCode@self` scope a custom role
+        // would carry without full `manage:ContentAsCode`.
+        can('manage', 'ContentAsCode', {
+            organizationUuid: member.organizationUuid,
+            type: ProjectType.PREVIEW,
+            createdByUserUuid: member.userUuid,
+        });
         can('view', 'JobStatus', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -302,6 +302,14 @@ export const projectMemberAbilities: Record<
         can('manage', 'ContentAsCode', {
             projectUuid: member.projectUuid,
         });
+        // Redundant with the broad grant above, but kept so the system
+        // role mirrors the `manage:ContentAsCode@self` scope a custom role
+        // would carry without full `manage:ContentAsCode`.
+        can('manage', 'ContentAsCode', {
+            projectUuid: member.projectUuid,
+            type: ProjectType.PREVIEW,
+            createdByUserUuid: member.userUuid,
+        });
         can('view', 'JobStatus', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -132,6 +132,10 @@ const BASE_ROLE_SCOPES = {
         // Enterprise scopes
         'manage:SpotlightTableConfig',
         'manage:ContentAsCode',
+        // Redundant for developers (covered by the broad manage above) but
+        // surfaced so admin-cloned custom roles can drop full
+        // `manage:ContentAsCode` and keep self-preview write.
+        'manage:ContentAsCode@self',
         'manage:AiAgent',
         'manage:AiAgentDocument',
         'manage:AiAgentThread@self', // User's own threads
@@ -247,6 +251,7 @@ export const getNonEnterpriseScopesForRole = (
         'manage:AiAgentThread',
         'view:ContentAsCode',
         'manage:ContentAsCode',
+        'manage:ContentAsCode@self',
         'view:DataApp',
         'manage:DataApp',
         'manage:DataApp@space',

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -2291,6 +2291,41 @@ describe('scopeAbilityBuilder', () => {
             expect(ability.can('manage', contentAsCodeSubject)).toBe(true);
         });
 
+        it('manage:ContentAsCode@self allows upload only to own preview projects (PROD-8004)', () => {
+            const ability = buildAbility(['manage:ContentAsCode@self']);
+
+            const ownPreview = subject('ContentAsCode', {
+                organizationUuid: 'org-123',
+                projectUuid: 'project-123',
+                type: ProjectType.PREVIEW,
+                createdByUserUuid: 'user-456',
+            });
+            const ownProduction = subject('ContentAsCode', {
+                organizationUuid: 'org-123',
+                projectUuid: 'project-123',
+                type: ProjectType.DEFAULT,
+                createdByUserUuid: 'user-456',
+            });
+            const othersPreview = subject('ContentAsCode', {
+                organizationUuid: 'org-123',
+                projectUuid: 'project-123',
+                type: ProjectType.PREVIEW,
+                createdByUserUuid: 'another-user',
+            });
+
+            // Can upload to a preview project they created
+            expect(ability.can('manage', ownPreview)).toBe(true);
+
+            // Cannot upload to production, even their own
+            expect(ability.can('manage', ownProduction)).toBe(false);
+
+            // Cannot upload to a preview created by someone else
+            expect(ability.can('manage', othersPreview)).toBe(false);
+
+            // Does not grant blanket manage when the subject lacks self context
+            expect(ability.can('manage', contentAsCodeSubject)).toBe(false);
+        });
+
         it('content as code scopes are gated behind enterprise', () => {
             const builder = new AbilityBuilder<MemberAbility>(Ability);
             buildAbilityFromScopes(

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -501,6 +501,20 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'manage:ContentAsCode@self',
+        description:
+            'Upload content as code to preview projects created by the user',
+        isEnterprise: true,
+        group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        getConditions: (context) => [
+            {
+                projectUuid: context.projectUuid,
+                createdByUserUuid: context.userUuid || false,
+                type: ProjectType.PREVIEW,
+            },
+        ],
+    },
+    {
         name: 'manage:PersonalAccessToken',
         description: 'Create and manage personal access tokens',
         isEnterprise: true,


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-8004/add-managecontentascodeself-scope-for-writing-content-as-code-to-your](https://linear.app/lightdash/issue/PROD-8004/add-managecontentascodeself-scope-for-writing-content-as-code-to-your)

### Description:

Adds a new `manage:ContentAsCode@self` scope that restricts content-as-code upload permissions to preview projects created by the requesting user. This allows custom roles to grant write access scoped only to a user's own preview projects, without granting full `manage:ContentAsCode` across all projects.

The scope is surfaced on the `developer` role (redundantly alongside the existing broad `manage:ContentAsCode` grant) so that admin-cloned custom roles can drop the broad permission and retain only the self-preview write capability.

To support the permission check, `project.type` and `project.createdByUserUuid` are now passed into the `ContentAsCode` subject in the relevant `CoderService` authorization calls, enabling CASL to correctly evaluate conditions against these fields.