### PR TITLE
fix(ai-writeback): open PRs as the GitHub App, not the App connector (PROD-8076)

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -111,7 +111,7 @@ describe('AiWritebackService.applyAgentChanges', () => {
     ): AnyType =>
         (service as AnyType).applyAgentChanges({
             sandbox: { sandboxId: 'sbx-1' },
-            github: { installationId: 'inst-1', prToken: null },
+            github: { installationId: 'inst-1' },
             adoptedPr: null,
             turn: turnContext(),
             user: { userUuid: 'u1' },

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -30,10 +30,8 @@ import {
     createPullRequest,
     createSignedCommitOnBranch,
     getAppBotIdentity,
-    getAuthenticatedUser,
     getBranchHeadSha,
     getInstallationToken,
-    getOrRefreshToken,
     updatePullRequest,
 } from '../../../clients/github/Github';
 import type { GithubFileChanges } from '../../../clients/github/Github';
@@ -93,7 +91,6 @@ import type {
 } from './types';
 import {
     buildCoAuthorTrailer,
-    buildNoreplyEmail,
     classifyToolPhase,
     extractPrMetadata,
     getPhaseProgressText,
@@ -192,12 +189,14 @@ export class AiWritebackService extends BaseService {
 
     /**
      * Resolve GitHub auth for the organization. The installation access token
-     * authenticates the in-sandbox clone. We additionally resolve the OAuth user
-     * identity (the user who connected the GitHub App for the org) so the pull
-     * request is opened — and the signed commits authored — as a real user
-     * instead of the Lightdash app. Best-effort: any failure resolving the user
-     * identity falls back to the app installation + bot author. Throws only when
-     * no installation exists at all.
+     * authenticates the in-sandbox clone, and the pull request is opened — and
+     * the signed commits authored — as the Lightdash GitHub App itself. We
+     * deliberately do not attribute the PR to a GitHub user: the only user
+     * token we hold belongs to whoever connected the app for the org, which is
+     * almost never the person who triggered the writeback (e.g. via Slack), so
+     * using it misattributes the PR. The triggering user is recorded against
+     * the PR in our own DB instead (see recordWritebackPullRequest). Throws
+     * only when no installation exists at all.
      */
     private async getGithubInstallation(
         organizationUuid: string,
@@ -215,37 +214,10 @@ export class AiWritebackService extends BaseService {
         }
         const token = await getInstallationToken(installationId);
 
-        let prToken: string | null = null;
-        let commitAuthor: GithubCommitAuthor = {
+        const commitAuthor: GithubCommitAuthor = {
             name: COMMIT_AUTHOR_NAME,
             email: COMMIT_AUTHOR_EMAIL,
         };
-        try {
-            const { token: oauthToken, refreshToken } =
-                await this.githubAppInstallationsModel.getAuth(
-                    organizationUuid,
-                );
-            const refreshed = await getOrRefreshToken(oauthToken, refreshToken);
-            if (refreshed.token !== oauthToken) {
-                await this.githubAppInstallationsModel.updateAuth(
-                    organizationUuid,
-                    refreshed.token,
-                    refreshed.refreshToken,
-                );
-            }
-            const githubUser = await getAuthenticatedUser(refreshed.token);
-            prToken = refreshed.token;
-            commitAuthor = {
-                name: githubUser.login,
-                email: buildNoreplyEmail(githubUser),
-            };
-        } catch (error) {
-            this.logger.warn(
-                `AiWriteback: could not resolve GitHub user identity for org ${organizationUuid}; the PR will be opened by the app. ${getErrorMessage(
-                    error,
-                )}`,
-            );
-        }
 
         let coAuthorTrailer = CO_AUTHOR_TRAILER;
         try {
@@ -262,7 +234,6 @@ export class AiWritebackService extends BaseService {
         return {
             installationId,
             token,
-            prToken,
             commitAuthor,
             coAuthorTrailer,
         };
@@ -476,7 +447,6 @@ export class AiWritebackService extends BaseService {
         description,
         commitAuthor,
         coAuthorTrailer,
-        prToken,
         installationId,
         setStage,
     }: {
@@ -488,7 +458,6 @@ export class AiWritebackService extends BaseService {
         description: string;
         commitAuthor: GithubCommitAuthor;
         coAuthorTrailer: string;
-        prToken: string | null;
         installationId: string;
         setStage: SetStage;
     }): Promise<void> {
@@ -513,7 +482,7 @@ export class AiWritebackService extends BaseService {
             headline: title,
             body,
             fileChanges,
-            ...(prToken ? { token: prToken } : { installationId }),
+            installationId,
         });
     }
 
@@ -1467,7 +1436,6 @@ export class AiWritebackService extends BaseService {
                 prUrl: targetPrUrl,
                 githubConnection: turn.githubConnection,
                 installationId: github.installationId,
-                prToken: github.prToken,
                 commitAuthor: github.commitAuthor,
                 coAuthorTrailer: github.coAuthorTrailer,
                 setStage,
@@ -1504,7 +1472,6 @@ export class AiWritebackService extends BaseService {
             sandbox,
             githubConnection: turn.githubConnection,
             installationId: github.installationId,
-            prToken: github.prToken,
             commitAuthor: github.commitAuthor,
             coAuthorTrailer: github.coAuthorTrailer,
             setStage,
@@ -1578,7 +1545,6 @@ export class AiWritebackService extends BaseService {
         sandbox,
         githubConnection,
         installationId,
-        prToken,
         commitAuthor,
         coAuthorTrailer,
         setStage,
@@ -1588,7 +1554,6 @@ export class AiWritebackService extends BaseService {
         sandbox: Sandbox;
         githubConnection: GithubConnection;
         installationId: string;
-        prToken: string | null;
         commitAuthor: GithubCommitAuthor;
         coAuthorTrailer: string;
         setStage: SetStage;
@@ -1619,7 +1584,7 @@ export class AiWritebackService extends BaseService {
             ));
 
         const branch = `lightdash-ai-writeback/${randomUUID()}`;
-        const auth = prToken ? { token: prToken } : { installationId };
+        const auth = { installationId };
 
         // Create the feature branch on the remote at the base tip, then commit
         // onto it via the API so the commit is signed/verified. expectedHeadOid
@@ -1648,15 +1613,12 @@ export class AiWritebackService extends BaseService {
             description,
             commitAuthor,
             coAuthorTrailer,
-            prToken,
             installationId,
             setStage,
         });
 
         setStage('pull_request');
-        // Open the PR as the user when we resolved their OAuth token (passing a
-        // user token and omitting installationId makes getOctokit auth as the
-        // user); otherwise fall back to the app installation.
+        // The PR is always opened by the Lightdash GitHub App installation.
         const pr = await createPullRequest({
             owner: githubConnection.owner,
             repo: githubConnection.repo,
@@ -1681,7 +1643,6 @@ export class AiWritebackService extends BaseService {
         prUrl,
         githubConnection,
         installationId,
-        prToken,
         commitAuthor,
         coAuthorTrailer,
         setStage,
@@ -1692,7 +1653,6 @@ export class AiWritebackService extends BaseService {
         prUrl: string;
         githubConnection: GithubConnection;
         installationId: string;
-        prToken: string | null;
         commitAuthor: GithubCommitAuthor;
         coAuthorTrailer: string;
         setStage: SetStage;
@@ -1714,7 +1674,7 @@ export class AiWritebackService extends BaseService {
                 'Follow-up changes from the Lightdash AI writeback agent.',
             ));
 
-        const auth = prToken ? { token: prToken } : { installationId };
+        const auth = { installationId };
 
         // The sandbox is on the PR's branch (resumed, or freshly checked out
         // for a pasted link). Commit this turn's edits onto it via the API
@@ -1741,7 +1701,6 @@ export class AiWritebackService extends BaseService {
             description,
             commitAuthor,
             coAuthorTrailer,
-            prToken,
             installationId,
             setStage,
         });

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -91,6 +91,7 @@ import type {
 } from './types';
 import {
     buildCoAuthorTrailer,
+    buildUserCoAuthorTrailer,
     classifyToolPhase,
     extractPrMetadata,
     getPhaseProgressText,
@@ -1422,6 +1423,13 @@ export class AiWritebackService extends BaseService {
             };
         }
 
+        // Credit the Lightdash user who triggered the writeback as a co-author
+        // (the PR itself is opened by the app), alongside the app-bot trailer.
+        const userTrailer = buildUserCoAuthorTrailer(user);
+        const coAuthorTrailer = userTrailer
+            ? `${github.coAuthorTrailer}\n${userTrailer}`
+            : github.coAuthorTrailer;
+
         // Resume or pasted-link adoption: commit onto the existing PR's branch
         // (the sandbox is already on it) and refresh its title/description.
         if (turn.existingRow || adoptedPr) {
@@ -1437,7 +1445,7 @@ export class AiWritebackService extends BaseService {
                 githubConnection: turn.githubConnection,
                 installationId: github.installationId,
                 commitAuthor: github.commitAuthor,
-                coAuthorTrailer: github.coAuthorTrailer,
+                coAuthorTrailer,
                 setStage,
                 prTitle,
                 prDescription,
@@ -1473,7 +1481,7 @@ export class AiWritebackService extends BaseService {
             githubConnection: turn.githubConnection,
             installationId: github.installationId,
             commitAuthor: github.commitAuthor,
-            coAuthorTrailer: github.coAuthorTrailer,
+            coAuthorTrailer,
             setStage,
             prTitle,
             prDescription,

--- a/packages/backend/src/ee/services/AiWritebackService/pullRequest.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/pullRequest.ts
@@ -57,9 +57,7 @@ export const resolveAdoptedPullRequest = async ({
         );
     }
 
-    const auth = github.prToken
-        ? { token: github.prToken }
-        : { installationId: github.installationId };
+    const auth = { installationId: github.installationId };
     const pr = await getPullRequest({
         owner: githubConnection.owner,
         repo: githubConnection.repo,

--- a/packages/backend/src/ee/services/AiWritebackService/resolveAdoptedPullRequest.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/resolveAdoptedPullRequest.test.ts
@@ -20,7 +20,6 @@ const githubConnection: GithubConnection = {
 const github: GithubInstallation = {
     installationId: 'inst-1',
     token: 'tok',
-    prToken: null,
     commitAuthor: { name: 'a', email: 'a@b.c' },
     coAuthorTrailer: '',
 };

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -39,20 +39,11 @@ export type GithubInstallation = {
     installationId: string;
     /** Installation access token — authenticates the in-sandbox clone/push. */
     token: string;
-    /**
-     * OAuth user token used to open/update the pull request so it is attributed
-     * to the GitHub user who connected the app for the org, not the Lightdash
-     * app itself. `null` when no user identity could be resolved, in which case
-     * the PR falls back to being opened by the app installation.
-     */
-    prToken: string | null;
-    /** Author stamped on the writeback commits — the GitHub user, or the bot fallback. */
+    /** Author stamped on the (local) writeback commit — the Lightdash app identity. */
     commitAuthor: GithubCommitAuthor;
     /**
      * `Co-authored-by:` trailer appended to the commit message to credit the
-     * Lightdash app bot (resolved to its avatar-backed GitHub identity), so the
-     * agent's involvement is visible even though the commit is authored as the
-     * user.
+     * Lightdash app bot (resolved to its avatar-backed GitHub identity).
      */
     coAuthorTrailer: string;
 };

--- a/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
@@ -13,6 +13,7 @@ import {
 import {
     buildCoAuthorTrailer,
     buildNoreplyEmail,
+    buildUserCoAuthorTrailer,
     classifyToolPhase,
     extractPrMetadata,
     getPhaseProgressText,
@@ -351,6 +352,36 @@ describe('github identity helpers', () => {
         expect(buildCoAuthorTrailer({ id: 7, login: 'lightdash-bot' })).toBe(
             'Co-authored-by: lightdash-bot <7+lightdash-bot@users.noreply.github.com>',
         );
+    });
+
+    it('builds the user co-author trailer from name + email', () => {
+        expect(
+            buildUserCoAuthorTrailer({
+                firstName: 'Ada',
+                lastName: 'Lovelace',
+                email: 'ada@example.com',
+            }),
+        ).toBe('Co-authored-by: Ada Lovelace <ada@example.com>');
+    });
+
+    it('falls back to the email as the name when no name is set', () => {
+        expect(
+            buildUserCoAuthorTrailer({
+                firstName: '',
+                lastName: '',
+                email: 'ada@example.com',
+            }),
+        ).toBe('Co-authored-by: ada@example.com <ada@example.com>');
+    });
+
+    it('returns null when the user has no email to credit', () => {
+        expect(
+            buildUserCoAuthorTrailer({
+                firstName: 'Ada',
+                lastName: 'Lovelace',
+                email: undefined,
+            }),
+        ).toBeNull();
     });
 });
 

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -288,6 +288,21 @@ export const buildNoreplyEmail = ({ id, login }: GithubIdentity): string =>
 export const buildCoAuthorTrailer = (bot: GithubIdentity): string =>
     `Co-authored-by: ${bot.login} <${buildNoreplyEmail(bot)}>`;
 
+/**
+ * `Co-authored-by:` trailer crediting the Lightdash user who triggered the
+ * writeback. The PR is opened by the app, so this is how the requesting user is
+ * attributed on the commit. Returns null when we have no email to credit them by.
+ */
+export const buildUserCoAuthorTrailer = (user: {
+    firstName: string;
+    lastName: string;
+    email: string | undefined;
+}): string | null => {
+    if (!user.email) return null;
+    const name = `${user.firstName} ${user.lastName}`.trim() || user.email;
+    return `Co-authored-by: ${name} <${user.email}>`;
+};
+
 /** E2B treats `name` and `name:default` interchangeably, so an empty tag is fine. */
 export const resolveSandboxTemplateRef = ({
     name,


### PR DESCRIPTION
## What & why

Closes PROD-8076.

When AI writeback opens a pull request, it resolved the GitHub OAuth token stored against the org's GitHub App installation to author the commits and open the PR. That token belongs to **whoever connected the App** — not the user who triggered the writeback (e.g. via Slack). The result: every writeback PR was attributed to that one person regardless of who asked for it.

GitHub will only open a PR "as" an identity we hold a token for, and we have no personal token for an arbitrary triggering user. So this resolves the open question in the project brief ("should PRs be associated with the user asking or the app?") in favour of **the app**.

## Change

- `getGithubInstallation` no longer resolves the connector's OAuth token (`prToken`). The field is removed from `GithubInstallation` and threaded out of the whole writeback path.
- The PR is now always **opened**, and commits **signed**, as the Lightdash GitHub App installation.
- The `Co-authored-by` app-bot trailer is kept; the triggering user is still recorded against the PR in our own DB (`createdByUserUuid`).

This covers **both** the AI writeback PR and the preview-deploy PR — they share the same `run()` path. The separate `GitIntegrationService` (save-as-code) feature is intentionally untouched.

## Testing

Verified end-to-end against a real repo:

- Writeback ran install→sandbox→clone→agent→commit→push→pull_request, `lightdash compile` ok.
- Resulting PR opener = `lightdash-app-dev[bot]` (was the connector's account).
- Commit author = `lightdash-app-dev[bot]`, GPG-verified, with the app co-author trailer.

`pnpm -F backend typecheck` clean; `AiWritebackService` unit suite (34 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)