### PR TITLE
fix: replace Switch with Checkbox for x-axis padding control

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -15,7 +15,6 @@ import {
     NumberInput,
     Select,
     Stack,
-    Switch,
     Text,
     TextInput,
 } from '@mantine/core';
@@ -172,32 +171,30 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                     )}
 
                     {isNumericItem(xAxisField) && !dirtyLayout?.flipAxes && (
-                        <>
-                            <Switch
-                                label="Truncate x-axis"
-                                checked={
-                                    dirtyEchartsConfig?.xAxis?.[0]
-                                        ?.minOffset !== undefined ||
-                                    dirtyEchartsConfig?.xAxis?.[0]
-                                        ?.maxOffset !== undefined
+                        <Checkbox
+                            label="Extra padding"
+                            checked={
+                                dirtyEchartsConfig?.xAxis?.[0]?.minOffset !==
+                                    undefined ||
+                                dirtyEchartsConfig?.xAxis?.[0]?.maxOffset !==
+                                    undefined
+                            }
+                            onChange={(e) => {
+                                if (e.target.checked) {
+                                    setXMaxOffsetValue(
+                                        0,
+                                        DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE_PERCENTAGE,
+                                    );
+                                    setXMinOffsetValue(
+                                        0,
+                                        DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE_PERCENTAGE,
+                                    );
+                                } else {
+                                    setXMaxOffsetValue(0, undefined);
+                                    setXMinOffsetValue(0, undefined);
                                 }
-                                onChange={(e) => {
-                                    if (e.target.checked) {
-                                        setXMaxOffsetValue(
-                                            0,
-                                            DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE_PERCENTAGE,
-                                        );
-                                        setXMinOffsetValue(
-                                            0,
-                                            DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE_PERCENTAGE,
-                                        );
-                                    } else {
-                                        setXMaxOffsetValue(0, undefined);
-                                        setXMinOffsetValue(0, undefined);
-                                    }
-                                }}
-                            />
-                        </>
+                            }}
+                        />
                     )}
                     <Group spacing="xs">
                         <Group spacing="xs">


### PR DESCRIPTION
### Description:

Replaced the `Switch` component with `Checkbox` for the x-axis padding control in the chart configuration panel. Also updated the label from "Truncate x-axis" to "Extra padding" to better reflect the functionality.

This change improves the UI consistency by using the more appropriate `Checkbox` component for this binary toggle, and clarifies the control's purpose with a more descriptive label.

**Changes:**
- Removed `Switch` import from `@mantine/core`
- Replaced `Switch` component with `Checkbox` for x-axis offset control
- Updated label text from "Truncate x-axis" to "Extra padding"
- Removed unnecessary wrapper fragment around the control
- Maintained all existing functionality and event handling

**Test Plan:**
No testing needed — this is a UI component replacement with no behavioral changes. The checkbox functions identically to the previous switch implementation.

https://claude.ai/code/session_0173GgERsTQdtMFYre1n85a2