### PR TITLE
feat(ai-project-context): entry contract + review judge emits it

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -4,6 +4,7 @@ import type {
     AiAgentFixTarget,
     AiAgentImplicitSignalSource,
     AiAgentInteractionSource,
+    AiAgentJudgeProjectContextEntry,
     AiAgentModelMetadata,
     AiAgentRecommendation,
     AiAgentReviewClassifierConfidence,
@@ -113,6 +114,7 @@ export type DbAiAgentTurnSignal = {
     target_refs: AiAgentTargetRef[] | null;
     evidence_excerpts: AiAgentEvidenceExcerpt[] | null;
     recommendation: AiAgentRecommendation | null;
+    project_context_entry: AiAgentJudgeProjectContextEntry | null;
     owner_type: AiAgentReviewItemOwnerType | null;
     review_item_title: string | null;
     review_item_description: string | null;
@@ -137,6 +139,7 @@ export type AiAgentTurnSignalTable = Knex.CompositeTableType<
         | 'target_refs'
         | 'evidence_excerpts'
         | 'recommendation'
+        | 'project_context_entry'
         | 'owner_type'
         | 'review_item_title'
         | 'review_item_description'
@@ -154,6 +157,7 @@ export type AiAgentTurnSignalTable = Knex.CompositeTableType<
                 | 'target_refs'
                 | 'evidence_excerpts'
                 | 'recommendation'
+                | 'project_context_entry'
                 | 'owner_type'
                 | 'review_item_title'
                 | 'review_item_description'

--- a/packages/backend/src/ee/database/migrations/20260603101600_add_turn_signal_project_context_entry.ts
+++ b/packages/backend/src/ee/database/migrations/20260603101600_add_turn_signal_project_context_entry.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+const turnSignalTable = 'ai_agent_review_turn_signal';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(turnSignalTable, (table) => {
+        // Structured project_context entry the judge emits for project_context
+        // findings; consumed by the project_context writeback strategy.
+        table.jsonb('project_context_entry').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(turnSignalTable, (table) => {
+        table.dropColumn('project_context_entry');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -452,6 +452,7 @@ describe('AiAgentReviewClassifierModel', () => {
                         },
                     ],
                     recommendation: null,
+                    projectContextEntry: null,
                     reviewItem: {
                         fingerprint: FINGERPRINT,
                         title: 'Review airports.country',

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -874,6 +874,8 @@ export class AiAgentReviewClassifierModel {
                         targetRefs: latest.target_refs ?? [],
                         evidenceExcerpts: latest.evidence_excerpts ?? [],
                         recommendation: latest.recommendation,
+                        projectContextEntry:
+                            latest.project_context_entry ?? null,
                         createdAt: latest.created_at,
                     },
                 };
@@ -1160,6 +1162,9 @@ export class AiAgentReviewClassifierModel {
                         : null,
                     recommendation: finding
                         ? (this.jsonb(finding.recommendation) as never)
+                        : null,
+                    project_context_entry: finding
+                        ? (this.jsonb(finding.projectContextEntry) as never)
                         : null,
                     owner_type: finding?.reviewItem.ownerType,
                     review_item_title: finding?.reviewItem.title,

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -112,6 +112,7 @@ const makeJudgeOutput = (
         },
     ],
     recommendation: null,
+    projectContextEntry: null,
     reviewItem: {
         title: 'No review needed',
         description: 'Judge found no actionable issue.',
@@ -218,6 +219,42 @@ const makeProductJudgeOutput = (): AiAgentReviewClassifierJudgeOutput =>
         reviewItem: {
             title: 'Review AI agent product limitation',
             description: 'LLM judge found a product capability limitation.',
+        },
+    });
+
+const makeProjectContextJudgeOutput = (): AiAgentReviewClassifierJudgeOutput =>
+    makeJudgeOutput({
+        signal: 'implicit_correction',
+        implicitSignalSources: ['next_user_correction'],
+        confidence: 'high',
+        promotedToFinding: true,
+        promotionReason: 'LLM judge found missing project context.',
+        primaryRootCause: 'project_context',
+        secondaryRootCauses: [],
+        subcategories: ['wrong_explore_selection'],
+        fixTargets: ['project_context_rule'],
+        targetRefs: [
+            {
+                type: 'explore',
+                label: 'orders',
+                modelName: 'orders',
+                fieldName: 'orders',
+                setting: null,
+                key: null,
+            },
+        ],
+        ownerType: 'semantic_layer_owner',
+        projectContextEntry: {
+            op: 'create',
+            id: null,
+            kind: 'context',
+            content: 'Use the orders explore for revenue questions.',
+            terms: ['revenue'],
+            objects: ['orders'],
+        },
+        reviewItem: {
+            title: 'Review revenue routing',
+            description: 'LLM judge grouped missing project context.',
         },
     });
 
@@ -379,6 +416,38 @@ describe('AiAgentReviewClassifierService', () => {
                             'ai_agent_review_item:',
                         ),
                     }),
+                }),
+            }),
+        );
+    });
+
+    it('drops project context entries when the project context flag is disabled', async () => {
+        featureFlagService.get.mockImplementation(({ featureFlagId }) =>
+            Promise.resolve({
+                id: featureFlagId,
+                enabled: featureFlagId !== FeatureFlags.AiProjectContext,
+            }),
+        );
+        judgeTurn.mockResolvedValueOnce(makeProjectContextJudgeOutput());
+        model.listTurnReviewCandidates.mockResolvedValue([
+            makeCandidate({
+                nextUserPrompt: 'No, use orders for revenue questions.',
+            }),
+        ]);
+
+        const result = await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+            persistFindings: true,
+        });
+
+        expect(result.findingCount).toBe(1);
+        expect(model.createTurnSignal).toHaveBeenCalledWith(
+            expect.objectContaining({
+                finding: expect.objectContaining({
+                    primaryRootCause: 'project_context',
+                    projectContextEntry: null,
                 }),
             }),
         );

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -351,6 +351,14 @@ export class AiAgentReviewClassifierService extends BaseService {
         const runAgentConfig = args.candidates[0]
             ? await this.captureAgentConfigSnapshot(args.candidates[0])
             : AiAgentReviewClassifierService.emptyAgentConfigEvidence();
+        const projectContextFlag = await this.featureFlagService.get({
+            featureFlagId: FeatureFlags.AiProjectContext,
+            user: {
+                userUuid: args.requestedByUserUuid ?? 'system',
+                organizationUuid: args.organizationUuid,
+                organizationName: args.organizationName ?? '',
+            },
+        });
 
         const run = await this.aiAgentReviewClassifierModel.createRun({
             organizationUuid: args.organizationUuid,
@@ -395,6 +403,7 @@ export class AiAgentReviewClassifierService extends BaseService {
                     classifiedTurn: await this.classifyTurnWithJudge(
                         candidate,
                         runAgentConfig,
+                        { projectContextEnabled: projectContextFlag.enabled },
                     ),
                 })),
             );
