### PR TITLE
feat: gate pre-aggregates behind `PreAggregates` commercial feature flag with per-org DB override support

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from '@lightdash/common';
+import { CommercialFeatureFlags, ForbiddenError } from '@lightdash/common';
 import express, { Express } from 'express';
 import { AppArguments } from '../App';
 import { lightdashConfig } from '../config/lightdashConfig';
@@ -431,6 +431,20 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                                     models.getPreAggregateModel(),
                                 projectModel: models.getProjectModel(),
                                 prometheusMetrics,
+                                isPreAggregatesEnabled: async ({
+                                    organizationUuid,
+                                }) =>
+                                    (
+                                        await models.getFeatureFlagModel().get({
+                                            featureFlagId:
+                                                CommercialFeatureFlags.PreAggregates,
+                                            user: {
+                                                organizationUuid,
+                                                organizationName: '',
+                                                userUuid: '',
+                                            },
+                                        })
+                                    ).enabled,
                                 sharedResourceLimits: context.lightdashConfig
                                     .preAggregates.duckdbQueryMemoryLimit
                                     ? {
@@ -445,8 +459,18 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                             models.getPreAggregateDailyStatsModel(),
                         preAggregateResultsStorageClient:
                             clients.getPreAggregateResultsFileStorageClient(),
-                        isEnabled: () =>
-                            context.lightdashConfig.preAggregates.enabled,
+                        isEnabled: async ({ organizationUuid }) =>
+                            (
+                                await models.getFeatureFlagModel().get({
+                                    featureFlagId:
+                                        CommercialFeatureFlags.PreAggregates,
+                                    user: {
+                                        organizationUuid,
+                                        organizationName: '',
+                                        userUuid: '',
+                                    },
+                                })
+                            ).enabled,
                         dashboardModel: models.getDashboardModel(),
                         savedChartModel: models.getSavedChartModel(),
                         projectService: repository.getProjectService(),
@@ -522,11 +546,16 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectModel: models.getProjectModel(),
                     projectService: repository.getProjectService(),
                     schedulerClient: clients.getSchedulerClient(),
-                    exploreEnhancer: (explores) =>
+                    exploreEnhancer: async (explores, flagContext) =>
                         enhanceExploresForPreAggregates({
                             explores,
-                            enabled:
-                                context.lightdashConfig.preAggregates.enabled,
+                            enabled: (
+                                await models.getFeatureFlagModel().get({
+                                    featureFlagId:
+                                        CommercialFeatureFlags.PreAggregates,
+                                    user: flagContext,
+                                })
+                            ).enabled,
                         }),
                 }),
         },

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
@@ -1,0 +1,151 @@
+import { CommercialFeatureFlags } from '@lightdash/common';
+import { Knex } from 'knex';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import {
+    DbFeatureFlag,
+    DbFeatureFlagOverride,
+    FeatureFlagOverridesTableName,
+    FeatureFlagsTableName,
+} from '../../database/entities/featureFlags';
+import { CommercialFeatureFlagModel } from './CommercialFeatureFlagModel';
+
+type FakeRows = {
+    flag?: Partial<DbFeatureFlag>;
+    orgOverride?: Partial<DbFeatureFlagOverride>;
+};
+
+const buildFakeDatabase = (rows: FakeRows): Knex => {
+    const makeBuilder = (table: string) => {
+        const filters = new Set<string>();
+        const builder = {
+            where(column: string) {
+                filters.add(column);
+                return builder;
+            },
+            whereNull(column: string) {
+                filters.add(`${column}:null`);
+                return builder;
+            },
+            first() {
+                if (table === FeatureFlagsTableName) {
+                    return Promise.resolve(rows.flag);
+                }
+                if (
+                    table === FeatureFlagOverridesTableName &&
+                    filters.has('organization_uuid') &&
+                    filters.has('user_uuid:null')
+                ) {
+                    return Promise.resolve(rows.orgOverride);
+                }
+                return Promise.resolve(undefined);
+            },
+        };
+        return builder;
+    };
+    return ((table: string) => makeBuilder(table)) as unknown as Knex;
+};
+
+const buildModel = ({
+    database,
+    preAggregatesEnabled,
+}: {
+    database: Knex;
+    preAggregatesEnabled: boolean;
+}) =>
+    new CommercialFeatureFlagModel({
+        database,
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            enabledFeatureFlags: new Set<string>(),
+            disabledFeatureFlags: new Set<string>(),
+            preAggregates: {
+                ...lightdashConfigMock.preAggregates,
+                enabled: preAggregatesEnabled,
+            },
+        },
+    });
+
+const user = {
+    userUuid: '',
+    organizationUuid: 'org-uuid',
+    organizationName: 'Org',
+};
+
+describe('CommercialFeatureFlagModel', () => {
+    describe('PreAggregates', () => {
+        it('falls back to the env-derived config when no DB flag exists', async () => {
+            const model = buildModel({
+                database: buildFakeDatabase({}),
+                preAggregatesEnabled: true,
+            });
+
+            await expect(
+                model.get({
+                    featureFlagId: CommercialFeatureFlags.PreAggregates,
+                    user,
+                }),
+            ).resolves.toEqual({
+                id: CommercialFeatureFlags.PreAggregates,
+                enabled: true,
+            });
+        });
+
+        it('falls back to the env-derived config when DB default is null', async () => {
+            const model = buildModel({
+                database: buildFakeDatabase({
+                    flag: { default_enabled: null },
+                }),
+                preAggregatesEnabled: false,
+            });
+
+            await expect(
+                model.get({
+                    featureFlagId: CommercialFeatureFlags.PreAggregates,
+                    user,
+                }),
+            ).resolves.toEqual({
+                id: CommercialFeatureFlags.PreAggregates,
+                enabled: false,
+            });
+        });
+
+        it('uses the DB default when present', async () => {
+            const model = buildModel({
+                database: buildFakeDatabase({
+                    flag: { default_enabled: false },
+                }),
+                preAggregatesEnabled: true,
+            });
+
+            await expect(
+                model.get({
+                    featureFlagId: CommercialFeatureFlags.PreAggregates,
+                    user,
+                }),
+            ).resolves.toEqual({
+                id: CommercialFeatureFlags.PreAggregates,
+                enabled: false,
+            });
+        });
+
+        it('uses the org override before the DB default', async () => {
+            const model = buildModel({
+                database: buildFakeDatabase({
+                    flag: { default_enabled: false },
+                    orgOverride: { enabled: true },
+                }),
+                preAggregatesEnabled: false,
+            });
+
+            await expect(
+                model.get({
+                    featureFlagId: CommercialFeatureFlags.PreAggregates,
+                    user,
+                }),
+            ).resolves.toEqual({
+                id: CommercialFeatureFlags.PreAggregates,
+                enabled: true,
+            });
+        });
+    });
+});

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -14,6 +14,8 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             // Add new commercial handlers
             [CommercialFeatureFlags.AiCopilot]:
                 this.getAiCopilotFlag.bind(this),
