### PR TITLE
refactor(ai-writeback): extract pure helpers and add tests

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -1,0 +1,483 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
+import {
+    AnyType,
+    DbtProjectType,
+    FeatureFlags,
+    ForbiddenError,
+    WarehouseTypes,
+    type MemberAbility,
+    type SessionUser,
+} from '@lightdash/common';
+import { Sandbox } from 'e2b';
+import {
+    createPullRequest,
+    getAppBotIdentity,
+    getAuthenticatedUser,
+    getBranchHeadSha,
+    getInstallationToken,
+    getOrRefreshToken,
+} from '../../../clients/github/Github';
+import { AiWritebackService } from './AiWritebackService';
+import {
+    PR_DESCRIPTION_CLOSE,
+    PR_DESCRIPTION_OPEN,
+    PR_TITLE_CLOSE,
+    PR_TITLE_OPEN,
+} from './constants';
+
+// e2b (and the GitHub client → octokit) are ESM-only and break Jest's parser.
+// Stub the modules so the import graph stays CJS; the run() tests drive the
+// fakes, the unit tests below never reach them.
+jest.mock('e2b', () => ({
+    Sandbox: { create: jest.fn(), connect: jest.fn() },
+    CommandExitError: class CommandExitError extends Error {},
+    TimeoutError: class TimeoutError extends Error {},
+}));
+jest.mock('../../../clients/github/Github', () => ({
+    createBranch: jest.fn().mockResolvedValue(undefined),
+    createPullRequest: jest.fn(),
+    createSignedCommitOnBranch: jest.fn().mockResolvedValue(undefined),
+    getAppBotIdentity: jest.fn(),
+    getAuthenticatedUser: jest.fn(),
+    getBranchHeadSha: jest.fn(),
+    getInstallationToken: jest.fn(),
+    getOrRefreshToken: jest.fn(),
+    updatePullRequest: jest.fn().mockResolvedValue(undefined),
+}));
+
+const ORG = 'org-1';
+const PR_3 = 'https://github.com/acme/analytics/pull/3';
+const PR_7 = 'https://github.com/acme/analytics/pull/7';
+const PR_9 = 'https://github.com/acme/analytics/pull/9';
+
+const buildService = (overrides: Record<string, AnyType> = {}) =>
+    new AiWritebackService({
+        lightdashConfig: {} as AnyType,
+        analytics: { track: jest.fn() } as AnyType,
+        projectModel: { get: jest.fn() } as AnyType,
+        featureFlagModel: { get: jest.fn() } as AnyType,
+        githubAppInstallationsModel: {} as AnyType,
+        aiWritebackThreadModel: { findByAiThreadUuid: jest.fn() } as AnyType,
+        pullRequestsModel: {} as AnyType,
+        projectCiStatusModel: {} as AnyType,
+        ...overrides,
+    });
+
+const turnContext = (overrides: AnyType = {}): AnyType => ({
+    organizationUuid: ORG,
+    projectName: 'Analytics',
+    githubConnection: { owner: 'acme', repo: 'analytics', projectSubPath: '.' },
+    existingRow: null,
+    isResume: false,
+    warehouseType: null,
+    ...overrides,
+});
+
+const threadRow = (prUrl: string): AnyType => ({
+    ai_writeback_thread_uuid: 'w-1',
+    ai_thread_uuid: 'thread-1',
+    sandbox_id: 'sbx-1',
+    pull_request_uuid: 'pr-1',
+    created_at: new Date(),
+    pr_url: prUrl,
+});
+
+const adoptedPullRequest = (prUrl: string): AnyType => ({
+    prUrl,
+    owner: 'acme',
+    repo: 'analytics',
+    pullNumber: 9,
+    headRef: 'feature/x',
+});
+
+describe('AiWritebackService.applyAgentChanges', () => {
+    const setup = () => {
+        const service = buildService();
+        const open = jest
+            .spyOn(service as AnyType, 'openInitialPullRequest')
+            .mockResolvedValue(PR_7);
+        const update = jest
+            .spyOn(service as AnyType, 'updateExistingPullRequest')
+            .mockResolvedValue(undefined);
+        const record = jest
+            .spyOn(service as AnyType, 'recordWritebackPullRequest')
+            .mockResolvedValue(undefined);
+        return { service, open, update, record };
+    };
+
+    const applyAgentChanges = (
+        service: AiWritebackService,
+        args: AnyType,
+    ): AnyType =>
+        (service as AnyType).applyAgentChanges({
+            sandbox: { sandboxId: 'sbx-1' },
+            github: { installationId: 'inst-1', prToken: null },
+            adoptedPr: null,
+            turn: turnContext(),
+            user: { userUuid: 'u1' },
+            projectUuid: 'p1',
+            aiThreadUuid: undefined,
+            setStage: jest.fn(),
+            prTitle: 'T',
+            prDescription: 'D',
+            ...args,
+        });
+
+    it('does nothing when the agent made no changes (one-shot)', async () => {
+        const { service, open, update } = setup();
+        const result = await applyAgentChanges(service, { hasChanges: false });
+        expect(result).toEqual({
+            prUrl: null,
+            prCreated: false,
+            pauseOnExit: false,
+        });
+        expect(open).not.toHaveBeenCalled();
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it('keeps a resumed PR and sandbox warm when there are no changes', async () => {
+        const { service } = setup();
+        const result = await applyAgentChanges(service, {
+            hasChanges: false,
+            turn: turnContext({ existingRow: threadRow(PR_3), isResume: true }),
+        });
+        expect(result).toEqual({
+            prUrl: PR_3,
+            prCreated: false,
+            pauseOnExit: true,
+        });
+    });
+
+    it('updates the existing PR and pauses on a resume turn with changes', async () => {
+        const { service, update, record } = setup();
+        const result = await applyAgentChanges(service, {
+            hasChanges: true,
+            turn: turnContext({ existingRow: threadRow(PR_3), isResume: true }),
+        });
+        expect(result).toEqual({
+            prUrl: PR_3,
+            prCreated: false,
+            pauseOnExit: true,
+        });
+        expect(update).toHaveBeenCalledTimes(1);
+        expect(record).not.toHaveBeenCalled();
+    });
+
+    it('updates and records a pasted (adopted) PR when given a thread uuid', async () => {
+        const { service, update, record } = setup();
+        const result = await applyAgentChanges(service, {
+            hasChanges: true,
+            adoptedPr: adoptedPullRequest(PR_9),
+            aiThreadUuid: 'thread-1',
+        });
+        expect(result).toEqual({
+            prUrl: PR_9,
+            prCreated: false,
+            pauseOnExit: true,
+        });
+        expect(update).toHaveBeenCalledTimes(1);
+        expect(record).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not keep an adopted PR warm without a thread uuid', async () => {
+        const { service } = setup();
+        const result = await applyAgentChanges(service, {
+            hasChanges: true,
+            adoptedPr: adoptedPullRequest(PR_9),
+            aiThreadUuid: undefined,
+        });
+        expect(result.pauseOnExit).toBe(false);
+    });
+
+    it('opens and records a new PR for fresh changes in a thread', async () => {
+        const { service, open, update, record } = setup();
+        const result = await applyAgentChanges(service, {
+            hasChanges: true,
+            aiThreadUuid: 'thread-1',
+        });
+        expect(result).toEqual({
+            prUrl: PR_7,
+            prCreated: true,
+            pauseOnExit: true,
+        });
+        expect(open).toHaveBeenCalledTimes(1);
+        expect(update).not.toHaveBeenCalled();
+        expect(record).toHaveBeenCalledTimes(1);
+    });
+
+    it('kills the sandbox after a one-shot run opens a PR', async () => {
+        const { service } = setup();
+        const result = await applyAgentChanges(service, {
+            hasChanges: true,
+            aiThreadUuid: undefined,
+        });
+        expect(result).toMatchObject({ prCreated: true, pauseOnExit: false });
+    });
+});
+
+describe('AiWritebackService.prepareTurn', () => {
+    const userWithOrg = (canManage: boolean): SessionUser => {
+        const { build, can } = new AbilityBuilder<MemberAbility>(Ability);
+        if (canManage) can('manage', 'SourceCode', { organizationUuid: ORG });
+        return {
+            userUuid: 'u1',
+            organizationUuid: ORG,
+            organizationName: 'Acme',
+            organizationCreatedAt: new Date(),
+            role: 'admin',
+            ability: build(),
+        } as AnyType;
+    };
+
+    const githubProject = (): AnyType => ({
+        organizationUuid: ORG,
+        name: 'Analytics',
+        dbtConnection: {
+            type: DbtProjectType.GITHUB,
+            authorization_method: 'installation_id',
+            repository: 'acme/analytics',
+            branch: 'main',
+            project_sub_path: '/',
+        },
+        warehouseConnection: { type: WarehouseTypes.POSTGRES },
+    });
+
+    const prepareTurn = (service: AiWritebackService, user: SessionUser) =>
+        (service as AnyType).prepareTurn({
+            user,
+            projectUuid: 'p1',
+            aiThreadUuid: undefined,
+        });
+
+    it('rejects when the AI writeback feature flag is disabled', async () => {
+        const service = buildService({
+            featureFlagModel: {
+                get: jest.fn().mockResolvedValue({ enabled: false }),
+            } as AnyType,
+        });
+        await expect(prepareTurn(service, userWithOrg(true))).rejects.toThrow(
+            ForbiddenError,
+        );
+    });
+
+    it('rejects when the user cannot manage source code', async () => {
+        const service = buildService({
+            featureFlagModel: {
+                get: jest.fn().mockResolvedValue({ enabled: true }),
+            } as AnyType,
+            projectModel: {
+                get: jest.fn().mockResolvedValue(githubProject()),
+            } as AnyType,
+        });
+        await expect(prepareTurn(service, userWithOrg(false))).rejects.toThrow(
+            ForbiddenError,
+        );
+    });
+
+    it('resolves a fresh turn context for a permitted user', async () => {
+        const service = buildService({
+            featureFlagModel: {
+                get: jest.fn().mockResolvedValue({ enabled: true }),
+            } as AnyType,
+            projectModel: {
+                get: jest.fn().mockResolvedValue(githubProject()),
+            } as AnyType,
+            aiWritebackThreadModel: {
+                findByAiThreadUuid: jest.fn().mockResolvedValue(null),
+            } as AnyType,
+        });
+        await expect(
+            prepareTurn(service, userWithOrg(true)),
+        ).resolves.toMatchObject({
+            organizationUuid: ORG,
+            projectName: 'Analytics',
+            githubConnection: {
+                owner: 'acme',
+                repo: 'analytics',
+                projectSubPath: '.',
+            },
+            existingRow: null,
+            isResume: false,
+            warehouseType: WarehouseTypes.POSTGRES,
+        });
+    });
+});
+
+describe('AiWritebackService.run (mocked end-to-end)', () => {
+    const permittedUser = (): SessionUser => {
+        const { build, can } = new AbilityBuilder<MemberAbility>(Ability);
+        can('manage', 'SourceCode', { organizationUuid: ORG });
+        return {
+            userUuid: 'u1',
+            organizationUuid: ORG,
+            organizationName: 'Acme',
+            organizationCreatedAt: new Date(),
+            role: 'admin',
+            ability: build(),
+        } as AnyType;
+    };
+
+    // Final assistant message: a reply plus the structured PR title/description.
+    const agentReply = (): string =>
+        `Done.\n${PR_TITLE_OPEN}Add metric${PR_TITLE_CLOSE}\n` +
+        `${PR_DESCRIPTION_OPEN}Adds revenue.${PR_DESCRIPTION_CLOSE}`;
+
+    const fakeSandbox = (
+        agentExitCode: number,
+        hasChanges: boolean,
+    ): AnyType => ({
+        sandboxId: 'sbx-1',
+        files: {
+            write: jest.fn().mockResolvedValue(undefined),
+            read: jest.fn().mockResolvedValue('model contents'),
+            remove: jest.fn().mockResolvedValue(undefined),
+        },
+        git: {
+            clone: jest.fn().mockResolvedValue(undefined),
+            status: jest
+                .fn()
+                .mockResolvedValue({ hasChanges, currentBranch: 'main' }),
+            add: jest.fn().mockResolvedValue(undefined),
+            commit: jest.fn().mockResolvedValue(undefined),
+            createBranch: jest.fn().mockResolvedValue(undefined),
+        },
+        commands: {
+            run: jest.fn(async (command: string, opts: AnyType) => {
+                if (command.includes('claude')) {
+                    opts?.onStdout?.(
+                        `${JSON.stringify({
+                            type: 'assistant',
+                            message: {
+                                content: [{ type: 'text', text: agentReply() }],
+                            },
+                        })}\n`,
+                    );
+                    return { exitCode: agentExitCode, stdout: '' };
+                }
+                if (command.includes('--name-status')) {
+                    return { exitCode: 0, stdout: 'A\0models/x.sql\0' };
+                }
+                return { exitCode: 0, stdout: '' };
+            }),
+        },
+        pause: jest.fn().mockResolvedValue(undefined),
+        kill: jest.fn().mockResolvedValue(undefined),
+    });
+
+    const runService = (sandbox: AnyType) => {
+        const service = buildService({
+            lightdashConfig: {
+                siteUrl: 'https://app.example',
+                appRuntime: {
+                    e2bApiKey: 'e2b-key',
+                    e2bAiWritebackTemplateName: 'tpl',
+                    e2bAiWritebackTemplateTag: '',
+                },
+                aiWriteback: { anthropicApiKey: 'anthropic-key' },
+            } as AnyType,
+            featureFlagModel: {
+                get: jest.fn(({ featureFlagId }: AnyType) =>
+                    Promise.resolve({
+                        enabled: featureFlagId === FeatureFlags.AiWriteback,
+                    }),
+                ),
+            } as AnyType,
+            projectModel: {
+                get: jest.fn().mockResolvedValue({
+                    organizationUuid: ORG,
+                    name: 'Analytics',
+                    dbtConnection: {
+                        type: DbtProjectType.GITHUB,
+                        authorization_method: 'installation_id',
+                        repository: 'acme/analytics',
+                        branch: 'main',
+                        project_sub_path: '/',
+                    },
+                    warehouseConnection: null,
+                }),
+            } as AnyType,
+            githubAppInstallationsModel: {
+                getInstallationId: jest.fn().mockResolvedValue('inst-1'),
+                getAuth: jest
+                    .fn()
+                    .mockResolvedValue({ token: 'oauth', refreshToken: 'r' }),
+                updateAuth: jest.fn().mockResolvedValue(undefined),
+            } as AnyType,
+            aiWritebackThreadModel: {
+                findByAiThreadUuid: jest.fn().mockResolvedValue(null),
+                create: jest.fn().mockResolvedValue(undefined),
+            } as AnyType,
+            pullRequestsModel: {
+                findOrCreate: jest
+                    .fn()
+                    .mockResolvedValue({ pullRequestUuid: 'pr-uuid' }),
+            } as AnyType,
+        });
+        return service.run({
+            user: permittedUser(),
+            projectUuid: 'p1',
+            prompt: 'add a revenue metric',
+            source: 'web',
+        });
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (getInstallationToken as jest.Mock).mockResolvedValue('install-token');
+        (getOrRefreshToken as jest.Mock).mockResolvedValue({
+            token: 'oauth',
+            refreshToken: 'r',
+        });
+        (getAuthenticatedUser as jest.Mock).mockResolvedValue({
+            login: 'octocat',
+            id: 1,
+        });
+        (getAppBotIdentity as jest.Mock).mockResolvedValue({
+            login: 'lightdash-bot',
+            id: 2,
+        });
+        (getBranchHeadSha as jest.Mock).mockResolvedValue('base-oid');
+        (createPullRequest as jest.Mock).mockResolvedValue({
+            html_url: PR_7,
+        });
+    });
+
+    it('opens a PR and kills the sandbox for a one-shot run with changes', async () => {
+        const sandbox = fakeSandbox(0, true);
+        (Sandbox.create as jest.Mock).mockResolvedValue(sandbox);
+
+        const result = await runService(sandbox);
+
+        expect(result).toMatchObject({
+            output: 'Done.',
+            exitCode: 0,
+            prUrl: PR_7,
+            repository: 'acme/analytics',
+        });
+        expect(createPullRequest).toHaveBeenCalledTimes(1);
+        expect(sandbox.kill).toHaveBeenCalledTimes(1);
+        expect(sandbox.pause).not.toHaveBeenCalled();
+    });
+
+    it('skips the PR when the agent exits non-zero', async () => {
+        const sandbox = fakeSandbox(1, true);
+        (Sandbox.create as jest.Mock).mockResolvedValue(sandbox);
+
+        const result = await runService(sandbox);
+
+        expect(result).toMatchObject({ exitCode: 1, prUrl: null });
+        expect(createPullRequest).not.toHaveBeenCalled();
+        expect(sandbox.kill).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens no PR when the agent produced no changes', async () => {
+        const sandbox = fakeSandbox(0, false);
+        (Sandbox.create as jest.Mock).mockResolvedValue(sandbox);
+
+        const result = await runService(sandbox);
+
+        expect(result).toMatchObject({ exitCode: 0, prUrl: null });
+        expect(createPullRequest).not.toHaveBeenCalled();
+        expect(sandbox.kill).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1,7 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    assertUnreachable,
-    DbtProjectType,
     detectPreviewDeployWorkflow,
     FeatureFlags,
     ForbiddenError,
@@ -9,14 +7,12 @@ import {
     getErrorMessage,
     getPreviewDeploySecrets,
     isUserWithOrg,
-    isWorkflowFile,
     MissingConfigError,
     ParameterError,
     PullRequestProvider,
     PullRequestSource,
     WarehouseTypes,
     type AiWritebackRunResult,
-    type DbtProjectConfig,
     type PreviewDeploySecret,
     type ProjectCiStatus,
     type SessionUser,
@@ -62,20 +58,19 @@ import {
     COMPILE_STRIPPED_ENV_VARS,
     COMPILE_WRAPPER_PATH,
     CWD,
+    GATHER_REPO_CONTEXT_SANDBOX_PATH,
     GIT_TIMEOUT_MS,
     GIT_USERNAME,
-    PR_DESCRIPTION_CLOSE,
-    PR_DESCRIPTION_OPEN,
     PR_DESCRIPTION_PATH,
-    PR_TITLE_CLOSE,
-    PR_TITLE_OPEN,
     PR_TITLE_PATH,
+    PREVIEW_DEPLOY_SETUP_PROMPT,
     PROMPT_PATH,
     REPO_CONTEXT_TIMEOUT_MS,
     RUN_TIMEOUT_MS,
     SANDBOX_TIMEOUT_MS,
     SHARED_SKILL_PATH,
     SKILLS_DIR,
+    STDERR_TAIL_BYTES,
     SYSTEM_PROMPT_PATH,
     WAREHOUSE_SKILL_PATH,
 } from './constants';
@@ -85,6 +80,7 @@ import { loadWarehouseSkills, warehouseTypeToSkillKey } from './skills';
 import { buildSystemPrompt } from './templates';
 import type {
     AdoptedPullRequest,
+    AgentPhase,
     AiWritebackRunArgs,
     AiWritebackSource,
     AppliedChanges,
@@ -95,20 +91,25 @@ import type {
     TurnContext,
     WarehouseSkillKey,
 } from './types';
+import {
+    buildCoAuthorTrailer,
+    buildNoreplyEmail,
+    classifyToolPhase,
+    extractPrMetadata,
+    getPhaseProgressText,
+    interpretAgentEvent,
+    parseGitNameStatus,
+    parsePullNumber,
+    parseTrackedWorkflowPaths,
+    progressTextForStage,
+    resolveGithubConnection,
+    resolvePrMetadataValue,
+    resolveSandboxTemplateRef,
+    splitStreamBuffer,
+    summarizeToolInput,
+} from './utils';
 
 export type { AiWritebackRunArgs, AiWritebackSource } from './types';
-
-const GATHER_REPO_CONTEXT_SANDBOX_PATH = '/tmp/gather-repo-context.sh';
-
-// Synthetic prompt for the dedicated preview-deploy setup run. It leans on the
-// "Secondary task" section that run()'s system prompt already injects (with the
-// exact workflow files + secrets) when the repo has no preview-deploy workflow.
-const PREVIEW_DEPLOY_SETUP_PROMPT = [
-    'The user has agreed to set up Lightdash preview deploys for this project.',
-    'Your ONLY task this run is to add the Lightdash preview-deploy GitHub Actions workflow described in the "Secondary task: offer to set up Lightdash preview deploys" section of your instructions.',
-    'Keep the workflow structure exactly as shown in that section — the permissions blocks, secret names, lightdash commands, and job/trigger layout are security-reviewed and run with live credentials, so do NOT widen permissions, rename the files, or change the commands. You MAY adapt only the version pinning (action refs, Node version, @lightdash/cli version): use the versions shown by default, but if the repo already has a consistent version-pinning convention in its other .github/workflows files, match it instead. Do NOT modify any dbt models, YAML, or other files.',
-    'In your final reply, list the GitHub Actions repository secrets the user must add for the workflow to run.',
-].join(' ');
 
 type AiWritebackServiceDeps = {
     lightdashConfig: LightdashConfig;
@@ -190,45 +191,6 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
-     * Resolve the target GitHub repository and dbt project sub-folder from a
-     * Lightdash project's dbt connection. AI writeback clones over GitHub and
-     * opens a PR via the GitHub App, so only GitHub-backed dbt connections are
-     * supported.
-     *
-     * `repository` is stored as `owner/repo`. `project_sub_path` is the
-     * sub-folder holding the dbt project, relative to the repo root (stored
-     * with a leading slash, e.g. `/dbt`, and `/` for the repo root); it is
-     * normalised to a path relative to the repo root (`dbt`, or `.` for the
-     * root) so it can be passed straight to the compile's `--project-dir`.
-     */
-    private static resolveGithubConnection(connection: DbtProjectConfig): {
-        owner: string;
-        repo: string;
-        projectSubPath: string;
-    } {
-        if (connection.type !== DbtProjectType.GITHUB) {
-            throw new ParameterError(
-                `AI writeback requires a GitHub dbt connection, but this project uses "${connection.type}"`,
-            );
-        }
-        const [owner, repo] = connection.repository.split('/');
-        if (!owner || !repo) {
-            throw new ParameterError(
-                `Project's dbt connection has an invalid repository "${connection.repository}" (expected "owner/repo")`,
-            );
-        }
-        const relativeSubPath = connection.project_sub_path
-            .trim()
-            .replace(/^\/+/, '')
-            .replace(/\/+$/, '');
-        return {
-            owner,
-            repo,
-            projectSubPath: relativeSubPath === '' ? '.' : relativeSubPath,
-        };
-    }
-
-    /**
      * Resolve GitHub auth for the organization. The installation access token
      * authenticates the in-sandbox clone. We additionally resolve the OAuth user
      * identity (the user who connected the GitHub App for the org) so the pull
@@ -273,11 +235,9 @@ export class AiWritebackService extends BaseService {
             }
             const githubUser = await getAuthenticatedUser(refreshed.token);
             prToken = refreshed.token;
-            // Use the GitHub-provided noreply email so we never need the user's
-            // real address and the commit still links to their profile.
             commitAuthor = {
                 name: githubUser.login,
-                email: `${githubUser.id}+${githubUser.login}@users.noreply.github.com`,
+                email: buildNoreplyEmail(githubUser),
             };
         } catch (error) {
             this.logger.warn(
@@ -290,7 +250,7 @@ export class AiWritebackService extends BaseService {
         let coAuthorTrailer = CO_AUTHOR_TRAILER;
         try {
             const bot = await getAppBotIdentity(installationId);
-            coAuthorTrailer = `Co-authored-by: ${bot.login} <${bot.id}+${bot.login}@users.noreply.github.com>`;
+            coAuthorTrailer = buildCoAuthorTrailer(bot);
         } catch (error) {
             this.logger.warn(
                 `AiWriteback: could not resolve GitHub app bot identity for the co-author trailer; using the default. ${getErrorMessage(
@@ -312,52 +272,16 @@ export class AiWritebackService extends BaseService {
         return Math.round(performance.now() - start);
     }
 
-    /**
-     * Map an internal lifecycle stage to the short progress string surfaced
-     * to the user (e.g. via the Slack bot's "Thinking…" message). One source
-     * of truth so the wording stays consistent if a stage is renamed later.
-     * Keep the strings short — Slack renders them in a single context line.
-     */
-    private static progressTextForStage(
-        stage: AiWritebackFailureStage,
-    ): string | null {
-        switch (stage) {
-            case 'install':
-                return 'Setting up';
-            case 'sandbox':
-                return 'Starting sandbox';
-            case 'clone':
-                return 'Cloning project';
-            case 'agent':
-                return 'Starting sub agent';
-            case 'commit':
-                return 'Committing changes';
-            case 'push':
-                return 'Pushing to GitHub';
-            case 'pull_request':
-                // No user-facing label — the parent tool group is already
-                // labelled "Opening a pull request", so this progress
-                // event would just echo the heading and read as filler.
-                return null;
-            default:
-                return assertUnreachable(
-                    stage,
-                    `Unknown AiWritebackFailureStage: ${String(stage)}`,
-                );
-        }
-    }
-
     private async createSandbox(
         projectUuid: string,
     ): Promise<{ sandbox: Sandbox; durationMs: number }> {
         const start = performance.now();
         const { e2bAiWritebackTemplateName, e2bAiWritebackTemplateTag } =
             this.lightdashConfig.appRuntime;
-        // E2B treats `name` and `name:default` interchangeably, so an empty
-        // tag is fine — it just resolves to the implicit `default` build.
-        const templateRef = e2bAiWritebackTemplateTag
-            ? `${e2bAiWritebackTemplateName}:${e2bAiWritebackTemplateTag}`
-            : e2bAiWritebackTemplateName;
+        const templateRef = resolveSandboxTemplateRef({
+            name: e2bAiWritebackTemplateName,
+            tag: e2bAiWritebackTemplateTag,
+        });
         const sandbox = await Sandbox.create(templateRef, {
             timeoutMs: SANDBOX_TIMEOUT_MS,
             apiKey: this.getE2bApiKey(),
@@ -456,14 +380,11 @@ export class AiWritebackService extends BaseService {
         if (fromRepo !== null) {
             await sandbox.files.remove(repoPath).catch(() => {});
         }
-        const fromTmpTrimmed = (fromTmp ?? '').trim();
-        const fromRepoTrimmed = (fromRepo ?? '').trim();
-        let source: 'tmp' | 'repo-fallback' | 'default' = 'default';
-        if (fromTmpTrimmed.length > 0) {
-            source = 'tmp';
-        } else if (fromRepoTrimmed.length > 0) {
-            source = 'repo-fallback';
-        }
+        const { source, value } = resolvePrMetadataValue({
+            fromTmp,
+            fromRepo,
+            fallback,
+        });
         this.logger.info(
             `AiWriteback: resolved PR metadata '${fileName}' from ${source}` +
                 `${
@@ -472,52 +393,7 @@ export class AiWritebackService extends BaseService {
                         : ''
                 } (sandboxId=${sandbox.sandboxId})`,
         );
-        const resolved = fromTmpTrimmed || fromRepoTrimmed;
-        return resolved.length > 0 ? resolved : fallback;
-    }
-
-    /**
-     * Pull the PR title and description out of the agent's final stdout via
-     * the structured-output delimiters, and return a copy of the stdout with
-     * those blocks removed so they don't appear in the Slack reply. Either
-     * field may be null when the agent failed to emit it — in that case the
-     * caller falls back to the (less reliable) file-based metadata channel.
-     */
-    private extractPrMetadata(stdout: string): {
-        title: string | null;
-        description: string | null;
-        sanitizedStdout: string;
-    } {
-        const escape = (s: string): string =>
-            s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const titleRe = new RegExp(
-            `${escape(PR_TITLE_OPEN)}([\\s\\S]*?)${escape(PR_TITLE_CLOSE)}`,
-        );
-        const descRe = new RegExp(
-            `${escape(PR_DESCRIPTION_OPEN)}([\\s\\S]*?)${escape(
-                PR_DESCRIPTION_CLOSE,
-            )}`,
-        );
-        const title = stdout.match(titleRe)?.[1].trim() || null;
-        const description = stdout.match(descRe)?.[1].trim() || null;
-        const stripRe = new RegExp(
-            `${escape(PR_TITLE_OPEN)}[\\s\\S]*?${escape(
-                PR_TITLE_CLOSE,
-            )}|${escape(PR_DESCRIPTION_OPEN)}[\\s\\S]*?${escape(
-                PR_DESCRIPTION_CLOSE,
-            )}`,
-            'g',
-        );
-        const sanitizedStdout = stdout
-            .replace(stripRe, '')
-            .replace(/\n{3,}/g, '\n\n')
-            .trim();
-        this.logger.info(
-            `AiWriteback: extracted PR metadata from stdout (title=${
-                title !== null
-            }, description=${description !== null})`,
-        );
-        return { title, description, sanitizedStdout };
+        return value;
     }
 
     /**
@@ -571,18 +447,7 @@ export class AiWritebackService extends BaseService {
         const { stdout } = await sandbox.commands.run(
             `git -C ${CWD} diff --cached --name-status --no-renames -z`,
         );
-        const parts = stdout.split('\0').filter((p) => p.length > 0);
-        const addPaths: string[] = [];
-        const deletions: { path: string }[] = [];
-        for (let i = 0; i + 1 < parts.length; i += 2) {
-            const status = parts[i];
-            const path = parts[i + 1];
-            if (status.startsWith('D')) {
-                deletions.push({ path });
-            } else {
-                addPaths.push(path);
-            }
-        }
+        const { addPaths, deletions } = parseGitNameStatus(stdout);
         const additions = await Promise.all(
             addPaths.map(async (path) => ({
                 path,
@@ -688,10 +553,7 @@ export class AiWritebackService extends BaseService {
             const { stdout: fileList } = await sandbox.commands.run(
                 `git -C ${CWD} ls-files .github/workflows`,
             );
-            const paths = fileList
-                .split('\n')
-                .map((p) => p.trim())
-                .filter((p) => p.length > 0 && isWorkflowFile(p));
+            const paths = parseTrackedWorkflowPaths(fileList);
 
             const files: WorkflowFile[] = await Promise.all(
                 paths.map(async (path) => ({
@@ -860,7 +722,7 @@ export class AiWritebackService extends BaseService {
             // Stages can opt out of progress reporting by returning null
             // from progressTextForStage when their label would duplicate
             // the parent tool's heading or otherwise add no signal.
-            const progressText = AiWritebackService.progressTextForStage(stage);
+            const progressText = progressTextForStage(stage);
             if (progressText !== null) {
                 reportProgress(progressText);
             }
@@ -968,7 +830,12 @@ export class AiWritebackService extends BaseService {
                 title: prTitle,
                 description: prDescription,
                 sanitizedStdout,
-            } = this.extractPrMetadata(agent.stdout);
+            } = extractPrMetadata(agent.stdout);
+            this.logger.info(
+                `AiWriteback: extracted PR metadata from stdout (title=${
+                    prTitle !== null
+                }, description=${prDescription !== null})`,
+            );
 
             const { hasChanges } = await sandbox.git.status(CWD);
 
@@ -1121,9 +988,7 @@ export class AiWritebackService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
 
-        const githubConnection = AiWritebackService.resolveGithubConnection(
-            project.dbtConnection,
-        );
+        const githubConnection = resolveGithubConnection(project.dbtConnection);
 
         // Resume only when both the caller supplied a thread uuid AND we
         // have a stored sandbox for it. Otherwise we start fresh.
@@ -1374,151 +1239,56 @@ export class AiWritebackService extends BaseService {
             await sandbox.files.write(WAREHOUSE_SKILL_PATH, skills.warehouse);
         }
 
-        // Parse Claude Code's stream-json output line-by-line so the agent
-        // stage stops being a black box: we log every tool the agent uses
-        // (Read/Edit/Write/Bash/...) as it happens, plus a final summary with
-        // cost + tool-call counts. The Slack reply text and PR-metadata blocks
-        // are reconstituted by overwriting `assistantText` on each new
-        // assistant message — the final message wins, which is the one that
-        // carries the user-facing reply and the structured PR_TITLE/PR_DESCRIPTION
-        // tags (see extractPrMetadata).
+        // Run state folded from Claude Code's stream-json output. The final
+        // assistant message wins for `assistantText` — it carries the
+        // user-facing reply and the PR_TITLE/PR_DESCRIPTION blocks.
         let buffer = '';
         let assistantText = '';
         const toolCounts: Record<string, number> = {};
+        const phaseProgressText = getPhaseProgressText(source);
+        const seenPhases = new Set<AgentPhase>();
 
-        // Rolling tail of stderr so a non-zero exit / timeout can carry the
-        // actual error text into the Sentry event. The full stderr is already
-        // streamed through the per-chunk debug log; we keep only the last
-        // STDERR_TAIL_BYTES so we never inflate a Sentry payload.
-        const STDERR_TAIL_BYTES = 4096;
         let stderrTail = '';
         const appendStderrTail = (chunk: string) => {
             stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_BYTES);
         };
 
-        // Map a single agent tool call to a coarse "phase" so we can stream
-        // semantic progress to the user without firing once per tool. The
-        // ordering — discover → edit → compile — matches the order an
-        // attentive viewer would describe the work, but the agent itself
-        // is free to interleave; we just announce each phase the first time
-        // we see it.
-        type AgentPhase = 'discovering' | 'editing' | 'compiling';
-        // Phase labels are task-specific: a dbt writeback edits models, whereas
-        // preview-deploy setup writes CI workflow files — so "Editing models"
-        // would read as nonsense there.
-        const phaseProgressText: Record<AgentPhase, string> =
-            source === 'preview_deploy_setup'
-                ? {
-                      discovering: 'Inspecting repository',
-                      editing: 'Writing workflow files',
-                      compiling: 'Validating workflow',
-                  }
-                : {
-                      discovering: 'Discovering models',
-                      editing: 'Editing models',
-                      compiling: 'Compiling project',
-                  };
-        const classifyTool = (
-            name: string,
-            input: unknown,
-        ): AgentPhase | null => {
-            if (name === 'Bash') {
-                const command =
-                    input && typeof input === 'object'
-                        ? (input as { command?: unknown }).command
-                        : undefined;
-                if (
-                    typeof command === 'string' &&
-                    command.includes('lightdash compile')
-                ) {
-                    return 'compiling';
-                }
-                return null;
-            }
-            if (name === 'Edit' || name === 'Write') return 'editing';
-            if (name === 'Read' || name === 'Glob' || name === 'Grep') {
-                return 'discovering';
-            }
-            return null;
-        };
-        const seenPhases = new Set<AgentPhase>();
-
-        const summarizeToolInput = (input: unknown): string => {
-            if (input && typeof input === 'object') {
-                const i = input as Record<string, unknown>;
-                if (typeof i.file_path === 'string') return i.file_path;
-                if (typeof i.command === 'string')
-                    return i.command.slice(0, 120);
-                if (typeof i.pattern === 'string') return i.pattern;
-            }
-            try {
-                return JSON.stringify(input ?? null).slice(0, 120);
-            } catch {
-                return '<unserializable>';
-            }
-        };
-
         const handleEvent = (event: unknown): void => {
-            if (!event || typeof event !== 'object') return;
-            const e = event as {
-                type?: string;
-                message?: { content?: unknown };
-                total_cost_usd?: number;
-            };
-            if (e.type === 'assistant') {
-                const content = e.message?.content;
-                if (!Array.isArray(content)) return;
-                let messageText = '';
-                for (const c of content) {
-                    if (c && typeof c === 'object') {
-                        const block = c as {
-                            type?: string;
-                            text?: string;
-                            name?: string;
-                            input?: unknown;
-                        };
-                        if (
-                            block.type === 'text' &&
-                            typeof block.text === 'string'
-                        ) {
-                            messageText += block.text;
-                        } else if (
-                            block.type === 'tool_use' &&
-                            typeof block.name === 'string'
-                        ) {
-                            toolCounts[block.name] =
-                                (toolCounts[block.name] ?? 0) + 1;
-                            this.logger.info('AI writeback agent tool call', {
-                                event: 'ai_writeback.run.tool',
-                                source,
-                                sandboxId: sandbox.sandboxId,
-                                toolName: block.name,
-                                summary: summarizeToolInput(block.input),
-                            });
-                            const phase = classifyTool(block.name, block.input);
-                            if (phase && !seenPhases.has(phase)) {
-                                seenPhases.add(phase);
-                                reportProgress(phaseProgressText[phase]);
-                            }
-                        }
-                    }
-                }
-                if (messageText) assistantText = messageText;
-            } else if (e.type === 'result') {
+            const interpreted = interpretAgentEvent(event);
+            if (interpreted.type === 'result') {
                 this.logger.info('AI writeback agent run summary', {
                     event: 'ai_writeback.run.summary',
                     source,
                     sandboxId: sandbox.sandboxId,
-                    costUsd: e.total_cost_usd ?? null,
+                    costUsd: interpreted.costUsd,
                     warehouseType,
                     toolCounts,
                 });
+                return;
             }
+            if (interpreted.type === 'ignored') return;
+            for (const toolCall of interpreted.toolCalls) {
+                toolCounts[toolCall.name] =
+                    (toolCounts[toolCall.name] ?? 0) + 1;
+                this.logger.info('AI writeback agent tool call', {
+                    event: 'ai_writeback.run.tool',
+                    source,
+                    sandboxId: sandbox.sandboxId,
+                    toolName: toolCall.name,
+                    summary: summarizeToolInput(toolCall.input),
+                });
+                const phase = classifyToolPhase(toolCall);
+                if (phase && !seenPhases.has(phase)) {
+                    seenPhases.add(phase);
+                    reportProgress(phaseProgressText[phase]);
+                }
+            }
+            if (interpreted.text !== null) assistantText = interpreted.text;
         };
 
         const flushBuffer = (): void => {
-            const lines = buffer.split('\n');
-            buffer = lines.pop() ?? '';
+            const { lines, remainder } = splitStreamBuffer(buffer);
+            buffer = remainder;
             for (const line of lines) {
                 if (line.trim()) {
                     try {
@@ -1786,7 +1556,7 @@ export class AiWritebackService extends BaseService {
             source: PullRequestSource.AI_AGENT,
             owner: turn.githubConnection.owner,
             repo: turn.githubConnection.repo,
-            prNumber: AiWritebackService.parsePullNumber(prUrl),
+            prNumber: parsePullNumber(prUrl),
             prUrl,
         });
 
@@ -1980,23 +1750,11 @@ export class AiWritebackService extends BaseService {
         await updatePullRequest({
             owner: githubConnection.owner,
             repo: githubConnection.repo,
-            pullNumber: AiWritebackService.parsePullNumber(prUrl),
+            pullNumber: parsePullNumber(prUrl),
             title,
             body: description,
             ...auth,
         });
-    }
-
-    /** Extract the numeric PR id from a github.com/owner/repo/pull/<n> URL. */
-    private static parsePullNumber(prUrl: string): number {
-        const last = prUrl.split('/').pop();
-        const n = last ? Number(last) : NaN;
-        if (!Number.isInteger(n) || n <= 0) {
-            throw new ParameterError(
-                `Could not parse pull request number from URL: ${prUrl}`,
-            );
-        }
-        return n;
     }
 
     /**

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -120,3 +120,21 @@ export const CLAUDE_MODEL = 'claude-sonnet-4-6';
 // typical repos; this guards against an unusually large checkout taking long
 // enough to eat into the agent budget.
 export const REPO_CONTEXT_TIMEOUT_MS = 30 * 1000;
+
+// Where the host writes the repo-context gathering script inside the sandbox
+// before running it (see buildGatherRepoContextScript).
+export const GATHER_REPO_CONTEXT_SANDBOX_PATH = '/tmp/gather-repo-context.sh';
+
+// Last N bytes of the agent's stderr kept for diagnostics on a non-zero exit /
+// timeout, so the Sentry payload carries the real error without inflating it.
+export const STDERR_TAIL_BYTES = 4096;
+
+// Synthetic prompt for the dedicated preview-deploy setup run. It leans on the
+// "Secondary task" section that run()'s system prompt already injects (with the
+// exact workflow files + secrets) when the repo has no preview-deploy workflow.
+export const PREVIEW_DEPLOY_SETUP_PROMPT = [
+    'The user has agreed to set up Lightdash preview deploys for this project.',
+    'Your ONLY task this run is to add the Lightdash preview-deploy GitHub Actions workflow described in the "Secondary task: offer to set up Lightdash preview deploys" section of your instructions.',
+    'Keep the workflow structure exactly as shown in that section — the permissions blocks, secret names, lightdash commands, and job/trigger layout are security-reviewed and run with live credentials, so do NOT widen permissions, rename the files, or change the commands. You MAY adapt only the version pinning (action refs, Node version, @lightdash/cli version): use the versions shown by default, but if the repo already has a consistent version-pinning convention in its other .github/workflows files, match it instead. Do NOT modify any dbt models, YAML, or other files.',
+    'In your final reply, list the GitHub Actions repository secrets the user must add for the workflow to run.',
+].join(' ');

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -87,6 +87,50 @@ export type AiWritebackSource =
     | 'admin_review'
     | 'preview_deploy_setup';
 
+/** Coarse phase of the agent's work, inferred from the tools it calls. */
+export type AgentPhase = 'discovering' | 'editing' | 'compiling';
+
+export type AgentToolCall = {
+    name: string;
+    input: unknown;
+};
+
+/**
+ * The meaningful shapes of a Claude Code stream-json line. Everything the host
+ * reacts to (assistant text, tool calls, the final cost summary) is one of
+ * these; every other event type collapses to `ignored`.
+ */
+export type AgentStreamEvent =
+    | { type: 'assistant'; text: string | null; toolCalls: AgentToolCall[] }
+    | { type: 'result'; costUsd: number | null }
+    | { type: 'ignored' };
+
+/** Title/description parsed out of the agent's final stdout. */
+export type PrMetadata = {
+    title: string | null;
+    description: string | null;
+    sanitizedStdout: string;
+};
+
+/** Which channel a PR metadata value was ultimately recovered from. */
+export type PrMetadataSource = 'tmp' | 'repo-fallback' | 'default';
+
+export type ResolvedPrMetadata = {
+    source: PrMetadataSource;
+    value: string;
+};
+
+/** Paths parsed from `git diff --cached --name-status -z`, split by op. */
+export type StagedFileChanges = {
+    addPaths: string[];
+    deletions: { path: string }[];
+};
+
+export type GithubIdentity = {
+    login: string;
+    id: number;
+};
+
 export type AiWritebackRunArgs = {
     user: SessionUser;
     projectUuid: string;

--- a/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
@@ -1,0 +1,367 @@
+import {
+    DbtProjectType,
+    ParameterError,
+    type DbtGithubProjectConfig,
+    type DbtProjectConfig,
+} from '@lightdash/common';
+import {
+    PR_DESCRIPTION_CLOSE,
+    PR_DESCRIPTION_OPEN,
+    PR_TITLE_CLOSE,
+    PR_TITLE_OPEN,
+} from './constants';
+import {
+    buildCoAuthorTrailer,
+    buildNoreplyEmail,
+    classifyToolPhase,
+    extractPrMetadata,
+    getPhaseProgressText,
+    interpretAgentEvent,
+    parseGitNameStatus,
+    parsePullNumber,
+    parseTrackedWorkflowPaths,
+    progressTextForStage,
+    resolveGithubConnection,
+    resolvePrMetadataValue,
+    resolveSandboxTemplateRef,
+    splitStreamBuffer,
+    summarizeToolInput,
+} from './utils';
+
+const githubConfig = (
+    overrides: Partial<DbtGithubProjectConfig> = {},
+): DbtProjectConfig => ({
+    type: DbtProjectType.GITHUB,
+    authorization_method: 'installation_id',
+    repository: 'acme/analytics',
+    branch: 'main',
+    project_sub_path: '/',
+    ...overrides,
+});
+
+describe('resolveGithubConnection', () => {
+    it('splits owner/repo and normalises the repo-root sub-path', () => {
+        expect(resolveGithubConnection(githubConfig())).toEqual({
+            owner: 'acme',
+            repo: 'analytics',
+            projectSubPath: '.',
+        });
+    });
+
+    it('strips leading and trailing slashes from a nested sub-path', () => {
+        expect(
+            resolveGithubConnection(
+                githubConfig({ project_sub_path: '/dbt/project/' }),
+            ).projectSubPath,
+        ).toBe('dbt/project');
+    });
+
+    it('throws for a non-GitHub dbt connection', () => {
+        expect(() =>
+            resolveGithubConnection({ type: DbtProjectType.DBT }),
+        ).toThrow(ParameterError);
+    });
+
+    it('throws when the repository is not owner/repo', () => {
+        expect(() =>
+            resolveGithubConnection(githubConfig({ repository: 'analytics' })),
+        ).toThrow(ParameterError);
+    });
+});
+
+describe('parsePullNumber', () => {
+    it('extracts the trailing pull number', () => {
+        expect(
+            parsePullNumber('https://github.com/acme/analytics/pull/42'),
+        ).toBe(42);
+    });
+
+    it.each(['https://github.com/acme/analytics/pull/0', 'no-number', ''])(
+        'throws for %p',
+        (url) => {
+            expect(() => parsePullNumber(url)).toThrow(ParameterError);
+        },
+    );
+});
+
+describe('progressTextForStage', () => {
+    it('maps each side-effecting stage to a label', () => {
+        expect(progressTextForStage('install')).toBe('Setting up');
+        expect(progressTextForStage('sandbox')).toBe('Starting sandbox');
+        expect(progressTextForStage('clone')).toBe('Cloning project');
+        expect(progressTextForStage('agent')).toBe('Starting sub agent');
+        expect(progressTextForStage('commit')).toBe('Committing changes');
+        expect(progressTextForStage('push')).toBe('Pushing to GitHub');
+    });
+
+    it('opts pull_request out of progress reporting', () => {
+        expect(progressTextForStage('pull_request')).toBeNull();
+    });
+});
+
+describe('extractPrMetadata', () => {
+    const wrap = (title: string, description: string): string =>
+        `${PR_TITLE_OPEN}${title}${PR_TITLE_CLOSE}\n` +
+        `${PR_DESCRIPTION_OPEN}${description}${PR_DESCRIPTION_CLOSE}`;
+
+    it('parses title/description and strips the blocks from stdout', () => {
+        const stdout = `Here is the change.\n\n${wrap('Add metric', 'Adds a revenue metric.')}`;
+        expect(extractPrMetadata(stdout)).toEqual({
+            title: 'Add metric',
+            description: 'Adds a revenue metric.',
+            sanitizedStdout: 'Here is the change.',
+        });
+    });
+
+    it('returns null fields when the blocks are absent', () => {
+        expect(extractPrMetadata('just a reply')).toEqual({
+            title: null,
+            description: null,
+            sanitizedStdout: 'just a reply',
+        });
+    });
+
+    it('collapses the gap left behind into a single blank line', () => {
+        const stdout = `Top\n\n${PR_TITLE_OPEN}T${PR_TITLE_CLOSE}\n\n\nBottom`;
+        expect(extractPrMetadata(stdout).sanitizedStdout).toBe('Top\n\nBottom');
+    });
+});
+
+describe('resolvePrMetadataValue', () => {
+    it('prefers the tmp value', () => {
+        expect(
+            resolvePrMetadataValue({
+                fromTmp: '  Title  ',
+                fromRepo: 'Repo title',
+                fallback: 'fallback',
+            }),
+        ).toEqual({ source: 'tmp', value: 'Title' });
+    });
+
+    it('falls back to the repo copy when tmp is blank', () => {
+        expect(
+            resolvePrMetadataValue({
+                fromTmp: '   ',
+                fromRepo: ' Repo title ',
+                fallback: 'fallback',
+            }),
+        ).toEqual({ source: 'repo-fallback', value: 'Repo title' });
+    });
+
+    it('uses the fallback when both sources are empty', () => {
+        expect(
+            resolvePrMetadataValue({
+                fromTmp: null,
+                fromRepo: null,
+                fallback: 'fallback',
+            }),
+        ).toEqual({ source: 'default', value: 'fallback' });
+    });
+});
+
+describe('parseGitNameStatus', () => {
+    it('splits additions from deletions', () => {
+        const stdout = 'A\0added.sql\0M\0modified.yml\0D\0removed.sql\0';
+        expect(parseGitNameStatus(stdout)).toEqual({
+            addPaths: ['added.sql', 'modified.yml'],
+            deletions: [{ path: 'removed.sql' }],
+        });
+    });
+
+    it('returns empty changes for empty output', () => {
+        expect(parseGitNameStatus('')).toEqual({
+            addPaths: [],
+            deletions: [],
+        });
+    });
+});
+
+describe('parseTrackedWorkflowPaths', () => {
+    it('keeps only workflow yml/yaml files, trimmed', () => {
+        const stdout = [
+            '.github/workflows/deploy.yml',
+            '  .github/workflows/ci.yaml  ',
+            '.github/workflows/README.md',
+            'dbt/model.sql',
+            '',
+        ].join('\n');
+        expect(parseTrackedWorkflowPaths(stdout)).toEqual([
+            '.github/workflows/deploy.yml',
+            '.github/workflows/ci.yaml',
+        ]);
+    });
+});
+
+describe('interpretAgentEvent', () => {
+    it('reads assistant text and tool calls', () => {
+        const event = {
+            type: 'assistant',
+            message: {
+                content: [
+                    { type: 'text', text: 'Editing ' },
+                    { type: 'text', text: 'models' },
+                    {
+                        type: 'tool_use',
+                        name: 'Edit',
+                        input: { file_path: '/a' },
+                    },
+                ],
+            },
+        };
+        expect(interpretAgentEvent(event)).toEqual({
+            type: 'assistant',
+            text: 'Editing models',
+            toolCalls: [{ name: 'Edit', input: { file_path: '/a' } }],
+        });
+    });
+
+    it('returns null text when an assistant message has no text blocks', () => {
+        const event = {
+            type: 'assistant',
+            message: { content: [{ type: 'tool_use', name: 'Read' }] },
+        };
+        expect(interpretAgentEvent(event)).toEqual({
+            type: 'assistant',
+            text: null,
+            toolCalls: [{ name: 'Read', input: undefined }],
+        });
+    });
+
+    it('ignores an assistant message whose content is not an array', () => {
+        expect(
+            interpretAgentEvent({
+                type: 'assistant',
+                message: { content: 'x' },
+            }),
+        ).toEqual({ type: 'assistant', text: null, toolCalls: [] });
+    });
+
+    it('reads the final cost from a result event', () => {
+        expect(
+            interpretAgentEvent({ type: 'result', total_cost_usd: 0.42 }),
+        ).toEqual({ type: 'result', costUsd: 0.42 });
+    });
+
+    it.each([null, 'string', { type: 'system' }, undefined])(
+        'ignores %p',
+        (event) => {
+            expect(interpretAgentEvent(event)).toEqual({ type: 'ignored' });
+        },
+    );
+});
+
+describe('classifyToolPhase', () => {
+    it('classifies a lightdash compile Bash command as compiling', () => {
+        expect(
+            classifyToolPhase({
+                name: 'Bash',
+                input: { command: 'lightdash compile --project-dir .' },
+            }),
+        ).toBe('compiling');
+    });
+
+    it('does not classify other Bash commands', () => {
+        expect(
+            classifyToolPhase({ name: 'Bash', input: { command: 'ls -la' } }),
+        ).toBeNull();
+    });
+
+    it('classifies Edit/Write as editing and Read/Glob/Grep as discovering', () => {
+        expect(classifyToolPhase({ name: 'Write', input: {} })).toBe('editing');
+        expect(classifyToolPhase({ name: 'Edit', input: {} })).toBe('editing');
+        expect(classifyToolPhase({ name: 'Read', input: {} })).toBe(
+            'discovering',
+        );
+        expect(classifyToolPhase({ name: 'Grep', input: {} })).toBe(
+            'discovering',
+        );
+    });
+
+    it('returns null for an unknown tool', () => {
+        expect(classifyToolPhase({ name: 'TodoWrite', input: {} })).toBeNull();
+    });
+});
+
+describe('summarizeToolInput', () => {
+    it('prefers file_path, then command, then pattern', () => {
+        expect(summarizeToolInput({ file_path: '/models/x.sql' })).toBe(
+            '/models/x.sql',
+        );
+        expect(summarizeToolInput({ pattern: 'revenue' })).toBe('revenue');
+    });
+
+    it('truncates a long command to 120 chars', () => {
+        const command = 'x'.repeat(200);
+        expect(summarizeToolInput({ command })).toHaveLength(120);
+    });
+
+    it('falls back to JSON for shapeless input', () => {
+        expect(summarizeToolInput({ foo: 'bar' })).toBe('{"foo":"bar"}');
+    });
+
+    it('returns a placeholder for unserializable input', () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        expect(summarizeToolInput(circular)).toBe('<unserializable>');
+    });
+});
+
+describe('getPhaseProgressText', () => {
+    it('uses workflow wording for preview-deploy setup', () => {
+        expect(getPhaseProgressText('preview_deploy_setup')).toEqual({
+            discovering: 'Inspecting repository',
+            editing: 'Writing workflow files',
+            compiling: 'Validating workflow',
+        });
+    });
+
+    it('uses model wording for a normal writeback', () => {
+        expect(getPhaseProgressText('slack')).toEqual({
+            discovering: 'Discovering models',
+            editing: 'Editing models',
+            compiling: 'Compiling project',
+        });
+    });
+});
+
+describe('splitStreamBuffer', () => {
+    it('returns complete lines and carries the unterminated remainder', () => {
+        expect(splitStreamBuffer('a\nb\nhalf')).toEqual({
+            lines: ['a', 'b'],
+            remainder: 'half',
+        });
+    });
+
+    it('leaves an empty remainder when the buffer ends with a newline', () => {
+        expect(splitStreamBuffer('a\nb\n')).toEqual({
+            lines: ['a', 'b'],
+            remainder: '',
+        });
+    });
+});
+
+describe('github identity helpers', () => {
+    it('builds the noreply email', () => {
+        expect(buildNoreplyEmail({ id: 123, login: 'octocat' })).toBe(
+            '123+octocat@users.noreply.github.com',
+        );
+    });
+
+    it('builds the co-author trailer', () => {
+        expect(buildCoAuthorTrailer({ id: 7, login: 'lightdash-bot' })).toBe(
+            'Co-authored-by: lightdash-bot <7+lightdash-bot@users.noreply.github.com>',
+        );
+    });
+});
+
+describe('resolveSandboxTemplateRef', () => {
+    it('appends the tag when present', () => {
+        expect(resolveSandboxTemplateRef({ name: 'tpl', tag: 'v2' })).toBe(
+            'tpl:v2',
+        );
+    });
+
+    it('omits the tag separator when the tag is empty', () => {
+        expect(resolveSandboxTemplateRef({ name: 'tpl', tag: '' })).toBe('tpl');
+    });
+});

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -1,0 +1,298 @@
+import {
+    assertUnreachable,
+    DbtProjectType,
+    isWorkflowFile,
+    ParameterError,
+    type DbtProjectConfig,
+} from '@lightdash/common';
+import type { AiWritebackFailureStage } from '../../../analytics/LightdashAnalytics';
+import {
+    PR_DESCRIPTION_CLOSE,
+    PR_DESCRIPTION_OPEN,
+    PR_TITLE_CLOSE,
+    PR_TITLE_OPEN,
+} from './constants';
+import type {
+    AgentPhase,
+    AgentStreamEvent,
+    AgentToolCall,
+    AiWritebackSource,
+    GithubConnection,
+    GithubIdentity,
+    PrMetadata,
+    ResolvedPrMetadata,
+    StagedFileChanges,
+} from './types';
+
+export const resolveGithubConnection = (
+    connection: DbtProjectConfig,
+): GithubConnection => {
+    if (connection.type !== DbtProjectType.GITHUB) {
+        throw new ParameterError(
+            `AI writeback requires a GitHub dbt connection, but this project uses "${connection.type}"`,
+        );
+    }
+    const [owner, repo] = connection.repository.split('/');
+    if (!owner || !repo) {
+        throw new ParameterError(
+            `Project's dbt connection has an invalid repository "${connection.repository}" (expected "owner/repo")`,
+        );
+    }
+    // Normalise the stored sub-path (leading slash, `/` for root) to a path
+    // relative to the repo root so it can be passed to `--project-dir`.
+    const relativeSubPath = connection.project_sub_path
+        .trim()
+        .replace(/^\/+/, '')
+        .replace(/\/+$/, '');
+    return {
+        owner,
+        repo,
+        projectSubPath: relativeSubPath === '' ? '.' : relativeSubPath,
+    };
+};
+
+export const parsePullNumber = (prUrl: string): number => {
+    const last = prUrl.split('/').pop();
+    const pullNumber = last ? Number(last) : NaN;
+    if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+        throw new ParameterError(
+            `Could not parse pull request number from URL: ${prUrl}`,
+        );
+    }
+    return pullNumber;
+};
+
+/** `null` opts a stage out of progress reporting (its label would be noise). */
+export const progressTextForStage = (
+    stage: AiWritebackFailureStage,
+): string | null => {
+    switch (stage) {
+        case 'install':
+            return 'Setting up';
+        case 'sandbox':
+            return 'Starting sandbox';
+        case 'clone':
+            return 'Cloning project';
+        case 'agent':
+            return 'Starting sub agent';
+        case 'commit':
+            return 'Committing changes';
+        case 'push':
+            return 'Pushing to GitHub';
+        case 'pull_request':
+            return null;
+        default:
+            return assertUnreachable(
+                stage,
+                `Unknown AiWritebackFailureStage: ${String(stage)}`,
+            );
+    }
+};
+
+const escapeRegExp = (value: string): string =>
+    value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Parse the agent's PR title/description from the structured-output delimiters
+ * in its stdout, and return the stdout with those blocks stripped so they don't
+ * leak into the user-facing reply.
+ */
+export const extractPrMetadata = (stdout: string): PrMetadata => {
+    const titleRe = new RegExp(
+        `${escapeRegExp(PR_TITLE_OPEN)}([\\s\\S]*?)${escapeRegExp(
+            PR_TITLE_CLOSE,
+        )}`,
+    );
+    const descRe = new RegExp(
+        `${escapeRegExp(PR_DESCRIPTION_OPEN)}([\\s\\S]*?)${escapeRegExp(
+            PR_DESCRIPTION_CLOSE,
+        )}`,
+    );
+    const title = stdout.match(titleRe)?.[1].trim() || null;
+    const description = stdout.match(descRe)?.[1].trim() || null;
+    const stripRe = new RegExp(
+        `${escapeRegExp(PR_TITLE_OPEN)}[\\s\\S]*?${escapeRegExp(
+            PR_TITLE_CLOSE,
+        )}|${escapeRegExp(PR_DESCRIPTION_OPEN)}[\\s\\S]*?${escapeRegExp(
+            PR_DESCRIPTION_CLOSE,
+        )}`,
+        'g',
+    );
+    const sanitizedStdout = stdout
+        .replace(stripRe, '')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+    return { title, description, sanitizedStdout };
+};
+
+/**
+ * The agent has been observed writing PR metadata into the repo root instead of
+ * /tmp, so a repo-root copy is accepted as a fallback (the caller scrubs it from
+ * disk regardless so it can never reach a commit).
+ */
+export const resolvePrMetadataValue = ({
+    fromTmp,
+    fromRepo,
+    fallback,
+}: {
+    fromTmp: string | null;
+    fromRepo: string | null;
+    fallback: string;
+}): ResolvedPrMetadata => {
+    const fromTmpTrimmed = (fromTmp ?? '').trim();
+    const fromRepoTrimmed = (fromRepo ?? '').trim();
+    if (fromTmpTrimmed.length > 0) {
+        return { source: 'tmp', value: fromTmpTrimmed };
+    }
+    if (fromRepoTrimmed.length > 0) {
+        return { source: 'repo-fallback', value: fromRepoTrimmed };
+    }
+    return { source: 'default', value: fallback };
+};
+
+/** Parse `git diff --cached --name-status --no-renames -z` into add/delete ops. */
+export const parseGitNameStatus = (stdout: string): StagedFileChanges => {
+    const parts = stdout.split('\0').filter((part) => part.length > 0);
+    const addPaths: string[] = [];
+    const deletions: { path: string }[] = [];
+    for (let i = 0; i + 1 < parts.length; i += 2) {
+        const status = parts[i];
+        const path = parts[i + 1];
+        if (status.startsWith('D')) {
+            deletions.push({ path });
+        } else {
+            addPaths.push(path);
+        }
+    }
+    return { addPaths, deletions };
+};
+
+export const parseTrackedWorkflowPaths = (stdout: string): string[] =>
+    stdout
+        .split('\n')
+        .map((path) => path.trim())
+        .filter((path) => path.length > 0 && isWorkflowFile(path));
+
+/** Caller owns the side effects (logging, counting, progress). */
+export const interpretAgentEvent = (event: unknown): AgentStreamEvent => {
+    if (!event || typeof event !== 'object') return { type: 'ignored' };
+    const typed = event as {
+        type?: string;
+        message?: { content?: unknown };
+        total_cost_usd?: number;
+    };
+    if (typed.type === 'result') {
+        return { type: 'result', costUsd: typed.total_cost_usd ?? null };
+    }
+    if (typed.type !== 'assistant') return { type: 'ignored' };
+    const content = typed.message?.content;
+    if (!Array.isArray(content)) {
+        return { type: 'assistant', text: null, toolCalls: [] };
+    }
+    let messageText = '';
+    const toolCalls: AgentToolCall[] = [];
+    for (const block of content) {
+        if (block && typeof block === 'object') {
+            const typedBlock = block as {
+                type?: string;
+                text?: string;
+                name?: string;
+                input?: unknown;
+            };
+            if (
+                typedBlock.type === 'text' &&
+                typeof typedBlock.text === 'string'
+            ) {
+                messageText += typedBlock.text;
+            } else if (
+                typedBlock.type === 'tool_use' &&
+                typeof typedBlock.name === 'string'
+            ) {
+                toolCalls.push({
+                    name: typedBlock.name,
+                    input: typedBlock.input,
+                });
+            }
+        }
+    }
+    return { type: 'assistant', text: messageText || null, toolCalls };
+};
+
+export const classifyToolPhase = ({
+    name,
+    input,
+}: AgentToolCall): AgentPhase | null => {
+    if (name === 'Bash') {
+        const command =
+            input && typeof input === 'object'
+                ? (input as { command?: unknown }).command
+                : undefined;
+        if (
+            typeof command === 'string' &&
+            command.includes('lightdash compile')
+        ) {
+            return 'compiling';
+        }
+        return null;
+    }
+    if (name === 'Edit' || name === 'Write') return 'editing';
+    if (name === 'Read' || name === 'Glob' || name === 'Grep') {
+        return 'discovering';
+    }
+    return null;
+};
+
+export const summarizeToolInput = (input: unknown): string => {
+    if (input && typeof input === 'object') {
+        const fields = input as Record<string, unknown>;
+        if (typeof fields.file_path === 'string') return fields.file_path;
+        if (typeof fields.command === 'string') {
+            return fields.command.slice(0, 120);
+        }
+        if (typeof fields.pattern === 'string') return fields.pattern;
+    }
+    try {
+        return JSON.stringify(input ?? null).slice(0, 120);
+    } catch {
+        return '<unserializable>';
+    }
+};
+
+export const getPhaseProgressText = (
+    source: AiWritebackSource,
+): Record<AgentPhase, string> =>
+    source === 'preview_deploy_setup'
+        ? {
+              discovering: 'Inspecting repository',
+              editing: 'Writing workflow files',
+              compiling: 'Validating workflow',
+          }
+        : {
+              discovering: 'Discovering models',
+              editing: 'Editing models',
+              compiling: 'Compiling project',
+          };
+
+export const splitStreamBuffer = (
+    buffer: string,
+): { lines: string[]; remainder: string } => {
+    const parts = buffer.split('\n');
+    const remainder = parts.pop() ?? '';
+    return { lines: parts, remainder };
+};
+
+/** GitHub noreply email — links the commit to the profile without the real address. */
+export const buildNoreplyEmail = ({ id, login }: GithubIdentity): string =>
+    `${id}+${login}@users.noreply.github.com`;
+
+export const buildCoAuthorTrailer = (bot: GithubIdentity): string =>
+    `Co-authored-by: ${bot.login} <${buildNoreplyEmail(bot)}>`;
+
+/** E2B treats `name` and `name:default` interchangeably, so an empty tag is fine. */
+export const resolveSandboxTemplateRef = ({
+    name,
+    tag,
+}: {
+    name: string;
+    tag: string;
+}): string => (tag ? `${name}:${tag}` : name);


### PR DESCRIPTION
Closes: [PROD-8074](https://linear.app/lightdash/issue/PROD-8074/add-tests-to-writeback-service)

## Summary

Extracts the pure logic out of the ~2k-line `AiWritebackService` into a tested `utils.ts`, moves shared types into `types.ts` and constants into `constants.ts`, and turns the agent stream-json parser into a pure core. No behaviour change.

(No Linear ticket — standalone cleanup of the AI writeback service.)

## Why

`AiWritebackService.ts` had grown to ~2k lines, mixing run orchestration with pure string/JSON parsing that couldn't be unit-tested in isolation. Pulling the pure functions out makes the parsing directly testable and leaves the service focused on orchestration, matching the folder's existing one-concept-per-file split (`pullRequest.ts`, `skills.ts`, `templates.ts`).

## Files touched (6)

- `utils.ts` (new) — pure functions: connection / PR-number / workflow-path parsing, PR-metadata extraction, the stream-json interpreter, tool→phase classification, identity + template-ref formatting.
- `types.ts` — new shared types (`AgentStreamEvent`, `AgentPhase`, `AgentToolCall`, `StagedFileChanges`, `PrMetadata`, `GithubIdentity`).
- `constants.ts` — moved `PREVIEW_DEPLOY_SETUP_PROMPT`, `GATHER_REPO_CONTEXT_SANDBOX_PATH`, `STDERR_TAIL_BYTES` here.
- `AiWritebackService.ts` — now calls the extracted helpers; bodies thinned. Sandbox I/O stays in the service.
- `utils.test.ts` (new) — unit tests for the helpers.
- `AiWritebackService.test.ts` (new) — service tests for `applyAgentChanges` / `prepareTurn` plus a mocked end-to-end `run()`.

## Pattern

1. Move a pure block (static method or inline closure) into `utils.ts` as an exported function.
2. Move any types it needs into `types.ts`, any constants into `constants.ts`.
3. Replace the original with a call to the helper; keep logging and sandbox I/O at the call site.

## Non-trivial bits

- The stream-json handler splits into a pure `interpretAgentEvent` returning a discriminated `AgentStreamEvent`; the service keeps the mutable fold (tool counts, assistant text, progress reporting).
- `resolvePrMetadata` and `collectFileChanges` stay in the service (sandbox I/O) but delegate their parsing to pure helpers (`resolvePrMetadataValue`, `parseGitNameStatus`).
- Removed now-unused `@lightdash/common` imports (`assertUnreachable`, `DbtProjectType`, `isWorkflowFile`, `DbtProjectConfig`).
- The service test stubs `e2b` and the GitHub client — both ESM-only and break Jest's parser on import; the mocked `run()` tests drive the fakes.

Before:
  AiWritebackService.ts   2026 lines  (orchestration + parsing + formatting)

After:
  AiWritebackService.ts   1783 lines  (orchestration + sandbox I/O)
  utils.ts                 298 lines  (pure, fully unit-tested)
  types.ts / constants.ts  shared types + constants

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend` jest on the `AiWritebackService` folder — 90 tests pass (5 suites)
- [x] Live end-to-end: 3 concurrent writeback runs via the API against a GitHub-backed project each returned exit 0 (`lightdash compile: ok`) and opened a PR
- [ ] CI green

## Diff size

6 files, +1284 / -316.