### PR TITLE
feat(pivot): warehouse-computed row totals for pivot tables

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -128,7 +128,7 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Calculates totals for a previously-executed query, referenced by its queryUuid. Re-runs the source query's MetricQuery against the warehouse so totals are correct for every metric type (count distinct, average, ratio, etc.) — unlike client-side cell summation, which only works for sum/count. For pivoted source queries, produces one warehouse-computed total per pivoted column. For non-pivoted source queries, produces a single-row grand total. Currently only `kind: 'columnTotal'` is supported.
+     * Calculates totals for a previously-executed query, referenced by its queryUuid. Re-runs the source query's MetricQuery against the warehouse so totals are correct for every metric type (count distinct, average, ratio, etc.) — unlike client-side cell summation, which only works for sum/count. The requested `kind` selects which totals to compute.
      * @summary Calculate totals
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -34329,7 +34329,14 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CalculateTotalKind: {
         dataType: 'refAlias',
-        type: { dataType: 'enum', enums: ['columnTotal'], validators: {} },
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['columnTotal'] },
+                { dataType: 'enum', enums: ['rowTotal'] },
+            ],
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ExecuteAsyncCalculateTotalRequestParams: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -35046,9 +35046,8 @@
             },
             "CalculateTotalKind": {
                 "type": "string",
-                "enum": ["columnTotal"],
-                "nullable": false,
-                "description": "Kinds of totals derivable from an executed pivot query. Only `columnTotal`\nis implemented today; follow-up PRs will widen the union to enable the\ncommented-out variants below."
+                "enum": ["columnTotal", "rowTotal"],
+                "description": "Kinds of totals derivable from an executed pivot query. Follow-up PRs\nwill widen the union to enable the commented-out variants below."
             },
             "ExecuteAsyncCalculateTotalRequestParams": {
                 "properties": {
@@ -60802,7 +60801,7 @@
                         }
                     }
                 },