+            [CommercialFeatureFlags.PreAggregates]:
+                this.getPreAggregatesFlag.bind(this),
         };
     }
 
@@ -39,5 +41,14 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
 
         const dbResult = await this.tryGetFromDatabase({ user, featureFlagId });
         return dbResult ?? { id: featureFlagId, enabled: false };
+    }
+
+    private async getPreAggregatesFlag(
+        args: FeatureFlagLogicArgs,
+    ): Promise<{ id: string; enabled: boolean }> {
+        return this.getWithEnvFallback(
+            args,
+            this.lightdashConfig.preAggregates.enabled,
+        );
     }
 }

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -50,7 +50,7 @@ type EePreAggregateStrategyArgs = {
     preAggregationDuckDbClient: PreAggregationDuckDbClient;
     preAggregateDailyStatsModel: PreAggregateDailyStatsModel;
     preAggregateResultsStorageClient: S3ResultsFileStorageClient;
-    isEnabled: () => boolean;
+    isEnabled: (args: { organizationUuid: string }) => Promise<boolean>;
     dashboardModel: Pick<DashboardModel, 'getByIdOrSlug'>;
     savedChartModel: Pick<SavedChartModel, 'get'>;
     projectService: Pick<ProjectService, 'getExplore'>;
@@ -63,7 +63,9 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
 
     private readonly resultsStorageClient: S3ResultsFileStorageClient;
 
-    private readonly isEnabled: () => boolean;
+    private readonly isEnabled: (args: {
+        organizationUuid: string;
+    }) => Promise<boolean>;
 
     private readonly dashboardModel: Pick<DashboardModel, 'getByIdOrSlug'>;
 
@@ -81,16 +83,18 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
         this.projectService = args.projectService;
     }
 
