### PR TITLE
fix(ai-agent): keep categorical filters when querying non-contiguous date ranges

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/tests/testCases.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/testCases.ts
@@ -220,6 +220,25 @@ export const testCases: TestCase[] = [
             `The response did NOT use limit+sort to approximate the time window`,
         ].join('\n'),
     },
+    {
+        // IMPORTANT: regression test for #23766 — a categorical filter must NOT be
+        // dropped when combined with non-contiguous date periods. Previously the agent
+        // OR'd the whole dimension group, making the categorical filter optional.
+        name: 'should keep categorical filter when combined with non-contiguous date periods',
+        prompt: 'Total order amount for completed orders in either March or May 2024',
+        expectedAnswer: [
+            `Response contains total order amount for completed orders in March and May 2024`,
+            `explore: orders`,
+            `metric: total order amount`,
+            `filters: order date in March 2024 or May 2024 AND status equals completed`,
+        ].join('\n'),
+        expectedToolOutcome: [
+            `The response added a date filter selecting March 2024 and May 2024 (e.g. an equals rule on a month-grain date field with both month values, or two inBetween ranges)`,
+            `The response added a dimension filter for status with value ["completed"]`,
+            `Crucially, the status (categorical) filter MUST be present — it must NOT be dropped`,
+            `The status filter must be combined with the date selection under AND, so completed status applies to both March and May (not OR'd across the whole group, which would make status optional)`,
+        ].join('\n'),
+    },
 ];
 
 type Context = {

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -54,7 +54,8 @@ If the user mentions any time window ("last 3 months", "this quarter", "past yea
 
 - Use \`inThePast\` for relative windows, \`inBetween\` for explicit ranges.
 - Date fields from joined tables work identically to base-table date fields in filters. Prefer filtering on a joined-table date over no filter at all.
-- Comparing two non-contiguous ranges (e.g. "Mar 1–6 vs Apr 1–6"): set filters type to \`or\` and add one \`inBetween\` entry per range on the same date fieldId. A single date can't satisfy both ranges under AND.
+- Selecting or comparing multiple non-contiguous periods (e.g. "Mar or May 2025"): prefer a single \`equals\` rule on the date field at the requested granularity with one value per period (e.g. a month-grain field with values \`2025-03-01\` and \`2025-05-01\`). This keeps every filter under AND.
+- Never set the dimension filter \`type\` to \`or\` when the query also has a categorical (or any non-date) filter. \`or\` applies across all dimension filters in the group, so the categorical filter becomes optional and is silently dropped. Only use \`type: or\` with one \`inBetween\` per range when the date ranges are the sole dimension filter and no granularity-aligned \`equals\` rule fits (e.g. arbitrary day ranges like "Mar 1–6 vs Apr 1–6").
 - Use \`limit\` only for explicit "top N" / "show me 10 rows" requests, never to approximate a time window.
 
 ## Table calculations (when to reach for them)


### PR DESCRIPTION
## Closes #23766

### Problem
When the AI agent is asked for data across two non-contiguous time periods combined with a categorical filter, the categorical filter is silently dropped. The date filters apply correctly but the categorical condition is absent.

E.g. "How many demos were held in 2025 either Mar or May" returns only the two monthly date filters — the `activity_type = demo` filter is missing. The single-period equivalents ("demos in Mar 2025") keep both filters.

### Root cause
`packages/backend/src/ee/services/ai/prompts/systemV2Template.ts` instructed the agent to set the dimension filter group `type` to `or` for non-contiguous date ranges. The AI filter schema (`filtersSchemaV2`) is **flat** — a single `type: 'and' | 'or'` governs the entire `dimensions` array — so `or` makes *every* dimension filter optional, including any categorical filter in the same group.

### Fix (prompt-only)
Rewrite the time-filtering guidance:
- Prefer a single `equals` rule on the date field at the requested granularity with one value per period (e.g. a month-grain field with values `2025-03-01` and `2025-05-01`). This keeps the whole group under AND, so the categorical filter survives.
- Never set the dimension group `type` to `or` when a non-date filter is present. The `or` + `inBetween`-per-range escape hatch is retained only for date-only queries with arbitrary ranges.

No schema change. The query engine already supports the AND-combined result.

### Out of scope
Arbitrary non-aligned day ranges combined with a categorical filter (e.g. "Mar 1–6 vs Apr 1–6 demos") still can't be expressed in the flat schema — that needs nested filter-group support in the AI tool schema, which is a larger follow-up.

### Tests
Added a regression eval case in `testCases.ts` asserting the status filter is kept (under AND) when combined with non-contiguous date periods (March or May 2024).

🤖 Generated with [Claude Code](https://claude.com/claude-code)