### PR TITLE
feat(data-apps): promote data apps from preview to production

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1351,6 +1351,20 @@ export type DataAppDuplicatedEvent = BaseTrack & {
     };
 };
 
+export type DataAppPromotedEvent = BaseTrack & {
+    event: 'data_app.promoted';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        version: number;
+        action: 'create' | 'update';
+        promotedFromAppUuid: string;
+        promotedFromProjectId: string;
+    };
+};
+
 export type DataAppEvent =
     | DataAppCreatedEvent
     | DataAppIteratedEvent
@@ -1360,7 +1374,8 @@ export type DataAppEvent =
     | DataAppImageUploadedEvent
     | DataAppViewedEvent
     | DataAppVersionRestoredEvent
-    | DataAppDuplicatedEvent;
+    | DataAppDuplicatedEvent
+    | DataAppPromotedEvent;
 
 export type AiWritebackStartedEvent = BaseTrack & {
     event: 'ai_writeback.started';

--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -24,6 +24,10 @@ export type DbApp = {
     sandbox_id: string | null;
     template: Exclude<DataAppTemplate, 'custom'> | null;
     design_uuid: string | null;
+    // The production app this (preview) app was promoted into. Null until the
+    // app is first promoted. Lives on the preview side so a single production
+    // app can be the upstream of many preview apps.
+    upstream_app_uuid: string | null;
     created_at: Date;
     created_by_user_uuid: string;
     deleted_at: Date | null;
@@ -45,6 +49,7 @@ export type AppsTable = Knex.CompositeTableType<
                 | 'sandbox_id'
                 | 'template'
                 | 'design_uuid'
+                | 'upstream_app_uuid'
             >
         >,
     Partial<
@@ -54,6 +59,8 @@ export type AppsTable = Knex.CompositeTableType<
             | 'description'
             | 'space_uuid'
             | 'sandbox_id'
+            | 'design_uuid'
+            | 'upstream_app_uuid'
             | 'deleted_at'
             | 'deleted_by_user_uuid'
             | 'views_count'

--- a/packages/backend/src/database/migrations/20260602100000_add_upstream_app_uuid_to_apps.ts
+++ b/packages/backend/src/database/migrations/20260602100000_add_upstream_app_uuid_to_apps.ts
@@ -1,0 +1,25 @@
+import { Knex } from 'knex';
+
+const AppsTableName = 'apps';
+const UpstreamAppUuidColumn = 'upstream_app_uuid';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AppsTableName, (table) => {
+        // Link from a preview app to the production app it was promoted into.
+        // Stored on the preview side so one production app can be the upstream
+        // of many preview apps (a project can have many preview projects).
+        table
+            .uuid(UpstreamAppUuidColumn)
+            .nullable()
+            .references('app_id')
+            .inTable(AppsTableName)
+            .onDelete('SET NULL')
+            .index();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AppsTableName, (table) => {
+        table.dropColumn(UpstreamAppUuidColumn);
+    });
+}

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -15,6 +15,8 @@ import {
     type ApiGetAppResponse,
     type ApiMyAppsResponse,
     type ApiPreviewTokenResponse,
+    type ApiPromoteAppDiffResponse,
+    type ApiPromoteAppResponse,
     type ApiRestoreAppVersionResponse,
     type ApiTogglePinnedItem,
     type ApiUpdateAppRequest,
@@ -306,6 +308,65 @@ export class AppGenerateController extends BaseController {
         return {
             status: 'ok',
             results: result,
+        };
+    }
+
+    /**
+     * Preview what promoting this app into its upstream (production) project
+     * will do: create a new production app or update the linked one, and which
+     * space it will land in.
+     * @summary Get data app promotion diff
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{appUuid}/promoteDiff')
+    @OperationId('getAppPromoteDiff')
+    async getAppPromoteDiff(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+    ): Promise<ApiPromoteAppDiffResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.getAppGenerateService().getPromoteAppDiff(
+            toSessionUser(req.account),
+            projectUuid,
+            appUuid,
+        );
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Promote this app from a preview project into its upstream (production)
+     * project. Snapshots the latest ready version as a new production version.
+     * @summary Promote data app to production
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/{appUuid}/promote')
+    @OperationId('promoteApp')
+    async promoteApp(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+    ): Promise<ApiPromoteAppResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.getAppGenerateService().promoteApp(
+            toSessionUser(req.account),
+            projectUuid,
+            appUuid,
+        );
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results,
         };
     }
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -110,6 +110,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getOrganizationDesignModel(),
                     pinnedListModel: models.getPinnedListModel(),
                     projectModel: models.getProjectModel(),
+                    spaceModel: models.getSpaceModel(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                     savedChartService: repository.getSavedChartService(),
@@ -117,6 +118,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getSpacePermissionService(),
                     dashboardService: repository.getDashboardService(),
                     projectService: repository.getProjectService(),
+                    promoteService: repository.getPromoteService(),
                 }),
             embedService: ({ repository, context, models }) =>
                 new EmbedService({

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -35,6 +35,8 @@ import {
     type ChartSampleData,
     type DataAppClaudeModel,
     type DataAppTemplate,
+    type PromoteAppAction,
+    type PromoteAppDiff,
     type SessionUser,
     type TogglePinnedItemInfo,
 } from '@lightdash/common';
@@ -64,10 +66,12 @@ import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagMo
 import { OrganizationDesignModel } from '../../../models/OrganizationDesignModel';
 import { PinnedListModel } from '../../../models/PinnedListModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { SpaceModel } from '../../../models/SpaceModel';
 import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
 import type { DashboardService } from '../../../services/DashboardService/DashboardService';
 import type { ProjectService } from '../../../services/ProjectService/ProjectService';
+import type { PromoteService } from '../../../services/PromoteService/PromoteService';
 import type { SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
@@ -90,11 +94,13 @@ type AppGenerateServiceDeps = {
     organizationDesignModel: OrganizationDesignModel;
     pinnedListModel: PinnedListModel;
     projectModel: ProjectModel;
+    spaceModel: SpaceModel;
     schedulerClient: CommercialSchedulerClient;
     savedChartService: SavedChartService;
     spacePermissionService: SpacePermissionService;
     dashboardService: DashboardService;
     projectService: ProjectService;
+    promoteService: PromoteService;
 };
 
 type GenerateAppResult = {
@@ -126,6 +132,8 @@ export class AppGenerateService extends BaseService {
 
     private readonly projectModel: ProjectModel;
 
+    private readonly spaceModel: SpaceModel;
+
     private readonly schedulerClient: CommercialSchedulerClient;
 
     private readonly savedChartService: SavedChartService;
@@ -135,6 +143,8 @@ export class AppGenerateService extends BaseService {
     private readonly dashboardService: DashboardService;
 
     private readonly projectService: ProjectService;
+
+    private readonly promoteService: PromoteService;
 
     constructor({
         lightdashConfig,
@@ -146,11 +156,13 @@ export class AppGenerateService extends BaseService {
         organizationDesignModel,
         pinnedListModel,
         projectModel,
+        spaceModel,
         schedulerClient,
         savedChartService,
         spacePermissionService,
         dashboardService,
         projectService,
+        promoteService,
     }: AppGenerateServiceDeps) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -162,11 +174,13 @@ export class AppGenerateService extends BaseService {
         this.organizationDesignModel = organizationDesignModel;
         this.pinnedListModel = pinnedListModel;
         this.projectModel = projectModel;
+        this.spaceModel = spaceModel;
         this.schedulerClient = schedulerClient;
         this.savedChartService = savedChartService;
         this.spacePermissionService = spacePermissionService;
         this.dashboardService = dashboardService;
         this.projectService = projectService;
+        this.promoteService = promoteService;
     }
 
     /**
@@ -3671,6 +3685,306 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     }
 
     /**
+     * Build the `resources` for a copied version (duplicate or promotion).
+     * Carries the chart/dashboard refs and Claude model from the source, but
+     * drops images and clarifications — both are scoped to the source app and
+     * don't survive the copy. The visual result is preserved because bundled
+     * images live in the copied dist assets, not in `resources.images`.
+     */
+    private static buildCopiedResources(
+        sourceResources: AppVersionResources | null,
+    ): AppVersionResources {
+        return {
+            images: [],
+            charts: sourceResources?.charts ?? [],
+            dashboardName: sourceResources?.dashboardName ?? null,
+            clarifications: [],
+            ...(sourceResources?.claudeModel
+                ? { claudeModel: sourceResources.claudeModel }
+                : {}),
+        };
+    }
+
+    /**
+     * Resolve the upstream (production) project a preview app can be promoted
+     * into, throwing when the app's project is not a preview linked to an
+     * upstream. Returns the upstream project's uuid, name and org uuid.
+     */
+    private async getUpstreamProjectForPromotion(projectUuid: string): Promise<{
+        upstreamProjectUuid: string;
+        upstreamProjectName: string;
+        upstreamOrganizationUuid: string;
+    }> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        if (!project.upstreamProjectUuid) {
+            throw new ParameterError(
+                'Data apps can only be promoted from a preview project linked to an upstream project',
+            );
+        }
+        const upstreamProject = await this.projectModel.getSummary(
+            project.upstreamProjectUuid,
+        );
+        return {
+            upstreamProjectUuid: upstreamProject.projectUuid,
+            upstreamProjectName: upstreamProject.name,
+            upstreamOrganizationUuid: upstreamProject.organizationUuid,
+        };
+    }
+
+    /**
+     * Find the live production app a preview app is currently linked to, or
+     * undefined when there is none (never promoted, or the production app was
+     * deleted). The link lives on the preview row as `upstream_app_uuid`; we
+     * additionally guard that it still points into the expected upstream
+     * project so a stale link can never resolve to the wrong app.
+     */
+    private async findLinkedUpstreamApp(
+        previewApp: Pick<DbApp, 'upstream_app_uuid'>,
+        upstreamProjectUuid: string,
+    ): Promise<(DbApp & { organization_uuid: string }) | undefined> {
+        if (!previewApp.upstream_app_uuid) {
+            return undefined;
+        }
+        const upstreamApp = await this.appModel.findAppByUuid(
+            previewApp.upstream_app_uuid,
+        );
+        if (!upstreamApp || upstreamApp.project_uuid !== upstreamProjectUuid) {
+            return undefined;
+        }
+        return upstreamApp;
+    }
+
+    /**
+     * Preview what promoting a data app into its upstream project will do —
+     * whether it creates a new production app or updates an existing one, and
+     * which space it will land in. Read-only; drives the confirmation dialog.
+     */
+    async getPromoteAppDiff(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+    ): Promise<PromoteAppDiff> {
+        await this.assertDataAppsEnabled(user);
+        const sourceApp = await this.appModel.getApp(appUuid, projectUuid);
+        await this.assertCanManageApp(
+            user,
+            sourceApp,
+            'Insufficient permissions to promote this data app',
+        );
+
+        const { upstreamProjectUuid, upstreamProjectName } =
+            await this.getUpstreamProjectForPromotion(projectUuid);
+
+        const upstreamApp = await this.findLinkedUpstreamApp(
+            sourceApp,
+            upstreamProjectUuid,
+        );
+
+        const space = sourceApp.space_uuid
+            ? await this.spaceModel.getSpaceSummary(sourceApp.space_uuid)
+            : null;
+
+        return {
+            action: upstreamApp ? 'update' : 'create',
+            upstreamProjectUuid,
+            upstreamProjectName,
+            upstreamAppUuid: upstreamApp?.app_id ?? null,
+            space: space ? { name: space.name, path: space.path } : null,
+        };
+    }
+
+    /**
+     * Promote a data app from a preview project into its upstream (production)
+     * project. The latest ready version is snapshotted as a single new version
+     * in production: a fresh app on first promotion, or an appended version on
+     * the linked production app on follow-up promotions. Built S3 artifacts are
+     * server-side copied into the production app's prefix; the source app is
+     * never modified beyond recording the upstream link.
+     *
+     * Out of scope (v1): chart references in `resources.charts` keep their
+     * preview uuids — the app renders (artifacts are self-contained) but
+     * re-iterating in production won't resolve them.
+     */
+    async promoteApp(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+    ): Promise<{
+        appUuid: string;
+        projectUuid: string;
+        version: number;
+        action: PromoteAppAction;
+    }> {
+        await this.assertDataAppsEnabled(user);
+
+        const sourceApp = await this.appModel.getApp(appUuid, projectUuid);
+        await this.assertCanManageApp(
+            user,
+            sourceApp,
+            'Insufficient permissions to promote this data app',
+        );
+
+        const {
+            upstreamProjectUuid,
+            upstreamProjectName,
+            upstreamOrganizationUuid,
+        } = await this.getUpstreamProjectForPromotion(projectUuid);
+
+        // Authoring rights on the upstream project itself — viewers of the
+        // preview must not be able to write into production.
+        this.assertDataAppAbility(
+            user,
+            'create',
+            upstreamOrganizationUuid,
+            upstreamProjectUuid,
+            'Insufficient permissions to promote into the upstream project',
+        );
+
+        const sourceVersion = await this.appModel.getLatestReadyVersion(
+            sourceApp.app_id,
+        );
+        if (!sourceVersion) {
+            throw new ParameterError(
+                'Cannot promote an app that has no successful version',
+            );
+        }
+
+        // Resolve the upstream space (creating it + ancestors if missing) so
+        // the production app mirrors the preview app's placement. Spaceless
+        // apps land at the project root.
+        const targetSpaceUuid = sourceApp.space_uuid
+            ? await this.promoteService.getOrCreateUpstreamSpace(
+                  user,
+                  sourceApp.space_uuid,
+                  upstreamProjectUuid,
+              )
+            : null;
+
+        // Designs are org-scoped and the preview shares the upstream org, so
+        // the design carries over — but guard against a since-deleted design.
+        const targetDesignUuid =
+            sourceApp.design_uuid &&
+            (await this.organizationDesignModel.findInOrganization(
+                upstreamOrganizationUuid,
+                sourceApp.design_uuid,
+            ))
+                ? sourceApp.design_uuid
+                : null;
+
+        const resources = AppGenerateService.buildCopiedResources(
+            sourceVersion.resources ?? null,
+        );
+        // Frame the production version's chat bubble like a duplicate's: the
+        // verb "Promote" plus a markdown link (rendered as an anchor by
+        // ChatMessageContent) back to the preview version it came from, for
+        // provenance.
+        const sourceDisplayName = sourceApp.name || 'untitled app';
+        const sourcePreviewPath = `/projects/${projectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/preview`;
+        const prompt = `Promote [${sourceDisplayName}](${sourcePreviewPath})`;
+        const { client: s3Client, bucket } = this.getS3Client();
+
+        // Re-read the link immediately before branching to narrow (not fully
+        // close) the window where two concurrent first-promotions could both
+        // create a production app. A duplicate is a rare, recoverable outcome.
+        const upstreamApp = await this.findLinkedUpstreamApp(
+            sourceApp,
+            upstreamProjectUuid,
+        );
+
+        const metadata = {
+            name: sourceApp.name,
+            description: sourceApp.description,
+            space_uuid: targetSpaceUuid,
+            design_uuid: targetDesignUuid,
+        };
+
+        const action: PromoteAppAction = upstreamApp ? 'update' : 'create';
+        const targetAppUuid = upstreamApp?.app_id ?? uuidv4();
+        const targetVersion = upstreamApp
+            ? ((await this.appModel.getLatestVersion(targetAppUuid))?.version ??
+                  0) + 1
+            : 1;
+
+        const copiedKeys = await AppGenerateService.copyVersionS3Prefix(
+            s3Client,
+            bucket,
+            { appUuid: sourceApp.app_id, version: sourceVersion.version },
+            { appUuid: targetAppUuid, version: targetVersion },
+        );
+
+        try {
+            if (upstreamApp) {
+                await this.appModel.createVersion(
+                    targetAppUuid,
+                    { version: targetVersion, prompt },
+                    'ready',
+                    user.userUuid,
+                    resources,
+                );
+                await this.appModel.syncPromotedApp(targetAppUuid, metadata);
+            } else {
+                await this.appModel.createWithVersion(
+                    {
+                        app_id: targetAppUuid,
+                        project_uuid: upstreamProjectUuid,
+                        created_by_user_uuid: user.userUuid,
+                        template: sourceApp.template,
+                        ...metadata,
+                    },
+                    { version: targetVersion, prompt },
+                    'ready',
+                    resources,
+                );
+                await this.appModel.setUpstreamAppUuid(
+                    sourceApp.app_id,
+                    targetAppUuid,
+                );
+            }
+            await this.appModel.updateStatusMessage(
+                targetAppUuid,
+                targetVersion,
+                `Promoted to ${upstreamProjectName}`,
+            );
+        } catch (error) {
+            // DB write failed — drop the orphaned S3 copy. On the update path
+            // the copy targets a new (unreferenced) version prefix, so it is
+            // always safe to delete. Cleanup failures are logged and swallowed.
+            await this.cleanupRestoredS3Keys(
+                s3Client,
+                bucket,
+                targetAppUuid,
+                copiedKeys,
+            );
+            throw error;
+        }
+
+        this.analytics.track({
+            event: 'data_app.promoted',
+            userId: user.userUuid,
+            properties: {
+                organizationId: upstreamOrganizationUuid,
+                projectId: upstreamProjectUuid,
+                appUuid: targetAppUuid,
+                version: targetVersion,
+                action,
+                promotedFromAppUuid: sourceApp.app_id,
+                promotedFromProjectId: projectUuid,
+            },
+        });
+
+        this.logger.info(
+            `App ${sourceApp.app_id} v${sourceVersion.version}: promoted (${action}) to app ${targetAppUuid} v${targetVersion} in project ${upstreamProjectUuid} (user=${user.userUuid}, copied ${copiedKeys.length} S3 object(s))`,
+        );
+
+        return {
+            appUuid: targetAppUuid,
+            projectUuid: upstreamProjectUuid,
+            version: targetVersion,
+            action,
+        };
+    }
+
+    /**
      * Duplicate an existing app the user can view into a new personal app
      * owned by the requester. The new app starts at v1 with the source's
      * latest ready version's S3 artifacts (dist.tar + source.tar + any
@@ -3716,16 +4030,9 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             );
         }
 
-        const sourceResources = sourceVersion.resources ?? null;
-        const resources: AppVersionResources = {
-            images: [],
-            charts: sourceResources?.charts ?? [],
-            dashboardName: sourceResources?.dashboardName ?? null,
-            clarifications: [],
-            ...(sourceResources?.claudeModel
-                ? { claudeModel: sourceResources.claudeModel }
-                : {}),
-        };
+        const resources = AppGenerateService.buildCopiedResources(
+            sourceVersion.resources ?? null,
+        );
 
         const newAppUuid = uuidv4();
         const newVersion = 1;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8596,6 +8596,100 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PromoteAppAction: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['create'] },
+                { dataType: 'enum', enums: ['update'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PromoteAppDiff: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                space: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                path: { dataType: 'string', required: true },
+                                name: { dataType: 'string', required: true },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                upstreamAppUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                upstreamProjectName: { dataType: 'string', required: true },
+                upstreamProjectUuid: { dataType: 'string', required: true },
+                action: { ref: 'PromoteAppAction', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_PromoteAppDiff_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'PromoteAppDiff', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiPromoteAppDiffResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_PromoteAppDiff_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess__appUuid-string--projectUuid-string--version-number--action-PromoteAppAction__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    results: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            action: { ref: 'PromoteAppAction', required: true },
+                            version: { dataType: 'double', required: true },
+                            projectUuid: { dataType: 'string', required: true },
+                            appUuid: { dataType: 'string', required: true },
+                        },
+                        required: true,
+                    },
+                    status: { dataType: 'enum', enums: ['ok'], required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiPromoteAppResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess__appUuid-string--projectUuid-string--version-number--action-PromoteAppAction__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess__appUuid-string--name-string--description-string__': {
         dataType: 'refAlias',
         type: {
@@ -11235,7 +11329,7 @@ const models: TsoaRoute.Models = {
             dataType: 'union',
             subSchemas: [
                 { dataType: 'enum', enums: ['generateDashboard'] },
-                { dataType: 'enum', enums: ['runQuery'] },
+                { dataType: 'enum', enums: ['generateVisualization'] },
                 { dataType: 'enum', enums: ['runSql'] },
                 { dataType: 'enum', enums: ['proposeChange'] },
                 { dataType: 'enum', enums: ['findContent'] },
@@ -12178,7 +12272,7 @@ const models: TsoaRoute.Models = {
             dataType: 'union',
             subSchemas: [
                 { dataType: 'enum', enums: ['generateDashboard'] },
-                { dataType: 'enum', enums: ['runQuery'] },
+                { dataType: 'enum', enums: ['generateVisualization'] },
                 { dataType: 'enum', enums: ['runSql'] },
                 { dataType: 'enum', enums: ['findContent'] },
                 { dataType: 'enum', enums: ['generateBarVizConfig'] },
@@ -12196,11 +12290,13 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['readContent'] },
                 { dataType: 'enum', enums: ['editContent'] },
                 { dataType: 'enum', enums: ['createContent'] },
+                { dataType: 'enum', enums: ['runContentQuery'] },
                 { dataType: 'enum', enums: ['improveContext'] },
                 { dataType: 'enum', enums: ['listProjects'] },
                 { dataType: 'enum', enums: ['getProjectInfo'] },
                 { dataType: 'enum', enums: ['loadSkill'] },
                 { dataType: 'enum', enums: ['proposeWriteback'] },
+                { dataType: 'enum', enums: ['runQuery'] },
                 { dataType: 'enum', enums: ['runSavedChart'] },
                 { dataType: 'enum', enums: ['listWarehouseTables'] },
                 { dataType: 'enum', enums: ['describeWarehouseTable'] },
@@ -12234,11 +12330,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12296,11 +12392,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12955,6 +13051,40 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
+                                                                explore: {
+                                                                    dataType:
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                        },
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13004,12 +13134,6 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                                 table: {
                                                                                     dataType:
                                                                                         'string',
@@ -13020,6 +13144,12 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -13047,40 +13177,6 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                explore: {
-                                                                    dataType:
-                                                                        'nestedObjectLiteral',
-                                                                    nestedProperties:
-                                                                        {
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            joinedTables:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                    },
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                        },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -13285,11 +13381,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13424,11 +13520,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -26910,7 +27006,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -26920,7 +27016,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -26930,7 +27026,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -26943,7 +27039,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -27598,7 +27694,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27608,7 +27704,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27618,7 +27714,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -27631,7 +27727,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -40776,6 +40872,140 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'duplicateApp',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_getAppPromoteDiff: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/promoteDiff',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.getAppPromoteDiff,
+        ),
+
+        async function AppGenerateController_getAppPromoteDiff(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_getAppPromoteDiff,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAppPromoteDiff',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_promoteApp: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/promote',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.promoteApp,
+        ),
+
+        async function AppGenerateController_promoteApp(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_promoteApp,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'promoteApp',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -9946,6 +9946,104 @@
             "ApiDuplicateAppResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__appUuid-string--version-number__"
             },
+            "PromoteAppAction": {
+                "type": "string",
+                "enum": ["create", "update"]
+            },
+            "PromoteAppDiff": {
+                "properties": {
+                    "space": {
+                        "properties": {
+                            "path": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["path", "name"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "upstreamAppUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "upstreamProjectName": {
+                        "type": "string"
+                    },
+                    "upstreamProjectUuid": {
+                        "type": "string"
+                    },
+                    "action": {
+                        "$ref": "#/components/schemas/PromoteAppAction"
+                    }
+                },
+                "required": [
+                    "space",
+                    "upstreamAppUuid",
+                    "upstreamProjectName",
+                    "upstreamProjectUuid",
+                    "action"
+                ],
+                "type": "object",
+                "description": "Preview of what promoting a data app from a preview project into its\nupstream (production) project will do. Drives the confirmation dialog."
+            },
+            "ApiSuccess_PromoteAppDiff_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/PromoteAppDiff"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiPromoteAppDiffResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_PromoteAppDiff_"
+            },
+            "ApiSuccess__appUuid-string--projectUuid-string--version-number--action-PromoteAppAction__": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "action": {
+                                "$ref": "#/components/schemas/PromoteAppAction"
+                            },
+                            "version": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "projectUuid": {
+                                "type": "string"
+                            },
+                            "appUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "action",
+                            "version",
+                            "projectUuid",
+                            "appUuid"
+                        ],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiPromoteAppResponse": {
+                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--projectUuid-string--version-number--action-PromoteAppAction__"
+            },
             "ApiSuccess__appUuid-string--name-string--description-string__": {
                 "properties": {
                     "results": {
@@ -12828,7 +12926,7 @@
                 "type": "string",
                 "enum": [
                     "generateDashboard",
-                    "runQuery",
+                    "generateVisualization",
                     "runSql",
                     "proposeChange",
                     "findContent"
@@ -13744,7 +13842,7 @@
                 "type": "string",
                 "enum": [
                     "generateDashboard",
-                    "runQuery",
+                    "generateVisualization",
                     "runSql",
                     "findContent",
                     "generateBarVizConfig",
@@ -13762,11 +13860,13 @@
                     "readContent",
                     "editContent",
                     "createContent",
+                    "runContentQuery",
                     "improveContext",
                     "listProjects",
                     "getProjectInfo",
                     "loadSkill",
                     "proposeWriteback",
+                    "runQuery",
                     "runSavedChart",
                     "listWarehouseTables",
                     "describeWarehouseTable",
@@ -13791,8 +13891,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13850,8 +13950,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14151,57 +14251,6 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "isFromJoinedTable",
-                                                                                "fieldValueType",
-                                                                                "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "fieldId",
-                                                                                "table",
-                                                                                "label",
-                                                                                "description",
-                                                                                "name"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "baseTable": {
@@ -14228,6 +14277,57 @@
                                                                         ],
                                                                         "type": "object"
                                                                     },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "fieldValueType",
+                                                                                "fieldFilterType",
+                                                                                "fieldType",
+                                                                                "table",
+                                                                                "label",
+                                                                                "fieldId",
+                                                                                "description",
+                                                                                "name"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -14238,8 +14338,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "fields",
                                                                     "explore",
+                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14364,19 +14464,6 @@
                                                     "slug",
                                                     "name"
                                                 ],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
                                                 "type": "object"
                                             },
                                             {
@@ -27905,22 +27992,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -28480,22 +28567,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -29973,13 +30060,13 @@
                         "type": "number",
                         "format": "double",
                         "nullable": true,
-                        "description": "Max number of cells (rows × columns) a CSV/Excel export may contain for\nthis org (overrides `LIGHTDASH_CSV_CELLS_LIMIT`; `null` inherits it).\nAlways resolved to an effective number in API responses."
+                        "description": "Max number of cells (rows × columns) a CSV/Excel export may contain for\nthis org. Inherits `LIGHTDASH_CSV_CELLS_LIMIT` and is capped by\n`LIGHTDASH_CSV_MAX_LIMIT` (the ceiling); `null` inherits the\ndefault. Always resolved to an effective number in API responses."
                     },
                     "queryLimit": {
                         "type": "number",
                         "format": "double",
                         "nullable": true,
-                        "description": "Max number of rows a query/export may return for this org (overrides the\ninstance-wide `LIGHTDASH_QUERY_MAX_LIMIT`; `null` inherits it). Always\nresolved to an effective number in API responses so the frontend can\ndisplay it directly."
+                        "description": "Max number of rows a query may return for this org. Inherits and is\ncapped by the instance-wide `LIGHTDASH_QUERY_MAX_LIMIT` (the ceiling);\n`null` inherits it. Always resolved to an effective number in API\nresponses so the frontend can display it directly."
                     },
                     "scheduledDeliveryExpirationSecondsGoogleChat": {
                         "type": "number",
@@ -30107,13 +30194,13 @@
                         "type": "number",
                         "format": "double",
                         "nullable": true,
-                        "description": "Max number of rows a query/export may return for this org (overrides the\ninstance-wide `LIGHTDASH_QUERY_MAX_LIMIT`; `null` inherits it). Always\nresolved to an effective number in API responses so the frontend can\ndisplay it directly."
+                        "description": "Max number of rows a query may return for this org. Inherits and is\ncapped by the instance-wide `LIGHTDASH_QUERY_MAX_LIMIT` (the ceiling);\n`null` inherits it. Always resolved to an effective number in API\nresponses so the frontend can display it directly."
                     },
                     "csvCellsLimit": {
                         "type": "number",
                         "format": "double",
                         "nullable": true,
-                        "description": "Max number of cells (rows × columns) a CSV/Excel export may contain for\nthis org (overrides `LIGHTDASH_CSV_CELLS_LIMIT`; `null` inherits it).\nAlways resolved to an effective number in API responses."
+                        "description": "Max number of cells (rows × columns) a CSV/Excel export may contain for\nthis org. Inherits `LIGHTDASH_CSV_CELLS_LIMIT` and is capped by\n`LIGHTDASH_CSV_MAX_LIMIT` (the ceiling); `null` inherits the\ndefault. Always resolved to an effective number in API responses."
                     }
                 },
                 "type": "object",
@@ -37382,7 +37469,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3072.0",
+        "version": "0.3074.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -479,6 +479,44 @@ export class AppModel {
     }
 
     /**
+     * Record that a preview app has been promoted into a production app. The
+     * link lives on the preview (source) row so one production app can be the
+     * upstream of many preview apps. Setting it is idempotent — re-promoting
+     * the same preview app just rewrites the same value.
+     */
+    async setUpstreamAppUuid(
+        appId: string,
+        upstreamAppUuid: string,
+    ): Promise<void> {
+        await this.database(AppsTableName)
+            .where({ app_id: appId })
+            .update({ upstream_app_uuid: upstreamAppUuid });
+    }
+
+    /**
+     * Sync the metadata of an existing production app from its preview source
+     * during a follow-up promotion. Only touches the fields promotion owns —
+     * versions are appended separately, the link and ownership stay put.
+     */
+    async syncPromotedApp(
+        appId: string,
+        update: Pick<
+            DbApp,
+            'name' | 'description' | 'space_uuid' | 'design_uuid'
+        >,
+    ): Promise<DbApp> {
+        const [row] = await this.database(AppsTableName)
+            .where({ app_id: appId })
+            .whereNull('deleted_at')
+            .update(update)
+            .returning('*');
+        if (!row) {
+            throw new NotFoundError(`App not found: ${appId}`);
+        }
+        return row;
+    }
+
+    /**
      * Atomically set auto-generated name/description, but only for fields
      * that are still at their empty-string default. Used by the background
      * pipeline so it cannot clobber edits the user made while the build

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -1429,6 +1429,53 @@ export class PromoteService extends BaseService {
         };
     }
 
+    /**
+     * Resolve a single source space (by its path) into the upstream project,
+     * creating it — and any missing ancestors — when absent. Returns the
+     * upstream space uuid.
+     *
+     * Data-app promotion needs only to place one entity into a space, so this
+     * builds the minimal space change set (the space plus its ancestors) and
+     * reuses `upsertSpaces` for the actual create + parent-chain + permission
+     * copy, rather than assembling a full chart/dashboard PromotionChanges.
+     */
+    async getOrCreateUpstreamSpace(
+        user: SessionUser,
+        sourceSpaceUuid: string,
+        upstreamProjectUuid: string,
+    ): Promise<string> {
+        const promotedSpace =
+            await this.spaceModel.getSpaceSummary(sourceSpaceUuid);
+
+        const ancestorUuids = await this.spaceModel.getSpaceAncestors({
+            spaceUuid: sourceSpaceUuid,
+            projectUuid: promotedSpace.projectUuid,
+        });
+        const ancestors =
+            ancestorUuids.length > 0
+                ? await this.spaceModel.find({ spaceUuids: ancestorUuids })
+                : [];
+
+        const spaceChanges = await Promise.all(
+            [promotedSpace, ...ancestors].map((space) =>
+                this.getSpaceChange(upstreamProjectUuid, space),
+            ),
+        );
+
+        const result = await this.upsertSpaces(
+            user,
+            promotedSpace.projectUuid,
+            {
+                spaces: spaceChanges,
+                dashboards: [],
+                charts: [],
+            },
+        );
+
+        return PromoteService.getSpaceByPath(result.spaces, promotedSpace.path)
+            .uuid;
+    }
+
     async upsertSpaces(
         user: SessionUser,
         projectUuid: string, // The base project uuid

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -250,6 +250,34 @@ export type ApiDuplicateAppResponse = ApiSuccess<{
     version: number;
 }>;
 
+export type PromoteAppAction = 'create' | 'update';
+
+/**
+ * Preview of what promoting a data app from a preview project into its
+ * upstream (production) project will do. Drives the confirmation dialog.
+ */
+export type PromoteAppDiff = {
+    // 'create' on first promotion, 'update' when the preview app is already
+    // linked to a live production app (a new version is appended).
+    action: PromoteAppAction;
+    upstreamProjectUuid: string;
+    upstreamProjectName: string;
+    // The production app that will be updated, or null when it will be created.
+    upstreamAppUuid: string | null;
+    // The space (mirrored by path) the app will land in, or null for the
+    // production project root.
+    space: { name: string; path: string } | null;
+};
+
+export type ApiPromoteAppDiffResponse = ApiSuccess<PromoteAppDiff>;
+
+export type ApiPromoteAppResponse = ApiSuccess<{
+    appUuid: string;
+    projectUuid: string;
+    version: number;
+    action: PromoteAppAction;
+}>;
+
 export type ApiDeleteAppResponse = ApiSuccessEmpty;
 
 export type ApiAppSummary = {

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -44,6 +44,8 @@ import type {
     ApiOrganizationDesignResponse,
     ApiOrganizationDesignsResponse,
     ApiPreviewTokenResponse,
+    ApiPromoteAppDiffResponse,
+    ApiPromoteAppResponse,
     ApiUpdateAiOrganizationSettingsResponse,
     ApiUpdateUserAgentPreferencesResponse,
     DecodedEmbed,
@@ -1108,6 +1110,8 @@ type ApiResults =
     | ApiGenerateAppResponse['results']
     | ApiGetAppResponse['results']
     | ApiMyAppsResponse['results']
+    | ApiPromoteAppResponse['results']
+    | ApiPromoteAppDiffResponse['results']
     | ApiPreviewTokenResponse['results']
     | ApiAppImageUploadResponse['results']
     | ApiOrganizationDesignResponse['results']

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -24,9 +24,10 @@ import {
     IconTrash,
     IconUsers,
 } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { type FC, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
+import { PromoteAppModal } from '../../../features/apps/components/PromoteAppModal';
 import { useDuplicateApp } from '../../../features/apps/hooks/useDuplicateApp';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
@@ -82,6 +83,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const navigate = useNavigate();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { data: project } = useProject(projectUuid);
+    const [isPromoteAppOpen, setIsPromoteAppOpen] = useState(false);
     const { mutate: duplicateApp } = useDuplicateApp();
     const organizationUuid = user.data?.organizationUuid;
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
@@ -442,6 +444,21 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                         </div>
                                     </Tooltip>
                                 )}
+                            {item.type === ResourceViewItemType.DATA_APP &&
+                                project?.upstreamProjectUuid !== undefined && (
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconDatabaseExport}
+                                            />
+                                        }
+                                        onClick={() =>
+                                            setIsPromoteAppOpen(true)
+                                        }
+                                    >
+                                        Promote data app
+                                    </Menu.Item>
+                                )}
 
                             {user.data?.ability.can(
                                 'manage',
@@ -622,6 +639,16 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                     }}
                 ></PromotionConfirmDialog>
             )}
