### PR TITLE
fix(ai): add timeout to MCP client connect and tool-discovery calls

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -119,6 +119,7 @@ export const aiCopilotConfigSchema = z
             .min(0)
             .max(1)
             .default(0.6),
+        mcpConnectionTimeoutMs: z.number().positive().default(20_000),
     })
     .refine(
         ({ providers, defaultProvider, enabled }) =>

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -315,6 +315,7 @@ export const lightdashConfigMock: LightdashConfig = {
     mcp: {
         enabled: true,
         runSqlMaxLimit: 5000,
+        timeoutMs: 20_000,
     },
     customRoles: {
         enabled: false,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -243,6 +243,7 @@ export const lightdashConfigMock: LightdashConfig = {
                 },
             },
             verifiedAnswerSimilarityThreshold: 0.6,
+            mcpConnectionTimeoutMs: 20_000,
             defaultEmbeddingModelProvider: 'openai',
         },
     },
@@ -315,7 +316,6 @@ export const lightdashConfigMock: LightdashConfig = {
     mcp: {
         enabled: true,
         runSqlMaxLimit: 5000,
-        timeoutMs: 20_000,
     },
     customRoles: {
         enabled: false,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1259,6 +1259,7 @@ export type LightdashConfig = {
     mcp: {
         enabled: boolean;
         runSqlMaxLimit: number;
+        timeoutMs: number;
     };
     customRoles: {
         enabled: boolean;
@@ -2332,6 +2333,10 @@ export const parseConfig = (): LightdashConfig => {
             runSqlMaxLimit:
                 getIntegerFromEnvironmentVariable('MCP_RUN_SQL_MAX_LIMIT') ||
                 AI_DEFAULT_MAX_QUERY_LIMIT,
+            timeoutMs:
+                getIntegerFromEnvironmentVariable(
+                    'MCP_CONNECTION_TIMEOUT_MS',
+                ) || 20_000,
         },
         customRoles: {
             enabled: process.env.CUSTOM_ROLES_ENABLED === 'true',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -987,6 +987,9 @@ export const getAiConfig = () => ({
         getFloatFromEnvironmentVariable(
             'AI_VERIFIED_ANSWER_SIMILARITY_THRESHOLD',
         ) ?? 0.6,
+    mcpConnectionTimeoutMs:
+        getIntegerFromEnvironmentVariable('AI_COPILOT_MCP_TIMEOUT_MS') ||
+        20_000,
 });
 
 export type LoggingConfig = {
@@ -1259,7 +1262,6 @@ export type LightdashConfig = {
     mcp: {
         enabled: boolean;
         runSqlMaxLimit: number;
-        timeoutMs: number;
     };
     customRoles: {
         enabled: boolean;
@@ -2333,10 +2335,6 @@ export const parseConfig = (): LightdashConfig => {
             runSqlMaxLimit:
                 getIntegerFromEnvironmentVariable('MCP_RUN_SQL_MAX_LIMIT') ||
                 AI_DEFAULT_MAX_QUERY_LIMIT,
-            timeoutMs:
-                getIntegerFromEnvironmentVariable(
-                    'MCP_CONNECTION_TIMEOUT_MS',
-                ) || 20_000,
         },
         customRoles: {
             enabled: process.env.CUSTOM_ROLES_ENABLED === 'true',

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
@@ -7,6 +7,7 @@ import {
     AiAgentMcpRuntimeClient,
     createHttpMcpClient,
     McpAuthorizationRequiredError,
+    McpTimeoutError,
 } from './AiAgentMcpRuntimeClient';
 import type { AiAgentMcpServer } from './types/aiAgent';
 
@@ -46,10 +47,8 @@ describe('resolveMcpTools', () => {
         aiAgentModel,
         lightdashConfig: {
             siteUrl: 'https://lightdash.example.com',
-            mcp: {
-                enabled: true,
-                runSqlMaxLimit: 5000,
-                timeoutMs: 20_000,
+            ai: {
+                copilot: { mcpConnectionTimeoutMs: 20_000 },
             },
         } as LightdashConfig,
     });
@@ -298,7 +297,7 @@ describe('resolveMcpTools', () => {
             aiAgentModel,
             lightdashConfig: {
                 siteUrl: 'https://lightdash.example.com',
-                mcp: { enabled: true, runSqlMaxLimit: 5000, timeoutMs: 20 },
+                ai: { copilot: { mcpConnectionTimeoutMs: 20 } },
             } as LightdashConfig,
         });
         const server = getMcpServer({ name: 'Slow MCP' });
@@ -333,7 +332,7 @@ describe('resolveMcpTools', () => {
             aiAgentModel,
             lightdashConfig: {
                 siteUrl: 'https://lightdash.example.com',
-                mcp: { enabled: true, runSqlMaxLimit: 5000, timeoutMs: 20 },
+                ai: { copilot: { mcpConnectionTimeoutMs: 20 } },
             } as LightdashConfig,
         });
         const close = jest.fn().mockResolvedValue(undefined);
@@ -381,14 +380,17 @@ describe('createHttpMcpClient', () => {
         );
 
         await expect(
-            createHttpMcpClient({
-                uuid: 'oauth-server',
-                name: 'OAuth MCP',
-                url: 'https://oauth.example.com/mcp',
-                authType: 'oauth',
-                resolvedCredential: null,
-                resolvedCredentialScope: null,
-            }),
+            createHttpMcpClient(
+                {
+                    uuid: 'oauth-server',
+                    name: 'OAuth MCP',
+                    url: 'https://oauth.example.com/mcp',
+                    authType: 'oauth',
+                    resolvedCredential: null,
+                    resolvedCredentialScope: null,
+                },
+                20_000,
+            ),
         ).rejects.toEqual(
             new McpAuthorizationRequiredError(
                 'OAuth MCP',
@@ -396,5 +398,53 @@ describe('createHttpMcpClient', () => {
                 'user',
             ),
         );
+    });
+
+    it('wraps transport fetch so a hanging request times out as McpTimeoutError', async () => {
+        let transportFetch: typeof globalThis.fetch | undefined;
+        jest.mocked(mcpSdk.createMCPClient).mockImplementation(
+            async (config) => {
+                const { transport } = config;
+                if ('fetch' in transport) {
+                    transportFetch = transport.fetch as typeof globalThis.fetch;
+                }
+                return {
+                    serverInfo: { name: 'Hang MCP', version: '1.0.0' },
+                    tools: async () => ({}),
+                    close: jest.fn().mockResolvedValue(undefined),
+                } as unknown as MCPClient;
+            },
+        );
+
+        await createHttpMcpClient(
+            {
+                uuid: 'hang-server',
+                name: 'Hang MCP',
+                url: 'https://hang.example.com/mcp',
+                authType: 'none',
+                resolvedCredential: null,
+                resolvedCredentialScope: null,
+            },
+            20,
+        );
+
+        expect(transportFetch).toBeDefined();
+
+        const fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(
+            (_input, init) =>
+                new Promise((_resolve, reject) => {
+                    init?.signal?.addEventListener('abort', () => {
+                        reject(init.signal?.reason);
+                    });
+                }),
+        );
+
+        try {
+            await expect(
+                transportFetch!('https://hang.example.com/mcp'),
+            ).rejects.toBeInstanceOf(McpTimeoutError);
+        } finally {
+            fetchSpy.mockRestore();
+        }
     });
 });

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
@@ -46,6 +46,11 @@ describe('resolveMcpTools', () => {
         aiAgentModel,
         lightdashConfig: {
             siteUrl: 'https://lightdash.example.com',
+            mcp: {
+                enabled: true,
+                runSqlMaxLimit: 5000,
+                timeoutMs: 20_000,
+            },
         } as LightdashConfig,
     });
 
@@ -286,6 +291,82 @@ describe('resolveMcpTools', () => {
             credentialScope: 'user',
             userUuid: 'user-uuid',
         });
+    });
+
+    it('marks a server unavailable when the connection times out', async () => {
+        const fastTimeoutClient = new AiAgentMcpRuntimeClient({
+            aiAgentModel,
+            lightdashConfig: {
+                siteUrl: 'https://lightdash.example.com',
+                mcp: { enabled: true, runSqlMaxLimit: 5000, timeoutMs: 20 },
+            } as LightdashConfig,
+        });
+        const server = getMcpServer({ name: 'Slow MCP' });
+
+        createHttpMcpClientSpy.mockImplementation(
+            () =>
+                new Promise<MCPClient>(() => {
+                    // never resolves — simulates a hung MCP server
+                }),
+        );
+
+        const result = await fastTimeoutClient.resolveTools({
+            mcpServers: [server],
+            userUuid: 'user-uuid',
+            debugLoggingEnabled: false,
+        });
+
+        expect(result.tools).toEqual({});
+        expect(result.unavailableMcpServers).toEqual([
+            {
+                serverUuid: server.uuid,
+                serverName: 'Slow MCP',
+                message:
+                    'The MCP server took too long to respond and was disconnected. Check that it is available, then try again.',
+                status: 'error',
+            },
+        ]);
+    });
+
+    it('closes a client that connects after the timeout (late-close)', async () => {
+        const fastTimeoutClient = new AiAgentMcpRuntimeClient({
+            aiAgentModel,
+            lightdashConfig: {
+                siteUrl: 'https://lightdash.example.com',
+                mcp: { enabled: true, runSqlMaxLimit: 5000, timeoutMs: 20 },
+            } as LightdashConfig,
+        });
+        const close = jest.fn().mockResolvedValue(undefined);
+        const server = getMcpServer({ name: 'Slow MCP' });
+
+        let resolveConnect: ((client: MCPClient) => void) | undefined;
+        createHttpMcpClientSpy.mockImplementation(
+            () =>
+                new Promise<MCPClient>((resolve) => {
+                    resolveConnect = resolve;
+                }),
+        );
+
+        const result = await fastTimeoutClient.resolveTools({
+            mcpServers: [server],
+            userUuid: 'user-uuid',
+            debugLoggingEnabled: false,
+        });
+
+        expect(result.unavailableMcpServers).toHaveLength(1);
+        expect(close).not.toHaveBeenCalled();
+
+        resolveConnect!({
+            serverInfo: { name: 'Slow MCP', version: '1.0.0' },
+            tools: async () => ({}),
+            close,
+        } as unknown as MCPClient);
+
+        await new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+
+        expect(close).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -376,6 +376,13 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
     }
 }
 
+export class McpTimeoutError extends Error {
+    constructor(operation: string, timeoutMs: number) {
+        super(`MCP ${operation} timed out after ${timeoutMs}ms`);
+        this.name = 'McpTimeoutError';
+    }
+}
+
 export const isMcpAuthorizationError = (error: unknown): boolean =>
     error instanceof UnauthorizedError ||
     (error instanceof Error &&
@@ -476,6 +483,10 @@ const getMcpUserFacingErrorMessage = (error: Error): string => {
         return error.message;
     }
 
+    if (error instanceof McpTimeoutError) {
+        return 'The MCP server took too long to respond and was disconnected. Check that it is available, then try again.';
+    }
+
     if (error.message.includes('MCP HTTP Transport Error')) {
         if (
             error.message.includes('HTTP 401') ||
@@ -531,14 +542,73 @@ export const createHttpMcpClient = async (
     }
 };
 
+const withMcpTimeout = <T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    operation: string,
+    onLateResolve?: (value: T) => void,
+): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+        let timedOut = false;
+        const timer = setTimeout(() => {
+            timedOut = true;
+            reject(new McpTimeoutError(operation, timeoutMs));
+        }, timeoutMs);
+
+        void promise.then(
+            (value) => {
+                clearTimeout(timer);
+                if (timedOut) {
+                    onLateResolve?.(value);
+                } else {
+                    resolve(value);
+                }
+            },
+            (error) => {
+                clearTimeout(timer);
+                if (!timedOut) {
+                    reject(error);
+                }
+            },
+        );
+    });
+
+export const createHttpMcpClientWithTimeout = (
+    mcpServer: McpServerConnectionArgs,
+    timeoutMs: number,
+    onUncaughtError?: (error: unknown) => void,
+): Promise<MCPClient> =>
+    withMcpTimeout(
+        createHttpMcpClient(mcpServer, onUncaughtError),
+        timeoutMs,
+        `connection to "${mcpServer.name}"`,
+        (client) => {
+            void client.close().catch((closeError) => {
+                Logger.error(
+                    `[AiAgent][MCP][${mcpServer.name}] Failed to close MCP client abandoned after connection timeout`,
+                    closeError,
+                );
+            });
+        },
+    );
+
 export const testMcpConnection = async (
     mcpServer: McpServerConnectionArgs,
+    timeoutMs: number,
     onUncaughtError?: (error: unknown) => void,
 ): Promise<McpConnectionMetadata> => {
-    const client = await createHttpMcpClient(mcpServer, onUncaughtError);
+    const client = await createHttpMcpClientWithTimeout(
+        mcpServer,
+        timeoutMs,
+        onUncaughtError,
+    );
 
     try {
-        await client.tools();
+        await withMcpTimeout(
+            client.tools(),
+            timeoutMs,
+            `tool discovery for "${mcpServer.name}"`,
+        );
         return {
             iconUrl: getMcpServerIconUrl(client.serverInfo, mcpServer.url),
         };
@@ -649,7 +719,6 @@ export class AiAgentMcpRuntimeClient {
         return mcpServer.resolvedCredentialScope ?? 'user';
     }
 
-    // eslint-disable-next-line class-methods-use-this
     async testConnection(args: {
         name: string;
         url: string;
@@ -671,6 +740,7 @@ export class AiAgentMcpRuntimeClient {
                     : null,
                 resolvedCredentialScope: args.bearerToken ? 'shared' : null,
             },
+            this.lightdashConfig.mcp.timeoutMs,
             args.onUncaughtError,
         );
     }
@@ -810,7 +880,7 @@ export class AiAgentMcpRuntimeClient {
         let mcpClient: MCPClient | undefined;
 
         try {
-            mcpClient = await createHttpMcpClient(
+            mcpClient = await createHttpMcpClientWithTimeout(
                 {
                     ...args.mcpServer,
                     oauthProvider:
@@ -826,6 +896,7 @@ export class AiAgentMcpRuntimeClient {
                               })
                             : undefined,
                 },
+                this.lightdashConfig.mcp.timeoutMs,
                 (error) => {
                     Logger.error(
                         `[AiAgent][MCP][${args.mcpServer.name}] Uncaught MCP client error during tool discovery`,
@@ -834,7 +905,11 @@ export class AiAgentMcpRuntimeClient {
                 },
             );
 
-            const tools = await mcpClient.listTools();
+            const tools = await withMcpTimeout(
+                mcpClient.listTools(),
+                this.lightdashConfig.mcp.timeoutMs,
+                `tool discovery for "${args.mcpServer.name}"`,
+            );
 
             await this.persistRuntimeState({
                 serverUuid: args.mcpServer.uuid,
@@ -922,8 +997,9 @@ export class AiAgentMcpRuntimeClient {
 
                 try {
                     log(`Connecting to ${mcpServer.name} (${mcpServer.url})`);
-                    mcpClient = await createHttpMcpClient(
+                    mcpClient = await createHttpMcpClientWithTimeout(
                         mcpServer,
+                        this.lightdashConfig.mcp.timeoutMs,
                         (error) => {
                             Logger.error(
                                 `[AiAgent][MCP][${mcpServer.name}] Uncaught MCP client error`,
@@ -932,7 +1008,11 @@ export class AiAgentMcpRuntimeClient {
                         },
                     );
 
-                    const tools = await mcpClient.tools();
+                    const tools = await withMcpTimeout(
+                        mcpClient.tools(),
+                        this.lightdashConfig.mcp.timeoutMs,
+                        `tool discovery for "${mcpServer.name}"`,
+                    );
                     await this.persistRuntimeState({
                         serverUuid: mcpServer.uuid,
                         connectionStatus: 'connected',

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -377,9 +377,17 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
 }
 
 export class McpTimeoutError extends Error {
-    constructor(operation: string, timeoutMs: number) {
-        super(`MCP ${operation} timed out after ${timeoutMs}ms`);
+    constructor(
+        timeoutMs: number,
+        options?: { operation?: string; cause?: unknown },
+    ) {
+        super(
+            `MCP ${options?.operation ?? 'request'} timed out after ${timeoutMs}ms`,
+        );
         this.name = 'McpTimeoutError';
+        if (options?.cause !== undefined) {
+            this.cause = options.cause;
+        }
     }
 }
 
@@ -506,11 +514,37 @@ const getMcpUserFacingErrorMessage = (error: Error): string => {
     return 'We could not connect to the MCP server. Check that it is available and try again.';
 };
 
+const isTimeoutAbortError = (error: unknown): boolean =>
+    (error instanceof DOMException || error instanceof Error) &&
+    error.name === 'TimeoutError';
+
+// A fetch that aborts each request after `timeoutMs`, so a hanging MCP server
+// tears down the underlying connection instead of leaking it.
+const createMcpTimeoutFetch =
+    (timeoutMs: number): typeof globalThis.fetch =>
+    async (input, init) => {
+        const timeoutSignal = AbortSignal.timeout(timeoutMs);
+        const signal = init?.signal
+            ? AbortSignal.any([init.signal, timeoutSignal])
+            : timeoutSignal;
+
+        try {
+            return await fetch(input, { ...init, signal });
+        } catch (error) {
+            if (isTimeoutAbortError(error)) {
+                throw new McpTimeoutError(timeoutMs, { cause: error });
+            }
+            throw error;
+        }
+    };
+
 export const createHttpMcpClient = async (
     mcpServer: McpServerConnectionArgs,
+    timeoutMs: number,
     onUncaughtError?: (error: unknown) => void,
 ): Promise<MCPClient> => {
     const bearerToken = getBearerToken(mcpServer);
+    const timeoutFetch = createMcpTimeoutFetch(timeoutMs);
 
     try {
         return await createMCPClient({
@@ -523,6 +557,7 @@ export const createHttpMcpClient = async (
                               requestInit: {
                                   redirect: 'error',
                               },
+                              fetch: timeoutFetch,
                           },
                       )
                     : {
@@ -534,6 +569,7 @@ export const createHttpMcpClient = async (
                                 }
                               : undefined,
                           redirect: 'error',
+                          fetch: timeoutFetch,
                       },
             onUncaughtError,
         });
@@ -552,7 +588,7 @@ const withMcpTimeout = <T>(
         let timedOut = false;
         const timer = setTimeout(() => {
             timedOut = true;
-            reject(new McpTimeoutError(operation, timeoutMs));
+            reject(new McpTimeoutError(timeoutMs, { operation }));
         }, timeoutMs);
 
         void promise.then(
@@ -579,7 +615,7 @@ export const createHttpMcpClientWithTimeout = (
     onUncaughtError?: (error: unknown) => void,
 ): Promise<MCPClient> =>
     withMcpTimeout(
-        createHttpMcpClient(mcpServer, onUncaughtError),
+        createHttpMcpClient(mcpServer, timeoutMs, onUncaughtError),
         timeoutMs,
         `connection to "${mcpServer.name}"`,
         (client) => {
@@ -740,7 +776,7 @@ export class AiAgentMcpRuntimeClient {
                     : null,
                 resolvedCredentialScope: args.bearerToken ? 'shared' : null,
             },
-            this.lightdashConfig.mcp.timeoutMs,
+            this.lightdashConfig.ai.copilot.mcpConnectionTimeoutMs,
             args.onUncaughtError,
         );
     }
@@ -896,7 +932,7 @@ export class AiAgentMcpRuntimeClient {
                               })
                             : undefined,
                 },
-                this.lightdashConfig.mcp.timeoutMs,
+                this.lightdashConfig.ai.copilot.mcpConnectionTimeoutMs,
                 (error) => {
                     Logger.error(
                         `[AiAgent][MCP][${args.mcpServer.name}] Uncaught MCP client error during tool discovery`,
@@ -907,7 +943,7 @@ export class AiAgentMcpRuntimeClient {
 
             const tools = await withMcpTimeout(
                 mcpClient.listTools(),
-                this.lightdashConfig.mcp.timeoutMs,
+                this.lightdashConfig.ai.copilot.mcpConnectionTimeoutMs,
                 `tool discovery for "${args.mcpServer.name}"`,
             );
 
@@ -999,7 +1035,7 @@ export class AiAgentMcpRuntimeClient {
                     log(`Connecting to ${mcpServer.name} (${mcpServer.url})`);
                     mcpClient = await createHttpMcpClientWithTimeout(
                         mcpServer,
-                        this.lightdashConfig.mcp.timeoutMs,
+                        this.lightdashConfig.ai.copilot.mcpConnectionTimeoutMs,
                         (error) => {
                             Logger.error(
                                 `[AiAgent][MCP][${mcpServer.name}] Uncaught MCP client error`,
@@ -1010,7 +1046,7 @@ export class AiAgentMcpRuntimeClient {
 
                     const tools = await withMcpTimeout(
                         mcpClient.tools(),
-                        this.lightdashConfig.mcp.timeoutMs,
+                        this.lightdashConfig.ai.copilot.mcpConnectionTimeoutMs,
                         `tool discovery for "${mcpServer.name}"`,
                     );
                     await this.persistRuntimeState({


### PR DESCRIPTION
Closes: PROD-8039

### Description:

MCP client calls had no timeout, so a hanging MCP server could stall admin create/refresh requests and end-user chat requests for up to ~5 minutes (the undici default) with no clear error. This adds an `MCP_CONNECTION_TIMEOUT_MS` config (default 20s) and wraps both the connection and the `tools()`/`listTools()` calls at all three call sites (`testConnection`, `listTools`, `resolveTools`) in a timeout helper, using a per-server timeout in `resolveTools` so one slow server doesn't block the rest. On timeout the server is marked `error` with a user-facing message, and a client that connects after the timeout fires is closed to avoid leaking a transport connection. Includes unit tests covering the timeout and late-close behaviour.