@@ -489,6 +498,7 @@ export class AiAgentReviewClassifierService extends BaseService {
     private async classifyTurnWithJudge(
         candidate: AiAgentReviewClassifierTurnCandidate,
         agentConfig: AiAgentReviewAgentConfigEvidence,
+        args: { projectContextEnabled: boolean },
     ): Promise<AiAgentReviewClassifierClassifiedTurn> {
         const reviewEvidence = await this.buildReviewEvidence(
             candidate,
@@ -604,6 +614,12 @@ export class AiAgentReviewClassifierService extends BaseService {
                 )?.capabilityKey ?? null,
         });
 
+        const projectContextEntry =
+            args.projectContextEnabled &&
+            judgeOutput.primaryRootCause === 'project_context'
+                ? judgeOutput.projectContextEntry
+                : null;
+
         return {
             signal,
             finding: {
@@ -614,6 +630,7 @@ export class AiAgentReviewClassifierService extends BaseService {
                 targetRefs,
                 evidenceExcerpts: judgeOutput.evidenceExcerpts,
                 recommendation,
+                projectContextEntry,
                 reviewItem: {
                     fingerprint,
                     title: judgeOutput.reviewItem.title,
@@ -955,7 +972,15 @@ For targetRefs, return compact refs:
 - setting: agent config setting for agent_config targets, otherwise null.
 - key: runtime/product capability key when useful, otherwise null.
 reviewItem.title should be concise and admin-facing.
-reviewItem.description should summarize why this grouping exists.`,
+reviewItem.description should summarize why this grouping exists.
+
+Set projectContextEntry ONLY when primaryRootCause=project_context and a single durable, project-specific fact (a business definition or acronym, routing/join guidance, or object-scoped context) would prevent this class of failure in future turns. Otherwise set it to null.
+- op: "update" if one of the project context entries already injected into the reviewed turn was present but insufficient (reference its id); otherwise "create".
+- id: the existing entry id when op="update", otherwise null.
+- kind: definition | context. Use "definition" for acronyms and business vocabulary ("X means Y"); use "context" for everything else (routing/join rules, guidance, durable object-scoped facts).
+- content: a single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').
+- terms: the prompt-facing trigger words/phrases that should surface this entry (e.g. ["HR","high risk"]). Required for definitions.
+- objects: the semantic objects this fact concerns, from targetRefs — explore names and/or field ids in the \`table_field\` form shown as fieldId in field results (e.g. "payments_total_amount"); [] when purely prompt-driven.`,
                 },
                 {
                     role: 'user',

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -58,6 +58,7 @@ const baseItem = (
             targetRefs: [],
         },
         createdAt: new Date('2026-05-26T00:00:00.000Z'),
+        projectContextEntry: null,
     },
     ...overrides,
 });

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -1,4 +1,5 @@
 import {
+    aiAgentJudgeProjectContextEntrySchema,
     getAiAgentConfigSnapshotHash,
     getAiAgentReviewItemFingerprint,
     getAiAgentReviewItemFingerprintScope,
@@ -83,6 +84,56 @@ describe('getAiAgentReviewItemFingerprint', () => {
                 primaryRootCause: 'semantic_layer',
             }),
         ).toThrow('projectUuid is required for semantic_layer fingerprints');
+    });
+});
+
+describe('aiAgentJudgeProjectContextEntrySchema', () => {
+    test('accepts a create entry', () => {
+        const result = aiAgentJudgeProjectContextEntrySchema.safeParse({
+            op: 'create',
+            id: null,
+            kind: 'definition',
+            content: '"HR" = the high-risk diabetes cohort.',
+            terms: ['HR'],
+            objects: [],
+        });
+        expect(result.success).toBe(true);
+    });
+
+    test('accepts an update entry referencing an existing id', () => {
+        const result = aiAgentJudgeProjectContextEntrySchema.safeParse({
+            op: 'update',
+            id: 'hr-abbreviation',
+            kind: 'definition',
+            content: 'updated definition',
+            terms: ['HR'],
+            objects: ['patient_health_scores'],
+        });
+        expect(result.success).toBe(true);
+    });
+
+    test('rejects an update entry without an id', () => {
+        const result = aiAgentJudgeProjectContextEntrySchema.safeParse({
+            op: 'update',
+            id: null,
+            kind: 'definition',
+            content: 'updated definition',
+            terms: ['HR'],
+            objects: [],
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects an unknown kind', () => {
+        const result = aiAgentJudgeProjectContextEntrySchema.safeParse({
+            op: 'create',
+            id: null,
+            kind: 'nonsense',
+            content: 'x',
+            terms: [],
+            objects: [],
+        });
+        expect(result.success).toBe(false);
     });
 });
 

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -3,6 +3,7 @@ import type { ApiSuccess } from '../../types/api/success';
 import type { MetricQuery } from '../../types/metricQuery';
 import type { QueryHistoryStatus } from '../../types/queryHistory';
 import type { AiAgentDocumentStructuredSummary } from './documentTypes';
+import { projectContextEntryKinds } from './projectContext';
 import type { AiAgentReviewClassifierEventType } from './requestTypes';
 
 export type AiAgentReviewClassifierSubject = {
@@ -354,6 +355,40 @@ const aiAgentJudgeTargetRefSchema = z.object({
     key: z.string().nullable(),
 });
 
+// Structured project_context living-document entry the judge emits for
+// project_context findings. `id` is required when op === 'update' (the entry
+// it reviewed was already injected into the turn, so it can reference the id).
+export const aiAgentJudgeProjectContextEntrySchema = z
+    .object({
+        op: z.enum(['create', 'update']),
+        id: z.string().min(1).nullable(),
+        kind: z.enum(projectContextEntryKinds),
+        content: z.string(),
+        terms: z.array(z.string()),
+        objects: z.array(z.string()),
+    })
+    .superRefine((entry, ctx) => {
+        if (entry.op === 'update' && !entry.id) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'id is required when op is update',
+                path: ['id'],
+            });
+        }
+    });
+
+// Concrete type (not z.infer) so tsoa can resolve it where it surfaces in API
+// responses (AiAgentReviewItemSummary). Kept structurally in sync with
+// aiAgentJudgeProjectContextEntrySchema above.
+export type AiAgentJudgeProjectContextEntry = {
+    op: 'create' | 'update';
+    id: string | null;
+    kind: 'definition' | 'context';
+    content: string;
+    terms: string[];
+    objects: string[];
+};
+
 export const aiAgentReviewClassifierJudgeOutputSchema = z.object({
     signal: z.enum([
         'normal_refinement',
@@ -469,6 +504,7 @@ export const aiAgentReviewClassifierJudgeOutputSchema = z.object({
         title: z.string(),
         description: z.string(),
     }),
+    projectContextEntry: aiAgentJudgeProjectContextEntrySchema.nullable(),
 });
 
 export type AiAgentReviewClassifierJudgeOutput = z.infer<
@@ -521,6 +557,7 @@ export type AiAgentReviewItemSummary = AiAgentReviewItem & {
         targetRefs: AiAgentTargetRef[];
         evidenceExcerpts: AiAgentEvidenceExcerpt[];
         recommendation: AiAgentRecommendation | null;
+        projectContextEntry: AiAgentJudgeProjectContextEntry | null;
         createdAt: Date;
     } | null;
 };
@@ -685,6 +722,7 @@ export type AiAgentReviewClassifierSignalFinding = {
     targetRefs: AiAgentTargetRef[];
     evidenceExcerpts: AiAgentEvidenceExcerpt[];
     recommendation: AiAgentRecommendation | null;
+    projectContextEntry: AiAgentJudgeProjectContextEntry | null;
     reviewItem: {
         fingerprint: string;
         title: string;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -34,6 +34,7 @@ export * from './aiAgentReviewClassifierTypes';
 export * from './documentTypes';
 export * from './filterExploreByTags';
 export * from './followUpTools';
+export * from './projectContext';
 export * from './requestTypes';
 export * from './schemas';
 export * from './schemas/agentReadiness';

--- a/packages/common/src/ee/AiAgent/projectContext.test.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.test.ts
@@ -1,0 +1,297 @@
+import { ParseError } from '../../types/errors';
+import {
+    loadProjectContextFile,
+    mergeProjectContextEntry,
+    serializeProjectContextFile,
+    type ProjectContextEntry,
+} from './projectContext';
+
+const entry = (
+    overrides: Partial<ProjectContextEntry> & Pick<ProjectContextEntry, 'id'>,
+): ProjectContextEntry => ({
+    kind: 'context',
+    content: 'content',
+    terms: [],
+    objects: [],
+    ...overrides,
+});
+
+describe('loadProjectContextFile', () => {
+    test('parses a fully-specified entry', () => {
+        const yaml = `
+- id: hr-abbreviation
+  kind: definition
+  content: '"HR" = the high-risk diabetes cohort, not human resources.'
+  terms: [HR, high risk]
+  objects: [patient_health_scores.diabetes_risk_category]
+`;
+        expect(loadProjectContextFile(yaml)).toEqual([
+            {
+                id: 'hr-abbreviation',
+                kind: 'definition',
+                content:
+                    '"HR" = the high-risk diabetes cohort, not human resources.',
+                terms: ['HR', 'high risk'],
+                objects: ['patient_health_scores.diabetes_risk_category'],
+            },
+        ]);
+    });
+
+    test('applies defaults for optional fields', () => {
+        const yaml = `
+- id: fiscal-year
+  kind: context
+  content: 'Fiscal year starts in February.'
+`;
+        expect(loadProjectContextFile(yaml)).toEqual([
+            {
+                id: 'fiscal-year',
+                kind: 'context',
+                content: 'Fiscal year starts in February.',
+                terms: [],
+                objects: [],
+            },
+        ]);
+    });
+
+    test('strips legacy global fields', () => {
+        const yaml = `
+- id: fiscal-year
+  kind: context
+  content: 'Fiscal year starts in February.'
+  global: true
+`;
+        expect(loadProjectContextFile(yaml)[0]).not.toHaveProperty('global');
+    });
+
+    test('returns an empty array for empty content', () => {
+        expect(loadProjectContextFile('')).toEqual([]);
+        expect(loadProjectContextFile('   \n  ')).toEqual([]);
+    });
+
+    test('throws when the top level is not a list', () => {
+        expect(() => loadProjectContextFile('id: foo')).toThrow(ParseError);
+    });
+
+    test('throws when an entry is missing required fields', () => {
+        const yaml = `
+- id: broken
+  kind: definition
+- id: ok
+  kind: definition
+  content: 'a valid fact'
+`;
+        expect(() => loadProjectContextFile(yaml)).toThrow(ParseError);
+    });
+
+    test('throws when an entry kind is not a known value', () => {
+        const yaml = `
+- id: broken
+  kind: nonsense
+  content: 'whatever'
+`;
+        expect(() => loadProjectContextFile(yaml)).toThrow(ParseError);
+    });
+
+    test('derives an id from the first term when absent', () => {
+        const yaml = `
+- kind: definition
+  content: '"HR" = high-risk cohort.'
+  terms: [HR, high risk]
+`;
+        expect(loadProjectContextFile(yaml)[0].id).toBe('hr');
+    });
+
+    test('suffixes derived ids to keep them unique within the file', () => {
+        const yaml = `
+- kind: definition
+  content: first
+  terms: [HR]
+- kind: definition
+  content: second
+  terms: [HR]
+`;
+        expect(loadProjectContextFile(yaml).map((e) => e.id)).toEqual([
+            'hr',
+            'hr-1',
+        ]);
+    });
+
+    test('preserves unknown keys (passthrough) so future fields round-trip', () => {
+        const yaml = `
+- id: hr
+  kind: definition
+  content: x
+  priority: high
+`;
+        expect(loadProjectContextFile(yaml)[0]).toMatchObject({
+            id: 'hr',
+            priority: 'high',
+        });
+    });
+});
+
+describe('mergeProjectContextEntry', () => {
+    test('creates a new entry with an id derived from the first term', () => {
+        const result = mergeProjectContextEntry([], {
+            op: 'create',
+            id: null,
+            kind: 'definition',
+            content: '"HR" = high-risk cohort.',
+            terms: ['HR'],
+            objects: [],
+        });
+        expect(result.op).toBe('create');
+        expect(result.entryId).toBe('hr');
+        expect(result.entries).toEqual([
+            {
+                id: 'hr',
+                kind: 'definition',
+                content: '"HR" = high-risk cohort.',
+                terms: ['HR'],
+                objects: [],
+            },
+        ]);
+    });
+
+    test('creates with an explicit id when provided', () => {
+        const result = mergeProjectContextEntry([], {
+            op: 'create',
+            id: 'patient-routing',
+            kind: 'context',
+            content: 'Attribute payments via customer_order_payments.',
+            terms: [],
+            objects: ['payments'],
+        });
+        expect(result.entryId).toBe('patient-routing');
+        expect(result.entries).toHaveLength(1);
+    });
+
+    test('updates an existing entry by id', () => {
+        const existing = entry({
+            id: 'fiscal',
+            kind: 'context',
+            content: 'old',
+        });
+        const result = mergeProjectContextEntry([existing], {
+            op: 'update',
+            id: 'fiscal',
+            kind: 'context',
+            content: 'Fiscal year starts in February.',
+            terms: [],
+            objects: [],
+        });
+        expect(result.op).toBe('update');
+        expect(result.entries).toEqual([
+            {
+                id: 'fiscal',
+                kind: 'context',
+                content: 'Fiscal year starts in February.',
+                terms: [],
+                objects: [],
+            },
+        ]);
+    });
+
+    test('rejects an update without an id', () => {
+        expect(() =>
+            mergeProjectContextEntry([], {
+                op: 'update',
+                id: null,
+                kind: 'context',
+                content: 'Fiscal year starts in February.',
+                terms: [],
+                objects: [],
+            }),
+        ).toThrow('requires an entry id');
+    });
+
+    test('suffixes a generated id that collides with an existing one', () => {
+        const result = mergeProjectContextEntry([entry({ id: 'hr' })], {
+            op: 'create',
+            id: null,
+            kind: 'definition',
+            content: 'another HR meaning',
+            terms: ['HR'],
+            objects: [],
+        });
+        expect(result.entryId).toBe('hr-1');
+        expect(result.entries).toHaveLength(2);
+    });
+
+    test('treats a create whose explicit id already exists as an update (dedup)', () => {
+        const result = mergeProjectContextEntry([entry({ id: 'hr' })], {
+            op: 'create',
+            id: 'hr',
+            kind: 'definition',
+            content: 'replaced',
+            terms: [],
+            objects: [],
+        });
+        expect(result.op).toBe('update');
+        expect(result.entries).toHaveLength(1);
+        expect(result.entries[0].content).toBe('replaced');
+    });
+});
+
+describe('serializeProjectContextFile', () => {
+    test('round-trips through the parser', () => {
+        const entries = [
+            entry({
+                id: 'hr',
+                kind: 'definition',
+                content: 'x',
+                terms: ['HR'],
+            }),
+            entry({ id: 'fy', kind: 'context', content: 'y' }),
+        ];
+        expect(
+            loadProjectContextFile(serializeProjectContextFile(entries)),
+        ).toEqual(entries);
+    });
+
+    test('produces an empty list for no entries', () => {
+        expect(loadProjectContextFile(serializeProjectContextFile([]))).toEqual(
+            [],
+        );
+    });
+
+    test('serializes to a versioned { version, entries } document', () => {
+        const output = serializeProjectContextFile([
+            entry({ id: 'hr', kind: 'definition', content: 'x' }),
+        ]);
+        expect(output).toContain('version: 1');
+        expect(output).toContain('entries:');
+    });
+
+    test('parses the versioned { version, entries } shape', () => {
+        const yaml = `
+version: 1
+entries:
+  - id: hr
+    kind: definition
+    content: '"HR" = high-risk cohort.'
+    terms: [HR]
+`;
+        expect(loadProjectContextFile(yaml)).toEqual([
+            {
+                id: 'hr',
+                kind: 'definition',
+                content: '"HR" = high-risk cohort.',
+                terms: ['HR'],
+                objects: [],
+            },
+        ]);
+    });
+
+    test('throws on unsupported document versions', () => {
+        const yaml = `
+version: 2
+entries:
+  - id: hr
+    kind: definition
+    content: '"HR" = high-risk cohort.'
+`;
+        expect(() => loadProjectContextFile(yaml)).toThrow(ParseError);
+    });
+});

--- a/packages/common/src/ee/AiAgent/projectContext.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.ts
@@ -1,0 +1,209 @@
+import Ajv from 'ajv';
+import AjvErrors from 'ajv-errors';
+import betterAjvErrors from 'better-ajv-errors';
+import * as yaml from 'js-yaml';
+import { z } from 'zod';
+import lightdashProjectContextSchema from '../../schemas/json/lightdash-project-context-1.0.json';
+import { ParseError } from '../../types/errors';
+
+// Two kinds, by retrieval intent: `definition` is term-triggered (acronyms,
+// vocabulary, "X means Y"); `context` is the object-scoped catch-all
+// (routing/join rules, guidance, durable facts). Splitting out more kinds later
+// is additive.
+export const projectContextEntryKinds = ['definition', 'context'] as const;
+
+// Top-level file version. The file is `{ version, entries }`; bumping this is
+// the escape hatch for a future hard schema break, without per-entry churn.
+export const PROJECT_CONTEXT_FILE_VERSION = 1;
+
+// Canonical, post-ingest entry: `id` is always present (derived if the file
+// omitted it). This is what selection, the cache, and the API speak.
+export const projectContextEntrySchema = z.object({
+    id: z.string().min(1),
+    kind: z.enum(projectContextEntryKinds),
+    content: z.string().min(1),
+    terms: z.array(z.string()).default([]),
+    objects: z.array(z.string()).default([]),
+});
+
+export type ProjectContextEntry = z.infer<typeof projectContextEntrySchema>;
+
+// File-input shape, deliberately lax for human authors: `id` is optional
+// (derived at ingest) and unknown keys are preserved so a field a newer
+// Lightdash adds round-trips instead of being silently dropped. The legacy
+// `global` key is stripped explicitly during load.
+type ProjectContextFileEntry = Omit<
+    ProjectContextEntry,
+    'id' | 'terms' | 'objects'
+> & {
+    id?: string;
+    terms?: string[];
+    objects?: string[];
+    [key: string]: unknown;
+};
+
+// Judge-emitted write-path entry (op + nullable id, no global). Mirrors
+// aiAgentJudgeProjectContextEntrySchema; redeclared here to keep this module
+// free of the review-classifier types.
+export type ProjectContextWritebackEntry = {
+    op: 'create' | 'update';
+    id: string | null;
+    kind: ProjectContextEntry['kind'];
+    content: string;
+    terms: string[];
+    objects: string[];
+};
+
+const slugifyId = (value: string): string =>
+    value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+/**
+ * Apply a judge-emitted entry to the current file entries, by id. A create with
+ * no id derives a stable id from the first term/content (suffixed on collision);
+ * an explicit id that already exists updates in place (dedup backstop).
+ */
+export const mergeProjectContextEntry = (
+    existing: ProjectContextEntry[],
+    judgeEntry: ProjectContextWritebackEntry,
+): {
+    entries: ProjectContextEntry[];
+    entryId: string;
+    op: 'create' | 'update';
+} => {
+    const ids = new Set(existing.map((e) => e.id));
+    if (judgeEntry.op === 'update' && !judgeEntry.id) {
+        throw new Error('Project context update requires an entry id');
+    }
+
+    let entryId: string;
+    if (judgeEntry.id) {
+        entryId = judgeEntry.id;
+    } else {
+        const base =
+            slugifyId(judgeEntry.terms[0] ?? judgeEntry.content) ||
+            judgeEntry.kind;
+        entryId = base;
+        let suffix = 1;
+        while (ids.has(entryId)) {
+            entryId = `${base}-${suffix}`;
+            suffix += 1;
+        }
+    }
+
+    const index = existing.findIndex((e) => e.id === entryId);
+    const op: 'create' | 'update' = index >= 0 ? 'update' : 'create';
+    const merged: ProjectContextEntry = {
+        id: entryId,
+        kind: judgeEntry.kind,
+        content: judgeEntry.content,
+        terms: judgeEntry.terms,
+        objects: judgeEntry.objects,
+    };
+
+    const entries =
+        index >= 0
+            ? existing.map((e, i) => (i === index ? merged : e))
+            : [...existing, merged];
+
+    return { entries, entryId, op };
+};
+
+export const serializeProjectContextFile = (
+    entries: ProjectContextEntry[],
+): string => {
+    if (entries.length === 0) {
+        return '';
+    }
+    return yaml.dump(
+        { version: PROJECT_CONTEXT_FILE_VERSION, entries },
+        { lineWidth: -1 },
+    );
+};
+
+// Derive a stable id from the first term (or content) when the author omitted
+// one, suffixing on collision so ids stay unique within the file.
+const deriveEntryId = (
+    entry: { id?: string; terms: string[]; content: string },
+    used: Set<string>,
+): string => {
+    const base = entry.id ?? slugifyId(entry.terms[0] ?? entry.content);
+    const fallback = base === '' ? 'entry' : base;
+    let id = fallback;
+    let suffix = 1;
+    while (used.has(id)) {
+        id = `${fallback}-${suffix}`;
+        suffix += 1;
+    }
+    return id;
+};
+
+/**
+ * Load project_context YAML contents. Accepts the canonical `{ version, entries }`
+ * shape and a legacy bare-array file. Invalid files throw with schema-backed
+ * errors, and `id` is derived when absent.
+ */
+export const loadProjectContextFile = (
+    yamlContents: string,
+): ProjectContextEntry[] => {
+    if (yamlContents.trim() === '') {
+        return [];
+    }
+
+    let loaded: unknown;
+    try {
+        loaded = yaml.load(yamlContents);
+    } catch (e) {
+        throw new ParseError(
+            `Invalid project_context.yml: ${
+                e instanceof Error ? e.message : 'failed to parse YAML'
+            }`,
+        );
+    }
+
+    const ajv = new Ajv({
+        coerceTypes: true,
+        allErrors: true,
+        allowUnionTypes: true,
+    });
+    AjvErrors(ajv);
+    const validate = ajv.compile(lightdashProjectContextSchema);
+
+    if (!validate(loaded)) {
+        const errors = betterAjvErrors(
+            lightdashProjectContextSchema,
+            loaded,
+            validate.errors || [],
+            { indent: 2 },
+        );
+        throw new ParseError(
+            `Invalid project_context.yml with errors:\n${errors}`,
+        );
+    }
+
+    const rawEntries = (
+        Array.isArray(loaded)
+            ? loaded
+            : (loaded as { entries: unknown[] }).entries
+    ) as ProjectContextFileEntry[];
+    const entries: ProjectContextEntry[] = [];
+    const usedIds = new Set<string>();
+    for (const item of rawEntries) {
+        const entry = { ...item };
+        const explicitId = entry.id;
+        const terms = entry.terms ?? [];
+        const objects = entry.objects ?? [];
+        delete entry.id;
+        delete entry.global;
+
+        const id = deriveEntryId(
+            { id: explicitId, terms, content: entry.content },
+            usedIds,
+        );
+        usedIds.add(id);
+        entries.push({ ...entry, id, terms, objects });
+    }
+    return entries;
+};

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -78,6 +78,7 @@ export * from './pivot/utils';
 export { default as chartAsCodeSchema } from './schemas/json/chart-as-code-1.0.json';
 export { default as dashboardAsCodeSchema } from './schemas/json/dashboard-as-code-1.0.json';
 export { default as lightdashDbtYamlSchema } from './schemas/json/lightdash-dbt-2.0.json';
+export { default as lightdashProjectContextSchema } from './schemas/json/lightdash-project-context-1.0.json';
 export { default as lightdashProjectConfigSchema } from './schemas/json/lightdash-project-config-1.0.json';
 export { default as modelAsCodeSchema } from './schemas/json/model-as-code-1.0.json';
 export * from './templating/liquidSql';

--- a/packages/common/src/schemas/json/lightdash-project-context-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-context-1.0.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.lightdash.com/lightdash/project-context.json",
+    "description": "Project-scoped AI agent context loaded from lightdash.project_context.yml",
+    "oneOf": [
+        {
+            "$ref": "#/definitions/document"
+        },
+        {
+            "$ref": "#/definitions/entries"
+        }
+    ],
+    "definitions": {
+        "document": {
+            "type": "object",
+            "properties": {
+                "version": {
+                    "type": "number",
+                    "const": 1
+                },
+                "entries": {
+                    "$ref": "#/definitions/entries"
+                }
+            },
+            "required": ["version", "entries"],
+            "additionalProperties": false
+        },
+        "entries": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/entry"
+            }
+        },
+        "entry": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Stable entry id. Optional; derived from terms/content when omitted."
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": ["definition", "context"],
+                    "description": "definition for acronyms/vocabulary; context for object-scoped guidance."
+                },
+                "content": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "One self-contained sentence."
+                },
+                "terms": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Prompt-facing trigger words/phrases.",
+                    "default": []
+                },
+                "objects": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Semantic objects this fact concerns.",
+                    "default": []
+                }
+            },
+            "required": ["kind", "content"],
+            "additionalProperties": true
+        }
+    }
+}

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -253,6 +253,14 @@ export enum FeatureFlags {
      * always on; this flag only controls who can see/configure the panel.
      */
     ProLimits = 'pro-limits',
+
+    /**
+     * Enable the (in-progress) project_context living document: ingest
+     * lightdash.project_context.yml on compile and inject the selected
+     * entries into the AI agent system prompt. Shared across the
+     * project_context slices so the whole feature ships atomically.
+     */
+    AiProjectContext = 'ai-project-context',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
## What

Introduces the **project_context entry contract** and has the review judge **emit** one.

- New versioned `lightdash.project_context.yml` entry shape (`kind` = `definition` | `context`, plus `content` / `terms` / `objects` / `global`) with a lax, quarantining parser (one bad entry never sinks the file) — `packages/common/.../projectContext.ts`.
- The review judge now emits a structured `projectContextEntry` on `project_context` findings, persisted on the turn signal (`ai_agent_review_turn_signal`).
- Adds the shared `ai-project-context` feature flag that gates the whole stack.

## Scope / regression analysis

- All new behavior is gated by `ai-project-context` (off → invisible).
- The judge addition only writes an extra nullable jsonb column on the turn signal; nothing consumes it until the writeback slice, so it's inert when the rest of the stack isn't enabled.
- EE-only; OSS build unaffected (kernel lives under `common/src/ee`, backend under `ee/`).

_Stack: PR 1 of 6. Foundation for ingest → load → writeback._

Relates: ZAP-475
