### PR TITLE
fix(dashboard): keep date zoom granularities across tab switches

### DIFF
--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -202,6 +202,16 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
         [availableCustomGranularities],
     );
 
+    // View mode: enabled standard granularities, reusing standardGranularities so
+    // sub-day options stay hidden when no TIMESTAMP dimension exists (matches edit mode).
+    const enabledStandardGranularities = useMemo(
+        () =>
+            standardGranularities.filter((g) =>
+                dateZoomGranularities.includes(g),
+            ),
+        [standardGranularities, dateZoomGranularities],
+    );
+
     // View mode: enabled custom granularities, reusing the sorted order from customGranularities
     const enabledCustomGranularities = useMemo(
         () =>
@@ -427,19 +437,17 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                                 </Menu.Item>
                             </Tooltip>
 
-                            {dateZoomGranularities
-                                .filter((g) => isStandardDateGranularity(g))
-                                .map((granularity) => (
-                                    <ViewModeGranularityItem
-                                        key={granularity}
-                                        granularity={granularity}
-                                        label={granularity}
-                                        isActive={
-                                            dateZoomGranularity === granularity
-                                        }
-                                        onSelect={handleSelectGranularity}
-                                    />
-                                ))}
+                            {enabledStandardGranularities.map((granularity) => (
+                                <ViewModeGranularityItem
+                                    key={granularity}
+                                    granularity={granularity}
+                                    label={granularity}
+                                    isActive={
+                                        dateZoomGranularity === granularity
+                                    }
+                                    onSelect={handleSelectGranularity}
+                                />
+                            ))}
 
                             {enabledCustomGranularities.length > 0 && (
                                 <>

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -10,7 +10,6 @@ import {
     isDashboardChartTileType,
     isFilterLockedOnTab,
     isStandardDateGranularity,
-    isSubDayGranularity,
     stripOverridesForLockedFiltersOnTab,
     type Dashboard,
     type DashboardFilterableField,
@@ -1610,9 +1609,6 @@ const DashboardGranularitySync: React.FC = () => {
     const availableCustomGranularities = useDashboardTileStatusContext(
         (c) => c.availableCustomGranularities,
     );
-    const dashboardHasTimestampDimension = useDashboardTileStatusContext(
-        (c) => c.dashboardHasTimestampDimension,
-    );
 
     // Use refs for values we read but should NOT trigger re-runs of the effect.
     // Reading dateZoomGranularities directly in the dep array would cause an
@@ -1647,9 +1643,11 @@ const DashboardGranularitySync: React.FC = () => {
         (c) => c.setDateZoomGranularity,
     );
 
-    // Once all charts have loaded, clean up stale granularities:
-    // - Custom granularities no longer provided by any explore
-    // - Sub-day granularities when no TIMESTAMP dimensions exist
+    // Once all charts have loaded, clean up stale custom granularities that are
+    // no longer provided by any explore. Standard granularities are never pruned
+    // here: sub-day options are hidden at render time when no TIMESTAMP dimension
+    // exists (see DateZoom), so pruning them would destructively drop the editor's
+    // configured options when only some tabs expose timestamp dimensions.
     // Also resets the active dateZoomGranularity if it's a stale custom value
     // (custom granularities are not validated earlier to avoid a race condition
     // where the URL param is cleared before charts finish loading).
@@ -1663,16 +1661,9 @@ const DashboardGranularitySync: React.FC = () => {
         const availableCustomGranularityKeys = new Set(
             Object.keys(availableCustomGranularities),
         );
-        const isAvailable = (g: string) => {
-            if (!isStandardDateGranularity(g)) {
-                return availableCustomGranularityKeys.has(g);
-            }
-            // Strip sub-day standard granularities when no timestamp dims
-            if (!dashboardHasTimestampDimension && isSubDayGranularity(g)) {
-                return false;
-            }
-            return true;
-        };
+        const isAvailable = (g: string) =>
+            isStandardDateGranularity(g) ||
+            availableCustomGranularityKeys.has(g);
 
         const filtered = currentGranularities.filter(isAvailable);
         if (
@@ -1697,7 +1688,6 @@ const DashboardGranularitySync: React.FC = () => {
     }, [
         areAllChartsLoaded,
         availableCustomGranularities,
-        dashboardHasTimestampDimension,
         setDateZoomGranularities,
         setDefaultDateZoomGranularity,
         setDateZoomGranularity,

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -191,6 +191,13 @@ const DashboardTileStatusProvider: React.FC<
         setScreenshotErroredTiles(new Set());
     }, [dashboardTiles, activeTab]);
 
+    // Reset loaded tracking when the active tab changes so areAllChartsLoaded
+    // reflects the newly mounted tab's tiles, not stale entries from a
+    // previously visited tab.
+    useEffect(() => {
+        setLoadedTiles(new Set());
+    }, [activeTab]);
+
     // Memoized mapping of tile UUIDs to their display names
     const tileNamesById = useMemo(() => {
         if (!dashboardTiles) return {};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-8071
Closes: #23773

### Description:

Enabling a sub-day Date Zoom granularity (e.g. Hour) in edit mode was silently dropped after switching dashboard tabs and back. The configured granularity list was destructively pruned based only on the active tab's mounted tiles, and `loadedTiles` was never reset on tab change — so returning to a tab let the cleanup fire against a transient/partial state and remove the granularity permanently. This PR stops pruning standard granularities from the saved config (DateZoom already hides sub-day options at render time when no TIMESTAMP dimension exists, keeping only the stale custom-granularity cleanup) and resets loaded-tile tracking when the active tab changes so `areAllChartsLoaded` can't read stale-true mid-transition.