### PR TITLE
fix(scheduler): enforce manage:GoogleSheets when reassigning gsheets syncs

### DIFF
--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -222,4 +222,146 @@ describe('SchedulerService', () => {
             ).not.toHaveBeenCalled();
         });
     });
+
+    describe('reassignSchedulerOwner', () => {
+        const gsheetsScheduler: ChartScheduler = {
+            ...chartSchedulerInPrivateSpace,
+            schedulerUuid: 'gsheetsSchedulerUuid',
+            createdBy: 'currentOwnerUuid',
+            format: SchedulerFormat.GSHEETS,
+        };
+
+        // manage:ScheduledDeliveries but NOT manage:GoogleSheets (custom role)
+        const actorWithoutGoogleSheets = buildUser([
+            {
+                subject: 'ScheduledDeliveries',
+                action: ['manage'],
+                conditions: { organizationUuid },
+            },
+        ]);
+
+        const actorWithGoogleSheets = buildUser([
+            {
+                subject: 'ScheduledDeliveries',
+                action: ['manage'],
+                conditions: { organizationUuid },
+            },
+            {
+                subject: 'GoogleSheets',
+                action: ['manage'],
+                conditions: { organizationUuid },
+            },
+        ]);
+
+        // create:ScheduledDeliveries but NOT create:GoogleSheets (custom role)
+        const newOwnerWithoutGoogleSheets = buildUser([
+            {
+                subject: 'ScheduledDeliveries',
+                action: ['create'],
+                conditions: { projectUuid },
+            },
+        ]);
+
+        const newOwnerWithGoogleSheets = buildUser([
+            {
+                subject: 'ScheduledDeliveries',
+                action: ['create'],
+                conditions: { projectUuid },
+            },
+            {
+                subject: 'GoogleSheets',
+                action: ['create'],
+                conditions: { projectUuid },
+            },
+        ]);
+
+        const buildReassignService = (newOwner: SessionUser) => {
+            const projectModel = {
+                getSummary: jest.fn(async () => ({
+                    organizationUuid,
+                    projectUuid,
+                })),
+            };
+            const reassignSchedulerModel = {
+                getSchedulersByUuid: jest.fn(async () => [gsheetsScheduler]),
+                updateOwner: jest.fn(async () => {}),
+            };
+            const userModel = {
+                findSessionUserAndOrgByUuid: jest.fn(async () => newOwner),
+                getRefreshToken: jest.fn(async () => 'refresh-token'),
+            };
+
+            const reassignService = new SchedulerService({
+                lightdashConfig: lightdashConfigMock,
+                analytics: analyticsMock,
+                schedulerModel:
+                    reassignSchedulerModel as unknown as SchedulerModel,
+                dashboardModel: {} as DashboardModel,
+                savedChartModel: savedChartModel as unknown as SavedChartModel,
+                savedSqlModel: {} as SavedSqlModel,
+                appModel: {} as AppModel,
+                projectModel: projectModel as unknown as ProjectModel,
+                schedulerClient: schedulerClient as unknown as SchedulerClient,
+                slackClient: {} as SlackClient,
+                emailClient: {} as EmailClient,
+                userModel: userModel as unknown as UserModel,
+                googleDriveClient: {} as GoogleDriveClient,
+                userService: {} as UserService,
+                jobModel: {} as JobModel,
+                spacePermissionService:
+                    spacePermissionService as unknown as SpacePermissionService,
+            });
+
+            return { reassignService, reassignSchedulerModel };
+        };
+
+        test('should throw ForbiddenError when actor lacks manage:GoogleSheets for a GSHEETS scheduler', async () => {
+            const { reassignService, reassignSchedulerModel } =
+                buildReassignService(newOwnerWithGoogleSheets);
+
+            await expect(
+                reassignService.reassignSchedulerOwner(
+                    actorWithoutGoogleSheets,
+                    projectUuid,
+                    [gsheetsScheduler.schedulerUuid],
+                    newOwnerWithGoogleSheets.userUuid,
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+
+            expect(reassignSchedulerModel.updateOwner).not.toHaveBeenCalled();
+        });
+
+        test('should throw ForbiddenError when new owner lacks manage:GoogleSheets for a GSHEETS scheduler', async () => {
+            const { reassignService, reassignSchedulerModel } =
+                buildReassignService(newOwnerWithoutGoogleSheets);
+
+            await expect(
+                reassignService.reassignSchedulerOwner(
+                    actorWithGoogleSheets,
+                    projectUuid,
+                    [gsheetsScheduler.schedulerUuid],
+                    newOwnerWithoutGoogleSheets.userUuid,
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+
+            expect(reassignSchedulerModel.updateOwner).not.toHaveBeenCalled();
+        });
+
+        test('should reassign GSHEETS scheduler when both actor and new owner have manage:GoogleSheets', async () => {
+            const { reassignService, reassignSchedulerModel } =
+                buildReassignService(newOwnerWithGoogleSheets);
+
+            await reassignService.reassignSchedulerOwner(
+                actorWithGoogleSheets,
+                projectUuid,
+                [gsheetsScheduler.schedulerUuid],
+                newOwnerWithGoogleSheets.userUuid,
+            );
+
+            expect(reassignSchedulerModel.updateOwner).toHaveBeenCalledWith(
+                [gsheetsScheduler.schedulerUuid],
+                newOwnerWithGoogleSheets.userUuid,
+            );
+        });
+    });
 });

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -937,6 +937,23 @@ export class SchedulerService extends BaseService {
             ) {
                 throw new ForbiddenError();
             }
+
+            if (
+                scheduler.format === SchedulerFormat.GSHEETS &&
+                auditedAbility.cannot(
+                    'manage',
+                    subject('GoogleSheets', {
+                        organizationUuid,
+                        projectUuid,
+                        metadata: {
+                            schedulerUuid: scheduler.schedulerUuid,
+                            schedulerFormat: scheduler.format,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
         }
 
         // Validate new owner exists, is a member of the organization, and can create scheduled deliveries
@@ -979,11 +996,27 @@ export class SchedulerService extends BaseService {
             );
         }
 
-        // Check if any schedulers are GSHEETS format - new owner must have Google refresh token
+        // Check if any schedulers are GSHEETS format - new owner must be able to
+        // create Google Sheets syncs and have an active Google connection
         const hasGsheetsSchedulers = schedulers.some(
             (s) => s.format === SchedulerFormat.GSHEETS,
         );
         if (hasGsheetsSchedulers) {
+            if (
+                // eslint-disable-next-line no-direct-ability-check -- Checking newOwner's capability, not caller's access control. Caller's manage check is audited above.
+                newOwner.ability.cannot(
+                    'create',
+                    subject('GoogleSheets', {
+                        organizationUuid,
+                        projectUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    'New owner does not have permission to create Google Sheets scheduled deliveries',
+                );
+            }
+
             try {
                 await this.userModel.getRefreshToken(newOwnerUserUuid);
             } catch (error) {


### PR DESCRIPTION
Closes: PROD-8038

### Description:

`reassignSchedulerOwner` only checked `manage:ScheduledDeliveries` for the actor and `create:ScheduledDeliveries` for the new owner, so a custom role lacking `manage:GoogleSheets` could still reassign Google Sheets syncs and a new owner without the scope could be assigned them (built-in roles are unaffected since the scope is granted org-wide). This adds a per-scheduler `manage:GoogleSheets` check for the actor and a `create:GoogleSheets` check for the new owner, both gated on GSHEETS format and mirroring the existing enforcement in `checkUserCanUpdateSchedulerResource`. The pre-existing Google refresh-token connectivity check is kept alongside the new authorization checks. Added unit tests covering a custom-role actor and new owner that lack the scope, plus the success path.