+            {isPromoteAppOpen &&
+                projectUuid &&
+                item.type === ResourceViewItemType.DATA_APP && (
+                    <PromoteAppModal
+                        projectUuid={projectUuid}
+                        appUuid={item.data.uuid}
+                        opened
+                        onClose={() => setIsPromoteAppOpen(false)}
+                    />
+                )}
         </>
     );
 };

--- a/packages/frontend/src/features/apps/components/PromoteAppModal.tsx
+++ b/packages/frontend/src/features/apps/components/PromoteAppModal.tsx
@@ -1,0 +1,93 @@
+import { Group, Loader, Stack, Text } from '@mantine-8/core';
+import { IconFolder, IconRocket } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useNavigate } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import { usePromoteApp, usePromoteAppDiff } from '../hooks/usePromoteApp';
+
+type Props = {
+    projectUuid: string;
+    appUuid: string;
+    opened: boolean;
+    onClose: () => void;
+};
+
+export const PromoteAppModal: FC<Props> = ({
+    projectUuid,
+    appUuid,
+    opened,
+    onClose,
+}) => {
+    const navigate = useNavigate();
+    const { data: diff, isInitialLoading: isDiffLoading } = usePromoteAppDiff(
+        { projectUuid, appUuid },
+        { enabled: opened },
+    );
+    const { mutate: promote, isLoading: isPromoting } = usePromoteApp();
+
+    const handleConfirm = () => {
+        promote(
+            { projectUuid, appUuid },
+            {
+                onSuccess: (result) => {
+                    onClose();
+                    void navigate(
+                        `/projects/${result.projectUuid}/apps/${result.appUuid}`,
+                    );
+                },
+            },
+        );
+    };
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Promote data app"
+            icon={IconRocket}
+            size="md"
+            confirmLabel="Promote"
+            confirmLoading={isPromoting}
+            confirmDisabled={isDiffLoading || !diff}
+            onConfirm={handleConfirm}
+        >
+            {isDiffLoading || !diff ? (
+                <Group justify="center" py="md">
+                    <Loader size="sm" />
+                </Group>
+            ) : (
+                <Stack gap="sm">
+                    <Text size="sm">
+                        {diff.action === 'update' ? (
+                            <>
+                                This will add a new version to the existing app
+                                in{' '}
+                                <Text span fw={600}>
+                                    {diff.upstreamProjectName}
+                                </Text>
+                                .
+                            </>
+                        ) : (
+                            <>
+                                This will create a new app in{' '}
+                                <Text span fw={600}>
+                                    {diff.upstreamProjectName}
+                                </Text>{' '}
+                                from the latest version.
+                            </>
+                        )}
+                    </Text>
+                    <Group gap="xs">
+                        <MantineIcon icon={IconFolder} color="ldGray.6" />
+                        <Text size="sm" c="dimmed">
+                            {diff.space
+                                ? `Space: ${diff.space.name}`
+                                : 'Personal app (no space)'}
+                        </Text>
+                    </Group>
+                </Stack>
+            )}
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/features/apps/hooks/usePromoteApp.ts
+++ b/packages/frontend/src/features/apps/hooks/usePromoteApp.ts
@@ -1,0 +1,64 @@
+import {
+    type ApiError,
+    type ApiPromoteAppDiffResponse,
+    type ApiPromoteAppResponse,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+type PromoteAppParams = {
+    projectUuid: string;
+    appUuid: string;
+};
+
+type PromoteAppDiff = ApiPromoteAppDiffResponse['results'];
+type PromoteAppResult = ApiPromoteAppResponse['results'];
+
+const getPromoteAppDiff = ({ projectUuid, appUuid }: PromoteAppParams) =>
+    lightdashApi<PromoteAppDiff>({
+        method: 'GET',
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/promoteDiff`,
+        body: undefined,
+    });
+
+export const usePromoteAppDiff = (
+    params: PromoteAppParams | undefined,
+    { enabled }: { enabled: boolean },
+) =>
+    useQuery<PromoteAppDiff, ApiError>({
+        queryKey: ['appPromoteDiff', params?.projectUuid, params?.appUuid],
+        queryFn: () => getPromoteAppDiff(params!),
+        enabled: enabled && !!params,
+    });
+
+const promoteApp = ({ projectUuid, appUuid }: PromoteAppParams) =>
+    lightdashApi<PromoteAppResult>({
+        method: 'POST',
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/promote`,
+        body: undefined,
+    });
+
+export const usePromoteApp = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<PromoteAppResult, ApiError, PromoteAppParams>({
+        mutationFn: promoteApp,
+        onSuccess: (result) => {
+            void queryClient.invalidateQueries({ queryKey: ['myApps'] });
+            void queryClient.invalidateQueries({ queryKey: ['content'] });
+            showToastSuccess({
+                title:
+                    result.action === 'update'
+                        ? 'Data app updated in production'
+                        : 'Data app promoted to production',
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to promote app',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -35,6 +35,7 @@ import {
     IconArrowUp,
     IconCopy,
     IconDatabase,
+    IconDatabaseExport,
     IconBrush,
     IconDots,
     IconExternalLink,
@@ -98,6 +99,7 @@ import {
 import AppTemplatePicker from '../features/apps/AppTemplatePicker';
 import ChatBubbleMeta from '../features/apps/ChatBubbleMeta';
 import ChatMessageContent from '../features/apps/ChatMessageContent';
+import { PromoteAppModal } from '../features/apps/components/PromoteAppModal';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -123,6 +125,7 @@ import {
 import { useOrganizationDesigns } from '../features/organizationDesigns/hooks/useOrganizationDesigns';
 import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
+import { useProject } from '../hooks/useProject';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
@@ -529,6 +532,11 @@ const AppGenerate: FC = () => {
     const [isMoveToSpaceOpen, setIsMoveToSpaceOpen] = useState(false);
     const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [isPromoteModalOpen, setIsPromoteModalOpen] = useState(false);
+
+    // Promotion is only offered from a preview project linked to an upstream.
+    const { data: project } = useProject(projectUuid);
+    const isPreviewProject = !!project?.upstreamProjectUuid;
     const { mutateAsync: contentAction, isLoading: isMovingToSpace } =
         useContentAction(projectUuid);
 
@@ -2398,6 +2406,27 @@ const AppGenerate: FC = () => {
                                                 ? 'Move to space'
                                                 : 'Add to space'}
                                         </Menu.Item>
+                                        {isPreviewProject &&
+                                            latestReadyVersion && (
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconDatabaseExport
+                                                            }
+                                                            size={14}
+                                                        />
+                                                    }
+                                                    disabled={!activeAppUuid}
+                                                    onClick={() =>
+                                                        setIsPromoteModalOpen(
+                                                            true,
+                                                        )
+                                                    }
+                                                >
+                                                    Promote
+                                                </Menu.Item>
+                                            )}
                                         <Menu.Divider />
                                         <Menu.Item
                                             color="red"
@@ -2477,6 +2506,14 @@ const AppGenerate: FC = () => {
                                 initialDescription={appDescription}
                                 onClose={() => setIsUpdateModalOpen(false)}
                                 onConfirm={() => setIsUpdateModalOpen(false)}
+                            />
+                        )}
+                        {isPromoteModalOpen && activeAppUuid && (
+                            <PromoteAppModal
+                                projectUuid={projectUuid}
+                                appUuid={activeAppUuid}
+                                opened
+                                onClose={() => setIsPromoteModalOpen(false)}
                             />
                         )}
                         {isDeleteModalOpen && activeAppUuid && (


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/PROD-8040/implement-promotion-flow

### Description:
Add a promotion flow for data apps. A data app that was manually created in a preview project can be promoted into its upstream (production) project.

- First promotion creates a new production app; follow-up promotions append a new version to the linked production app, tracked via a preview-side `upstream_app_uuid` link (one production app can be upstream of many preview apps).
- Snapshots the latest ready version as a single production version, copying the built S3 artifacts; resolves the app's space (by path) into the upstream project, creating it if missing.
- Adds POST/GET promote + promoteDiff endpoints, a "Promote" menu action and a confirmation dialog.

