### PR TITLE
test: add unit tests for OrganizationSsoModel, OrganizationSsoService, and GenericOidcSsoPanel

### DIFF
--- a/packages/backend/src/models/OrganizationSsoModel.test.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.test.ts
@@ -1,0 +1,171 @@
+import { OrganizationSsoProvider } from '@lightdash/common';
+import knex, { Knex } from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { OrganizationSsoConfigurationsTableName } from '../database/entities/organizationSsoConfigurations';
+import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
+import { OrganizationSsoModel } from './OrganizationSsoModel';
+
+const ORG_UUID = '00000000-0000-0000-0000-000000000001';
+
+const storedConfig = {
+    oauth2ClientId: 'client-id',
+    oauth2ClientSecret: 'secret',
+    oauth2TenantId: 'tenant-id',
+};
+
+// Stub encryption: decrypt() returns the JSON the model expects to parse,
+// encrypt() returns an opaque buffer. The config blob is never inspected here.
+const encryptionUtil = {
+    encrypt: jest.fn(() => Buffer.from('encrypted')),
+    decrypt: jest.fn(() => JSON.stringify(storedConfig)),
+} as unknown as EncryptionUtil;
+
+const dbRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    organization_sso_configuration_uuid: '00000000-0000-0000-0000-0000000000aa',
+    organization_uuid: ORG_UUID,
+    provider: OrganizationSsoProvider.AZUREAD,
+    config: Buffer.from('encrypted'),
+    enabled: true,
+    override_email_domains: false,
+    email_domains: [],
+    allow_password: true,
+    ...overrides,
+});
+
+describe('OrganizationSsoModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new OrganizationSsoModel({
+        database: database as unknown as Knex,
+        encryptionUtil,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+        jest.clearAllMocks();
+    });
+
+    describe('findEnabledMethodsForEmailDomain', () => {
+        it('restricts to enabled rows whose org has verified the domain (EXISTS) and whose override branch matches', async () => {
+            tracker.on
+                .select(OrganizationSsoConfigurationsTableName)
+                .responseOnce([dbRow()]);
+
+            await model.findEnabledMethodsForEmailDomain('acme.com');
+
+            expect(tracker.history.select).toHaveLength(1);
+            const { sql, bindings } = tracker.history.select[0];
+            const lowered = sql.toLowerCase();
+
+            // Only enabled methods are considered.
+            expect(lowered).toContain('"enabled"');
+            expect(bindings).toContain(true);
+
+            // Verified-domain EXISTS clause, correlated by organization_uuid and
+            // gated on a non-null verified_at.
+            expect(lowered).toContain('exists');
+            expect(lowered).toContain('organization_domain_verifications');
+            expect(lowered).toContain('"verified_at" is not null');
+
+            // Override branch: override=false routes all verified domains;
+            // override=true requires the domain to be in the method's subset.
+            expect(lowered).toContain('override_email_domains');
+            expect(lowered).toContain('= any');
+            expect(bindings).toContain(false); // override=false branch
+            // Domain appears twice: once in the EXISTS domain match, once in the
+            // ANY(email_domains) subset check.
+            expect(bindings.filter((b) => b === 'acme.com')).toHaveLength(2);
+        });
+
+        it('normalizes the email domain to lowercase before matching', async () => {
+            tracker.on
+                .select(OrganizationSsoConfigurationsTableName)
+                .responseOnce([]);
+
+            await model.findEnabledMethodsForEmailDomain('ACME.com');
+
+            const { bindings } = tracker.history.select[0];
+            expect(bindings).toContain('acme.com');
+            expect(bindings).not.toContain('ACME.com');
+        });
+
+        it('decrypts and maps each row into an OrganizationSsoMethod', async () => {
+            tracker.on
+                .select(OrganizationSsoConfigurationsTableName)
+                .responseOnce([
+                    dbRow({
+                        override_email_domains: true,
+                        email_domains: ['acme.com'],
+                        allow_password: false,
+                    }),
+                ]);
+
+            const methods =
+                await model.findEnabledMethodsForEmailDomain('acme.com');
+
+            expect(encryptionUtil.decrypt).toHaveBeenCalledTimes(1);
+            expect(methods).toEqual([
+                {
+                    organizationUuid: ORG_UUID,
+                    provider: OrganizationSsoProvider.AZUREAD,
+                    config: storedConfig,
+                    enabled: true,
+                    overrideEmailDomains: true,
+                    emailDomains: ['acme.com'],
+                    allowPassword: false,
+                },
+            ]);
+        });
+
+        it('defaults a null email_domains column to an empty array', async () => {
+            tracker.on
+                .select(OrganizationSsoConfigurationsTableName)
+                .responseOnce([dbRow({ email_domains: null })]);
+
+            const methods =
+                await model.findEnabledMethodsForEmailDomain('acme.com');
+
+            expect(methods[0].emailDomains).toEqual([]);
+        });
+    });
+
+    describe('findGoogleMethodsForEmailDomain', () => {
+        it('matches the verified domain but does NOT filter on enabled, so a disabled policy row is returned', async () => {
+            tracker.on
+                .select(OrganizationSsoConfigurationsTableName)
+                .responseOnce([
+                    dbRow({
+                        provider: OrganizationSsoProvider.GOOGLE,
+                        enabled: false,
+                    }),
+                ]);
+
+            const methods =
+                await model.findGoogleMethodsForEmailDomain('acme.com');
+
+            const { sql, bindings } = tracker.history.select[0];
+            const lowered = sql.toLowerCase();
+            // Scoped to the google provider rows...
+            expect(bindings).toContain(OrganizationSsoProvider.GOOGLE);
+            // ...still gated on verified-domain EXISTS + the override branch...
+            expect(lowered).toContain('exists');
+            expect(lowered).toContain('organization_domain_verifications');
+            expect(lowered).toContain('= any');
+            // ...but NOT on enabled — a disabled row is exactly what suppresses
+            // Google for the org, so it must come back. (The `true` binding here
+            // is the override_email_domains=true branch, not an enabled filter.)
+            expect(lowered).not.toContain('"enabled"');
+            expect(methods).toEqual([
+                {
+                    organizationUuid: ORG_UUID,
+                    enabled: false,
+                    allowPassword: true,
+                },
+            ]);
+        });
+    });
+});

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.mock.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.mock.ts
@@ -1,0 +1,104 @@
+import { Ability } from '@casl/ability';
+import {
+    AzureAdSsoConfig,
+    OrganizationMemberRole,
+    OrganizationSsoProvider,
+    PossibleAbilities,
+    SessionAccount,
+} from '@lightdash/common';
+import { OrganizationSsoMethod } from '../../models/OrganizationSsoModel';
+
+export const ORG_UUID = 'test-org-uuid';
+export const OTHER_ORG_UUID = 'other-org-uuid';
+export const USER_UUID = 'test-user-uuid';
+
+const baseUser = {
+    type: 'registered' as const,
+    id: '1',
+    email: 'admin@acme.com',
+    firstName: 'Test',
+    lastName: 'User',
+    userUuid: USER_UUID,
+    isActive: true,
+    role: OrganizationMemberRole.ADMIN,
+    abilityRules: [] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    timezone: null,
+    isSetupComplete: true,
+    userId: 1,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+};
+
+const accountMethods = {
+    isAuthenticated: () => true,
+    isRegisteredUser: () => true,
+    isAnonymousUser: () => false,
+    isSessionUser: () => true,
+    isJwtUser: () => false,
+    isServiceAccount: () => false,
+    isPatUser: () => false,
+    isOauthUser: () => false,
+};
+
+const manageOrganizationAbility = new Ability<PossibleAbilities>([
+    { subject: 'Organization', action: ['manage'] },
+]);
+
+/** Org admin who can manage the organization — the happy-path account. */
+export const mockAdminAccount = {
+    authentication: { type: 'session' as const, source: 'test-session-cookie' },
+    user: { ...baseUser, ability: manageOrganizationAbility },
+    organization: {
+        organizationUuid: ORG_UUID,
+        name: 'Test Organization',
+        createdAt: new Date('2024-01-01'),
+    },
+    ...accountMethods,
+} as SessionAccount;
+
+/** Member of the org with an empty ability — cannot manage SSO. */
+export const mockAccountNoPermission = {
+    ...mockAdminAccount,
+    user: { ...baseUser, ability: new Ability<PossibleAbilities>([]) },
+} as SessionAccount;
+
+/** Authenticated user not attached to any organization. */
+export const mockAccountNoOrg = {
+    ...mockAdminAccount,
+    organization: undefined,
+} as unknown as SessionAccount;
+
+export const azureAdMethod = (
+    overrides: Partial<
+        OrganizationSsoMethod<OrganizationSsoProvider.AZUREAD>
+    > = {},
+): OrganizationSsoMethod<OrganizationSsoProvider.AZUREAD> => ({
+    organizationUuid: ORG_UUID,
+    provider: OrganizationSsoProvider.AZUREAD,
+    config: {
+        oauth2ClientId: 'stored-client-id',
+        oauth2ClientSecret: 'stored-secret',
+        oauth2TenantId: 'stored-tenant-id',
+    } satisfies AzureAdSsoConfig,
+    enabled: true,
+    overrideEmailDomains: false,
+    emailDomains: [],
+    allowPassword: true,
+    ...overrides,
+});
+
+export const enabledMethodForOrg = (
+    organizationUuid: string,
+    provider: OrganizationSsoProvider = OrganizationSsoProvider.OKTA,
+): OrganizationSsoMethod<OrganizationSsoProvider> =>
+    ({
+        organizationUuid,
+        provider,
+        config: {},
+        enabled: true,
+        overrideEmailDomains: false,
+        emailDomains: [],
+        allowPassword: true,
+    }) as OrganizationSsoMethod<OrganizationSsoProvider>;

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.test.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.test.ts
@@ -1,0 +1,350 @@
+import {
+    FeatureFlags,
+    ForbiddenError,
+    OrganizationSsoProvider,
+    ParameterError,
+} from '@lightdash/common';
+import { LightdashConfig } from '../../config/parseConfig';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
+import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
+import { OrganizationDomainVerificationModel } from '../../models/OrganizationDomainVerificationModel';
+import { OrganizationSsoModel } from '../../models/OrganizationSsoModel';
+import { UserModel } from '../../models/UserModel';
+import { OrganizationSsoService } from './OrganizationSsoService';
+import {
+    azureAdMethod,
+    enabledMethodForOrg,
+    mockAccountNoOrg,
+    mockAccountNoPermission,
+    mockAdminAccount,
+    ORG_UUID,
+    OTHER_ORG_UUID,
+    USER_UUID,
+} from './OrganizationSsoService.mock';
+
+const buildService = () => {
+    const organizationSsoModel = {
+        findMethod: jest.fn(),
+        findEnabledMethodsForEmailDomain: jest.fn(),
+        findGoogleMethodsForEmailDomain: jest.fn(),
+        upsert: jest.fn(),
+        delete: jest.fn(),
+    };
+    const organizationDomainVerificationModel = {
+        findVerifiedDomains: jest.fn().mockResolvedValue([]),
+    };
+    const featureFlagModel = {
+        // Enabled by default — individual tests override to exercise the guard.
+        get: jest.fn().mockResolvedValue({
+            id: FeatureFlags.SsoOrganizationSettings,
+            enabled: true,
+        }),
+    };
+    const userModel = {
+        findUserByEmail: jest.fn(),
+        getOrganizationsForUser: jest.fn(),
+    };
+
+    const service = new OrganizationSsoService({
+        lightdashConfig: {} as LightdashConfig,
+        organizationSsoModel:
+            organizationSsoModel as unknown as OrganizationSsoModel,
+        organizationAllowedEmailDomainsModel:
+            {} as OrganizationAllowedEmailDomainsModel,
+        organizationDomainVerificationModel:
+            organizationDomainVerificationModel as unknown as OrganizationDomainVerificationModel,
+        featureFlagModel: featureFlagModel as unknown as FeatureFlagModel,
+        userModel: userModel as unknown as UserModel,
+    });
+
+    return {
+        service,
+        organizationSsoModel,
+        organizationDomainVerificationModel,
+        featureFlagModel,
+        userModel,
+    };
+};
+
+describe('OrganizationSsoService', () => {
+    describe('assertFeatureEnabled', () => {
+        it('throws ForbiddenError when the per-org SSO feature flag is disabled', async () => {
+            const { service, featureFlagModel } = buildService();
+            featureFlagModel.get.mockResolvedValue({
+                id: FeatureFlags.SsoOrganizationSettings,
+                enabled: false,
+            });
+
+            await expect(
+                service.getAzureAdConfig(mockAdminAccount),
+            ).rejects.toThrow(ForbiddenError);
+            await expect(
+                service.getAzureAdConfig(mockAdminAccount),
+            ).rejects.toThrow('Per-organization SSO settings are not enabled');
+        });
+
+        it('queries the SsoOrganizationSettings flag for the account organization', async () => {
+            const { service, featureFlagModel, organizationSsoModel } =
+                buildService();
+            organizationSsoModel.findMethod.mockResolvedValue(undefined);
+
+            await service.getAzureAdConfig(mockAdminAccount);
+
+            expect(featureFlagModel.get).toHaveBeenCalledWith({
+                user: {
+                    userUuid: USER_UUID,
+                    organizationUuid: ORG_UUID,
+                    organizationName: 'Test Organization',
+                },
+                featureFlagId: FeatureFlags.SsoOrganizationSettings,
+            });
+        });
+    });
+
+    describe('assertCanManageSso', () => {
+        it('throws ForbiddenError when the account has no organization', async () => {
+            const { service } = buildService();
+
+            await expect(
+                service.getAzureAdConfig(mockAccountNoOrg),
+            ).rejects.toThrow('User is not part of an organization');
+        });
+
+        it('throws ForbiddenError when the account cannot manage the organization', async () => {
+            const { service } = buildService();
+
+            await expect(
+                service.getAzureAdConfig(mockAccountNoPermission),
+            ).rejects.toThrow(ForbiddenError);
+        });
+
+        it('allows an org admin through (returns null when no config exists)', async () => {
+            const { service, organizationSsoModel } = buildService();
+            organizationSsoModel.findMethod.mockResolvedValue(undefined);
+
+            await expect(
+                service.getAzureAdConfig(mockAdminAccount),
+            ).resolves.toBeNull();
+            expect(organizationSsoModel.findMethod).toHaveBeenCalledWith(
+                ORG_UUID,
+                OrganizationSsoProvider.AZUREAD,
+            );
+        });
+    });
+
+    describe('validateEmailDomains', () => {
+        it('rejects malformed email domains', async () => {
+            const { service, organizationSsoModel } = buildService();
+
+            await expect(
+                service.upsertAzureAdConfig(mockAdminAccount, {
+                    oauth2ClientId: 'client-id',
+                    oauth2ClientSecret: 'secret',
+                    oauth2TenantId: 'tenant-id',
+                    emailDomains: ['not a domain'],
+                }),
+            ).rejects.toThrow(ParameterError);
+            await expect(
+                service.upsertAzureAdConfig(mockAdminAccount, {
+                    oauth2ClientId: 'client-id',
+                    oauth2ClientSecret: 'secret',
+                    oauth2TenantId: 'tenant-id',
+                    emailDomains: ['not a domain'],
+                }),
+            ).rejects.toThrow('Invalid email domain format');
+            expect(organizationSsoModel.upsert).not.toHaveBeenCalled();
+        });
+
+        it('rejects public email provider domains that no org can claim', async () => {
+            const { service, organizationSsoModel } = buildService();
+
+            await expect(
+                service.upsertAzureAdConfig(mockAdminAccount, {
+                    oauth2ClientId: 'client-id',
+                    oauth2ClientSecret: 'secret',
+                    oauth2TenantId: 'tenant-id',
+                    emailDomains: ['gmail.com'],
+                }),
+            ).rejects.toThrow("can't be claimed");
+            expect(organizationSsoModel.upsert).not.toHaveBeenCalled();
+        });
+
+        it('rejects domains the org has not verified when override is enabled', async () => {
+            const { service, organizationDomainVerificationModel } =
+                buildService();
+            organizationDomainVerificationModel.findVerifiedDomains.mockResolvedValue(
+                [{ domain: 'verified.com' }],
+            );
+
+            await expect(
+                service.upsertAzureAdConfig(mockAdminAccount, {
+                    oauth2ClientId: 'client-id',
+                    oauth2ClientSecret: 'secret',
+                    oauth2TenantId: 'tenant-id',
+                    overrideEmailDomains: true,
+                    emailDomains: ['unverified.com'],
+                }),
+            ).rejects.toThrow('must be verified before they can be used');
+        });
+
+        it('does not require verification when override is disabled', async () => {
+            const {
+                service,
+                organizationSsoModel,
+                organizationDomainVerificationModel,
+            } = buildService();
+            organizationSsoModel.findMethod
+                .mockResolvedValueOnce(undefined)
+                .mockResolvedValueOnce(azureAdMethod());
+
+            await service.upsertAzureAdConfig(mockAdminAccount, {
+                oauth2ClientId: 'client-id',
+                oauth2ClientSecret: 'secret',
+                oauth2TenantId: 'tenant-id',
+                overrideEmailDomains: false,
+                emailDomains: ['acme.com'],
+            });
+
+            expect(
+                organizationDomainVerificationModel.findVerifiedDomains,
+            ).not.toHaveBeenCalled();
+            expect(organizationSsoModel.upsert).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('secret preservation on update', () => {
+        it('preserves the stored client secret when none is provided on update', async () => {
+            const { service, organizationSsoModel } = buildService();
+            organizationSsoModel.findMethod
+                .mockResolvedValueOnce(azureAdMethod()) // existing read
+                .mockResolvedValueOnce(azureAdMethod()); // read-back
+
+            await service.upsertAzureAdConfig(mockAdminAccount, {
+                oauth2ClientId: 'new-client-id',
+                oauth2TenantId: 'new-tenant-id',
+            });
+
+            expect(organizationSsoModel.upsert).toHaveBeenCalledWith(
+                ORG_UUID,
+                OrganizationSsoProvider.AZUREAD,
+                expect.objectContaining({
+                    oauth2ClientId: 'new-client-id',
+                    oauth2ClientSecret: 'stored-secret',
+                    oauth2TenantId: 'new-tenant-id',
+                }),
+                expect.anything(),
+                USER_UUID,
+            );
+        });
+
+        it('uses the provided secret when one is supplied on update', async () => {
+            const { service, organizationSsoModel } = buildService();
+            organizationSsoModel.findMethod
+                .mockResolvedValueOnce(azureAdMethod())
+                .mockResolvedValueOnce(azureAdMethod());
+
+            await service.upsertAzureAdConfig(mockAdminAccount, {
+                oauth2ClientId: 'new-client-id',
+                oauth2ClientSecret: 'rotated-secret',
+                oauth2TenantId: 'new-tenant-id',
+            });
+
+            expect(organizationSsoModel.upsert).toHaveBeenCalledWith(
+                ORG_UUID,
+                OrganizationSsoProvider.AZUREAD,
+                expect.objectContaining({
+                    oauth2ClientSecret: 'rotated-secret',
+                }),
+                expect.anything(),
+                USER_UUID,
+            );
+        });
+
+        it('throws ParameterError when creating without a client secret', async () => {
+            const { service, organizationSsoModel } = buildService();
+            organizationSsoModel.findMethod.mockResolvedValue(undefined);
+
+            await expect(
+                service.upsertAzureAdConfig(mockAdminAccount, {
+                    oauth2ClientId: 'client-id',
+                    oauth2TenantId: 'tenant-id',
+                }),
+            ).rejects.toThrow('oauth2ClientSecret is required');
+            expect(organizationSsoModel.upsert).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('findEnabledMethodsForEmail cross-org filter', () => {
+        it('returns [] for an email without a domain', async () => {
+            const { service, organizationSsoModel } = buildService();
+
+            await expect(
+                service.findEnabledMethodsForEmail('no-domain'),
+            ).resolves.toEqual([]);
+            expect(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('lowercases the domain before querying', async () => {
+            const { service, organizationSsoModel } = buildService();
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [],
+            );
+
+            await service.findEnabledMethodsForEmail('User@ACME.com');
+
+            expect(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).toHaveBeenCalledWith('acme.com');
+        });
+
+        it('returns no matches without looking up the user', async () => {
+            const { service, organizationSsoModel, userModel } = buildService();
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [],
+            );
+
+            await expect(
+                service.findEnabledMethodsForEmail('user@acme.com'),
+            ).resolves.toEqual([]);
+            expect(userModel.findUserByEmail).not.toHaveBeenCalled();
+        });
+
+        it('returns every match for a brand-new user with no account yet', async () => {
+            const { service, organizationSsoModel, userModel } = buildService();
+            const matches = [
+                enabledMethodForOrg(ORG_UUID),
+                enabledMethodForOrg(OTHER_ORG_UUID),
+            ];
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                matches,
+            );
+            userModel.findUserByEmail.mockResolvedValue(undefined);
+
+            await expect(
+                service.findEnabledMethodsForEmail('user@acme.com'),
+            ).resolves.toEqual(matches);
+            expect(userModel.getOrganizationsForUser).not.toHaveBeenCalled();
+        });
+
+        it('filters matches to the orgs an existing user already belongs to', async () => {
+            const { service, organizationSsoModel, userModel } = buildService();
+            const ownOrgMethod = enabledMethodForOrg(ORG_UUID);
+            const otherOrgMethod = enabledMethodForOrg(OTHER_ORG_UUID);
+            organizationSsoModel.findEnabledMethodsForEmailDomain.mockResolvedValue(
+                [ownOrgMethod, otherOrgMethod],
+            );
+            userModel.findUserByEmail.mockResolvedValue({
+                userUuid: USER_UUID,
+            });
+            userModel.getOrganizationsForUser.mockResolvedValue([
+                { organizationUuid: ORG_UUID },
+            ]);
+
+            await expect(
+                service.findEnabledMethodsForEmail('user@acme.com'),
+            ).resolves.toEqual([ownOrgMethod]);
+        });
+    });
+});

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.test.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVerifiedDomains } from '../../../hooks/organization/useOrganizationDomainVerification';
+import {
+    useDeleteGenericOidcSsoConfig,
+    useGenericOidcSsoConfig,
+    useUpsertGenericOidcSsoConfig,
+} from '../../../hooks/organization/useOrganizationSso';
+import { renderWithProviders } from '../../../testing/testUtils';
+import GenericOidcSsoPanel from './GenericOidcSsoPanel';
+
+vi.mock('../../../hooks/organization/useOrganizationSso', () => ({
+    useGenericOidcSsoConfig: vi.fn(),
+    useUpsertGenericOidcSsoConfig: vi.fn(),
+    useDeleteGenericOidcSsoConfig: vi.fn(),
+}));
+
+vi.mock(
+    '../../../hooks/organization/useOrganizationDomainVerification',
+    () => ({
+        useVerifiedDomains: vi.fn(),
+    }),
+);
+
+// FormSection wraps the form in a Mantine Collapse whose open animation never
+// settles in jsdom, hiding the content from role queries. Render children
+// directly so we can exercise the form itself.
+vi.mock('../../ProjectConnection/Inputs/FormSection', () => ({
+    default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+const mockUseConfig = vi.mocked(useGenericOidcSsoConfig);
+const mockUseUpsert = vi.mocked(useUpsertGenericOidcSsoConfig);
+const mockUseDelete = vi.mocked(useDeleteGenericOidcSsoConfig);
+const mockUseVerifiedDomains = vi.mocked(useVerifiedDomains);
+
+const existingConfig = {
+    clientId: 'existing-client-id',
+    metadataDocumentEndpoint:
+        'https://idp.example.com/.well-known/openid-configuration',
+    scopes: null,
+    hasClientSecret: true,
+    enabled: true,
+    overrideEmailDomains: false,
+    emailDomains: [],
+    allowPassword: true,
+};
+
+let mutate: ReturnType<typeof vi.fn>;
+
+const renderPanel = () =>
+    renderWithProviders(
+        <MemoryRouter>
+            <GenericOidcSsoPanel />
+        </MemoryRouter>,
+    );
+
+// userEvent.click on the submit button doesn't reliably trigger implicit form
+// submission under jsdom; submit the form element directly instead.
+const submitForm = () => fireEvent.submit(document.querySelector('form')!);
+
+beforeEach(() => {
+    mutate = vi.fn();
+    mockUseUpsert.mockReturnValue({
+        mutate,
+        isLoading: false,
+    } as unknown as ReturnType<typeof useUpsertGenericOidcSsoConfig>);
+    mockUseDelete.mockReturnValue({
+        mutate: vi.fn(),
+        mutateAsync: vi.fn(),
+        isLoading: false,
+    } as unknown as ReturnType<typeof useDeleteGenericOidcSsoConfig>);
+    mockUseVerifiedDomains.mockReturnValue({
+        data: [],
+        isInitialLoading: false,
+    } as unknown as ReturnType<typeof useVerifiedDomains>);
+});
+
+describe('GenericOidcSsoPanel form validation', () => {
+    it('blocks submission and shows errors when required fields are empty', async () => {
+        mockUseConfig.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useGenericOidcSsoConfig>);
+
+        renderPanel();
+        submitForm();
+
+        expect(
+            await screen.findByText('Discovery document URL is required'),
+        ).toBeInTheDocument();
+        expect(
+            await screen.findByText('Client ID is required'),
+        ).toBeInTheDocument();
+        expect(
+            await screen.findByText('Client secret is required'),
+        ).toBeInTheDocument();
+        expect(mutate).not.toHaveBeenCalled();
+    });
+
+    it('requires at least one domain when override is enabled', async () => {
+        const user = userEvent.setup();
+        mockUseConfig.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useGenericOidcSsoConfig>);
+        mockUseVerifiedDomains.mockReturnValue({
+            data: [{ domain: 'acme.com' }],
+            isInitialLoading: false,
+        } as unknown as ReturnType<typeof useVerifiedDomains>);
+
+        renderPanel();
+
+        await user.click(
+            screen.getByRole('checkbox', {
+                name: /Restrict to specific verified domains/,
+            }),
+        );
+        submitForm();
+
+        expect(
+            await screen.findByText(
+                'Add at least one domain when override is enabled',
+            ),
+        ).toBeInTheDocument();
+        expect(mutate).not.toHaveBeenCalled();
+    });
+
+    it('does not require a client secret when editing an existing configuration', async () => {
+        mockUseConfig.mockReturnValue({
+            data: existingConfig,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useGenericOidcSsoConfig>);
+
+        renderPanel();
+        submitForm();
+
+        // Prefilled required fields + existing secret means validation passes
+        // and the upsert fires without a re-entered secret.
+        await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+        expect(
+            screen.queryByText('Client secret is required'),
+        ).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7985/test-coverage-for-organization-sso-service-model-panels

### Description:

Adds unit test coverage for the `OrganizationSsoModel`, `OrganizationSsoService`, and `GenericOidcSsoPanel` components.

**`OrganizationSsoModel` tests** verify that:
- `findEnabledMethodsForEmailDomain` builds the correct SQL query, including the `enabled` filter, the verified-domain `EXISTS` clause, and the `override_email_domains` branch logic
- Email domains are normalized to lowercase before matching
- Rows are correctly decrypted and mapped to `OrganizationSsoMethod` objects
- A `null` `email_domains` column defaults to an empty array
- `findGoogleMethodsForEmailDomain` returns rows regardless of their `enabled` state, so that a disabled Google SSO policy can still suppress Google sign-in for an org

**`OrganizationSsoService` tests** cover:
- The `SsoOrganizationSettings` feature flag guard throwing `ForbiddenError` when disabled
- Authorization checks rejecting accounts with no organization or insufficient permissions
- Email domain validation rejecting malformed domains, public provider domains (e.g. `gmail.com`), and unverified domains when `overrideEmailDomains` is enabled
- Secret preservation on update — the stored client secret is kept when no new secret is provided, replaced when one is supplied, and a `ParameterError` is thrown when creating a new config without a secret
- The `findEnabledMethodsForEmail` cross-org filter, including domain lowercasing, short-circuiting on no matches, returning all matches for new users, and filtering to only the orgs an existing user already belongs to

**`GenericOidcSsoPanel` form validation tests** confirm that:
- Submitting an empty form surfaces validation errors for the discovery document URL, client ID, and client secret fields
- Enabling the domain override without selecting any domains produces a validation error
- Editing an existing configuration does not require re-entering the client secret