### PR TITLE
feat: add pop hash tool for agents

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -17,6 +17,7 @@ import { getDescribeWarehouseTable } from '../tools/describeWarehouseTable';
 import { getEditContent } from '../tools/editContent';
 import { getFindContent } from '../tools/findContent';
 import { getGenerateDashboardV2 } from '../tools/generateDashboardV2';
+import { getGenerateHashes } from '../tools/generateHashes';
 import { getGenerateUuids } from '../tools/generateUuids';
 import { getGenerateVisualization } from '../tools/generateVisualization';
 import { getGetDashboardCharts } from '../tools/getDashboardCharts';
@@ -310,6 +311,7 @@ const getAgentTools = (
                   loadSkill: dependencies.loadSkill,
               })
             : null;
+    const generateHashes = getGenerateHashes();
     const generateUuids = getGenerateUuids();
 
     const listProjects = getListProjects({
@@ -342,6 +344,7 @@ const getAgentTools = (
               }),
         generateVisualization,
         runSavedChart,
+        generateHashes,
         generateUuids,
         ...(args.canManageAgent ? { improveContext } : {}),
         ...(args.enableSelfImprovement && args.canManageAgent

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/SKILL.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/SKILL.md
@@ -158,9 +158,12 @@ Spaces can be nested. Use `parent/child` syntax in `spaceSlug` for sub-spaces, f
 | `sankey`     | Flow diagrams            | `sankey-chart-reference`     |
 | `custom`     | Vega-Lite                | `custom-viz-reference`       |
 
+For period comparisons, read `period-over-period-reference` in addition to the chart type reference.
+
 Start with:
 
 - `dashboard-reference` for dashboards
     - `dashboard-best-practices` for tips on effective dashboard design
 - `cartesian-chart-reference` for bar, line, area, or scatter charts
 - the specific chart resource for any other chart type
+- `period-over-period-reference` when adding or editing period-over-period comparison metrics

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/period-over-period-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/period-over-period-reference.md
@@ -1,0 +1,322 @@
+---
+name: period-over-period-reference
+description: Period over period comparison configuration for Lightdash chart JSON.
+---
+
+# Period over Period (PoP) Comparison Reference
+
+## Overview
+
+Period over Period comparison adds a "previous period" version of any metric to your chart. For example, show this month's revenue alongside last month's revenue, or this year's order count next to last year's.
+
+PoP is implemented through **additional metrics** in the `metricQuery`. Define an additional metric with `generationType: "periodOverPeriod"` that references a base metric and a time dimension, then Lightdash offsets the time window to pull comparison data.
+
+## Supported Granularities
+
+| Granularity | Example Comparison           |
+| ----------- | ---------------------------- |
+| `DAY`       | Yesterday vs today           |
+| `WEEK`      | Last week vs this week       |
+| `MONTH`     | Last month vs this month     |
+| `QUARTER`   | Last quarter vs this quarter |
+| `YEAR`      | Last year vs this year       |
+
+## JSON Structure
+
+### The PoP Additional Metric
+
+Add a PoP metric to `metricQuery.additionalMetrics`:
+
+```json
+{
+    "metricQuery": {
+        "additionalMetrics": [
+            {
+                "baseMetricId": "<explore>_<base_metric_name>",
+                "generationType": "periodOverPeriod",
+                "granularity": "YEAR",
+                "hidden": true,
+                "label": "Order Count (Previous year)",
+                "name": "<metric_name>__pop__<granularity>_<offset>__<hash>",
+                "periodOffset": 1,
+                "sql": "${TABLE}.column_name",
+                "table": "<explore_name>",
+                "timeDimensionId": "<explore>_<time_dim>_<grain>",
+                "type": "count"
+            }
+        ]
+    }
+}
+```
+
+### Including the PoP Metric in the Query
+
+The PoP metric's field ID must appear in `metricQuery.metrics`:
+
+```json
+{
+    "metricQuery": {
+        "metrics": [
+            "country_orders_order_count",
+            "country_orders_order_count__pop__year_1__lqse0r"
+        ]
+    }
+}
+```
+
+The field ID format is `<table>_<metric_name>` where `<metric_name>` is the deterministic name from the additional metric.
+
+## Key Properties
+
+| Property          | Required | Description                                                            |
+| ----------------- | -------- | ---------------------------------------------------------------------- |
+| `baseMetricId`    | Yes      | Field ID of the original metric (e.g. `orders_total_revenue`)          |
+| `generationType`  | Yes      | Must be `periodOverPeriod`                                             |
+| `granularity`     | Yes      | Time granularity: `DAY`, `WEEK`, `MONTH`, `QUARTER`, `YEAR`            |
+| `hidden`          | Yes      | Always `true`; PoP metrics don't appear in the sidebar                 |
+| `label`           | Yes      | Display name (e.g. "Revenue (Previous month)")                         |
+| `name`            | Yes      | Deterministic name with hash suffix                                    |
+| `periodOffset`    | Yes      | Number of periods back (1 = previous period, 2 = two periods ago)      |
+| `sql`             | Yes      | Same SQL expression as the base metric                                 |
+| `table`           | Yes      | Table/explore name                                                     |
+| `timeDimensionId` | Yes      | Field ID of the time dimension including grain suffix                  |
+| `type`            | Yes      | Same aggregation type as base metric (`sum`, `count`, `average`, etc.) |
+| `format`          | No       | Number format (e.g. `usd`, `percent`); copy from base metric           |
+| `round`           | No       | Decimal places; copy from base metric                                  |
+
+## Metric Name Generation
+
+PoP metric names follow a deterministic pattern:
+
+```text
+<base_metric_name>__pop__<granularity>_<periodOffset>__<hash>
+```
+
+Where `<hash>` is a base-36 hash of `<timeDimensionId>|<granularity>|<periodOffset>`.
+
+### Computing the Hash
+
+Use `generateHashes` with inputs formatted as `<timeDimensionId>|<granularity>|<periodOffset>`:
+
+```json
+{
+    "inputs": ["country_orders_order_date_year|YEAR|1"]
+}
+```
+
+## Complete Example: Year-over-Year Table Chart
+
+```json
+{
+    "chartConfig": {
+        "config": {
+            "columns": {
+                "country_orders_country": {
+                    "frozen": true,
+                    "name": "Country",
+                    "visible": true
+                },
+                "country_orders_order_count": {
+                    "name": "Order Count",
+                    "visible": true
+                },
+                "country_orders_order_count__pop__year_1__lqse0r": {
+                    "name": "Order Count (Previous Year)",
+                    "visible": true
+                },
+                "country_orders_order_date_year": {
+                    "name": "Year",
+                    "visible": true
+                }
+            },
+            "conditionalFormattings": [],
+            "hideRowNumbers": false,
+            "metricsAsRows": false,
+            "showColumnCalculation": true,
+            "showResultsTotal": false,
+            "showRowCalculation": false,
+            "showSubtotals": false,
+            "showTableNames": false
+        },
+        "type": "table"
+    },
+    "contentType": "chart",
+    "description": "Compares total order count per country across years using period-over-period comparison. Shows current year orders alongside previous year orders in a table.",
+    "metricQuery": {
+        "additionalMetrics": [
+            {
+                "baseMetricId": "country_orders_order_count",
+                "generationType": "periodOverPeriod",
+                "granularity": "YEAR",
+                "hidden": true,
+                "label": "Order Count (Previous year)",
+                "name": "order_count__pop__year_1__lqse0r",
+                "periodOffset": 1,
+                "sql": "${TABLE}.order_id",
+                "table": "country_orders",
+                "timeDimensionId": "country_orders_order_date_year",
+                "type": "count"
+            }
+        ],
+        "customDimensions": [],
+        "dimensions": [
+            "country_orders_country",
+            "country_orders_order_date_year"
+        ],
+        "exploreName": "country_orders",
+        "filters": {},
+        "limit": 500,
+        "metrics": [
+            "country_orders_order_count",
+            "country_orders_order_count__pop__year_1__lqse0r"
+        ],
+        "sorts": [
+            {
+                "descending": true,
+                "fieldId": "country_orders_order_date_year"
+            },
+            {
+                "descending": false,
+                "fieldId": "country_orders_country"
+            }
+        ],
+        "tableCalculations": []
+    },
+    "name": "Country Orders - Year over Year Comparison",
+    "slug": "country-orders-yoy-comparison",
+    "spaceSlug": "jaffle-shop",
+    "tableConfig": {
+        "columnOrder": [
+            "country_orders_country",
+            "country_orders_order_date_year",
+            "country_orders_order_count",
+            "country_orders_order_count__pop__year_1__lqse0r"
+        ]
+    },
+    "tableName": "country_orders",
+    "version": 1
+}
+```
+
+## Using PoP with Different Chart Types
+
+### Table Charts
+
+PoP columns appear as additional metric columns. Null values, where no comparison data exists, display as null. Use `showColumnCalculation: true` to show totals.
+
+### Cartesian Charts (Line, Bar, Area)
+
+Add the PoP metric to `layout.yField` and create a separate series in `eChartsConfig.series`:
+
+```json
+{
+    "chartConfig": {
+        "config": {
+            "eChartsConfig": {
+                "series": [
+                    {
+                        "encode": {
+                            "xRef": {
+                                "field": "orders_order_date_month"
+                            },
+                            "yRef": {
+                                "field": "orders_total_revenue"
+                            }
+                        },
+                        "type": "line"
+                    },
+                    {
+                        "encode": {
+                            "xRef": {
+                                "field": "orders_order_date_month"
+                            },
+                            "yRef": {
+                                "field": "orders_total_revenue__pop__month_1__<hash>"
+                            }
+                        },
+                        "type": "line"
+                    }
+                ]
+            },
+            "layout": {
+                "xField": "orders_order_date_month",
+                "yField": [
+                    "orders_total_revenue",
+                    "orders_total_revenue__pop__month_1__<hash>"
+                ]
+            }
+        },
+        "type": "cartesian"
+    }
+}
+```
+
+### Big Number Charts
+
+PoP can power the comparison value in big number charts, showing the delta from the previous period.
+
+## Workflow: Adding PoP via UI then Managing as JSON
+
+1. Create the base chart in the Lightdash UI
+2. Click on a metric column header in the results table
+3. Select **Add period comparison**
+4. Choose the time dimension and offset, then save
+5. Read the chart JSON through content tools
+6. The JSON will contain the complete `additionalMetrics` configuration
+7. Manage via `editContent` patches going forward
+
+## Common Patterns
+
+### Month-over-Month Revenue
+
+```json
+{
+    "additionalMetrics": [
+        {
+            "baseMetricId": "orders_total_revenue",
+            "generationType": "periodOverPeriod",
+            "granularity": "MONTH",
+            "periodOffset": 1,
+            "timeDimensionId": "orders_order_date_month"
+        }
+    ]
+}
+```
+
+### Same Quarter Last Year
+
+```json
+{
+    "additionalMetrics": [
+        {
+            "baseMetricId": "orders_total_revenue",
+            "generationType": "periodOverPeriod",
+            "granularity": "YEAR",
+            "periodOffset": 1,
+            "timeDimensionId": "orders_order_date_quarter"
+        }
+    ]
+}
+```
+
+### Comparing to 3 Months Ago
+
+```json
+{
+    "additionalMetrics": [
+        {
+            "baseMetricId": "orders_total_revenue",
+            "generationType": "periodOverPeriod",
+            "granularity": "MONTH",
+            "periodOffset": 3,
+            "timeDimensionId": "orders_order_date_month"
+        }
+    ]
+}
+```
+
+## Important Notes
+
+- The time dimension in `dimensions` must match the grain referenced by `timeDimensionId`. For year-over-year, use `_year` suffix; for month-over-month, use `_month`.
+- Countries/categories that only exist in one period will show null for the comparison column; this is expected behavior.
+- PoP metrics must be listed in both `additionalMetrics` and `metrics` arrays.

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -2788,6 +2788,59 @@ Table calculations perform row-by-row calculations on query results without coll
     },
   },
   {
+    "description": "Generate deterministic base-36 hashes for input strings.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "inputs": {
+          "description": "Input strings to hash.",
+          "items": {
+            "type": "string",
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "type": "array",
+        },
+      },
+      "required": [
+        "inputs",
+      ],
+      "type": "object",
+    },
+    "name": "generateHashes",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
     "description": "Generate one or more UUIDs to use as stable identifiers when creating new objects.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -7444,6 +7497,7 @@ exports[`AI agent tool contracts matches the shared agent tool definition names 
   "runSql",
   "discoverFields",
   "generateDashboard",
