### PR TITLE
feat: scope DuckDB S3 pre-aggregate materialization access by org and project

### DIFF
--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -145,12 +145,14 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
     }
 
     async resolveExecution({
+        organizationUuid,
         projectUuid,
         queryUuid,
         warehouseQuery,
         preAggregationRoute,
         resolveArgs,
     }: {
+        organizationUuid: string;
         projectUuid: string;
         queryUuid: string;
         warehouseQuery: string;
@@ -177,6 +179,7 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
         }
 
         const resolution = await this.duckDbClient.resolve({
+            organizationUuid,
             projectUuid,
             queryUuid,
             metricQuery: resolveArgs.metricQuery,
@@ -210,8 +213,8 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
         };
     }
 
-    createExecutionWarehouseClient(): WarehouseClient {
-        return this.duckDbClient.createExecutionWarehouseClient();
+    createExecutionWarehouseClient(scope?: string): WarehouseClient {
+        return this.duckDbClient.createExecutionWarehouseClient(scope);
     }
 
     recordStats(params: {

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
@@ -80,6 +80,7 @@ describe('PreAggregationDuckDbClient', () => {
     };
 
     const baseResolveArgs = {
+        organizationUuid: 'organizationUuid',
         projectUuid: 'projectUuid',
         metricQuery: {
             ...metricQueryMock,
@@ -213,6 +214,54 @@ describe('PreAggregationDuckDbClient', () => {
                 instanceCacheKey: 'pre-aggregate-query-instance',
             }),
         );
+    });
+
+    test('scopes DuckDB S3 access for scoped materialization URIs', async () => {
+        const { client, createDuckdbWarehouseClient } = getClient({
+            activeMaterialization: {
+                materializationUuid: 'mat-1',
+                queryUuid: 'mat-query-1',
+                materializationUri:
+                    's3://mock_preagg_bucket/pre-aggregates/organizationUuid/projectUuid/abc123.jsonl',
+                format: 'jsonl' as const,
+                columns: null,
+                materializedAt: new Date('2024-01-01T00:00:00.000Z'),
+                totalBytes: 987654,
+            },
+        });
+
+        await client.resolve(baseResolveArgs);
+
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledWith(
+            expect.objectContaining({
+                s3Config: expect.objectContaining({
+                    scope: 's3://mock_preagg_bucket/pre-aggregates/organizationUuid/projectUuid/',
+                }),
+                instanceCacheKey:
+                    'pre-aggregate-query-instance:s3://mock_preagg_bucket/pre-aggregates/organizationUuid/projectUuid/',
+            }),
+        );
+    });
+
+    test('rejects scoped materialization URIs outside the current org/project', async () => {
+        const { client, createDuckdbWarehouseClient } = getClient({
+            activeMaterialization: {
+                materializationUuid: 'mat-1',
+                queryUuid: 'mat-query-1',
+                materializationUri:
+                    's3://mock_preagg_bucket/pre-aggregates/other-org/projectUuid/abc123.jsonl',
+                format: 'jsonl' as const,
+                columns: null,
+                materializedAt: new Date('2024-01-01T00:00:00.000Z'),
+                totalBytes: 987654,
+            },
+        });
+
+        await expect(client.resolve(baseResolveArgs)).resolves.toEqual({
+            resolved: false,
+            reason: PreAggregationDuckDbResolveReason.INVALID_MATERIALIZATION_URI,
+        });
+        expect(createDuckdbWarehouseClient).not.toHaveBeenCalled();
     });
 
     test('logs selected materialization metadata for debugging', async () => {

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -35,7 +35,11 @@ import {
     getDuckdbPreAggregateSqlTable,
     getPreAggregateDuckdbLocator,
 } from '../PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable';
-import { getDuckdbRuntimeConfig } from './getDuckdbRuntimeConfig';
+import {
+    getDuckdbRuntimeConfig,
+    getPreAggregateStorageScope,
+    isPreAggregateUriInScope,
+} from './getDuckdbRuntimeConfig';
 
 const PRE_AGGREGATE_QUERY_INSTANCE_CACHE_KEY = 'pre-aggregate-query-instance';
 
@@ -53,6 +57,7 @@ type PreAggregationDuckDbClientArgs = {
 };
 
 export type ResolvePreAggregationDuckDbArgs = {
+    organizationUuid: string;
     projectUuid: string;
     queryUuid?: string;
     queryTags?: RunQueryTags;
@@ -78,6 +83,7 @@ export enum PreAggregationDuckDbResolveReason {
     MISSING_PRE_AGGREGATE_S3_CONFIG = 'missing_pre_aggregate_s3_config',
     MISSING_DUCKDB_RUNTIME_CONFIG = 'missing_duckdb_runtime_config',
     NO_ACTIVE_MATERIALIZATION = 'no_active_materialization',
+    INVALID_MATERIALIZATION_URI = 'invalid_materialization_uri',
     RESOLVE_ERROR = 'resolve_error',
 }
 
@@ -101,7 +107,7 @@ export class PreAggregationDuckDbClient {
 
     private readonly prometheusMetrics?: PrometheusMetrics;
 
-    private cachedWarehouseClient: WarehouseClient | null = null;
+    private cachedWarehouseClients = new Map<string, WarehouseClient>();
 
     constructor(args: PreAggregationDuckDbClientArgs) {
         this.lightdashConfig = args.lightdashConfig;
@@ -125,25 +131,31 @@ export class PreAggregationDuckDbClient {
                 ));
     }
 
-    private getOrCreateWarehouseClient(): WarehouseClient {
-        if (!this.cachedWarehouseClient) {
+    private getOrCreateWarehouseClient(scope?: string): WarehouseClient {
+        const cacheKey = scope ?? 'legacy-global';
+        const cachedWarehouseClient = this.cachedWarehouseClients.get(cacheKey);
+        if (!cachedWarehouseClient) {
             const duckdbRuntimeConfig = getDuckdbRuntimeConfig(
                 this.lightdashConfig.preAggregates.s3,
+                { scope },
             );
 
             if (!duckdbRuntimeConfig) {
                 throw new Error('Missing DuckDB runtime config');
             }
 
-            this.cachedWarehouseClient = this.createDuckdbWarehouseClient({
+            const warehouseClient = this.createDuckdbWarehouseClient({
                 s3Config: duckdbRuntimeConfig,
                 sharedResourceLimits: this.sharedResourceLimits,
-                instanceCacheKey: PRE_AGGREGATE_QUERY_INSTANCE_CACHE_KEY,
+                instanceCacheKey: scope
+                    ? `${PRE_AGGREGATE_QUERY_INSTANCE_CACHE_KEY}:${scope}`
+                    : PRE_AGGREGATE_QUERY_INSTANCE_CACHE_KEY,
             });
+            this.cachedWarehouseClients.set(cacheKey, warehouseClient);
 
             Logger.info('DuckDB warehouse client created and cached for reuse');
         }
-        return this.cachedWarehouseClient;
+        return this.cachedWarehouseClients.get(cacheKey)!;
     }
 
     static getPreAggregationResolutionErrorMessage({
@@ -161,6 +173,8 @@ export class PreAggregationDuckDbClient {
         switch (reason) {
             case PreAggregationDuckDbResolveReason.NO_ACTIVE_MATERIALIZATION:
                 return `No active materialization found for pre-aggregate explore "${preAggregateExploreName}"`;
+            case PreAggregationDuckDbResolveReason.INVALID_MATERIALIZATION_URI:
+                return `Pre-aggregate materialization for "${preAggregateExploreName}" is outside the allowed storage scope`;
             case PreAggregationDuckDbResolveReason.MISSING_PRE_AGGREGATE_S3_CONFIG:
                 return 'Pre-aggregate DuckDB routing is unavailable: missing S3 configuration';
             case PreAggregationDuckDbResolveReason.MISSING_DUCKDB_RUNTIME_CONFIG:
@@ -177,8 +191,8 @@ export class PreAggregationDuckDbClient {
         }
     }
 
-    createExecutionWarehouseClient(): WarehouseClient {
-        return this.getOrCreateWarehouseClient();
+    createExecutionWarehouseClient(scope?: string): WarehouseClient {
+        return this.getOrCreateWarehouseClient(scope);
     }
 
     async resolve(
@@ -274,6 +288,30 @@ export class PreAggregationDuckDbClient {
             return {
                 resolved: false,
                 reason: PreAggregationDuckDbResolveReason.NO_ACTIVE_MATERIALIZATION,
+            };
+        }
+
+        const { bucket } = preAggregateS3Config;
+        const expectedScope = getPreAggregateStorageScope({
+            bucket,
+            organizationUuid: args.organizationUuid,
+            projectUuid: args.projectUuid,
+        });
+        const activeUriIsScoped = isPreAggregateUriInScope({
+            uri: activeMaterialization.materializationUri,
+            bucket,
+            organizationUuid: args.organizationUuid,
+            projectUuid: args.projectUuid,
+        });
+        const isScopedPreAggregateUri =
+            activeMaterialization.materializationUri.includes(
+                '/pre-aggregates/',
+            );
+
+        if (isScopedPreAggregateUri && !activeUriIsScoped) {
+            return {
+                resolved: false,
+                reason: PreAggregationDuckDbResolveReason.INVALID_MATERIALIZATION_URI,
             };
         }
 
@@ -385,7 +423,9 @@ export class PreAggregationDuckDbClient {
             });
         }
 
-        const warehouseClient = this.getOrCreateWarehouseClient();
+        const warehouseClient = this.getOrCreateWarehouseClient(
+            activeUriIsScoped ? expectedScope : undefined,
+        );
 
         return {
             resolved: true,

--- a/packages/backend/src/ee/services/AsyncQueryService/getDuckdbRuntimeConfig.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/getDuckdbRuntimeConfig.ts
@@ -7,7 +7,49 @@ export type DuckdbRuntimeConfig = {
     secretKey?: string;
     forcePathStyle: boolean;
     useSsl: boolean;
+    scope?: string;
 };
+
+export const getPreAggregateStoragePrefix = ({
+    organizationUuid,
+    projectUuid,
+}: {
+    organizationUuid: string;
+    projectUuid: string;
+}): string => `pre-aggregates/${organizationUuid}/${projectUuid}/`;
+
+export const getPreAggregateStorageScope = ({
+    bucket,
+    organizationUuid,
+    projectUuid,
+}: {
+    bucket: string;
+    organizationUuid: string;
+    projectUuid: string;
+}): string =>
+    `s3://${bucket}/${getPreAggregateStoragePrefix({
+        organizationUuid,
+        projectUuid,
+    })}`;
+
+export const isPreAggregateUriInScope = ({
+    uri,
+    bucket,
+    organizationUuid,
+    projectUuid,
+}: {
+    uri: string;
+    bucket: string;
+    organizationUuid: string;
+    projectUuid: string;
+}): boolean =>
+    uri.startsWith(
+        getPreAggregateStorageScope({
+            bucket,
+            organizationUuid,
+            projectUuid,
+        }),
+    );
 
 const parseDuckdbS3Endpoint = (
     endpoint: string,
@@ -37,6 +79,9 @@ const parseDuckdbS3Endpoint = (
 
 export const getDuckdbRuntimeConfig = (
     s3Config: LightdashConfig['preAggregates']['s3'],
+    options?: {
+        scope?: string;
+    },
 ): DuckdbRuntimeConfig | undefined => {
     if (!s3Config) {
         return undefined;
@@ -51,5 +96,6 @@ export const getDuckdbRuntimeConfig = (
         secretKey: s3Config.secretKey,
         forcePathStyle: s3Config.forcePathStyle === true,
         useSsl,
+        scope: options?.scope,
     };
 };

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -26,6 +26,7 @@ import type { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import type { FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import type { INatsClient } from '../../clients/NatsClient';
+import { createLocalParquetUploadStream } from '../../clients/ResultsFileStorageClients/LocalParquetUploadStream';
 import type { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { LightdashConfig } from '../../config/parseConfig';
@@ -126,6 +127,16 @@ jest.mock('@lightdash/warehouses', () => ({
     ...jest.requireActual('@lightdash/warehouses'),
     SshTunnel: jest.fn(() => mockSshTunnel),
 }));
+
+jest.mock(
+    '../../clients/ResultsFileStorageClients/LocalParquetUploadStream',
+    () => ({
+        createLocalParquetUploadStream: jest.fn(() => ({
+            write: jest.fn(),
+            close: jest.fn(),
+        })),
+    }),
+);
 
 const projectModel = {
     getWithSensitiveFields: jest.fn(async () => projectWithSensitiveFields),
@@ -2091,6 +2102,75 @@ describe('AsyncQueryService', () => {
                 }),
             );
         });
+
+        test('scopes pre-aggregate materialization result files by org and project', async () => {
+            const mockProjectModel = {
+                ...projectModel,
+                getWarehouseCredentialsForProject: jest.fn(() =>
+                    Promise.resolve(warehouseClientMock.credentials),
+                ),
+                getWarehouseClientFromCredentials: jest.fn(() => ({
+                    ...warehouseClientMock,
+                    runQuery: jest.fn(async () => resultsWith1Row),
+                })),
+            };
+
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                projectModel: mockProjectModel as unknown as ProjectModel,
+            });
+            const mockStorageClient =
+                service.resultsStorageClient as unknown as {
+                    createUploadStream: jest.Mock;
+                };
+            mockStorageClient.createUploadStream = jest.fn(() => ({
+                write: jest.fn(),
+                close: jest.fn(),
+            }));
+            service.queryHistoryModel.update = jest.fn();
+
+            await service.runAsyncWarehouseQuery({
+                userUuid: sessionAccount.user.id,
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                isRegisteredUser: true,
+                projectUuid,
+                query: 'SELECT * FROM test_table',
+                fieldsMap: {},
+                queryTags: {
+                    query_context:
+                        QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION,
+                },
+                warehouseCredentialsOverrides: undefined,
+                queryUuid: 'test-query-uuid',
+                cacheKey: 'test-cache-key',
+                pivotConfiguration: undefined,
+                originalColumns: undefined,
+                queryCreatedAt: new Date(),
+                displayTimezone: null,
+            });
+
+            expect(mockStorageClient.createUploadStream).toHaveBeenCalledWith(
+                expect.stringMatching(
+                    new RegExp(
+                        `^pre-aggregates/${sessionAccount.organization.organizationUuid}/${projectUuid}/.*\\.jsonl$`,
+                    ),
+                ),
+                expect.objectContaining({
+                    contentType: 'application/jsonl',
+                }),
+            );
+            expect(service.queryHistoryModel.update).toHaveBeenCalledWith(
+                'test-query-uuid',
+                projectUuid,
+                expect.objectContaining({
+                    results_file_name: expect.stringMatching(
+                        new RegExp(
+                            `^pre-aggregates/${sessionAccount.organization.organizationUuid}/${projectUuid}/`,
+                        ),
+                    ),
+                }),
+                expect.any(Object),
+            );
+        });
     });
 
     describe('runAsyncWarehouseQuery', () => {
@@ -2310,6 +2390,64 @@ describe('AsyncQueryService', () => {
                     results_file_name: expect.any(String),
                 }),
                 expect.any(Object), // session account
+            );
+        });
+
+        test('scopes DuckDB S3 access for parquet pre-aggregate materialization uploads', async () => {
+            const mockProjectModel = {
+                ...projectModel,
+                getWarehouseCredentialsForProject: jest.fn(() =>
+                    Promise.resolve(warehouseClientMock.credentials),
+                ),
+                getWarehouseClientFromCredentials: jest.fn(() => ({
+                    ...warehouseClientMock,
+                    runQuery: jest.fn(async () => resultsWith1Row),
+                })),
+            };
+
+            const service = getMockedAsyncQueryService(
+                {
+                    ...lightdashConfigMock,
+                    preAggregates: {
+                        ...lightdashConfigMock.preAggregates,
+                        parquetEnabled: true,
+                    },
+                },
+                {
+                    projectModel: mockProjectModel as unknown as ProjectModel,
+                },
+            );
+            service.queryHistoryModel.update = jest.fn();
+
+            await service.runAsyncWarehouseQuery({
+                userUuid: sessionAccount.user.id,
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                isRegisteredUser: true,
+                projectUuid,
+                query: 'SELECT * FROM test_table',
+                fieldsMap: {},
+                queryTags: {
+                    query_context:
+                        QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION,
+                },
+                warehouseCredentialsOverrides: undefined,
+                queryUuid: 'test-query-uuid',
+                cacheKey: 'test-cache-key',
+                pivotConfiguration: undefined,
+                originalColumns: undefined,
+                queryCreatedAt: new Date(),
+                displayTimezone: null,
+            });
+
+            expect(createLocalParquetUploadStream).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    parquetS3Uri: expect.stringMatching(
+                        /^s3:\/\/mock_preagg_bucket\/pre-aggregates\/organizationUuid\/project uuid\/.+\.parquet$/,
+                    ),
+                    s3Config: expect.objectContaining({
+                        scope: 's3://mock_preagg_bucket/pre-aggregates/organizationUuid/project uuid/',
+                    }),
+                }),
             );
         });
     });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -122,7 +122,11 @@ import { type FileStorageClient } from '../../clients/FileStorage/FileStorageCli
 import type { INatsClient } from '../../clients/NatsClient';
 import { createLocalParquetUploadStream } from '../../clients/ResultsFileStorageClients/LocalParquetUploadStream';
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
-import { getDuckdbRuntimeConfig } from '../../ee/services/AsyncQueryService/getDuckdbRuntimeConfig';
+import {
+    getDuckdbRuntimeConfig,
+    getPreAggregateStoragePrefix,
+    getPreAggregateStorageScope,
+} from '../../ee/services/AsyncQueryService/getDuckdbRuntimeConfig';
 import Logger from '../../logging/logger';
 import { measureTime } from '../../logging/measureTime';
 import { getSchedulerContext } from '../../logging/winston';
@@ -1964,6 +1968,7 @@ export class AsyncQueryService extends ProjectService {
     }
 
     private async resolveAsyncQueryExecutionPlan({
+        organizationUuid,
         projectUuid,
         warehouseQuery,
         metricQuery,
@@ -1980,6 +1985,7 @@ export class AsyncQueryService extends ProjectService {
         queryUuid,
         useTimezoneAwareDateTrunc,
     }: {
+        organizationUuid: string;
         projectUuid: string;
         warehouseQuery: string;
         metricQuery: MetricQuery;
@@ -2005,6 +2011,7 @@ export class AsyncQueryService extends ProjectService {
         }
 
         const resolution = await this.preAggregateStrategy.resolveExecution({
+            organizationUuid,
             projectUuid,
             queryUuid,
             warehouseQuery,
@@ -2074,8 +2081,33 @@ export class AsyncQueryService extends ProjectService {
         displayTimezone,
     }: RunAsyncPreAggregateQueryArgs) {
         try {
+            const preAggregateBucket =
+                this.lightdashConfig.preAggregates.s3?.bucket;
+            const expectedScope = preAggregateBucket
+                ? getPreAggregateStorageScope({
+                      bucket: preAggregateBucket,
+                      organizationUuid,
+                      projectUuid,
+                  })
+                : undefined;
+            const referencesPreAggregateScopedStorage =
+                preAggregateQuery.includes('/pre-aggregates/');
+
+            if (
+                referencesPreAggregateScopedStorage &&
+                (!expectedScope || !preAggregateQuery.includes(expectedScope))
+            ) {
+                throw new ForbiddenError(
+                    'Pre-aggregate query references storage outside the allowed scope',
+                );
+            }
+
             const duckDbWarehouseClient =
-                this.preAggregateStrategy.createExecutionWarehouseClient();
+                this.preAggregateStrategy.createExecutionWarehouseClient(
+                    referencesPreAggregateScopedStorage
+                        ? expectedScope
+                        : undefined,
+                );
 
             await this.runAsyncWarehouseQuery({
                 userUuid,
@@ -2342,21 +2374,38 @@ export class AsyncQueryService extends ProjectService {
                 queryTags.query_context ===
                     QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION;
 
-            const fileName = QueryHistoryModel.createUniqueResultsFileName(
+            const baseFileName = QueryHistoryModel.createUniqueResultsFileName(
                 cacheKey,
                 {
                     sqlSafe: isParquetMaterialization,
                 },
             );
+            const isPreAggregateMaterialization =
+                queryTags.query_context ===
+                QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION;
+            const fileName = isPreAggregateMaterialization
+                ? `${getPreAggregateStoragePrefix({
+                      organizationUuid,
+                      projectUuid,
+                  })}${baseFileName}`
+                : baseFileName;
             const resultsStorageClient = this.getResultsStorageClientForContext(
                 queryTags.query_context,
             );
 
             if (isParquetMaterialization) {
+                const bucket = this.lightdashConfig.preAggregates.s3?.bucket;
+                const scope = bucket
+                    ? getPreAggregateStorageScope({
+                          bucket,
+                          organizationUuid,
+                          projectUuid,
+                      })
+                    : undefined;
                 const s3Config = getDuckdbRuntimeConfig(
                     this.lightdashConfig.preAggregates.s3,
+                    { scope },
                 );
-                const bucket = this.lightdashConfig.preAggregates.s3?.bucket;
                 if (!s3Config || !bucket) {
                     throw new Error(
                         'Missing S3 configuration for stream-to-parquet',
@@ -3485,6 +3534,7 @@ export class AsyncQueryService extends ProjectService {
                     const resolveStart = Date.now();
                     const executionPlan =
                         await this.resolveAsyncQueryExecutionPlan({
+                            organizationUuid,
                             projectUuid,
                             warehouseQuery: query,
                             metricQuery,

--- a/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -51,6 +51,7 @@ export interface PreAggregateStrategy {
     }): PreAggregationRoutingDecision;
 
     resolveExecution(params: {
+        organizationUuid: string;
         projectUuid: string;
         queryUuid: string;
         warehouseQuery: string;
@@ -58,7 +59,7 @@ export interface PreAggregateStrategy {
         resolveArgs: ResolveExecutionArgs;
     }): Promise<PreAggregateExecutionResolution>;
 
-    createExecutionWarehouseClient(): WarehouseClient;
+    createExecutionWarehouseClient(scope?: string): WarehouseClient;
 
     recordStats(params: {
         projectUuid: string;

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -411,6 +411,40 @@ describe('DuckdbWarehouseClient', () => {
         expect(secretSql).toContain('USE_SSL false');
     });
 
+    it('should scope DuckDB S3 secrets when configured', async () => {
+        const runMock = jest.fn();
+        const streamMock = jest.fn(async () =>
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(streamMock, runMock),
+        );
+
+        const client = DuckdbWarehouseClient.createForPreAggregate({
+            type: 'duckdb_s3',
+            s3Config: {
+                endpoint: 'localhost:9000',
+                region: 'us-east-1',
+                forcePathStyle: true,
+                useSsl: false,
+                scope: 's3://preagg-bucket/pre-aggregates/org-1/project-1/',
+            },
+        });
+
+        await client.runQuery('SELECT 1 AS val');
+
+        const secretSql = runMock.mock.calls
+            .map(([sql]) => sql as string)
+            .find((sql) =>
+                sql.includes('CREATE OR REPLACE SECRET __lightdash_s3'),
+            );
+
+        expect(secretSql).toContain(
+            "SCOPE 's3://preagg-bucket/pre-aggregates/org-1/project-1/'",
+        );
+    });
+
     it('should treat instanceCacheKey as the shared instance identity', async () => {
         const runMock = jest.fn();
         const streamMock = jest.fn(async () =>

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -91,6 +91,7 @@ export type DuckdbS3SessionConfig = {
     secretKey?: string;
     forcePathStyle: boolean;
     useSsl: boolean;
+    scope?: string;
 };
 
 export type DuckdbResourceLimits = {
@@ -921,9 +922,13 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         const secretClause = s3Config.secretKey
             ? `SECRET '${escape(s3Config.secretKey)}',`
             : '';
+        const scopeClause = s3Config.scope
+            ? `SCOPE '${escape(s3Config.scope)}',`
+            : '';
 
         return `CREATE OR REPLACE SECRET __lightdash_s3 (
             TYPE s3,
+            ${scopeClause}
             ${providerClause}
             ${keyIdClause}
             ${secretClause}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8068/fix-s3-leak-on-pre-aggregates

  - Materializations are stored under pre-aggregates/<orgUuid>/<projectUuid>/.
  - DuckDB S3 secrets use SCOPE.
  - Active materialization URIs outside the current org/project scope are rejected.
  - Worker-side scoped-storage references are checked before execution.
  - Tests cover backend routing, materialization prefixing, URI rejection, and DuckDB SCOPE.
  - I also validated it live: scoped DuckDB could read the valid object, could not read a copied fake cross-org object, while unscoped DuckDB could
    read that same fake object.

### Description:

Adds org/project-scoped S3 access controls for pre-aggregate materialization files. Pre-aggregate result files are now stored under a `pre-aggregates/{organizationUuid}/{projectUuid}/` path prefix, and DuckDB S3 secrets are configured with a matching `SCOPE` clause to restrict access to only that path.

When resolving a pre-aggregate query, the materialization URI is validated to ensure it falls within the expected org/project scope. If a scoped URI is detected that belongs to a different org or project, resolution is rejected with an `INVALID_MATERIALIZATION_URI` reason rather than allowing cross-tenant data access.

DuckDB warehouse clients are now cached per scope (rather than as a single global instance), so scoped and unscoped clients can coexist without interfering with each other.