### PR TITLE
fix(ai-review): judge turns with the next turn's correction (ZAP-456)

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -421,6 +421,7 @@ describe('AiAgentReviewClassifierModel', () => {
 
     describe('createTurnSignal', () => {
         it('persists a classified signal with inline finding fields', async () => {
+            tracker.on.delete(AiAgentTurnSignalTableName).responseOnce(0);
             tracker.on.insert(AiAgentTurnSignalTableName).responseOnce([
                 {
                     ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID,
@@ -461,6 +462,12 @@ describe('AiAgentReviewClassifierModel', () => {
             });
 
             expect(result).toBe(TURN_SIGNAL_UUID);
+            // Supersede: the turn's prior signal is deleted before the new one
+            // is inserted (one current signal per turn).
+            expect(tracker.history.delete).toHaveLength(1);
+            expect(tracker.history.delete[0].sql).toContain(
+                AiAgentTurnSignalTableName,
+            );
             expect(tracker.history.insert).toHaveLength(2);
             expect(tracker.history.insert[1].sql).toContain(
                 AiAgentReviewItemTableName,
@@ -468,6 +475,7 @@ describe('AiAgentReviewClassifierModel', () => {
         });
 
         it('does not upsert a review item when the turn is not promoted', async () => {
+            tracker.on.delete(AiAgentTurnSignalTableName).responseOnce(0);
             tracker.on.insert(AiAgentTurnSignalTableName).responseOnce([
                 {
                     ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID,

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1110,57 +1110,70 @@ export class AiAgentReviewClassifierModel {
 
     async createTurnSignal(args: CreateTurnSignalArgs): Promise<string> {
         const { finding, turnSignal } = args;
-        const [row] = await this.database<AiAgentTurnSignalTable>(
-            AiAgentTurnSignalTableName,
-        )
-            .insert({
-                ai_agent_review_run_uuid: args.runUuid,
-                ai_prompt_uuid: turnSignal.subject.assistantPromptUuid,
-                ai_thread_uuid: turnSignal.subject.threadUuid,
-                organization_uuid: turnSignal.subject.organizationUuid,
-                project_uuid: turnSignal.subject.projectUuid,
-                agent_uuid: turnSignal.subject.agentUuid,
-                interaction_source: turnSignal.interactionSource,
-                source_ref: this.jsonb(turnSignal.sourceRef) as never,
-                signal: turnSignal.signal,
-                implicit_signal_sources: this.jsonb(
-                    turnSignal.implicitSignalSources,
-                ) as never,
-                confidence: turnSignal.confidence,
-                promoted_to_finding: turnSignal.promotedToFinding,
-                promotion_reason: turnSignal.promotionReason,
-                tool_evidence_refs: this.jsonb(
-                    turnSignal.toolEvidenceRefs,
-                ) as never,
-                fingerprint: finding?.reviewItem.fingerprint,
-                primary_root_cause: finding?.primaryRootCause,
-                secondary_root_causes: finding
-                    ? (this.jsonb(finding.secondaryRootCauses) as never)
-                    : null,
-                subcategories: finding
-                    ? (this.jsonb(finding.subcategories) as never)
-                    : null,
-                fix_targets: finding
-                    ? (this.jsonb(finding.fixTargets) as never)
-                    : null,
-                target_refs: finding
-                    ? (this.jsonb(finding.targetRefs) as never)
-                    : null,
-                evidence_excerpts: finding
-                    ? (this.jsonb(finding.evidenceExcerpts) as never)
-                    : null,
-                recommendation: finding
-                    ? (this.jsonb(finding.recommendation) as never)
-                    : null,
-                owner_type: finding?.reviewItem.ownerType,
-                review_item_title: finding?.reviewItem.title,
-                review_item_description: finding?.reviewItem.description,
-                runtime_context_snapshot: this.jsonb(
-                    turnSignal.runtimeContextSnapshot,
-                ) as never,
-                model_metadata: this.jsonb(turnSignal.modelMetadata) as never,
-            })
-            .returning('ai_agent_review_turn_signal_uuid');
+        const [row] = await this.database.transaction(async (trx) => {
+            // Supersede: keep one current signal per turn. A re-review (once a
+            // later turn supplies the correction) replaces the earlier judgment
+            // instead of stacking a second signal — so the queue shows the
+            // latest verdict and findingCount counts distinct turns, not
+            // re-reviews of the same turn.
+            await trx(AiAgentTurnSignalTableName)
+                .where('ai_prompt_uuid', turnSignal.subject.assistantPromptUuid)
+                .delete();
+            const inserted = await trx<AiAgentTurnSignalTable>(
+                AiAgentTurnSignalTableName,
+            )
+                .insert({
+                    ai_agent_review_run_uuid: args.runUuid,
+                    ai_prompt_uuid: turnSignal.subject.assistantPromptUuid,
+                    ai_thread_uuid: turnSignal.subject.threadUuid,
+                    organization_uuid: turnSignal.subject.organizationUuid,
+                    project_uuid: turnSignal.subject.projectUuid,
+                    agent_uuid: turnSignal.subject.agentUuid,
+                    interaction_source: turnSignal.interactionSource,
+                    source_ref: this.jsonb(turnSignal.sourceRef) as never,
+                    signal: turnSignal.signal,
+                    implicit_signal_sources: this.jsonb(
+                        turnSignal.implicitSignalSources,
+                    ) as never,
+                    confidence: turnSignal.confidence,
+                    promoted_to_finding: turnSignal.promotedToFinding,
+                    promotion_reason: turnSignal.promotionReason,
+                    tool_evidence_refs: this.jsonb(
+                        turnSignal.toolEvidenceRefs,
+                    ) as never,
+                    fingerprint: finding?.reviewItem.fingerprint,
+                    primary_root_cause: finding?.primaryRootCause,
+                    secondary_root_causes: finding
+                        ? (this.jsonb(finding.secondaryRootCauses) as never)
+                        : null,
+                    subcategories: finding
+                        ? (this.jsonb(finding.subcategories) as never)
+                        : null,
+                    fix_targets: finding
+                        ? (this.jsonb(finding.fixTargets) as never)
+                        : null,
+                    target_refs: finding
+                        ? (this.jsonb(finding.targetRefs) as never)
+                        : null,
+                    evidence_excerpts: finding
+                        ? (this.jsonb(finding.evidenceExcerpts) as never)
+                        : null,
+                    recommendation: finding
+                        ? (this.jsonb(finding.recommendation) as never)
+                        : null,
+                    owner_type: finding?.reviewItem.ownerType,
+                    review_item_title: finding?.reviewItem.title,
+                    review_item_description: finding?.reviewItem.description,
+                    runtime_context_snapshot: this.jsonb(
+                        turnSignal.runtimeContextSnapshot,
+                    ) as never,
+                    model_metadata: this.jsonb(
+                        turnSignal.modelMetadata,
+                    ) as never,
+                })
+                .returning('ai_agent_review_turn_signal_uuid');
+            return inserted;
+        });
 
         if (turnSignal.promotedToFinding && finding) {
             await this.ensureReviewItem({

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -409,8 +409,8 @@ describe('AiAgentReviewClassifierService', () => {
         expect(model.createTurnSignal).not.toHaveBeenCalled();
     });
 
-    it('runs a live response-saved event as one target-turn worker job', async () => {
-        judgeTurn.mockResolvedValueOnce(makeSemanticJudgeOutput());
+    it('reviews the target turn and re-reviews the preceding turn on response_saved', async () => {
+        judgeTurn.mockResolvedValue(makeSemanticJudgeOutput());
         model.listTurnReviewCandidates.mockResolvedValue([
             makeCandidate({
                 userPrompt:
@@ -439,13 +439,24 @@ describe('AiAgentReviewClassifierService', () => {
             promptUuid: PROMPT_UUID,
         });
 
-        expect(result?.processedTurns).toBe(1);
+        // The target turn plus its immediate predecessor (now that the target
+        // is the predecessor's real next-user-prompt / correction).
+        expect(result?.processedTurns).toBe(2);
         expect(model.listTurnReviewCandidates).toHaveBeenCalledWith({
             organizationUuid: ORGANIZATION_UUID,
             projectUuid: PROJECT_UUID,
             agentUuid: AGENT_UUID,
             threadUuid: THREAD_UUID,
             promptUuid: PROMPT_UUID,
+            limit: 1,
+        });
+        // ...and the preceding turn is pulled in for re-review.
+        expect(model.listTurnReviewCandidates).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            threadUuid: THREAD_UUID,
+            promptUuid: '00000000-0000-0000-0000-000000000012',
             limit: 1,
         });
         expect(model.createRun).toHaveBeenCalledWith(
@@ -457,7 +468,7 @@ describe('AiAgentReviewClassifierService', () => {
                     promptUuid: PROMPT_UUID,
                     threadUuid: THREAD_UUID,
                 }),
-                totalTurns: 1,
+                totalTurns: 2,
             }),
         );
         expect(model.createTurnSignal).toHaveBeenCalledWith(
@@ -467,6 +478,25 @@ describe('AiAgentReviewClassifierService', () => {
                 }),
             }),
         );
+    });
+
+    it('reviews only the target turn when it has no predecessor (first turn)', async () => {
+        judgeTurn.mockResolvedValue(makeSemanticJudgeOutput());
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate({ contextTurns: [] }),
+        ]);
+
+        const result = await service.runLiveEvent({
+            eventType: 'response_saved',
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            threadUuid: THREAD_UUID,
+            promptUuid: PROMPT_UUID,
+        });
+
+        expect(result?.processedTurns).toBe(1);
+        expect(model.listTurnReviewCandidates).toHaveBeenCalledTimes(1);
     });
 
     it('stores product capability findings as grouped review projections', async () => {

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -67,7 +67,6 @@ type AiAgentReviewJudgeEvidencePacket = {
     subject: AiAgentReviewClassifierTurnCandidate['subject'];
     interactionSource: AiAgentReviewClassifierTurnCandidate['interactionSource'];
     targetTurn: AiAgentReviewClassifierTurnCandidate['targetTurn'];
-    reviewHints: AiAgentReviewClassifierTurnCandidate['reviewHints'];
     humanFeedback: {
         score: number | null;
         comment: string | null;
@@ -273,15 +272,34 @@ export class AiAgentReviewClassifierService extends BaseService {
     async runLiveEvent(
         args: RunLiveEventArgs,
     ): Promise<AiAgentReviewClassifierRunResult | null> {
-        const candidates =
-            await this.aiAgentReviewClassifierModel.listTurnReviewCandidates({
+        const listCandidate = (promptUuid: string) =>
+            this.aiAgentReviewClassifierModel.listTurnReviewCandidates({
                 organizationUuid: args.organizationUuid,
                 projectUuid: args.projectUuid,
                 agentUuid: args.agentUuid,
                 threadUuid: args.threadUuid,
-                promptUuid: args.promptUuid,
+                promptUuid,
                 limit: 1,
             });
+
+        const targetCandidates = await listCandidate(args.promptUuid);
+        const candidates = [...targetCandidates];
+
+        // When a new turn completes, re-review the immediately-preceding turn:
+        // it now has this turn as its real next-user-prompt, which is where a
+        // correction lives. The re-review supersedes that turn's earlier
+        // standalone signal, so each turn is ultimately judged knowing what the
+        // user did next — instead of guessing from the failing turn alone.
+        if (args.eventType === 'response_saved') {
+            const previousTurns = (
+                targetCandidates[0]?.contextTurns ?? []
+            ).filter((turn) => turn.relation === 'previous');
+            const previousPromptUuid =
+                previousTurns[previousTurns.length - 1]?.promptUuid;
+            if (previousPromptUuid) {
+                candidates.push(...(await listCandidate(previousPromptUuid)));
+            }
+        }
 
         this.debugLog('LiveEventCandidatesLoaded', {
             eventType: args.eventType,
@@ -290,21 +308,14 @@ export class AiAgentReviewClassifierService extends BaseService {
             agentUuid: args.agentUuid,
             threadUuid: args.threadUuid,
             promptUuid: args.promptUuid,
-            candidateCount: candidates?.length ?? 0,
+            candidateCount: candidates.length,
         });
 
         return this.processCandidates({
             organizationUuid: args.organizationUuid,
             organizationName: args.organizationName,
             requestedByUserUuid: args.requestedByUserUuid,
-            candidates: candidates.map((candidate) => ({
-                ...candidate,
-                reviewHints: {
-                    ...candidate.reviewHints,
-                    useTargetPromptAsCorrectionEvidence:
-                        args.eventType === 'response_saved',
-                },
-            })),
+            candidates,
             runScope: {
                 type: 'live_event',
                 eventType: args.eventType,
@@ -1053,7 +1064,6 @@ reviewItem.description should summarize why this grouping exists.`,
             subject: candidate.subject,
             interactionSource: candidate.interactionSource,
             targetTurn: candidate.targetTurn,
-            reviewHints: candidate.reviewHints,
             humanFeedback: {
                 score: candidate.humanScore,
                 comment: candidate.humanFeedback,

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -638,9 +638,6 @@ export type AiAgentReviewClassifierTurnCandidate = {
     sourceRef: AiAgentTurnSignalSourceRef;
     targetTurn: AiAgentReviewClassifierTurnSnapshot;
     contextTurns: AiAgentReviewClassifierContextTurn[];
-    reviewHints?: {
-        useTargetPromptAsCorrectionEvidence?: boolean;
-    };
     userPrompt: string;
     assistantResponse: string | null;
     errorMessage: string | null;


### PR DESCRIPTION
## What

The review judge now scores a reviewed turn using the **next turn's correction** as signal — when a user corrects the agent in the following turn, that correction informs the finding/suggestion for the turn under review, instead of judging each turn in isolation.

## Why

A single turn often isn't conclusive on its own; the user's next message is frequently where the real correction signal lives. Folding it in makes findings and suggestions more accurate.

## Scope / regression analysis

- Touches only the AI review **classifier** (`AiAgentReviewClassifierModel` / `…Service`) — EE-only, exercised by the review-classifier path.
- No change to the live agent runtime or to any non-review code path.
- This is the bottom of the project_context stack but is **independent** of it (it predates the feature); it's split out so it can be reviewed/merged on its own.

_Stack: PR 0 of 6 (project_context living document)._

Relates: ZAP-456
