### PR TITLE
fix: type editContent patch schema

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -624,21 +624,23 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
     },
   },
   {
-    "description": "Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting.",
+    "description": "Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {
         "patch": {
-          "description": "RFC6902 Patch to apply to the current dashboard or chart JSON.",
+          "description": "RFC6902 Patch objects array to apply to the current dashboard or chart JSON",
+          "items": {},
+          "type": "array",
         },
         "slug": {
-          "description": "Slug of the dashboard or chart to edit.",
+          "description": "Slug of the dashboard or chart to edit",
           "minLength": 1,
           "type": "string",
         },
         "type": {
-          "description": "Type of Lightdash content to edit.",
+          "description": "Type of Lightdash content to edit",
           "enum": [
             "dashboard",
             "chart",
@@ -649,6 +651,7 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
       "required": [
         "slug",
         "type",
+        "patch",
       ],
       "type": "object",
     },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditContentArgs.ts
@@ -1,17 +1,17 @@
 import { z } from 'zod';
 
 export const TOOL_EDIT_CONTENT_DESCRIPTION =
-    'Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting.';
+    'Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting';
 
 export const toolEditContentArgsSchema = z.object({
-    slug: z.string().min(1).describe('Slug of the dashboard or chart to edit.'),
+    slug: z.string().min(1).describe('Slug of the dashboard or chart to edit'),
     type: z
         .enum(['dashboard', 'chart'])
-        .describe('Type of Lightdash content to edit.'),
+        .describe('Type of Lightdash content to edit'),
     patch: z
-        .unknown()
+        .array(z.unknown())
         .describe(
-            'RFC6902 Patch to apply to the current dashboard or chart JSON.',
+            'RFC6902 Patch objects array to apply to the current dashboard or chart JSON',
         ),
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/utils/contentToolResultNavigation.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/contentToolResultNavigation.test.ts
@@ -17,6 +17,8 @@ const dashboardEditResult = {
             name: 'Jaffle dashboard',
             uuid: '2ba751c1-521f-4af5-a910-e40917f2c24e',
             href: '/projects/project-uuid/dashboards/jaffle-dashboard',
+            warnings: [],
+            versionUuids: { before: null, after: null },
         },
     },
 } as AiAgentToolResult;

--- a/packages/frontend/src/providers/Dashboard/dashboardAiAgentChangePlanner.test.ts
+++ b/packages/frontend/src/providers/Dashboard/dashboardAiAgentChangePlanner.test.ts
@@ -19,7 +19,9 @@ const dashboardEditPart = {
             slug: 'jaffle-dashboard',
             name: 'Jaffle dashboard',
             uuid: 'dashboard-uuid',
-            url: '/projects/project-uuid/dashboards/jaffle-dashboard',
+            href: '/projects/project-uuid/dashboards/jaffle-dashboard',
+            warnings: [],
+            versionUuids: { before: null, after: null },
         },
     },
 } as StreamPart;
@@ -41,7 +43,9 @@ const chartEditPart = {
             slug: 'orders-over-time',
             name: 'Orders over time',
             uuid: 'chart-uuid',
-            url: '/projects/project-uuid/saved/chart-uuid',
+            href: '/projects/project-uuid/saved/chart-uuid',
+            warnings: [],
+            versionUuids: { before: null, after: null },
         },
     },
 } as StreamPart;


### PR DESCRIPTION
### Description
- Require `editContent.patch` to be an array in the shared tool schema.
- Update the AI agent tool contract snapshot.

### Testing
- `pnpm -F common typecheck`
- `pnpm -F backend test agentToolContracts.snapshot.test.ts --runInBand -u`

Closes: ZAP-473