+  "generateHashes",
   "generateUuids",
   "getDashboardCharts",
   "readContent",

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -9,6 +9,7 @@ import { getFindContent } from './findContent';
 import { getFindExplores } from './findExplores';
 import { getFindFields } from './findFields';
 import { getGenerateDashboardV2 } from './generateDashboardV2';
+import { getGenerateHashes } from './generateHashes';
 import { getGenerateUuids } from './generateUuids';
 import { getGenerateVisualization } from './generateVisualization';
 import { getGetDashboardCharts } from './getDashboardCharts';
@@ -117,6 +118,7 @@ const makeAgentTools = () => {
             createOrUpdateArtifact: noop,
             getPrompt: noop,
         }),
+        generateHashes: getGenerateHashes(),
         generateUuids: getGenerateUuids(),
         getDashboardCharts: getGetDashboardCharts({
             getDashboardCharts: noop,

--- a/packages/backend/src/ee/services/ai/tools/generateHashes.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateHashes.ts
@@ -1,0 +1,34 @@
+import {
+    generateHashesToolDefinition,
+    hashStringToBase36,
+} from '@lightdash/common';
+import { tool } from 'ai';
+import { toModelOutput } from '../utils/toModelOutput';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+
+const toolDefinition = generateHashesToolDefinition.for('agent');
+
+export const getGenerateHashes = () =>
+    tool({
+        ...toolDefinition,
+        execute: async ({ inputs }) => {
+            try {
+                return {
+                    result: JSON.stringify({
+                        hashes: inputs.map(hashStringToBase36),
+                    }),
+                    metadata: {
+                        status: 'success' as const,
+                    },
+                };
+            } catch (error) {
+                return {
+                    result: toolErrorHandler(error, 'Error generating hashes.'),
+                    metadata: {
+                        status: 'error' as const,
+                    },
+                };
+            }
+        },
+        toModelOutput: ({ output }) => toModelOutput(output),
+    });

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -29,6 +29,7 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     generateTimeSeriesVizConfig: 'time_series_chart',
     generateBarVizConfig: 'vertical_bar_chart',
     loadSkill: 'load_skill',
+    generateHashes: 'generate_hashes',
     generateUuids: 'generate_uuids',
     generateVisualization: 'query_result',
     runQuery: 'query_result',

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -8,6 +8,7 @@ import {
     type ToolFindDashboardsOutput,
     type ToolFindExploresOutput,
     type ToolFindFieldsOutput,
+    type ToolGenerateHashesOutput,
     type ToolGenerateUuidsOutput,
     type ToolGetKnowledgeDocumentContentOutput,
     type ToolImproveContextOutput,
@@ -43,6 +44,7 @@ export type AgentToolOutput =
     | ToolFindDashboardsOutput
     | ToolFindExploresOutput
     | ToolFindFieldsOutput
+    | ToolGenerateHashesOutput
     | ToolGenerateUuidsOutput
     | ToolGetKnowledgeDocumentContentOutput
     | ToolDescribeWarehouseTableOutput

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -2,6 +2,7 @@ export * from './toolDefinitions';
 export * from './toolQueryResultSchemas';
 export * from './toolDiscoverFieldsArgs';
 export * from './toolEditContentArgs';
+export * from './toolGenerateHashesArgs';
 export * from './toolGenerateUuidsArgs';
 export * from './toolLoadSkillArgs';
 export * from './toolMcpQueryResultDescription';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -70,6 +70,11 @@ import {
     toolFindFieldsOutputSchema,
 } from './toolFindFieldsArgs';
 import {
+    TOOL_GENERATE_HASHES_DESCRIPTION,
+    toolGenerateHashesArgsSchema,
+    toolGenerateHashesOutputSchema,
+} from './toolGenerateHashesArgs';
+import {
     TOOL_GENERATE_UUIDS_DESCRIPTION,
     toolGenerateUuidsArgsSchema,
     toolGenerateUuidsOutputSchema,
@@ -390,6 +395,15 @@ export const generateUuidsToolDefinition = defineTool({
     availability: ['agent'],
     inputSchema: toolGenerateUuidsArgsSchema,
     agent: { outputSchema: toolGenerateUuidsOutputSchema },
+});
+
+export const generateHashesToolDefinition = defineTool({
+    name: 'generateHashes',
+    title: 'Generate hashes',
+    description: TOOL_GENERATE_HASHES_DESCRIPTION,
+    availability: ['agent'],
+    inputSchema: toolGenerateHashesArgsSchema,
+    agent: { outputSchema: toolGenerateHashesOutputSchema },
 });
 
 export const getDashboardChartsToolDefinition = defineTool({
@@ -735,6 +749,7 @@ type AgentToolDefinitionsByName = {
     runSql: typeof runSqlToolDefinition;
     discoverFields: typeof discoverFieldsToolDefinition;
     generateDashboard: typeof generateDashboardToolDefinition;
+    generateHashes: typeof generateHashesToolDefinition;
     generateUuids: typeof generateUuidsToolDefinition;
     getDashboardCharts: typeof getDashboardChartsToolDefinition;
     readContent: typeof readContentToolDefinition;
@@ -772,6 +787,7 @@ export const agentToolDefinitionsByName: AgentToolDefinitionsByName = {
     runSql: runSqlToolDefinition,
     discoverFields: discoverFieldsToolDefinition,
     generateDashboard: generateDashboardToolDefinition,
+    generateHashes: generateHashesToolDefinition,
     generateUuids: generateUuidsToolDefinition,
     getDashboardCharts: getDashboardChartsToolDefinition,
     readContent: readContentToolDefinition,
@@ -811,6 +827,7 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     renderChartToolDefinition,
     discoverFieldsToolDefinition,
     generateDashboardToolDefinition,
+    generateHashesToolDefinition,
     generateUuidsToolDefinition,
     getDashboardChartsToolDefinition,
     readContentToolDefinition,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateHashesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateHashesArgs.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import { baseOutputMetadataSchema } from '../outputMetadata';
+
+export const TOOL_GENERATE_HASHES_DESCRIPTION =
+    'Generate deterministic base-36 hashes for input strings.';
+
+export const toolGenerateHashesArgsSchema = z.object({
+    inputs: z
+        .array(z.string())
+        .min(1)
+        .max(20)
+        .describe('Input strings to hash.'),
+});
+
+export const toolGenerateHashesOutputSchema = z.object({
+    result: z.string(),
+    metadata: baseOutputMetadataSchema,
+});
+
+export type ToolGenerateHashesArgs = z.infer<
+    typeof toolGenerateHashesArgsSchema
+>;
+
+export type ToolGenerateHashesOutput = z.infer<
+    typeof toolGenerateHashesOutputSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -14,6 +14,7 @@ const VisualizationTools = [
 export const ToolNameSchema = z.enum([
     ...VisualizationTools,
     'generateDashboard',
+    'generateHashes',
     'generateUuids',
     'findContent',
     'listContent',
@@ -67,6 +68,7 @@ export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     generateTableVizConfig: 'Generating a table',
     generateTimeSeriesVizConfig: 'Generating a line chart',
     generateDashboard: 'Generating a dashboard',
+    generateHashes: 'Generating hashes',
     generateUuids: 'Generating UUIDs',
     findCharts: 'Finding relevant charts',
     getDashboardCharts: 'Looking up dashboard charts',
@@ -105,6 +107,7 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         generateTableVizConfig: 'Generated a table',
         generateTimeSeriesVizConfig: 'Generated a line chart',
         generateDashboard: 'Generated a dashboard',
+        generateHashes: 'Generated hashes',
         generateUuids: 'Generated UUIDs',
         findCharts: 'Found relevant charts',
         getDashboardCharts: 'Found dashboard charts',

--- a/packages/common/src/types/periodOverPeriodComparison.ts
+++ b/packages/common/src/types/periodOverPeriodComparison.ts
@@ -61,7 +61,7 @@ export const isSupportedPeriodOverPeriodGranularity = (
     granularity: TimeFrames,
 ) => validPeriodOverPeriodGranularities.includes(granularity);
 
-const hashStringToBase36 = (input: string): string => {
+export const hashStringToBase36 = (input: string): string => {
     // Deterministic, non-cryptographic hash (no deps).
     // Polynomial rolling hash modulo a large prime (lint-safe: no bitwise ops).
     const MODULUS = 2_147_483_647; // 2^31 - 1

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -103,6 +103,7 @@ type StreamSegment = TextSegment | ToolGroup | SqlApprovalSegment;
 const HIDDEN_TOOL_NAMES = new Set<AiAgentToolName>([
     'improveContext',
     'proposeChange',
+    'generateHashes',
     'generateUuids',
 ]);
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -98,6 +98,7 @@ const TOOLS_WITHOUT_LATEST_DESCRIPTION = new Set<string>([
     'listProjects',
     'getProjectInfo',
     'listContent',
+    'generateHashes',
     'generateUuids',
     'improveContext',
     'loadSkill',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
@@ -39,6 +39,7 @@ import { type ToolCallSummary } from './utils/types';
 // is supplied wherever the trace is meaningful.
 const TOOLS_WITHOUT_DESCRIPTION = new Set<ToolName>([
     'discoverFields',
+    'generateHashes',
     'generateUuids',
     'getProjectInfo',
     'improveContext',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -255,6 +255,7 @@ export const ToolCallDescription: FC<{
         case 'getProjectInfo':
         case 'listContent':
         case 'discoverFields':
+        case 'generateHashes':
         case 'generateUuids':
         case 'improveContext':
         case 'loadSkill':

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallChipLabel.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallChipLabel.ts
@@ -122,6 +122,7 @@ export const getToolCallChipLabel = (
         case 'runSql':
         case 'runContentQuery':
         case 'runSavedChart':
+        case 'generateHashes':
         case 'improveContext':
         case 'proposeChange':
             return null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
@@ -37,6 +37,7 @@ export const getToolIcon = (toolName: AiAgentToolName) => {
             generateTimeSeriesVizConfig: IconChartLine,
             generateTableVizConfig: IconTable,
             generateDashboard: IconLayoutDashboard,
+            generateHashes: IconSelector,
             generateUuids: IconSelector,
             findContent: IconSearch,
             listContent: IconFolder,


### PR DESCRIPTION
### Summary
- add generateHashes agent tool for deterministic PoP metric suffixes
- add built-in PoP chart reference for content JSON
- register generateHashes across stored result parsing, evaluator, and frontend tool-call UI seams

### Tests
- pnpm -F backend test -- agentToolContracts.snapshot.test.ts --runInBand
- pnpm -F common test -- periodOverPeriodComparison.test.ts --runInBand
- pnpm -F common test -- defineTool.test.ts --runInBand
- pnpm -F common typecheck
- pnpm -F backend typecheck
- pnpm -F frontend typecheck

Closes: ZAP-474