### PR TITLE
fix: warn agents about unused chart dimensions

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -593,6 +593,12 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                 "uuid": {
                   "type": "string",
                 },
+                "warnings": {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
               },
               "required": [
                 "status",
@@ -600,6 +606,7 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                 "name",
                 "uuid",
                 "href",
+                "warnings",
               ],
               "type": "object",
             },
@@ -706,6 +713,12 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                   ],
                   "type": "object",
                 },
+                "warnings": {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
               },
               "required": [
                 "status",
@@ -713,6 +726,7 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                 "name",
                 "uuid",
                 "href",
+                "warnings",
                 "versionUuids",
               ],
               "type": "object",

--- a/packages/backend/src/ee/services/ai/tools/createContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/createContent.ts
@@ -1,6 +1,7 @@
 import { createContentToolDefinition } from '@lightdash/common';
 import { tool } from 'ai';
 import type { CreateContentFn } from '../types/aiAgentDependencies';
+import { getChartContentWarnings } from '../utils/contentWarnings';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 
@@ -14,11 +15,21 @@ const contentResult = ({
     content,
     href,
     type,
+    warnings,
 }: {
     content: unknown;
     href: string;
     type: 'dashboard' | 'chart';
-}) => `<${type} href="${href}" />\n---\n${JSON.stringify(content, null, 2)}`;
+    warnings: string[];
+}) => {
+    const warningText =
+        warnings.length > 0 ? `\n---\n${warnings.join('\n')}` : '';
+    return `<${type} href="${href}" />\n---\n${JSON.stringify(
+        content,
+        null,
+        2,
+    )}${warningText}`;
+};
 
 export const getCreateContent = ({ createContent }: Dependencies) =>
     tool({
@@ -29,12 +40,17 @@ export const getCreateContent = ({ createContent }: Dependencies) =>
                     type,
                     content,
                 } as Parameters<CreateContentFn>[0]);
+                const warnings =
+                    result.type === 'chart'
+                        ? getChartContentWarnings(result.content)
+                        : [];
                 const metadata = {
                     status: 'success' as const,
                     slug: result.content.slug,
                     name: result.content.name,
                     uuid: result.uuid,
                     href: result.href,
+                    warnings,
                 };
 
                 return {
@@ -42,6 +58,7 @@ export const getCreateContent = ({ createContent }: Dependencies) =>
                         content: result.content,
                         href: metadata.href,
                         type: result.type,
+                        warnings,
                     }),
                     metadata,
                 };

--- a/packages/backend/src/ee/services/ai/tools/editContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/editContent.ts
@@ -1,6 +1,7 @@
 import { editContentToolDefinition } from '@lightdash/common';
 import { tool } from 'ai';
 import type { EditContentFn } from '../types/aiAgentDependencies';
+import { getChartContentWarnings } from '../utils/contentWarnings';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 
@@ -14,11 +15,21 @@ const contentResult = ({
     content,
     href,
     type,
+    warnings,
 }: {
     content: unknown;
     href: string;
     type: 'dashboard' | 'chart';
-}) => `<${type} href="${href}" />\n---\n${JSON.stringify(content, null, 2)}`;
+    warnings: string[];
+}) => {
+    const warningText =
+        warnings.length > 0 ? `\n---\n${warnings.join('\n')}` : '';
+    return `<${type} href="${href}" />\n---\n${JSON.stringify(
+        content,
+        null,
+        2,
+    )}${warningText}`;
+};
 
 export const getEditContent = ({ editContent }: Dependencies) =>
     tool({
@@ -26,6 +37,10 @@ export const getEditContent = ({ editContent }: Dependencies) =>
         execute: async ({ slug, type, patch }) => {
             try {
                 const result = await editContent({ slug, type, patch });
+                const warnings =
+                    result.type === 'chart'
+                        ? getChartContentWarnings(result.content)
+                        : [];
                 const metadata = {
                     status: 'success' as const,
                     slug: result.content.slug,
@@ -33,6 +48,7 @@ export const getEditContent = ({ editContent }: Dependencies) =>
                     uuid: result.uuid,
                     href: result.href,
                     versionUuids: result.versionUuids,
+                    warnings,
                 };
 
                 return {
@@ -40,6 +56,7 @@ export const getEditContent = ({ editContent }: Dependencies) =>
                         content: result.content,
                         href: metadata.href,
                         type: result.type,
+                        warnings,
                     }),
                     metadata,
                 };

--- a/packages/backend/src/ee/services/ai/utils/contentWarnings.ts
+++ b/packages/backend/src/ee/services/ai/utils/contentWarnings.ts
@@ -1,0 +1,20 @@
+import { getUnusedDimensions, type ChartAsCode } from '@lightdash/common';
+
+export const getChartContentWarnings = (content: ChartAsCode): string[] => {
+    const { unusedDimensions } = getUnusedDimensions({
+        chartType: content.chartConfig.type,
+        chartConfig: content.chartConfig.config,
+        pivotDimensions: content.pivotConfig?.columns ?? [],
+        queryDimensions: content.metricQuery.dimensions,
+    });
+
+    if (unusedDimensions.length === 0) {
+        return [];
+    }
+
+    return [
+        `Warning: metricQuery.dimensions includes fields not used by the chart configuration: ${unusedDimensions.join(
+            ', ',
+        )}. Use each dimension in layout.xField, layout.yField, or pivotConfig.columns, otherwise remove it.`,
+    ];
+};

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolCreateContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolCreateContentArgs.ts
@@ -92,6 +92,7 @@ const toolCreateContentMetadataSchema = z.discriminatedUnion('status', [
         name: z.string(),
         uuid: z.string(),
         href: z.string(),
+        warnings: z.array(z.string()),
     }),
 ]);
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditContentArgs.ts
@@ -23,6 +23,7 @@ const toolEditContentMetadataSchema = z.discriminatedUnion('status', [
         name: z.string(),
         uuid: z.string(),
         href: z.string(),
+        warnings: z.array(z.string()),
         versionUuids: z.object({
             before: z.string().nullable(),
             after: z.string().nullable(),


### PR DESCRIPTION
Closes: ZAP-466

### Description
- Add model-visible warnings when createContent or editContent saves chart content with metricQuery dimensions unused by the cartesian chart config.
- Reuse shared unused-dimension validation semantics and expose warnings in tool metadata.
- Update AI agent tool contract schema snapshots for the new warnings field.

### Verification
- pnpm -F backend test -- src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts --runInBand