-                "description": "Calculates totals for a previously-executed query, referenced by its queryUuid. Re-runs the source query's MetricQuery against the warehouse so totals are correct for every metric type (count distinct, average, ratio, etc.) — unlike client-side cell summation, which only works for sum/count. For pivoted source queries, produces one warehouse-computed total per pivoted column. For non-pivoted source queries, produces a single-row grand total. Currently only `kind: 'columnTotal'` is supported.",
+                "description": "Calculates totals for a previously-executed query, referenced by its queryUuid. Re-runs the source query's MetricQuery against the warehouse so totals are correct for every metric type (count distinct, average, ratio, etc.) — unlike client-side cell summation, which only works for sum/count. The requested `kind` selects which totals to compute.",
                 "summary": "Calculate totals",
                 "tags": ["v2", "Query"],
                 "security": [],

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -175,6 +175,7 @@ import { getPivotedColumns } from './getPivotedColumns';
 import {
     getColumnTotalQueryFromSource,
     getGrandTotalMetricQuery,
+    getRowTotalQueryFromSource,
 } from './getTotalsQueryFromSource';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
 import {
@@ -4052,12 +4053,6 @@ export class AsyncQueryService extends ProjectService {
     }): Promise<ApiExecuteAsyncMetricQueryResults> {
         assertIsAccountWithOrg(account);
 
-        if (kind !== 'columnTotal') {
-            throw new NotSupportedError(
-                `Calculate-total kind "${kind}" is not yet supported`,
-            );
-        }
-
         // `get` enforces the query belongs to this project and was created by
         // this account — that ownership authorizes the totals query, so we skip
         // the explore-level CASL gate (which embed JWT callers can't pass).
@@ -4070,11 +4065,27 @@ export class AsyncQueryService extends ProjectService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
-        const { metricQuery, pivotConfiguration } =
-            getColumnTotalQueryFromSource({
-                metricQuery: source.metricQuery,
-                pivotConfiguration: source.pivotConfiguration,
-            });
+        const sourceInputs = {
+            metricQuery: source.metricQuery,
+            pivotConfiguration: source.pivotConfiguration,
+        };
+        let metricQuery: MetricQuery;
+        let pivotConfiguration: PivotConfiguration | undefined;
+        switch (kind) {
+            case 'columnTotal':
+                ({ metricQuery, pivotConfiguration } =
+                    getColumnTotalQueryFromSource(sourceInputs));
+                break;
+            case 'rowTotal':
+                ({ metricQuery, pivotConfiguration } =
+                    getRowTotalQueryFromSource(sourceInputs));
+                break;
+            default:
+                return assertUnreachable(
+                    kind,
+                    `Calculate-total kind "${kind}" is not yet supported`,
+                );
+        }
 
         // Reuse the source's parameter values so the totals query sees the
         // same parameter context as the original. The execution path

--- a/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.test.ts
@@ -8,6 +8,7 @@ import {
 import {
     getColumnTotalQueryFromSource,
     getGrandTotalMetricQuery,
+    getRowTotalQueryFromSource,
 } from './getTotalsQueryFromSource';
 
 const emptyFilters: MetricQuery['filters'] = {};
@@ -271,6 +272,208 @@ describe('getColumnTotalQueryFromSource', () => {
 
             expect(result.metricQuery.dimensions).toEqual([]);
             expect(result.pivotConfiguration).toBeUndefined();
+        });
+    });
+});
+
+describe('getRowTotalQueryFromSource', () => {
+    describe('pivoted source', () => {
+        it('keeps only index dimensions and clears groupByColumns', () => {
+            const result = getRowTotalQueryFromSource({
+                metricQuery: baseMetricQuery,
+                pivotConfiguration,
+            });
+
+            expect(result.metricQuery.dimensions).toEqual([
+                'orders_created_at',
+            ]);
+            expect(result.metricQuery.sorts).toEqual([]);
+            expect(result.metricQuery.tableCalculations).toEqual([]);
+            expect(result.pivotConfiguration).toBeDefined();
+            expect(result.pivotConfiguration?.groupByColumns).toEqual([]);
+            expect(result.pivotConfiguration?.indexColumn).toEqual(
+                pivotConfiguration.indexColumn,
+            );
+        });
+
+        it('handles an indexColumn array by expanding all references into dimensions', () => {
+            const multiIndexPivotConfiguration: PivotConfiguration = {
+                ...pivotConfiguration,
+                indexColumn: [
+                    {
+                        reference: 'orders_created_at',
+                        type: VizIndexType.TIME,
+                    },
+                    {
+                        reference: 'orders_status',
+                        type: VizIndexType.CATEGORY,
+                    },
+                ],
+                groupByColumns: [{ reference: 'orders_payment_method' }],
+            };
+
+            const result = getRowTotalQueryFromSource({
+                metricQuery: baseMetricQuery,
+                pivotConfiguration: multiIndexPivotConfiguration,
+            });
+
+            expect(result.metricQuery.dimensions).toEqual([
+                'orders_created_at',
+                'orders_status',
+            ]);
+            expect(result.pivotConfiguration?.indexColumn).toEqual(
+                multiIndexPivotConfiguration.indexColumn,
+            );
+        });
+
+        it('throws when an index column references a dimension not in the source query', () => {
+            expect(() =>
+                getRowTotalQueryFromSource({
+                    metricQuery: {
+                        ...baseMetricQuery,
+                        dimensions: ['orders_payment_method', 'orders_status'],
+                    },
+                    pivotConfiguration,
+                }),
+            ).toThrow(NotSupportedError);
+        });
+
+        it('strips period-over-period additional metrics so MetricQueryBuilder accepts the totals query', () => {
+            const popMetricQuery: MetricQuery = {
+                ...baseMetricQuery,
+                metrics: [
+                    'orders_total_revenue',
+                    'orders_total_revenue_pop_12m',
+                ],
+                additionalMetrics: [
+                    {
+                        name: 'total_revenue_pop_12m',
+                        table: 'orders',
+                        sql: '${TABLE}.revenue',
+                        type: 'sum' as never,
+                        generationType: 'periodOverPeriod',
+                        baseMetricId: 'orders_total_revenue',
+                        timeDimensionId: 'orders_created_at',
+                        granularity: 'MONTH' as never,
+                        periodOffset: 12,
+                    } as never,
+                ],
+            };
+
+            const result = getRowTotalQueryFromSource({
+                metricQuery: popMetricQuery,
+                pivotConfiguration,
+            });
+
+            expect(result.metricQuery.metrics).toEqual([
+                'orders_total_revenue',
+            ]);
+            expect(result.metricQuery.additionalMetrics).toEqual([]);
+        });
+
+        it('rejects sources that use metric filters', () => {
+            expect(() =>
+                getRowTotalQueryFromSource({
+                    metricQuery: {
+                        ...baseMetricQuery,
+                        filters: {
+                            metrics: {
+                                id: 'metric-filter-group',
+                                and: [
+                                    {
+                                        id: 'rule-1',
+                                        target: {
+                                            fieldId: 'orders_total_revenue',
+                                        },
+                                        operator: 'greaterThan' as never,
+                                        values: [0],
+                                    },
+                                ],
+                            } as never,
+                        },
+                    },
+                    pivotConfiguration,
+                }),
+            ).toThrow(NotSupportedError);
+        });
+
+        it('rejects sources that use table-calculation filters', () => {
+            expect(() =>
+                getRowTotalQueryFromSource({
+                    metricQuery: {
+                        ...baseMetricQuery,
+                        filters: {
+                            tableCalculations: {
+                                id: 'tc-filter-group',
+                                and: [
+                                    {
+                                        id: 'rule-1',
+                                        target: { fieldId: 'profit_margin' },
+                                        operator: 'greaterThan' as never,
+                                        values: [0],
+                                    },
+                                ],
+                            } as never,
+                        },
+                    },
+                    pivotConfiguration,
+                }),
+            ).toThrow(NotSupportedError);
+        });
+
+        it('clears sortOnlyDimensions and passthroughDimensions on the totals pivot config', () => {
+            const result = getRowTotalQueryFromSource({
+                metricQuery: baseMetricQuery,
+                pivotConfiguration: {
+                    ...pivotConfiguration,
+                    sortOnlyDimensions: [
+                        { reference: 'orders_payment_method' },
+                    ],
+                    passthroughDimensions: [{ reference: 'orders_status' }],
+                },
+            });
+
+            expect(
+                result.pivotConfiguration?.sortOnlyDimensions,
+            ).toBeUndefined();
+            expect(
+                result.pivotConfiguration?.passthroughDimensions,
+            ).toBeUndefined();
+        });
+    });
+
+    describe('non-pivoted source', () => {
+        it('throws when the source has no pivot configuration', () => {
+            expect(() =>
+                getRowTotalQueryFromSource({
+                    metricQuery: baseMetricQuery,
+                    pivotConfiguration: null,
+                }),
+            ).toThrow(NotSupportedError);
+        });
+
+        it('throws when the pivot configuration has no groupBy columns', () => {
+            expect(() =>
+                getRowTotalQueryFromSource({
+                    metricQuery: baseMetricQuery,
+                    pivotConfiguration: {
+                        ...pivotConfiguration,
+                        groupByColumns: [],
+                    },
+                }),
+            ).toThrow(NotSupportedError);
+        });
+
+        it('throws when the pivot configuration has no index column', () => {
+            expect(() =>
+                getRowTotalQueryFromSource({
+                    metricQuery: baseMetricQuery,
+                    pivotConfiguration: {
+                        ...pivotConfiguration,
+                        indexColumn: undefined,
+                    },
+                }),
+            ).toThrow(NotSupportedError);
         });
     });
 });

--- a/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.ts
+++ b/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.ts
@@ -7,16 +7,35 @@ import {
     type PivotConfiguration,
 } from '@lightdash/common';
 
+const getPopMetricIds = (metricQuery: MetricQuery): Set<string> =>
+    new Set(
+        (metricQuery.additionalMetrics ?? [])
+            .filter(isPeriodOverPeriodAdditionalMetric)
+            .map(getItemId),
+    );
+
+const assertNoBlockingFilters = (
+    metricQuery: MetricQuery,
+    errorMessage: string,
+) => {
+    const hasMetricFilters =
+        !!metricQuery.filters.metrics &&
+        flattenFilterGroup(metricQuery.filters.metrics).length > 0;
+    const hasTableCalculationFilters =
+        !!metricQuery.filters.tableCalculations &&
+        flattenFilterGroup(metricQuery.filters.tableCalculations).length > 0;
+
+    if (hasMetricFilters || hasTableCalculationFilters) {
+        throw new NotSupportedError(errorMessage);
+    }
+};
+
 // Strip a MetricQuery down to a one-row grand total. PoP metrics are
 // dropped because they require their time dim to be selected.
 export const getGrandTotalMetricQuery = (
     metricQuery: MetricQuery,
 ): MetricQuery => {
-    const popMetricIds = new Set(
-        (metricQuery.additionalMetrics ?? [])
-            .filter(isPeriodOverPeriodAdditionalMetric)
-            .map(getItemId),
-    );
+    const popMetricIds = getPopMetricIds(metricQuery);
 
     const totalQuery: MetricQuery = {
         ...metricQuery,
@@ -31,28 +50,20 @@ export const getGrandTotalMetricQuery = (
         ),
     };
 
-    const hasMetricFilters =
-        !!totalQuery.filters.metrics &&
-        flattenFilterGroup(totalQuery.filters.metrics).length > 0;
-    const hasTableCalculationFilters =
-        !!totalQuery.filters.tableCalculations &&
-        flattenFilterGroup(totalQuery.filters.tableCalculations).length > 0;
-
-    if (hasMetricFilters || hasTableCalculationFilters) {
-        throw new NotSupportedError(
-            'Totals cannot be correctly calculated with metric filters or table calculation filters',
-        );
-    }
+    assertNoBlockingFilters(
+        totalQuery,
+        'Totals cannot be correctly calculated with metric filters or table calculation filters',
+    );
 
     return totalQuery;
 };
 