-    getRoutingDecision({
+    async getRoutingDecision({
+        organizationUuid,
         metricQuery,
         explore,
         context,
     }: {
+        organizationUuid: string;
         metricQuery: MetricQuery;
         explore: Explore;
         context: QueryExecutionContext;
-    }): PreAggregationRoutingDecision {
-        if (!this.isEnabled()) {
+    }): Promise<PreAggregationRoutingDecision> {
+        if (!(await this.isEnabled({ organizationUuid }))) {
             return { target: 'warehouse' };
         }
 

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
@@ -54,6 +54,9 @@ describe('PreAggregationDuckDbClient', () => {
         const createDuckdbWarehouseClient = jest
             .fn()
             .mockReturnValue(warehouseClientMock as unknown as WarehouseClient);
+        const isPreAggregatesEnabled = jest
+            .fn()
+            .mockResolvedValue(resolvedLightdashConfig.preAggregates.enabled);
 
         const client = new PreAggregationDuckDbClient({
             lightdashConfig: resolvedLightdashConfig,
@@ -68,6 +71,7 @@ describe('PreAggregationDuckDbClient', () => {
                               .duckdbQueryMemoryLimit,
                   }
                 : undefined,
+            isPreAggregatesEnabled,
             createDuckdbWarehouseClient,
         });
 
@@ -76,6 +80,7 @@ describe('PreAggregationDuckDbClient', () => {
             preAggregateModel,
             projectModel,
             createDuckdbWarehouseClient,
+            isPreAggregatesEnabled,
         };
     };
 

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -49,6 +49,9 @@ type PreAggregationDuckDbClientArgs = {
     projectModel: Pick<ProjectModel, 'getExploreFromCache'>;
     prometheusMetrics?: PrometheusMetrics;
     sharedResourceLimits?: DuckdbResourceLimits;
+    isPreAggregatesEnabled: (args: {
+        organizationUuid: string;
+    }) => Promise<boolean>;
     createDuckdbWarehouseClient?: (args: {
         s3Config: DuckdbS3SessionConfig;
         sharedResourceLimits?: DuckdbResourceLimits;
@@ -107,6 +110,10 @@ export class PreAggregationDuckDbClient {
 
     private readonly prometheusMetrics?: PrometheusMetrics;
 
+    private readonly isPreAggregatesEnabled: (args: {
+        organizationUuid: string;
+    }) => Promise<boolean>;
+
     private cachedWarehouseClients = new Map<string, WarehouseClient>();
 
     constructor(args: PreAggregationDuckDbClientArgs) {
@@ -115,6 +122,7 @@ export class PreAggregationDuckDbClient {
         this.projectModel = args.projectModel;
         this.prometheusMetrics = args.prometheusMetrics;
         this.sharedResourceLimits = args.sharedResourceLimits;
+        this.isPreAggregatesEnabled = args.isPreAggregatesEnabled;
         this.createDuckdbWarehouseClient =
             args.createDuckdbWarehouseClient ??
             ((warehouseArgs) =>
@@ -239,7 +247,11 @@ export class PreAggregationDuckDbClient {
     private async _resolve(
         args: ResolvePreAggregationDuckDbArgs,
     ): Promise<PreAggregationDuckDbResolution> {
-        if (!this.lightdashConfig.preAggregates.enabled) {
+        if (
+            !(await this.isPreAggregatesEnabled({
+                organizationUuid: args.organizationUuid,
+            }))
+        ) {
             return {
                 resolved: false,
                 reason: PreAggregationDuckDbResolveReason.PRE_AGGREGATES_DISABLED,

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -106,7 +106,7 @@ export class FeatureFlagModel {
     // DB value (user override → org override → flag default) wins. Falls
     // back to the env-derived value when the flag has no DB row and no
     // override applies.
-    private async getWithEnvFallback(
+    protected async getWithEnvFallback(
         args: FeatureFlagLogicArgs,
         envFallback: boolean,
     ): Promise<FeatureFlag> {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1240,7 +1240,7 @@ describe('AsyncQueryService', () => {
                     resolved: true,
                     query: 'SELECT * FROM duckdb_preagg',
                 }),
-                getRoutingDecision: ({ explore }) => {
+                getRoutingDecision: async ({ explore }) => {
                     if (
                         explore.type === ExploreType.PRE_AGGREGATE &&
                         explore.preAggregateSource

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -460,21 +460,24 @@ export class AsyncQueryService extends ProjectService {
         }
     }
 
-    private getPreAggregationRoutingDecision({
+    private async getPreAggregationRoutingDecision({
+        organizationUuid,
         metricQuery,
         explore,
         context,
         forceWarehouse,
     }: {
+        organizationUuid: string;
         metricQuery: MetricQuery;
         explore: Explore;
         context: QueryExecutionContext;
         forceWarehouse: boolean;
-    }): PreAggregationRoutingDecision {
+    }): Promise<PreAggregationRoutingDecision> {
         if (forceWarehouse) {
             return { target: 'warehouse' };
         }
         return this.preAggregateStrategy.getRoutingDecision({
+            organizationUuid,
             metricQuery,
             explore,
             context,
@@ -4020,7 +4023,8 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
         };
 
-        const routingDecision = this.getPreAggregationRoutingDecision({
+        const routingDecision = await this.getPreAggregationRoutingDecision({
+            organizationUuid,
             metricQuery,
             explore,
             context,
@@ -4494,7 +4498,8 @@ export class AsyncQueryService extends ProjectService {
             columnTimezone: getColumnTimezone(warehouseCredentials),
         });
 
-        const routingDecision = this.getPreAggregationRoutingDecision({
+        const routingDecision = await this.getPreAggregationRoutingDecision({
+            organizationUuid: savedChartOrganizationUuid,
             metricQuery: metricQueryWithLimit,
             explore,
             context,
@@ -4820,7 +4825,8 @@ export class AsyncQueryService extends ProjectService {
             columnTimezone: getColumnTimezone(warehouseCredentials),
         });
 
-        const routingDecision = this.getPreAggregationRoutingDecision({
+        const routingDecision = await this.getPreAggregationRoutingDecision({
+            organizationUuid,
             metricQuery: metricQueryWithLimit,
             explore,
             context,
@@ -6114,7 +6120,8 @@ export class AsyncQueryService extends ProjectService {
             columnTimezone: getColumnTimezone(warehouseCredentials),
         });
 
-        const routingDecision = this.getPreAggregationRoutingDecision({
+        const routingDecision = await this.getPreAggregationRoutingDecision({
+            organizationUuid,
             metricQuery,
             explore,
             context,

--- a/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -45,10 +45,11 @@ export type PreAggregateStatsFilters = {
 
 export interface PreAggregateStrategy {
     getRoutingDecision(params: {
+        organizationUuid: string;
         metricQuery: MetricQuery;
         explore: Explore;
         context: QueryExecutionContext;
-    }): PreAggregationRoutingDecision;
+    }): Promise<PreAggregationRoutingDecision>;
 
     resolveExecution(params: {
         organizationUuid: string;
@@ -108,7 +109,7 @@ export type PreAggregateExecutionResolution =
 
 /* eslint-disable class-methods-use-this */
 export class NoOpPreAggregateStrategy implements PreAggregateStrategy {
-    getRoutingDecision(): PreAggregationRoutingDecision {
+    async getRoutingDecision(): Promise<PreAggregationRoutingDecision> {
         return { target: 'warehouse' };
     }
 

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -19,7 +19,12 @@ import { BaseService } from './BaseService';
 
 export type DeployExploreEnhancer = (
     explores: (Explore | ExploreError)[],
-) => (Explore | ExploreError)[];
+    context: {
+        organizationUuid: string;
+        organizationName: string;
+        userUuid: string;
+    },
+) => Promise<(Explore | ExploreError)[]>;
 
 type ProjectServiceInterface = {
     saveExploresToCacheAndIndexCatalog: (args: {
@@ -59,7 +64,7 @@ export class DeployService extends BaseService {
         this.projectModel = args.projectModel;
         this.projectService = args.projectService;
         this.schedulerClient = args.schedulerClient;
-        this.exploreEnhancer = args.exploreEnhancer ?? ((e) => e);
+        this.exploreEnhancer = args.exploreEnhancer ?? (async (e) => e);
     }
 
     async startDeploySession(
@@ -209,11 +214,18 @@ export class DeployService extends BaseService {
                 DeploySessionStatus.FINALIZING,
             );
 
+            const project =
+                await this.projectModel.getWithSensitiveFields(projectUuid);
+
             // Get all explores from the session and enhance them
             // (e.g., EE generates virtual pre-aggregate explores from attached defs)
             const uploadedExplores =
                 await this.deploySessionModel.getAllExplores(sessionUuid);
-            const explores = this.exploreEnhancer(uploadedExplores);
+            const explores = await this.exploreEnhancer(uploadedExplores, {
+                organizationUuid: project.organizationUuid,
+                organizationName: user.organizationName ?? '',
+                userUuid: user.userUuid,
+            });
 
             this.logger.info(
                 `Finalizing deploy session ${sessionUuid} with ${explores.length} explores`,
@@ -232,8 +244,6 @@ export class DeployService extends BaseService {
             });
 
             // Schedule validation (same as in original finalizeDeploy)
-            const project =
-                await this.projectModel.getWithSensitiveFields(projectUuid);
             await this.schedulerClient.generateValidation({
                 userUuid: user.userUuid,
                 projectUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -22,6 +22,7 @@ import {
     calculateExploreWarningReport,
     ChartSourceType,
     ChartSummary,
+    CommercialFeatureFlags,
     CompiledDimension,
     ContentType,
     convertCustomMetricToDbt,
@@ -395,6 +396,27 @@ export class ProjectService extends BaseService {
     contentVerificationModel: ContentVerificationModel | undefined;
 
     organizationSettingsModel: OrganizationSettingsModel;
+
+    protected async isPreAggregatesEnabledForOrganization({
+        organizationUuid,
+        organizationName = '',
+        userUuid = '',
+    }: {
+        organizationUuid: string;
+        organizationName?: string;
+        userUuid?: string;
+    }): Promise<boolean> {
+        const { enabled } = await this.featureFlagModel.get({
+            featureFlagId: CommercialFeatureFlags.PreAggregates,
+            user: {
+                organizationUuid,
+                organizationName,
+                userUuid,
+            },
+        });
+
+        return enabled;
+    }
 
     constructor({
         lightdashConfig,
@@ -1872,13 +1894,33 @@ export class ProjectService extends BaseService {
         const {
             userUuid,
             projectUuid,
-            explores,
             compilationSource,
             jobUuid,
             requestMethod,
             projectConfigDefaults,
             cliVersion,
         } = args;
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const preAggregatesEnabled =
+            await this.isPreAggregatesEnabledForOrganization({
+                organizationUuid,
+                userUuid,
+            });
+        const explores = preAggregatesEnabled
+            ? args.explores
+            : args.explores
+                  .filter(
+                      (explore) =>
+                          isExploreError(explore) ||
+                          explore.type !== ExploreType.PRE_AGGREGATE,
+                  )
+                  .map((explore) =>
+                      isExploreError(explore)
+                          ? explore
+                          : { ...explore, preAggregates: undefined },
+                  );
+
         // We delete the explores when saving to cache which cascades to the catalog
         // So we need to get the current tagged catalog items before deleting the explores (to do a best effort re-tag) and icons
         const prevCatalogItemsWithTags =
@@ -1913,8 +1955,6 @@ export class ProjectService extends BaseService {
 
         const { cachedExploreUuids } =
             await this.projectModel.saveExploresToCache(projectUuid, explores);
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
 
         this.logger.info(
             `Saved ${cachedExploreUuids.length} explores to cache for project ${projectUuid}`,
@@ -2015,7 +2055,7 @@ export class ProjectService extends BaseService {
             prevMetricsTreeNodes,
         });
 
-        if (this.lightdashConfig.preAggregates.enabled) {
+        if (preAggregatesEnabled) {
             await this.syncAndEnqueuePreAggregateMaterializations({
                 projectUuid,
                 organizationUuid,
@@ -2583,9 +2623,15 @@ export class ProjectService extends BaseService {
             );
         }
 
+        const preAggregatesEnabled =
+            await this.isPreAggregatesEnabledForOrganization({
+                organizationUuid: project.organizationUuid,
+                userUuid: user.userUuid,
+            });
+
         const exploresWithPreAggregates = enhanceExploresForPreAggregates({
             explores,
-            enabled: this.lightdashConfig.preAggregates.enabled,
+            enabled: preAggregatesEnabled,
         });
 
         await this.saveExploresToCacheAndIndexCatalog({
@@ -3782,14 +3828,20 @@ export class ProjectService extends BaseService {
         metricQuery: MetricQuery;
         usePreAggregateCache: boolean;
     }): Promise<PreAggregateCheckResult> {
-        if (!this.lightdashConfig.preAggregates.enabled) {
-            throw new ForbiddenError('Pre-aggregates are not enabled');
-        }
-
         const { account, projectUuid, exploreName, metricQuery } = args;
 
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+
+        if (
+            !(await this.isPreAggregatesEnabledForOrganization({
+                organizationUuid,
+                organizationName: account.organization.name,
+                userUuid: account.user.id,
+            }))
+        ) {
+            throw new ForbiddenError('Pre-aggregates are not enabled');
+        }
 
         const auditedAbility = this.createAuditedAbility(account);
         if (
@@ -5991,12 +6043,18 @@ export class ProjectService extends BaseService {
         }, []);
     }
 
-    private canViewPreAggregateExplores(
+    private async canViewPreAggregateExplores(
         account: Account,
         organizationUuid: string,
         projectUuid: string,
-    ): boolean {
-        if (!this.lightdashConfig.preAggregates.enabled) {
+    ): Promise<boolean> {
+        if (
+            !(await this.isPreAggregatesEnabledForOrganization({
+                organizationUuid,
+                organizationName: account.organization.name,
+                userUuid: account.user.id,
+            }))
+        ) {
             return false;
         }
 
@@ -6038,11 +6096,11 @@ export class ProjectService extends BaseService {
         );
         const shouldIncludePreAggregateExplores =
             includePreAggregates &&
-            this.canViewPreAggregateExplores(
+            (await this.canViewPreAggregateExplores(
                 account,
                 organizationUuid,
                 projectUuid,
-            );
+            ));
         const visibleExploreSummaries = shouldIncludePreAggregateExplores
             ? allExploreSummaries
             : allExploreSummaries.filter(
@@ -6171,7 +6229,7 @@ export class ProjectService extends BaseService {
                     exploreNames,
                 );
                 const canViewPreAggregateExplores =
-                    this.canViewPreAggregateExplores(
+                    await this.canViewPreAggregateExplores(
                         account,
                         project.organizationUuid,
                         projectUuid,

--- a/packages/common/src/ee/commercialFeatureFlags.ts
+++ b/packages/common/src/ee/commercialFeatureFlags.ts
@@ -2,6 +2,7 @@ export enum CommercialFeatureFlags {
     Embedding = 'embedding',
     Scim = 'scim-token-management',
     AiCopilot = 'ai-copilot',
+    PreAggregates = 'pre-aggregates',
     ServiceAccounts = 'service-accounts',
     OrganizationWarehouseCredentials = 'organization-warehouse-credentials',
     CustomRoles = 'custom-roles',


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7561/per-org-feature-flag-and-multi-tenant-architecture-changes-for-pre


  - undefined DB flag follows PRE_AGGREGATES_ENABLED
  - DB false disables pre-aggregates
  - DB true enables pre-aggregates
  - org override false blocks the project-scoped pre-aggregate endpoint
  - tests and backend typecheck pass
  
### Description:

Moves the pre-aggregates feature flag from a static environment-variable config check (`lightdashConfig.preAggregates.enabled`) to a dynamic, per-organization feature flag lookup backed by the database.

A new `PreAggregates` entry has been added to `CommercialFeatureFlags` and a corresponding handler (`getPreAggregatesFlag`) registered in `CommercialFeatureFlagModel`, which uses the existing `getWithEnvFallback` mechanism so the env config still acts as a fallback when no database row exists.

All call sites that previously read `lightdashConfig.preAggregates.enabled` directly now call the feature flag model with the relevant `organizationUuid`, making the flag overridable per organization via the database. This affects:

- Pre-aggregate routing decisions in `PreAggregateStrategy` and `AsyncQueryService`
- DuckDB client resolution in `PreAggregationDuckDbClient`
- Explore enhancement and caching in `ProjectService` and `DeployService`
- The `canViewPreAggregateExplores` visibility check and the pre-aggregate check endpoint

The `exploreEnhancer` in `DeployService` is now async and receives a user/organization context so the feature flag can be evaluated at deploy time. The `getWithEnvFallback` method on `FeatureFlagModel` has been widened from `private` to `protected` to allow subclass access.

Unit tests have been added for `CommercialFeatureFlagModel` covering the priority order: org override → DB default → env fallback.