### PR TITLE
fix: remove unused table calculations warning from visualization

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
@@ -1,6 +1,5 @@
 import {
     hasUnusedDimensions,
-    hasUnusedTableCalculations,
     type ChartConfig,
     type ItemsMap,
     type MetricQuery,
@@ -88,25 +87,6 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
         dirtyPivotDimensions,
     ]);
 
-    // Determine if query includes table calculations not used in the cartesian chart config
-    const shouldShowUnusedTableCalcs = useMemo(() => {
-        const tableCalcNames =
-            resultsData?.metricQuery?.tableCalculations?.map((tc) => tc.name) ??
-            [];
-        return hasUnusedTableCalculations({
-            chartType: chartConfig.type,
-            chartConfig: chartConfig.config,
-            queryTableCalculations: tableCalcNames,
-            tableCalculationFilters:
-                resultsData?.metricQuery?.filters?.tableCalculations,
-        });
-    }, [
-        resultsData?.metricQuery?.filters?.tableCalculations,
-        resultsData?.metricQuery?.tableCalculations,
-        chartConfig?.type,
-        chartConfig.config,
-    ]);
-
     // Determine how many messages to show
     const messages = useMemo(() => {
         // Only show when not loading/fetching
@@ -116,11 +96,6 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
         if (shouldShowUnusedDims) {
             _messages.push(
                 'Your query includes dimensions that are not used in the chart configuration (x-axis, y-axis, or group by). Remove them from the query to avoid incorrect results.',
-            );
-        }
-        if (shouldShowUnusedTableCalcs) {
-            _messages.push(
-                'Your query includes table calculations that are not used in the chart configuration (x-axis, y-axis, or table calculation filters). Remove them from the query to avoid incorrect results unless you are using them intentionally.',
             );
         }
         if (shouldShowPivotMismatch) {
@@ -139,7 +114,6 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
         isQueryFetching,
         shouldShowPivotMismatch,
         shouldShowUnusedDims,
-        shouldShowUnusedTableCalcs,
         shouldShowPivotColumnLimit,
         maxColumnLimit,
     ]);


### PR DESCRIPTION
### Description:

Removes the warning message that alerts users when their query includes table calculations not used in the chart configuration. This includes:

- Removing the `hasUnusedTableCalculations` import from the utility functions
- Deleting the `shouldShowUnusedTableCalcs` memoized computation that checked for unused table calculations
- Removing the corresponding warning message from the messages array
- Cleaning up the dependency array in the messages memoization hook

The unused dimensions warning remains in place, but the table calculations warning is no longer displayed to users.

### Test Plan:

Existing tests should continue to pass. The warning logic for unused dimensions and pivot mismatches remains unchanged.

https://claude.ai/code/session_01MagyAK6QYUbJLfVhX91NSU