-type GetColumnTotalQueryFromSourceArgs = {
+type GetTotalQueryFromSourceArgs = {
     metricQuery: MetricQuery;
     pivotConfiguration: PivotConfiguration | null;
 };
 
-type GetColumnTotalQueryFromSourceResult = {
+type GetTotalQueryFromSourceResult = {
     metricQuery: MetricQuery;
     pivotConfiguration: PivotConfiguration | undefined;
 };
@@ -60,8 +71,8 @@ type GetColumnTotalQueryFromSourceResult = {
 // Pivoted source: re-aggregate by `groupByColumns`, drop `indexColumn`.
 // Non-pivoted: delegate to `getGrandTotalMetricQuery` (one row per metric).
 export const getColumnTotalQueryFromSource = (
-    source: GetColumnTotalQueryFromSourceArgs,
-): GetColumnTotalQueryFromSourceResult => {
+    source: GetTotalQueryFromSourceArgs,
+): GetTotalQueryFromSourceResult => {
     const groupByColumns = source.pivotConfiguration?.groupByColumns ?? [];
     const isPivoted = !!source.pivotConfiguration && groupByColumns.length > 0;
 
@@ -82,11 +93,7 @@ export const getColumnTotalQueryFromSource = (
     }
 
     // PoP entries would fail validation once the index dim is dropped.
-    const popMetricIds = new Set(
-        (source.metricQuery.additionalMetrics ?? [])
-            .filter(isPeriodOverPeriodAdditionalMetric)
-            .map(getItemId),
-    );
+    const popMetricIds = getPopMetricIds(source.metricQuery);
 
     const totalsMetricQuery: MetricQuery = {
         ...source.metricQuery,
@@ -101,18 +108,10 @@ export const getColumnTotalQueryFromSource = (
         ),
     };
 
-    const hasMetricFilters =
-        !!totalsMetricQuery.filters.metrics &&
-        flattenFilterGroup(totalsMetricQuery.filters.metrics).length > 0;
-    const hasTableCalculationFilters =
-        !!totalsMetricQuery.filters.tableCalculations &&
-        flattenFilterGroup(totalsMetricQuery.filters.tableCalculations).length >
-            0;
-    if (hasMetricFilters || hasTableCalculationFilters) {
-        throw new NotSupportedError(
-            'Column totals cannot be calculated when the source query uses metric or table-calculation filters',
-        );
-    }
+    assertNoBlockingFilters(
+        totalsMetricQuery,
+        'Column totals cannot be calculated when the source query uses metric or table-calculation filters',
+    );
 
     const totalsPivotConfiguration: PivotConfiguration = {
         ...source.pivotConfiguration!,
@@ -120,6 +119,89 @@ export const getColumnTotalQueryFromSource = (
         // once the pivot collapses to a single wide row.
         indexColumn: undefined,
         sortOnlyDimensions: undefined,
+    };
+
+    return {
+        metricQuery: totalsMetricQuery,
+        pivotConfiguration: totalsPivotConfiguration,
+    };
+};
+
+// Returns the field-id references for a `PivotConfiguration.indexColumn`,
+// which can be a single column, an array, or undefined.
+const getIndexColumnFieldIds = (
+    indexColumn: PivotConfiguration['indexColumn'],
+): string[] => {
+    if (!indexColumn) return [];
+    return Array.isArray(indexColumn)
+        ? indexColumn.map((c) => c.reference)
+        : [indexColumn.reference];
+};
+
+// Pivoted source: re-aggregate by `indexColumn`, drop `groupByColumns`.
+// Row totals are undefined for non-pivoted queries (each row already
+// carries its own metric values), so we reject that case explicitly.
+export const getRowTotalQueryFromSource = (
+    source: GetTotalQueryFromSourceArgs,
+): GetTotalQueryFromSourceResult => {
+    const groupByColumns = source.pivotConfiguration?.groupByColumns ?? [];
+    const isPivoted = !!source.pivotConfiguration && groupByColumns.length > 0;
+
+    if (!isPivoted) {
+        throw new NotSupportedError(
+            'Row totals are only supported for pivoted queries',
+        );
+    }
+
+    const indexFieldIds = getIndexColumnFieldIds(
+        source.pivotConfiguration!.indexColumn,
+    );
+    if (indexFieldIds.length === 0) {
+        throw new NotSupportedError(
+            'Row totals require a pivot index column on the source query',
+        );
+    }
+
+    const sourceDimensionIds = new Set(source.metricQuery.dimensions);
+    const missing = indexFieldIds.filter((id) => !sourceDimensionIds.has(id));
+    if (missing.length > 0) {
+        throw new NotSupportedError(
+            `Row total query references dimensions that were not in the source query: ${missing.join(', ')}`,
+        );
+    }
+
+    // PoP metrics are dropped to mirror `getColumnTotalQueryFromSource` —
+    // they assume a specific time-dim anchoring that may not survive the
+    // collapsed pivot, and keeping the two transforms symmetric makes the
+    // contract easier to reason about.
+    const popMetricIds = getPopMetricIds(source.metricQuery);
+
+    const totalsMetricQuery: MetricQuery = {
+        ...source.metricQuery,
+        dimensions: indexFieldIds,
+        sorts: [],
+        tableCalculations: [],
+        metrics: source.metricQuery.metrics.filter(
+            (id) => !popMetricIds.has(id),
+        ),
+        additionalMetrics: (source.metricQuery.additionalMetrics ?? []).filter(
+            (am) => !isPeriodOverPeriodAdditionalMetric(am),
+        ),
+    };
+
+    assertNoBlockingFilters(
+        totalsMetricQuery,
+        'Row totals cannot be calculated when the source query uses metric or table-calculation filters',
+    );
+
+    // `groupByColumns: []` opts out of the pivot SQL path in
+    // PivotQueryBuilder, so the totals query returns a flat shape:
+    // one row per index-dim value combination with plain metric columns.
+    const totalsPivotConfiguration: PivotConfiguration = {
+        ...source.pivotConfiguration!,
+        groupByColumns: [],
+        sortOnlyDimensions: undefined,
+        passthroughDimensions: undefined,
     };
 
     return {

--- a/packages/common/src/pivot/pivotQueryResults.mock.ts
+++ b/packages/common/src/pivot/pivotQueryResults.mock.ts
@@ -1620,11 +1620,14 @@ export const EXPECTED_COMPLEX_PIVOT_DATA: PivotData = {
         ],
     ],
     rowTotalFields: [
-        [null, null],
-        [null, null],
+        [null, null, null],
+        [null, null, null],
         [
             {
                 fieldId: 'payments_total_revenue',
+            },
+            {
+                fieldId: 'orders_average_order_size',
             },
             {
                 fieldId: 'orders_total_order_amount',
@@ -1632,9 +1635,9 @@ export const EXPECTED_COMPLEX_PIVOT_DATA: PivotData = {
         ],
     ],
     columnTotalFields: [[null, { fieldId: undefined }]],
-    rowTotals: [[52.5, 52.5]],
+    rowTotals: [[52.5, 52.5, 52.5]],
     columnTotals: [[52.5, 52.5, 52.5]],
-    cellsCount: 7,
+    cellsCount: 8,
     rowsCount: 1,
     pivotConfig: {
         pivotDimensions: ['payments_payment_method', 'orders_is_completed'],
@@ -1700,6 +1703,12 @@ export const EXPECTED_COMPLEX_PIVOT_DATA: PivotData = {
                         formatted: '52.5',
                     },
                 },
+                'row-total-2': {
+                    value: {
+                        raw: 52.5,
+                        formatted: '52.5',
+                    },
+                },
             },
         ],
         pivotColumnInfo: [
@@ -1745,6 +1754,12 @@ export const EXPECTED_COMPLEX_PIVOT_DATA: PivotData = {
             {
                 fieldId: 'row-total-1',
                 baseId: 'row-total-1',
+                underlyingId: 'orders_average_order_size',
+                columnType: 'rowTotal',
+            },
+            {
+                fieldId: 'row-total-2',
+                baseId: 'row-total-2',
                 underlyingId: 'orders_total_order_amount',
                 columnType: 'rowTotal',
             },
@@ -2015,6 +2030,12 @@ export const EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS: PivotData = {
                     value: {
                         raw: 52.5,
                         formatted: '$52.50',
+                    },
+                },
+                'row-total-0': {
+                    value: {
+                        raw: 52.5,
+                        formatted: '52.5',
                     },
                 },
             },

--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1,11 +1,15 @@
 import { type ItemsMap } from '../types/field';
+import { type PivotData } from '../types/pivot';
 import { type ResultRow } from '../types/results';
 import {
     SortByDirection,
     VizAggregationOptions,
     VizIndexType,
 } from '../visualizations/types';
-import { convertSqlPivotedRowsToPivotData } from './pivotQueryResults';
+import {
+    buildPivotRowTotalKey,
+    convertSqlPivotedRowsToPivotData,
+} from './pivotQueryResults';
 import {
     COMPLEX_SQL_PIVOT_DETAILS,
     COMPLEX_SQL_PIVOTED_ROWS,
@@ -18,6 +22,37 @@ import {
     SQL_PIVOT_DETAILS,
     SQL_PIVOTED_ROWS,
 } from './pivotQueryResults.mock';
+
+// Row totals are warehouse-only, so the tests feed the worker a warehouse map.
+// Reconstruct that map from an expected fixture's own row totals + index values
+// (using the row's metric label for metrics-as-rows, or the total column's
+// field for metrics-as-columns) so fixtures stay the single source of truth.
+const buildWarehouseRowTotalsFromExpected = (
+    expected: PivotData,
+): Record<string, Record<string, number>> => {
+    const map: Record<string, Record<string, number>> = {};
+    const fields = expected.rowTotalFields ?? [];
+    const lastFields = fields[fields.length - 1] ?? [];
+    (expected.rowTotals ?? []).forEach((totalsRow, rowIndex) => {
+        const indexCells = expected.indexValues[rowIndex] ?? [];
+        const entries = indexCells
+            .filter((cell) => cell.type === 'value')
+            .map((cell): [string, unknown] => [
+                cell.fieldId,
+                cell.type === 'value' ? cell.value?.raw : undefined,
+            ]);
+        const key = buildPivotRowTotalKey(entries);
+        if (!map[key]) map[key] = {};
+        const labelCell = indexCells.find((cell) => cell.type === 'label');
+        totalsRow.forEach((value, colIndex) => {
+            if (typeof value !== 'number') return;
+            const metricFieldId =
+                labelCell?.fieldId ?? lastFields[colIndex]?.fieldId;
+            if (metricFieldId) map[key][metricFieldId] = value;
+        });
+    });
+    return map;
+};
 
 describe('convertSqlPivotedRowsToPivotData', () => {
     it('should convert SQL-pivoted rows to PivotData format', () => {
@@ -60,8 +95,141 @@ describe('convertSqlPivotedRowsToPivotData', () => {
             getField: getFieldMock,
             getFieldLabel: (fieldId) => fieldId,
             groupedSubtotals: undefined,
+            warehouseRowTotals: buildWarehouseRowTotalsFromExpected(
+                EXPECTED_PIVOT_DATA_WITH_TOTALS,
+            ),
         });
         expect(result).toStrictEqual(EXPECTED_PIVOT_DATA_WITH_TOTALS);
+    });
+
+    it('uses warehouse row totals instead of the client-side sum when provided', () => {
+        const warehouseRowTotals = {
+            [buildPivotRowTotalKey([
+                ['orders_order_date_year', '2025-01-01T00:00:00Z'],
+            ])]: { payments_total_revenue: 999 },
+            [buildPivotRowTotalKey([
+                ['orders_order_date_year', '2024-01-01T00:00:00Z'],
+            ])]: { payments_total_revenue: 888 },
+            [buildPivotRowTotalKey([
+                ['orders_order_date_year', '2023-01-01T00:00:00Z'],
+            ])]: { payments_total_revenue: 777 },
+        };
+
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: SQL_PIVOTED_ROWS,
+            pivotDetails: SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: true,
+                columnTotals: false,
+                metricsAsRows: false,
+                columnOrder: [
+                    'payments_payment_method',
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+            warehouseRowTotals,
+        });
+
+        // Warehouse values replace the client-side sums (1746.77 / 1189.6 / 117.5)
+        expect(result.rowTotals).toStrictEqual([[999], [888], [777]]);
+        // The total column is still attributed to the metric field
+        expect(
+            result.rowTotalFields?.[result.rowTotalFields.length - 1],
+        ).toEqual([{ fieldId: 'payments_total_revenue' }]);
+    });
+
+    it('leaves the row total null (no client-side fallback) when a warehouse value is missing', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: SQL_PIVOTED_ROWS,
+            pivotDetails: SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: true,
+                columnTotals: false,
+                metricsAsRows: false,
+                columnOrder: [
+                    'payments_payment_method',
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+            // Only the 2025 row has a warehouse total; the others stay blank.
+            warehouseRowTotals: {
+                [buildPivotRowTotalKey([
+                    ['orders_order_date_year', '2025-01-01T00:00:00Z'],
+                ])]: { payments_total_revenue: 999 },
+            },
+        });
+
+        expect(result.rowTotals).toStrictEqual([[999], [null], [null]]);
+    });
+
+    it('leaves all row totals null when no warehouse totals are provided', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: SQL_PIVOTED_ROWS,
+            pivotDetails: SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: true,
+                columnTotals: false,
+                metricsAsRows: false,
+                columnOrder: [
+                    'payments_payment_method',
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        // No client-side computation: the column is allocated but blank.
+        expect(result.rowTotals).toStrictEqual([[null], [null], [null]]);
+        expect(
+            result.rowTotalFields?.[result.rowTotalFields.length - 1],
+        ).toEqual([{ fieldId: 'payments_total_revenue' }]);
+    });
+
+    it('matches warehouse totals keyed by the `<metric>_any` column and `.000Z` dates (real wire shape)', () => {
+        // The flat totals query streams metric columns with the aggregation
+        // suffix and dates with milliseconds — different from the pivot rows'
+        // `...00Z`. Both must still match the rendered rows.
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: SQL_PIVOTED_ROWS,
+            pivotDetails: SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: true,
+                columnTotals: false,
+                metricsAsRows: false,
+                columnOrder: [
+                    'payments_payment_method',
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+            warehouseRowTotals: {
+                [buildPivotRowTotalKey([
+                    ['orders_order_date_year', '2025-01-01T00:00:00.000Z'],
+                ])]: { payments_total_revenue_any: 999 },
+                [buildPivotRowTotalKey([
+                    ['orders_order_date_year', '2024-01-01T00:00:00.000Z'],
+                ])]: { payments_total_revenue_any: 888 },
+                [buildPivotRowTotalKey([
+                    ['orders_order_date_year', '2023-01-01T00:00:00.000Z'],
+                ])]: { payments_total_revenue_any: 777 },
+            },
+        });
+
+        expect(result.rowTotals).toStrictEqual([[999], [888], [777]]);
     });
 
     it('should convert SQL-pivoted rows with metricsAsRows: true to PivotData format', () => {
@@ -87,6 +255,9 @@ describe('convertSqlPivotedRowsToPivotData', () => {
                 return fieldId;
             },
             groupedSubtotals: undefined,
+            warehouseRowTotals: buildWarehouseRowTotalsFromExpected(
+                EXPECTED_PIVOT_DATA_METRICS_AS_ROWS,
+            ),
         });
 
         expect(result).toStrictEqual(EXPECTED_PIVOT_DATA_METRICS_AS_ROWS);
@@ -125,6 +296,9 @@ describe('convertSqlPivotedRowsToPivotData', () => {
                 return fieldId;
             },
             groupedSubtotals: undefined,
+            warehouseRowTotals: buildWarehouseRowTotalsFromExpected(
+                EXPECTED_COMPLEX_PIVOT_DATA,
+            ),
         });
 
         expect(result).toStrictEqual(EXPECTED_COMPLEX_PIVOT_DATA);
@@ -163,6 +337,9 @@ describe('convertSqlPivotedRowsToPivotData', () => {
                 return fieldId;
             },
             groupedSubtotals: undefined,
+            warehouseRowTotals: buildWarehouseRowTotalsFromExpected(
+                EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS,
+            ),
         });
 
         expect(result).toStrictEqual(
@@ -413,6 +590,9 @@ describe('parameter-aware cell formatting (PROD-437)', () => {
             getField: getFieldWithParameterFormat,
             getFieldLabel: (fieldId) => fieldId,
             groupedSubtotals: undefined,
+            warehouseRowTotals: buildWarehouseRowTotalsFromExpected(
+                EXPECTED_PIVOT_DATA_WITH_TOTALS,
+            ),
             parameters: { currency: 'eur' },
         });
 

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -33,6 +33,47 @@ type FieldFunction = (fieldId: string) => ItemsMap[string] | undefined;
 
 type FieldLabelFunction = (fieldId: string) => string | undefined;
 
+/**
+ * Warehouse-computed row totals, keyed by a stable index-value key (built with
+ * `buildPivotRowTotalKey`) → metric fieldId → numeric total. Produced by the
+ * `calculate-total` endpoint (`kind: 'rowTotal'`) and fed into the pivot worker
+ * so the displayed row totals are correct for every metric type — count
+ * distinct, average, ratios — instead of the client-side sum that only holds
+ * for additive metrics.
+ */
+export type PivotRowTotalsByIndex = Record<string, Record<string, number>>;
+
+// ISO 8601 datetime with an explicit timezone (e.g. 2026-01-01T00:00:00Z).
+const ISO_DATETIME_RE =
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/;
+
+// Canonicalize a raw index value to a stable string. Date columns serialize
+// differently between the pivot query (`...00Z`) and the flat totals query
+// (`...00.000Z`), so any ISO datetime is normalized to its ISO instant; other
+// values pass through as a plain string.
+const normalizeRowTotalRaw = (raw: unknown): string | null => {
+    if (raw === null || raw === undefined) return null;
+    const str = String(raw);
+    if (ISO_DATETIME_RE.test(str)) {
+        const parsed = new Date(str);
+        if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+    }
+    return str;
+};
+
+// Stable, order-independent key for matching a pivot row to its warehouse row
+// total. Both the worker (reading source pivot rows) and the frontend hook
+// (reading the flat totals query rows) must build the key from the same set of
+// index dimension fieldIds, so we sort by fieldId and normalize the raw value.
+export const buildPivotRowTotalKey = (
+    indexEntries: Array<[fieldId: string, raw: unknown]>,
+): string =>
+    JSON.stringify(
+        [...indexEntries]
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([fieldId, raw]) => [fieldId, normalizeRowTotalRaw(raw)]),
+    );
+
 // Backend `.formatted` strings don't resolve ${ld.parameters.*} placeholders
 // (parameters live on the client). For flat tables, useColumns re-formats per
 // cell. The pivot path stores backend values verbatim, so we do the same
@@ -173,17 +214,18 @@ const combinedRetrofit = (
         });
     });
 
+    // Row totals are warehouse-computed (see `convertSqlPivotedRowsToPivotData`),
+    // so they are correct for every metric type — no `isSummable` gate. A null
+    // total means no warehouse value was available for that cell; render blank.
     const getMetricAsRowTotalValueFromAxis = (
         total: unknown,
         rowIndex: number,
     ): ResultValue | null => {
         const value = last(data.indexValues[rowIndex]);
         if (!value || !value.fieldId) throw new Error('Invalid pivot data');
+        if (total === null || total === undefined) return null;
 
         const item = getField(value.fieldId);
-        if (!isSummable(item)) {
-            return null;
-        }
         const formattedValue = formatItemValue(item, total, false, parameters);
 
         return {
@@ -195,8 +237,9 @@ const combinedRetrofit = (
     const getRowTotalValueFromAxis = (
         field: TotalField | undefined,
         total: unknown,
-    ): ResultValue => {
+    ): ResultValue | null => {
         if (!field || !field.fieldId) throw new Error('Invalid pivot data');
+        if (total === null || total === undefined) return null;
         const item = getField(field.fieldId);
 
         const formattedValue = formatItemValue(item, total, false, parameters);
@@ -454,6 +497,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     getField,
     getFieldLabel,
     groupedSubtotals,
+    warehouseRowTotals,
     columnLimit,
     parameters,
 }: {
@@ -472,6 +516,14 @@ export const convertSqlPivotedRowsToPivotData = ({
     getField: FieldFunction;
     getFieldLabel: FieldLabelFunction;
     groupedSubtotals: Record<string, Record<string, number>[]> | undefined;
+    /**
+     * Warehouse-computed row totals from `calculate-total` (`kind: 'rowTotal'`).
+     * Row totals are exclusively warehouse-computed — there is no client-side
+     * fallback — so cells are blank until this resolves (or stay blank if the
+     * source query can't be totalled). Drives both the metrics-as-columns and
+     * metrics-as-rows layouts.
+     */
+    warehouseRowTotals?: PivotRowTotalsByIndex;
     columnLimit?: number;
     parameters?: ParametersValuesMap;
 }): PivotData => {
@@ -516,6 +568,17 @@ export const convertSqlPivotedRowsToPivotData = ({
         }
     } else {
         indexColumns = [];
+    }
+
+    // Full index references (including hidden index dims). The warehouse row
+    // total query groups by ALL index dims, and the source pivot rows are
+    // grouped the same way (hiding only affects rendering), so the lookup key
+    // must use every index dim — not just the visible `indexColumns`.
+    let allIndexColumnRefs: string[] = [];
+    if (pivotDetails.indexColumn) {
+        allIndexColumnRefs = Array.isArray(pivotDetails.indexColumn)
+            ? pivotDetails.indexColumn.map((col) => col.reference)
+            : [pivotDetails.indexColumn.reference];
     }
 
     // Filter value columns: visibleMetricFieldIds (allowlist) takes precedence
@@ -811,57 +874,6 @@ export const convertSqlPivotedRowsToPivotData = ({
     const N_DATA_ROWS = hasIndex ? dataValues.length : 1;
     const N_DATA_COLUMNS = hasHeader ? uniqueColumns.length : 1;
 
-    // Build column indices using unique columns
-    const columnIndices = uniqueColumns.reduce<RecursiveRecord<number>>(
-        (acc, valuesColumn, index) => {
-            const pivotValues = (pivotDetails.groupByColumns || []).map(
-                (col) =>
-                    valuesColumn.pivotValues.find(
-                        ({ referenceField }) =>
-                            referenceField === col.reference,
-                    )?.value,
-            );
-
-            // Create nested structure based on pivotValues
-            let current = acc;
-            for (let i = 0; i < pivotValues.length; i += 1) {
-                const pivotValue = String(pivotValues[i]);
-                if (
-                    !Object.prototype.hasOwnProperty.call(current, pivotValue)
-                ) {
-                    Object.defineProperty(current, pivotValue, {
-                        value: {},
-                        writable: true,
-                        enumerable: true,
-                        configurable: true,
-                    });
-                }
-                current = current[pivotValue] as RecursiveRecord<number>;
-            }
-
-            // For metricsAsRows, don't include metric in column key
-            if (!pivotConfig.metricsAsRows) {
-                Object.defineProperty(current, valuesColumn.referenceField, {
-                    value: index,
-                    writable: true,
-                    enumerable: true,
-                    configurable: true,
-                });
-            } else {
-                // Use a generic key since metrics are in rows, not columns
-                Object.defineProperty(current, 'value', {
-                    value: index,
-                    writable: true,
-                    enumerable: true,
-                    configurable: true,
-                });
-            }
-
-            return acc;
-        },
-        {},
-    );
-
     const summableMetricFieldIds = baseMetricsArray.filter((metricId) => {
         const field = getField(metricId);
 
@@ -873,9 +885,39 @@ export const convertSqlPivotedRowsToPivotData = ({
     });
 
     if (fullPivotConfig.rowTotals && hasHeader) {
+        // Row totals are exclusively warehouse-computed: look up the value for a
+        // (source row, metric) pair in `warehouseRowTotals`, keyed by the row's
+        // index-dim values. Returns null when no warehouse value is available
+        // (e.g. still loading, errored, or the source query can't be totalled)
+        // — there is no client-side fallback, so the cell renders blank.
+        const warehouseRowTotalValue = (
+            sourceRowIndex: number,
+            metricFieldId: string | undefined,
+        ): number | null => {
+            if (!warehouseRowTotals || !metricFieldId) return null;
+            const warehouseRow =
+                warehouseRowTotals[
+                    buildPivotRowTotalKey(
+                        allIndexColumnRefs.map((ref) => [
+                            ref,
+                            rows[sourceRowIndex]?.[ref]?.value?.raw,
+                        ]),
+                    )
+                ];
+            if (!warehouseRow) return null;
+            // The totals query column carries the metric aggregation suffix
+            // (`<metric>_any` for Lightdash metrics, matching PivotQueryBuilder
+            // naming); fall back to the bare id.
+            const value =
+                warehouseRow[`${metricFieldId}_any`] ??
+                warehouseRow[metricFieldId];
+            return typeof value === 'number' ? value : null;
+        };
+
         if (fullPivotConfig.metricsAsRows) {
             const N_TOTAL_COLS = 1;
             const N_TOTAL_ROWS = headerValues.length;
+            const N_METRICS = baseMetricsArray.length;
 
             rowTotalFields = create2DArray(N_TOTAL_ROWS, N_TOTAL_COLS);
             rowTotals = create2DArray(N_DATA_ROWS, N_TOTAL_COLS);
@@ -885,48 +927,42 @@ export const convertSqlPivotedRowsToPivotData = ({
                 fieldId: undefined,
             };
 
+            // Output rows fan out one per metric per source row (see indexValues
+            // construction), so row `i` is source `floor(i / N)` × metric `i % N`.
             rowTotals = rowTotals.map((row, rowIndex) =>
-                row.map(() =>
-                    dataValues[rowIndex].reduce(
-                        (acc, value) => acc + parseNumericValue(value),
-                        0,
-                    ),
-                ),
+                row.map(() => {
+                    if (N_METRICS === 0) return null;
+                    const sourceRowIndex = Math.floor(rowIndex / N_METRICS);
+                    const metricFieldId =
+                        baseMetricsArray[rowIndex % N_METRICS];
+                    return warehouseRowTotalValue(
+                        sourceRowIndex,
+                        metricFieldId,
+                    );
+                }),
             );
         } else {
-            const N_TOTAL_COLS = summableMetricFieldIds.length;
+            // One total column per visible base metric.
+            const N_TOTAL_COLS = baseMetricsArray.length;
             const N_TOTAL_ROWS = headerValues.length;
 
             rowTotalFields = create2DArray(N_TOTAL_ROWS, N_TOTAL_COLS);
             rowTotals = create2DArray(rows.length, N_TOTAL_COLS);
 
-            // Set the last header cell as the "Total"
-            summableMetricFieldIds.forEach((fieldId, metricIndex) => {
+            baseMetricsArray.forEach((fieldId, metricIndex) => {
                 rowTotalFields![N_TOTAL_ROWS - 1][metricIndex] = {
                     fieldId,
                 };
             });
 
             rowTotals = rowTotals.map((row, rowIndex) =>
-                row.map((_, totalColIndex) => {
-                    const totalColFieldId =
+                row.map((_, totalColIndex) =>
+                    warehouseRowTotalValue(
+                        rowIndex,
                         rowTotalFields![N_TOTAL_ROWS - 1][totalColIndex]
-                            ?.fieldId;
-                    const valueColIndices = totalColFieldId
-                        ? getAllIndicesForFieldId(
-                              columnIndices,
-                              totalColFieldId,
-                          )
-                        : [];
-                    return dataValues[rowIndex]
-                        .filter((__, dataValueColIndex) =>
-                            valueColIndices.includes(dataValueColIndex),
-                        )
-                        .reduce(
-                            (acc, value) => acc + parseNumericValue(value),
-                            0,
-                        );
-                }),
+                            ?.fieldId,
+                    ),
+                ),
             );
         }
     }

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -148,12 +148,10 @@ export type ExecuteAsyncQueryRequestParams =
     | ExecuteAsyncFieldValueSearchRequestParams;
 
 /**
- * Kinds of totals derivable from an executed pivot query. Only `columnTotal`
- * is implemented today; follow-up PRs will widen the union to enable the
- * commented-out variants below.
+ * Kinds of totals derivable from an executed pivot query. Follow-up PRs
+ * will widen the union to enable the commented-out variants below.
  */
-export type CalculateTotalKind = 'columnTotal';
-// | 'rowTotal'
+export type CalculateTotalKind = 'columnTotal' | 'rowTotal';
 // | 'columnSubtotal'
 // | 'rowSubtotal'
 // | 'grandTotal';

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -25,7 +25,10 @@ import { createWorkerFactory, useWorker } from '@shopify/react-web-worker';
 import uniq from 'lodash/uniq';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
-import { useAsyncCalculateTotal } from '../useAsyncCalculateTotal';
+import {
+    useAsyncCalculateRowTotal,
+    useAsyncCalculateTotal,
+} from '../useAsyncCalculateTotal';
 import { useCalculateSubtotals } from '../useCalculateSubtotals';
 import { useIsHidePivotDimsEnabled } from '../useIsHidePivotDimsEnabled';
 import { useIsPivotRowGroupingEnabled } from '../useIsPivotRowGroupingEnabled';
@@ -244,6 +247,29 @@ const useTableConfig = (
         invalidateCache,
     });
 
+    // Index dimension field ids the warehouse row-total query groups by — the
+    // worker keys each rendered row's total by these. Row totals are exclusively
+    // warehouse-computed (no client-side fallback) for SQL pivots, in both the
+    // metrics-as-columns and metrics-as-rows layouts.
+    const rowTotalIndexFieldIds = useMemo<string[]>(() => {
+        const indexColumn = resultsData?.pivotDetails?.indexColumn;
+        if (!indexColumn) return [];
+        return Array.isArray(indexColumn)
+            ? indexColumn.map((col) => col.reference)
+            : [indexColumn.reference];
+    }, [resultsData?.pivotDetails?.indexColumn]);
+    const canFetchAsyncRowTotals =
+        !!resultsData?.queryUuid &&
+        !!tableChartConfig?.showRowCalculation &&
+        !!resultsData?.pivotDetails;
+    const { data: asyncRowTotals } = useAsyncCalculateRowTotal({
+        projectUuid,
+        sourceQueryUuid: resultsData?.queryUuid,
+        indexFieldIds: rowTotalIndexFieldIds,
+        enabled: canFetchAsyncRowTotals,
+        invalidateCache,
+    });
+
     const { data: groupedSubtotals } = useCalculateSubtotals(
         embedToken && savedChartUuid
             ? {
@@ -404,6 +430,7 @@ const useTableConfig = (
                 getField,
                 getFieldLabel,
                 groupedSubtotals,
+                warehouseRowTotals: asyncRowTotals,
                 parameters,
             })
             .then((data) => {
@@ -434,6 +461,7 @@ const useTableConfig = (
         tableChartConfig?.showRowCalculation,
         worker,
         groupedSubtotals,
+        asyncRowTotals,
         parameters,
     ]);
 

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -1,21 +1,28 @@
 import {
+    buildPivotRowTotalKey,
     QueryHistoryStatus,
     type ApiError,
     type ApiExecuteAsyncMetricQueryResults,
+    type CalculateTotalKind,
+    type PivotRowTotalsByIndex,
+    type RawResultRow,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 import { pollForResults } from '../features/queryRunner/executeQuery';
+import { getResultsFromStream } from '../utils/request';
 
 type StartCalculateTotalArgs = {
     projectUuid: string;
     sourceQueryUuid: string;
+    kind: CalculateTotalKind;
     invalidateCache?: boolean;
 };
 
 const startCalculateTotalQuery = ({
     projectUuid,
     sourceQueryUuid,
+    kind,
     invalidateCache,
 }: StartCalculateTotalArgs) =>
     lightdashApi<ApiExecuteAsyncMetricQueryResults>({
@@ -23,7 +30,7 @@ const startCalculateTotalQuery = ({
         version: 'v2',
         method: 'POST',
         body: JSON.stringify({
-            kind: 'columnTotal',
+            kind,
             invalidateCache,
         }),
     });
@@ -33,9 +40,12 @@ const startCalculateTotalQuery = ({
 export type AsyncTotalsMap = Record<string, number>;
 
 const fetchTotals = async (
-    args: StartCalculateTotalArgs,
+    args: Omit<StartCalculateTotalArgs, 'kind'>,
 ): Promise<AsyncTotalsMap> => {
-    const { queryUuid } = await startCalculateTotalQuery(args);
+    const { queryUuid } = await startCalculateTotalQuery({
+        ...args,
+        kind: 'columnTotal',
+    });
 
     // Polling endpoint defaults to page=1, so the READY response already
     // contains the single totals row — no separate stream fetch needed.
@@ -95,5 +105,103 @@ export const useAsyncCalculateTotal = ({
             });
         },
         enabled: enabled && !!projectUuid && !!sourceQueryUuid,
+        retry: false,
+    });
+
+// Row totals re-run the source query collapsed across the pivot columns, so the
+// result is one flat row per index-value combination (index dims + metrics),
+// not the single wide row column totals return. We stream every row and key it
+// by the index-dim values so the pivot worker can match each rendered row.
+const fetchRowTotals = async (
+    args: Omit<StartCalculateTotalArgs, 'kind'> & {
+        indexFieldIds: string[];
+    },
+): Promise<PivotRowTotalsByIndex> => {
+    const { projectUuid, sourceQueryUuid, indexFieldIds, invalidateCache } =
+        args;
+    const { queryUuid } = await startCalculateTotalQuery({
+        projectUuid,
+        sourceQueryUuid,
+        kind: 'rowTotal',
+        invalidateCache,
+    });
+
+    const query = await pollForResults(projectUuid, queryUuid);
+
+    if (
+        query.status === QueryHistoryStatus.ERROR ||
+        query.status === QueryHistoryStatus.EXPIRED
+    ) {
+        throw new Error(query.error || 'Error computing totals');
+    }
+    if (query.status !== QueryHistoryStatus.READY) {
+        throw new Error('Unexpected query status while polling totals');
+    }
+
+    // One row per index combination — potentially more than a single page, so
+    // read the whole results file rather than the paginated poll response.
+    const fileUrl = `/api/v2/projects/${projectUuid}/query/${queryUuid}/results`;
+    const rows = await getResultsFromStream<RawResultRow>(fileUrl);
+
+    const indexFieldIdSet = new Set(indexFieldIds);
+    const map: PivotRowTotalsByIndex = {};
+    for (const row of rows) {
+        const key = buildPivotRowTotalKey(
+            indexFieldIds.map((fieldId) => [fieldId, row[fieldId]]),
+        );
+        const metricTotals: Record<string, number> = {};
+        for (const [fieldId, raw] of Object.entries(row)) {
+            if (indexFieldIdSet.has(fieldId)) continue;
+            const numeric = Number(raw);
+            if (Number.isFinite(numeric)) {
+                metricTotals[fieldId] = numeric;
+            }
+        }
+        map[key] = metricTotals;
+    }
+    return map;
+};
+
+export const useAsyncCalculateRowTotal = ({
+    projectUuid,
+    sourceQueryUuid,
+    indexFieldIds,
+    enabled,
+    invalidateCache,
+}: {
+    projectUuid: string | undefined;
+    sourceQueryUuid: string | undefined;
+    indexFieldIds: string[];
+    enabled: boolean;
+    invalidateCache?: boolean;
+}) =>
+    useQuery<PivotRowTotalsByIndex, ApiError>({
+        queryKey: [
+            'calculate_async_row_total',
+            projectUuid,
+            sourceQueryUuid,
+            indexFieldIds,
+            invalidateCache,
+        ],
+        queryFn: () => {
+            if (!projectUuid || !sourceQueryUuid) {
+                return Promise.reject(
+                    new Error(
+                        'Missing projectUuid or sourceQueryUuid for async row totals',
+                    ),
+                );
+            }
+            return fetchRowTotals({
+                projectUuid,
+                sourceQueryUuid,
+                indexFieldIds,
+                invalidateCache,
+            });
+        },
+        enabled:
+            enabled &&
+            !!projectUuid &&
+            !!sourceQueryUuid &&
+            indexFieldIds.length > 0,
         retry: false,
     });


### PR DESCRIPTION
Closes: PROD-7974

### Description:
Adds `kind: 'rowTotal'` to `POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total`, which re-runs the source pivot query with `groupByColumns` cleared and only the index dims kept, so the warehouse returns one correct total per index-value row for every metric type. The frontend (`useAsyncCalculateRowTotal`) streams those totals into the pivot worker, which now computes pivot-table row totals **exclusively from the warehouse** — no client-side cell summation — for both the metrics-as-columns and metrics-as-rows layouts. This fixes row totals for non-additive metrics (count distinct, average, ratios) that were previously wrong or hidden, leaving a cell blank when no warehouse value is available rather than showing an incorrect sum. This is the row-totals sibling of the merged column-totals PR #23590.


### Demos

<img width="4032" height="2456" alt="CleanShot 2026-06-02 at 13 16 02@2x" src="https://github.com/user-attachments/assets/1643cc6f-69de-418b-a238-9b8d290385c4" />


<img width="4032" height="2448" alt="CleanShot 2026-06-02 at 13 14 22@2x" src="https://github.com/user-attachments/assets/2029e5f6-7c99-445b-bd02-6e611326268e" />
