### PR TITLE
fix(apps): stop data app pages auto-scrolling under NavBar banner

### DIFF
--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -3,6 +3,14 @@
     overflow: hidden;
 }
 
+/* A fixed NavBar banner (preview / impersonation) reserves an extra 35px at
+   the top, so shrink to fit when one is present — otherwise the page overflows
+   the viewport and can be scrolled. Mirrors dashboardTabs/tabs.module.css. */
+:global(body:has(#preview-banner)) .layout,
+:global(body:has(#impersonation-banner)) .layout {
+    height: calc(100vh - 50px - 35px);
+}
+
 /* Hard pixel floor for the chat panel — react-resizable-panels' minSize is
    a percent of the group width, so on wide viewports a low percent still
    produces a sidebar too narrow for the prompt UI to render legibly.

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -503,7 +503,7 @@ const AppGenerate: FC = () => {
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const { user } = useApp();
     const ability = useAbilityContext();
-    const messagesEndRef = useRef<HTMLDivElement>(null);
+    const chatMessagesRef = useRef<HTMLDivElement>(null);
 
     // Fetch version history (polling is handled by the Web Worker below)
     const {
@@ -937,7 +937,11 @@ const AppGenerate: FC = () => {
     }, [persistLogs, interruptInFlightQueries, clearQueries]);
 
     const scrollToBottom = useCallback(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+        // Scroll the chat container itself rather than calling scrollIntoView
+        // on a child — scrollIntoView also scrolls outer ancestors (incl. the
+        // window), which pulls the navbar/preview banner out of view.
+        const el = chatMessagesRef.current;
+        el?.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
     }, []);
 
     useEffect(() => {
@@ -1464,7 +1468,10 @@ const AppGenerate: FC = () => {
                     className={classes.chatPanelOuter}
                 >
                     <Box className={classes.chatPanel}>
-                        <Box className={classes.chatMessages}>
+                        <Box
+                            ref={chatMessagesRef}
+                            className={classes.chatMessages}
+                        >
                             {hasUnloadedEarlierVersions && (
                                 <Group
                                     gap="xs"
@@ -1936,7 +1943,6 @@ const AppGenerate: FC = () => {
                                     )}
                                 </>
                             )}
-                            <Box ref={messagesEndRef} />
                         </Box>
 
                         {/* Chat Input */}

--- a/packages/frontend/src/pages/AppPreviewTest.module.css
+++ b/packages/frontend/src/pages/AppPreviewTest.module.css
@@ -4,6 +4,14 @@
     width: 100%;
 }
 
+/* A fixed NavBar banner (preview / impersonation) reserves an extra 35px at
+   the top, so shrink to fit when one is present — otherwise the page overflows
+   the viewport and can be scrolled. Mirrors dashboardTabs/tabs.module.css. */
+:global(body:has(#preview-banner)) .previewContainer,
+:global(body:has(#impersonation-banner)) .previewContainer {
+    height: calc(100vh - 50px - 35px);
+}
+
 .menuOverlay {
     position: absolute;
     top: var(--mantine-spacing-sm);


### PR DESCRIPTION
### Description:
The chat auto-scroll used scrollIntoView, which scrolls every scrollable ancestor including the window. A NavBar banner (preview / impersonation) reserves an extra 35px, so the data app layout (sized 100vh - 50px) overflowed the viewport and scrollIntoView kept dragging the page down, hiding the navbar/banner.

Scroll the chat container directly instead, and shrink the data app layouts by the banner height when a banner is present (matching the existing dashboardTabs convention) so the page no longer overflows.
