### PR TITLE
fix(ai-agent): tolerate Slack user lookup failures in thread list

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1630,11 +1630,27 @@ export class AiAgentService extends BaseService {
                 .map((thread) => thread.user.slackUserId),
         );
 
-        const slackUsers = await Promise.all(
-            slackUserIds.map((userId) =>
-                this.slackClient.getUserInfo(organizationUuid, userId!),
-            ),
-        );
+        // Resolve Slack users individually and tolerate failures: a single
+        // deleted/unknown Slack user (`user_not_found`) must not fail the whole
+        // thread list. Failed lookups fall back to the stored thread user name.
+        const slackUsers = (
+            await Promise.all(
+                slackUserIds.map(async (userId) => {
+                    try {
+                        return await this.slackClient.getUserInfo(
+                            organizationUuid,
+                            userId!,
+                        );
+                    } catch (error) {
+                        this.logger.warn(
+                            `Failed to fetch Slack user info for ${userId}`,
+                            { organizationUuid, error },
+                        );
+                        return null;
+                    }
+                }),
+            )
+        ).filter((slackUser) => slackUser !== null);
 
         const data = threads.map((thread) => {
             if (thread.createdFrom !== 'slack') {
@@ -1642,9 +1658,9 @@ export class AiAgentService extends BaseService {
             }
 
             const slackUser = slackUsers.find(
-                ({ id }) =>
+                (su) =>
                     thread.user.slackUserId !== null &&
-                    id === thread.user.slackUserId,
+                    su.id === thread.user.slackUserId,
             );
 
             return {


### PR DESCRIPTION
## Summary

Listing AI agent threads called `slackClient.getUserInfo` for every unique Slack author inside a single `Promise.all`. One failed lookup — e.g. a deleted Slack user returning `user_not_found` — rejected the whole batch, so the entire thread list endpoint failed instead of rendering the other threads.

Affects only Slack-created threads where an author can no longer be resolved; web-app threads were never touched.

## Root cause

`Promise.all` rejects as soon as any promise rejects, and `getUserInfo` throws on unknown users:

```ts
const slackUsers = await Promise.all(
    slackUserIds.map((userId) =>
        this.slackClient.getUserInfo(organizationUuid, userId!),
    ),
);
```

`getUserInfo` throws `UnexpectedServerError` when Slack returns `!response.ok` or a profile-less user. A single deleted account therefore took down the list for every thread, including healthy ones.

## Fix

Resolve each Slack user independently, log and drop failures, and let the existing `slackUser?.name ?? thread.user.name` fall back to the stored thread name.

```
Before:  [ok] [ok] [FAIL] [ok]  ──Promise.all──▶  reject → 500, no threads
After:   [ok] [ok] [skip] [ok]  ──filter null──▶  3 names resolved, 1 falls back to stored name
```

- `AiAgentService.ts` — wrap each `getUserInfo` in try/catch, `logger.warn` + return `null` on failure, then `.filter(u => u !== null)`. The later `.find` uses the narrowed non-null array.
- Out of scope: per-error-code handling (auth/rate-limit vs `user_not_found`) — all failures degrade to the stored name.

## Test plan

- [x] `pnpm -F backend typecheck` — passes (TS infers the non-null predicate on `.filter`)
- [x] `pnpm -F backend lint` — passes
- [ ] Manual: open the agent threads list in an org with a thread authored by a since-deleted Slack user — list renders, that thread shows its stored name

🤖 Generated with [Claude Code](https://claude.com/claude-code)