### PR TITLE
feat(ai-project-context): ingest & cache the project context file

### DIFF
--- a/packages/backend/src/ee/database/entities/projectContext.ts
+++ b/packages/backend/src/ee/database/entities/projectContext.ts
@@ -1,0 +1,11 @@
+import { ProjectContextEntry } from '@lightdash/common';
+
+export const ProjectContextDocumentTableName = 'project_context_document';
+
+// The whole project_context file as one blob per project.
+export type DbProjectContextDocument = {
+    project_uuid: string;
+    version: number;
+    entries: ProjectContextEntry[];
+    updated_at: Date;
+};

--- a/packages/backend/src/ee/database/migrations/20260603101700_project_context_document_and_search_terms.ts
+++ b/packages/backend/src/ee/database/migrations/20260603101700_project_context_document_and_search_terms.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+const documentTable = 'project_context_document';
+const projectsTable = 'projects';
+
+// The cached project context: the whole lightdash.project_context.yml file as
+// one blob per project, refreshed on compile and read wholesale by the agent.
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(documentTable, (table) => {
+        table
+            .uuid('project_uuid')
+            .primary()
+            .references('project_uuid')
+            .inTable(projectsTable)
+            .onDelete('CASCADE');
+        table.integer('version').notNullable().defaultTo(1);
+        table.jsonb('entries').notNullable().defaultTo('[]');
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(documentTable);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -27,6 +27,7 @@ import { DashboardSummaryModel } from './models/DashboardSummaryModel';
 import { EmbedModel } from './models/EmbedModel';
 import { ManagedAgentModel } from './models/ManagedAgentModel';
 import { ProjectCiStatusModel } from './models/ProjectCiStatusModel';
+import { ProjectContextModel } from './models/ProjectContextModel';
 import { ServiceAccountModel } from './models/ServiceAccountModel';
 import { enhanceExploresForPreAggregates } from './preAggregates/enhanceExploresForPreAggregates';
 import { preAggregatePostProcessor } from './preAggregates/postProcessor';
@@ -50,6 +51,7 @@ import { EmbedService } from './services/EmbedService/EmbedService';
 import { ManagedAgentService } from './services/ManagedAgentService/ManagedAgentService';
 import { McpService } from './services/McpService/McpService';
 import { OrganizationWarehouseCredentialsService } from './services/OrganizationWarehouseCredentialsService';
+import { ProjectContextService } from './services/ProjectContextService/ProjectContextService';
 import { ScimService } from './services/ScimService/ScimService';
 import { ServiceAccountService } from './services/ServiceAccountService/ServiceAccountService';
 import { CommercialSlackService } from './services/SlackService/SlackService';
@@ -87,6 +89,14 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
 
     return {
         serviceProviders: {
+            projectContextService: ({ models }) =>
+                new ProjectContextService({
+                    projectModel: models.getProjectModel(),
+                    githubAppInstallationsModel:
+                        models.getGithubAppInstallationsModel(),
+                    projectContextModel:
+                        models.getProjectContextModel<ProjectContextModel>(),
+                }),
             aiWritebackService: ({ context, models }) =>
                 new AiWritebackService({
                     lightdashConfig: context.lightdashConfig,
@@ -355,6 +365,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getContentVerificationModel(),
                     organizationSettingsModel:
                         models.getOrganizationSettingsModel(),
+                    projectContextModel:
+                        models.getProjectContextModel<ProjectContextModel>(),
                 }),
             instanceConfigurationService: ({
                 models,
@@ -553,6 +565,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new ProjectCiStatusModel({ database }),
             aiAgentReviewClassifierModel: ({ database }) =>
                 new AiAgentReviewClassifierModel({ database }),
+            projectContextModel: ({ database }) =>
+                new ProjectContextModel({ database }),
             aiRouterModel: ({ database }) => new AiRouterModel({ database }),
             aiOrganizationSettingsModel: ({ database }) =>
                 new AiOrganizationSettingsModel({ database }),
@@ -629,6 +643,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.serviceRepository.getAiAgentReviewClassifierService(),
                 aiAgentAdminService:
                     context.serviceRepository.getAiAgentAdminService<AiAgentAdminService>(),
+                projectContextService:
+                    context.serviceRepository.getProjectContextService<ProjectContextService>(),
             }),
         clientProviders: {
             schedulerClient: ({ context, models }) =>

--- a/packages/backend/src/ee/models/ProjectContextModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectContextModel.test.ts
@@ -1,0 +1,54 @@
+import {
+    PROJECT_CONTEXT_FILE_VERSION,
+    type ProjectContextEntry,
+} from '@lightdash/common';
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { ProjectContextDocumentTableName } from '../database/entities/projectContext';
+import { ProjectContextModel } from './ProjectContextModel';
+
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000001';
+
+describe('ProjectContextModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new ProjectContextModel({
+        database: database as unknown as Knex,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    test('stores entries as JSONB data instead of a JSON string', async () => {
+        const entries: ProjectContextEntry[] = [
+            {
+                id: 'hr',
+                kind: 'definition',
+                content: '"HR" = high-risk cohort.',
+                terms: ['HR'],
+                objects: [],
+            },
+        ];
+
+        tracker.on.insert(ProjectContextDocumentTableName).responseOnce([]);
+
+        await model.replaceEntriesForProject(PROJECT_UUID, entries);
+
+        expect(tracker.history.insert).toHaveLength(1);
+        expect(tracker.history.insert[0].bindings).toEqual(
+            expect.arrayContaining([
+                PROJECT_UUID,
+                PROJECT_CONTEXT_FILE_VERSION,
+                entries,
+            ]),
+        );
+        expect(tracker.history.insert[0].bindings).not.toContain(
+            JSON.stringify(entries),
+        );
+    });
+});

--- a/packages/backend/src/ee/models/ProjectContextModel.ts
+++ b/packages/backend/src/ee/models/ProjectContextModel.ts
@@ -1,0 +1,39 @@
+import {
+    PROJECT_CONTEXT_FILE_VERSION,
+    ProjectContextEntry,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { ProjectContextDocumentTableName } from '../database/entities/projectContext';
+
+export class ProjectContextModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    // The whole cached document for the project (empty when unset).
+    async getDocument(projectUuid: string): Promise<ProjectContextEntry[]> {
+        const row = await this.database(ProjectContextDocumentTableName)
+            .where('project_uuid', projectUuid)
+            .first();
+        return row ? (row.entries as ProjectContextEntry[]) : [];
+    }
+
+    // Replace-all: the file is the source of truth, so the cached blob is
+    // overwritten wholesale on every ingest.
+    async replaceEntriesForProject(
+        projectUuid: string,
+        entries: ProjectContextEntry[],
+    ): Promise<void> {
+        await this.database(ProjectContextDocumentTableName)
+            .insert({
+                project_uuid: projectUuid,
+                version: PROJECT_CONTEXT_FILE_VERSION,
+                entries,
+                updated_at: this.database.fn.now(),
+            })
+            .onConflict('project_uuid')
+            .merge(['version', 'entries', 'updated_at']);
+    }
+}

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -20,6 +20,7 @@ import { AiAgentService } from '../services/AiAgentService/AiAgentService';
 import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
 import type { EmbedService } from '../services/EmbedService/EmbedService';
 import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgentService';
+import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
 
 const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
@@ -33,6 +34,7 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     embedService: EmbedService;
     managedAgentService: ManagedAgentService;
     appGenerateService: AppGenerateService;
+    projectContextService: ProjectContextService;
 };
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
@@ -48,6 +50,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
     protected readonly appGenerateService: AppGenerateService;
 
+    protected readonly projectContextService: ProjectContextService;
+
     constructor(args: CommercialSchedulerWorkerArguments) {
         super(args);
         this.aiAgentService = args.aiAgentService;
@@ -57,6 +61,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.embedService = args.embedService;
         this.managedAgentService = args.managedAgentService;
         this.appGenerateService = args.appGenerateService;
+        this.projectContextService = args.projectContextService;
     }
 
     protected getCronItems() {
@@ -321,6 +326,35 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             },
             [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: async () => {
                 await this.appGenerateService.sweepStaleLocks();
+            },
+            [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: async (
+                payload,
+                helpers,
+            ) => {
+                try {
+                    const user =
+                        await this.userService.getSessionByUserUuidAndOrg(
+                            payload.userUuid,
+                            payload.organizationUuid,
+                        );
+                    await this.projectContextService.ingestProjectContext(
+                        user,
+                        payload.projectUuid,
+                    );
+                } catch (e) {
+                    await this.schedulerService.logSchedulerJob({
+                        task: SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT,
+                        jobId: helpers.job.id,
+                        scheduledTime: helpers.job.run_at,
+                        status: SchedulerJobStatus.ERROR,
+                        details: {
+                            error: getErrorMessage(e),
+                            projectUuid: payload.projectUuid,
+                            organizationUuid: payload.organizationUuid,
+                        },
+                    });
+                    throw e;
+                }
             },
             [SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS]: async (
                 payload,

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
@@ -1,0 +1,223 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
+import {
+    DbtProjectType,
+    ForbiddenError,
+    NotFoundError,
+    type MemberAbility,
+    type ProjectContextEntry,
+    type SessionUser,
+} from '@lightdash/common';
+import {
+    getFileContent,
+    getInstallationToken,
+} from '../../../clients/github/Github';
+import type { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
+import type { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import type { ProjectContextModel } from '../../models/ProjectContextModel';
+import {
+    projectContextFilePath,
+    ProjectContextService,
+} from './ProjectContextService';
+
+jest.mock('../../../clients/github/Github', () => ({
+    getFileContent: jest.fn(),
+    getInstallationToken: jest.fn(),
+}));
+
+const mockGetFileContent = getFileContent as jest.Mock;
+const mockGetInstallationToken = getInstallationToken as jest.Mock;
+
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000001';
+const ORG_UUID = '00000000-0000-0000-0000-000000000002';
+const USER_UUID = '00000000-0000-0000-0000-000000000003';
+
+const githubProject = {
+    organizationUuid: ORG_UUID,
+    dbtConnection: {
+        type: DbtProjectType.GITHUB,
+        repository: 'acme/analytics',
+        branch: 'main',
+        project_sub_path: '/',
+    },
+};
+
+const existingEntries = (): ProjectContextEntry[] => [
+    {
+        id: 'existing',
+        kind: 'context',
+        content: 'Existing cached context.',
+        terms: [],
+        objects: [],
+    },
+];
+
+const userWithIngestAccess = (canManage: boolean = true): SessionUser => {
+    const { build, can, rules } = new AbilityBuilder<MemberAbility>(Ability);
+    if (canManage) {
+        can('manage', 'CompileProject', {
+            organizationUuid: ORG_UUID,
+            projectUuid: PROJECT_UUID,
+        });
+    }
+
+    return {
+        userUuid: USER_UUID,
+        organizationUuid: ORG_UUID,
+        organizationName: 'Acme',
+        organizationCreatedAt: new Date(),
+        role: 'admin',
+        ability: build(),
+        abilityRules: rules,
+    } as SessionUser;
+};
+
+const makeService = (overrides: {
+    project?: unknown;
+    projectSummary?: unknown;
+    installationId?: string | undefined;
+    initialEntries?: ProjectContextEntry[];
+}) => {
+    let cachedEntries = overrides.initialEntries ?? existingEntries();
+    const projectModel = {
+        get: jest.fn().mockResolvedValue(overrides.project ?? githubProject),
+        getSummary: jest.fn().mockResolvedValue(
+            overrides.projectSummary ?? {
+                organizationUuid: ORG_UUID,
+                projectUuid: PROJECT_UUID,
+                type: undefined,
+            },
+        ),
+    } as unknown as ProjectModel;
+    const githubAppInstallationsModel = {
+        findInstallationId: jest
+            .fn()
+            .mockResolvedValue(
+                'installationId' in overrides
+                    ? overrides.installationId
+                    : 'install-1',
+            ),
+    } as unknown as GithubAppInstallationsModel;
+    const projectContextModel = {
+        replaceEntriesForProject: jest.fn(
+            async (_projectUuid: string, entries: ProjectContextEntry[]) => {
+                cachedEntries = entries;
+            },
+        ),
+    } as unknown as ProjectContextModel;
+    const service = new ProjectContextService({
+        projectModel,
+        githubAppInstallationsModel,
+        projectContextModel,
+    });
+    return { service, getCachedEntries: () => cachedEntries };
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetInstallationToken.mockResolvedValue('token-1');
+});
+
+describe('projectContextFilePath', () => {
+    test.each([
+        ['/', 'lightdash.project_context.yml'],
+        ['./', 'lightdash.project_context.yml'],
+        ['/transform/dbt', 'transform/dbt/lightdash.project_context.yml'],
+        ['transform/dbt/', 'transform/dbt/lightdash.project_context.yml'],
+    ])('resolves %s', (projectSubPath, filePath) => {
+        expect(projectContextFilePath(projectSubPath)).toBe(filePath);
+    });
+});
+
+describe('ProjectContextService.ingestProjectContext', () => {
+    test('requires compile-project access', async () => {
+        const { service, getCachedEntries } = makeService({});
+
+        await expect(
+            service.ingestProjectContext(
+                userWithIngestAccess(false),
+                PROJECT_UUID,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(getCachedEntries()).toEqual(existingEntries());
+    });
+
+    test('no-op when the project is not GitHub-backed', async () => {
+        const { service, getCachedEntries } = makeService({
+            project: {
+                organizationUuid: ORG_UUID,
+                dbtConnection: { type: DbtProjectType.DBT },
+            },
+        });
+        const result = await service.ingestProjectContext(
+            userWithIngestAccess(),
+            PROJECT_UUID,
+        );
+        expect(result).toEqual({
+            ingested: false,
+            reason: 'no_github_access',
+        });
+        expect(getCachedEntries()).toEqual(existingEntries());
+    });
+
+    test('no-op when the org has no GitHub App installation', async () => {
+        const { service, getCachedEntries } = makeService({
+            installationId: undefined,
+        });
+        const result = await service.ingestProjectContext(
+            userWithIngestAccess(),
+            PROJECT_UUID,
+        );
+        expect(result).toEqual({
+            ingested: false,
+            reason: 'no_github_access',
+        });
+        expect(getCachedEntries()).toEqual(existingEntries());
+    });
+
+    test('clears entries when the file is not found', async () => {
+        mockGetFileContent.mockRejectedValue(new NotFoundError('missing'));
+        const { service, getCachedEntries } = makeService({});
+        const result = await service.ingestProjectContext(
+            userWithIngestAccess(),
+            PROJECT_UUID,
+        );
+        expect(result).toEqual({ ingested: true, entryCount: 0 });
+        expect(getCachedEntries()).toEqual([]);
+    });
+
+    test('parses and replaces entries when the file is present', async () => {
+        mockGetFileContent.mockResolvedValue({
+            content: `
+- id: hr
+  kind: definition
+  content: '"HR" = high-risk cohort.'
+  terms: [HR]
+`,
+            sha: 'abc',
+        });
+        const { service, getCachedEntries } = makeService({});
+        const result = await service.ingestProjectContext(
+            userWithIngestAccess(),
+            PROJECT_UUID,
+        );
+        expect(result).toEqual({ ingested: true, entryCount: 1 });
+        expect(getCachedEntries()).toEqual([
+            {
+                id: 'hr',
+                kind: 'definition',
+                content: '"HR" = high-risk cohort.',
+                terms: ['HR'],
+                objects: [],
+            },
+        ]);
+    });
+
+    test('does not wipe entries on a transient GitHub error', async () => {
+        mockGetFileContent.mockRejectedValue(new Error('500 from GitHub'));
+        const { service, getCachedEntries } = makeService({});
+        await expect(
+            service.ingestProjectContext(userWithIngestAccess(), PROJECT_UUID),
+        ).rejects.toThrow('500 from GitHub');
+        expect(getCachedEntries()).toEqual(existingEntries());
+    });
+});

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
@@ -1,0 +1,183 @@
+import { subject } from '@casl/ability';
+import {
+    DbtProjectType,
+    ForbiddenError,
+    loadProjectContextFile,
+    NotFoundError,
+    type DbtProjectConfig,
+    type SessionUser,
+} from '@lightdash/common';
+import {
+    getFileContent,
+    getInstallationToken,
+} from '../../../clients/github/Github';
+import type { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
+import type { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { BaseService } from '../../../services/BaseService';
+import type { ProjectContextModel } from '../../models/ProjectContextModel';
+
+// The living document is a sibling of lightdash.config.yml inside the dbt
+// project directory, so it travels with the project's other Lightdash metadata.
+const PROJECT_CONTEXT_FILE_NAME = 'lightdash.project_context.yml';
+
+// Resolve the repo-relative path for the GitHub contents API: strip a leading
+// "./" or "/" and a trailing slash from project_sub_path, then prefix the file
+// name. project_sub_path "/" (repo root) yields the bare file name.
+export const projectContextFilePath = (projectSubPath: string): string => {
+    const trimmed = projectSubPath
+        .trim()
+        .replace(/^\.?\/+/, '')
+        .replace(/\/+$/, '');
+    return trimmed === ''
+        ? PROJECT_CONTEXT_FILE_NAME
+        : `${trimmed}/${PROJECT_CONTEXT_FILE_NAME}`;
+};
+
+export type ProjectContextIngestResult =
+    | { ingested: true; entryCount: number }
+    | { ingested: false; reason: string };
+
+type GithubAccess = {
+    owner: string;
+    repo: string;
+    branch: string;
+    projectSubPath: string;
+    installationId: string;
+    token: string;
+};
+
+type ProjectContextServiceDeps = {
+    projectModel: ProjectModel;
+    githubAppInstallationsModel: GithubAppInstallationsModel;
+    projectContextModel: ProjectContextModel;
+};
+
+export class ProjectContextService extends BaseService {
+    private readonly projectModel: ProjectModel;
+
+    private readonly githubAppInstallationsModel: GithubAppInstallationsModel;
+
+    private readonly projectContextModel: ProjectContextModel;
+
+    constructor(deps: ProjectContextServiceDeps) {
+        super();
+        this.projectModel = deps.projectModel;
+        this.githubAppInstallationsModel = deps.githubAppInstallationsModel;
+        this.projectContextModel = deps.projectContextModel;
+    }
+
+    private static resolveGithubConnection(connection: DbtProjectConfig): {
+        owner: string;
+        repo: string;
+        branch: string;
+        projectSubPath: string;
+    } | null {
+        if (connection.type !== DbtProjectType.GITHUB) {
+            return null;
+        }
+        const [owner, repo] = connection.repository.split('/');
+        if (!owner || !repo) {
+            return null;
+        }
+        return {
+            owner,
+            repo,
+            branch: connection.branch,
+            projectSubPath: connection.project_sub_path,
+        };
+    }
+
+    // Resolves the project's GitHub repo + an installation token, or null when
+    // the project isn't GitHub-backed / the org hasn't installed the app.
+    private async resolveGithubAccess(
+        projectUuid: string,
+    ): Promise<GithubAccess | null> {
+        const project = await this.projectModel.get(projectUuid);
+        const connection = ProjectContextService.resolveGithubConnection(
+            project.dbtConnection,
+        );
+        if (!connection) {
+            return null;
+        }
+        const installationId =
+            await this.githubAppInstallationsModel.findInstallationId(
+                project.organizationUuid,
+            );
+        if (!installationId) {
+            return null;
+        }
+        const token = await getInstallationToken(installationId);
+        return { ...connection, installationId, token };
+    }
+
+    private async assertCanIngestProjectContext(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        const { organizationUuid, type } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('CompileProject', {
+                    organizationUuid,
+                    projectUuid,
+                    type,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    /**
+     * Fetch lightdash.project_context.yml from the project's GitHub repo, parse
+     * it, and replace the cached entries. Degrades to a no-op (never throws) when
+     * the project isn't GitHub-backed or the org hasn't installed the GitHub App.
+     * A missing file clears the cache (the file is the source of truth); a
+     * transient GitHub error or a parse error is surfaced without wiping entries.
+     */
+    async ingestProjectContext(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ProjectContextIngestResult> {
+        await this.assertCanIngestProjectContext(user, projectUuid);
+
+        const access = await this.resolveGithubAccess(projectUuid);
+        if (!access) {
+            return { ingested: false, reason: 'no_github_access' };
+        }
+        const fileName = projectContextFilePath(access.projectSubPath);
+
+        let content: string;
+        try {
+            ({ content } = await getFileContent({
+                fileName,
+                owner: access.owner,
+                repo: access.repo,
+                branch: access.branch,
+                installationId: access.installationId,
+                token: access.token,
+            }));
+        } catch (error) {
+            if (error instanceof NotFoundError) {
+                // File removed (or never added): clear the cache.
+                await this.projectContextModel.replaceEntriesForProject(
+                    projectUuid,
+                    [],
+                );
+                return { ingested: true, entryCount: 0 };
+            }
+            throw error;
+        }
+
+        const entries = loadProjectContextFile(content);
+        await this.projectContextModel.replaceEntriesForProject(
+            projectUuid,
+            entries,
+        );
+        return { ingested: true, entryCount: entries.length };
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -143,6 +143,7 @@ export type ModelManifest = {
     aiWritebackThreadModel: unknown;
     projectCiStatusModel: unknown;
     aiAgentReviewClassifierModel: unknown;
+    projectContextModel: unknown;
     aiRouterModel: unknown;
     managedAgentModel: unknown;
     aiOrganizationSettingsModel: unknown;
@@ -752,6 +753,10 @@ export class ModelRepository
 
     public getProjectCiStatusModel<ModelImplT>(): ModelImplT {
         return this.getModel('projectCiStatusModel');
+    }
+
+    public getProjectContextModel<ModelImplT>(): ModelImplT {
+        return this.getModel('projectContextModel');
     }
 
     public getAiAgentReviewClassifierModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.test.ts
@@ -9,6 +9,8 @@ import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import type { CachedWarehouse, DbtClient } from '../types';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
 
+const readFileSpy = jest.spyOn(fs, 'readFile');
+
 describe('getLightdashProjectConfig', () => {
     const VALID_CONFIG_CONTENTS =
         'spotlight:\n' +
@@ -40,8 +42,6 @@ describe('getLightdashProjectConfig', () => {
 
     const INVALID_CONFIG_CONTENTS =
         'spotlight:\n default_visibility: invalid_value';
-
-    const readFileSpy = jest.spyOn(fs, 'readFile');
 
     const mockProjectAdapter = new DbtBaseProjectAdapter(
         jest.fn() as unknown as DbtClient,
@@ -95,8 +95,66 @@ describe('getLightdashProjectConfig', () => {
             });
         });
     });
+});
 
-    afterAll(() => {
-        jest.restoreAllMocks();
+describe('getProjectContext', () => {
+    const mockProjectAdapter = new DbtBaseProjectAdapter(
+        jest.fn() as unknown as DbtClient,
+        jest.fn() as unknown as WarehouseClient,
+        jest.fn() as unknown as CachedWarehouse,
+        SupportedDbtVersions.V1_9,
+        './some/path/to/dbt/project',
+    );
+
+    class MockedFSError extends Error {
+        code: string;
+
+        constructor(message: string, code: string) {
+            super(message);
+            this.code = code;
+        }
+    }
+
+    it('should load project context from lightdash.project_context.yml', async () => {
+        readFileSpy.mockResolvedValueOnce(`
+- id: hr
+  kind: definition
+  content: '"HR" = high-risk cohort.'
+  terms: [HR]
+`);
+
+        const context = await mockProjectAdapter.getProjectContext();
+
+        expect(context).toEqual([
+            {
+                id: 'hr',
+                kind: 'definition',
+                content: '"HR" = high-risk cohort.',
+                terms: ['HR'],
+                objects: [],
+            },
+        ]);
     });
+
+    it('should return an empty list when project context file is missing', async () => {
+        readFileSpy.mockRejectedValueOnce(
+            new MockedFSError('file not found', 'ENOENT'),
+        );
+
+        const context = await mockProjectAdapter.getProjectContext();
+
+        expect(context).toEqual([]);
+    });
+
+    it('should throw when project context file is invalid', async () => {
+        readFileSpy.mockResolvedValueOnce('id: hr');
+
+        await expect(mockProjectAdapter.getProjectContext()).rejects.toThrow(
+            /Invalid lightdash.project_context.yml with errors/,
+        );
+    });
+});
+
+afterAll(() => {
+    readFileSpy.mockRestore();
 });

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -19,6 +19,7 @@ import {
     InlineErrorType,
     isSupportedDbtAdapter,
     loadLightdashProjectConfig,
+    loadProjectContextFile,
     ManifestValidator,
     MissingCatalogEntryError,
     normaliseModelDatabase,
@@ -27,6 +28,7 @@ import {
     SupportedDbtAdapter,
     SupportedDbtVersions,
     type LightdashProjectConfig,
+    type ProjectContextEntry,
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
@@ -143,6 +145,31 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 return {
                     spotlight: DEFAULT_SPOTLIGHT_CONFIG,
                 };
+            }
+            throw e;
+        }
+    }
+
+    public async getProjectContext(): Promise<ProjectContextEntry[]> {
+        if (!this.dbtProjectDir) {
+            return [];
+        }
+
+        const configPath = path.join(
+            this.dbtProjectDir,
+            'lightdash.project_context.yml',
+        );
+
+        try {
+            const fileContents = await fs.readFile(configPath, 'utf8');
+            return loadProjectContextFile(fileContents);
+        } catch (e) {
+            Logger.debug(
+                `No lightdash.project_context.yml found in ${configPath}`,
+            );
+
+            if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
+                return [];
             }
             throw e;
         }

--- a/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.test.ts
@@ -16,3 +16,10 @@ describe('getLightdashProjectConfig', () => {
         });
     });
 });
+
+describe('getProjectContext', () => {
+    it('should return an empty project context list', async () => {
+        const context = await mockProjectAdapter.getProjectContext();
+        expect(context).toEqual([]);
+    });
+});

--- a/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.ts
@@ -5,6 +5,7 @@ import {
     ExploreError,
     LightdashProjectConfig,
     ParameterError,
+    type ProjectContextEntry,
     type RunQueryTags,
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
@@ -60,5 +61,10 @@ export class DbtNoneCredentialsProjectAdapter implements ProjectAdapter {
         return {
             spotlight: DEFAULT_SPOTLIGHT_CONFIG,
         };
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    public async getProjectContext(): Promise<ProjectContextEntry[]> {
+        return [];
     }
 }

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1613,6 +1613,22 @@ export class SchedulerClient {
         );
     }
 
+    // EE-only handler: re-ingests lightdash.project_context.yml after a compile.
+    // No-op in OSS (see SchedulerWorker), so it's safe to enqueue unconditionally.
+    async ingestProjectContext(payload: TraceTaskBase): Promise<void> {
+        const graphileClient = await this.graphileUtils;
+        await graphileClient.addJob(
+            SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT,
+            payload,
+            {
+                runAt: new Date(),
+                maxAttempts: 1,
+                priority: JobPriority.LOW,
+                jobKey: `ingest-project-context:${payload.projectUuid}`,
+            },
+        );
+    }
+
     async triggerManagedAgentHeartbeat(
         projectUuid: string,
         triggeredBy: 'manual' | 'on_enable',

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -212,6 +212,11 @@ const getTagsForTask: {
     }),
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: () => ({}),
+    [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
 } as const;
 
 const getTagsFromPayload = <T extends SchedulerTaskName>(

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -1257,6 +1257,9 @@ export class SchedulerWorker extends SchedulerTask {
             [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: async () => {
                 // EE-only: implemented in CommercialSchedulerWorker
             },
+            [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: async () => {
+                // EE-only: implemented in CommercialSchedulerWorker
+            },
         };
     }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -125,6 +125,7 @@ import {
     preAggregateUtils,
     Project,
     ProjectCatalog,
+    ProjectContextEntry,
     ProjectDefaults,
     ProjectGroupAccess,
     ProjectMemberProfile,
@@ -321,6 +322,12 @@ export type ProjectServiceArguments = {
     natsClient?: INatsClient;
     contentVerificationModel?: ContentVerificationModel;
     organizationSettingsModel: OrganizationSettingsModel;
+    projectContextModel?: {
+        replaceEntriesForProject(
+            projectUuid: string,
+            entries: ProjectContextEntry[],
+        ): Promise<void>;
+    };
 };
 
 export class ProjectService extends BaseService {
@@ -396,6 +403,15 @@ export class ProjectService extends BaseService {
 
     organizationSettingsModel: OrganizationSettingsModel;
 
+    projectContextModel:
+        | {
+              replaceEntriesForProject(
+                  projectUuid: string,
+                  entries: ProjectContextEntry[],
+              ): Promise<void>;
+          }
+        | undefined;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -432,6 +448,7 @@ export class ProjectService extends BaseService {
         spacePermissionService,
         contentVerificationModel,
         organizationSettingsModel,
+        projectContextModel,
     }: ProjectServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -471,6 +488,7 @@ export class ProjectService extends BaseService {
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
         this.organizationSettingsModel = organizationSettingsModel;
+        this.projectContextModel = projectContextModel;
     }
 
     static getMetricQueryExecutionProperties({
@@ -2430,7 +2448,7 @@ export class ProjectService extends BaseService {
                 async () => this.testProjectAdapter(createProject, user),
             );
 
-            const { explores, lightdashProjectConfig } =
+            const { explores, lightdashProjectConfig, projectContext } =
                 await this.jobModel.tryJobStep(
                     jobUuid,
                     JobStepType.COMPILING,
@@ -2439,17 +2457,28 @@ export class ProjectService extends BaseService {
                             // There's no project yet, so we don't track
                             const trackingParams = undefined;
 
-                            return {
-                                explores: await adapter.compileAllExplores(
+                            const compiledExplores =
+                                await adapter.compileAllExplores(
                                     trackingParams,
                                     false, // loadSources
                                     this.lightdashConfig.partialCompilation
                                         .enabled,
-                                ),
-                                lightdashProjectConfig:
-                                    await adapter.getLightdashProjectConfig(
-                                        trackingParams,
-                                    ),
+                                );
+                            const compiledProjectConfig =
+                                await adapter.getLightdashProjectConfig(
+                                    trackingParams,
+                                );
+                            const compiledProjectContext =
+                                await this.getProjectContextFromAdapter({
+                                    adapter,
+                                    user,
+                                    organizationUuid: user.organizationUuid,
+                                });
+
+                            return {
+                                explores: compiledExplores,
+                                lightdashProjectConfig: compiledProjectConfig,
+                                projectContext: compiledProjectContext,
                             };
                         } finally {
                             await adapter.destroy();
@@ -2501,6 +2530,10 @@ export class ProjectService extends BaseService {
                     await this.projectModel.setTableGroups(
                         newProjectUuid,
                         lightdashProjectConfig.table_groups,
+                    );
+                    await this.replaceProjectContext(
+                        newProjectUuid,
+                        projectContext,
                     );
                     await this.saveExploresToCacheAndIndexCatalog({
                         userUuid: user.userUuid,
@@ -2968,6 +3001,12 @@ export class ProjectService extends BaseService {
                                 await adapter.getLightdashProjectConfig(
                                     trackingParams,
                                 );
+                            const projectContext =
+                                await this.getProjectContextFromAdapter({
+                                    adapter,
+                                    user,
+                                    organizationUuid: user.organizationUuid,
+                                });
                             timings.getConfig.end = performance.now();
 
                             timings.yaml.start = performance.now();
@@ -2994,6 +3033,10 @@ export class ProjectService extends BaseService {
                             await this.projectModel.setTableGroups(
                                 projectUuid,
                                 lightdashProjectConfig.table_groups,
+                            );
+                            await this.replaceProjectContext(
+                                projectUuid,
+                                projectContext,
                             );
                             timings.parameters.end = performance.now();
                             timings.cacheExplores.start = performance.now();
@@ -5376,6 +5419,44 @@ export class ProjectService extends BaseService {
         };
     }
 
+    private async getProjectContextFromAdapter({
+        adapter,
+        user,
+        organizationUuid,
+    }: {
+        adapter: ProjectAdapter;
+        user: Pick<SessionUser, 'userUuid'> &
+            Partial<Pick<SessionUser, 'organizationName'>>;
+        organizationUuid: string;
+    }): Promise<ProjectContextEntry[] | undefined> {
+        if (!this.projectContextModel) {
+            return undefined;
+        }
+
+        const { enabled } = await this.featureFlagModel.get({
+            user: {
+                userUuid: user.userUuid,
+                organizationUuid,
+                organizationName: user.organizationName,
+            },
+            featureFlagId: FeatureFlags.AiProjectContext,
+        });
+        return enabled ? adapter.getProjectContext() : undefined;
+    }
+
+    private async replaceProjectContext(
+        projectUuid: string,
+        entries: ProjectContextEntry[] | undefined,
+    ): Promise<void> {
+        if (!this.projectContextModel || entries === undefined) {
+            return;
+        }
+        await this.projectContextModel.replaceEntriesForProject(
+            projectUuid,
+            entries,
+        );
+    }
+
     private async refreshTablesAndProjectConfig(
         user: Pick<SessionUser, 'userUuid'>,
         projectUuid: string,
@@ -5383,6 +5464,7 @@ export class ProjectService extends BaseService {
     ): Promise<{
         explores: (Explore | ExploreError)[];
         lightdashProjectConfig: LightdashProjectConfig;
+        projectContext: ProjectContextEntry[] | undefined;
     }> {
         // Checks that project exists
         const project = await this.projectModel.get(projectUuid);
@@ -5535,8 +5617,13 @@ export class ProjectService extends BaseService {
 
             const lightdashProjectConfig =
                 await adapter.getLightdashProjectConfig(trackingParams);
+            const projectContext = await this.getProjectContextFromAdapter({
+                adapter,
+                user,
+                organizationUuid: project.organizationUuid,
+            });
 
-            return { explores, lightdashProjectConfig };
+            return { explores, lightdashProjectConfig, projectContext };
         } catch (e) {
             if (!(e instanceof LightdashError)) {
                 Sentry.captureException(e);
@@ -5857,12 +5944,15 @@ export class ProjectService extends BaseService {
                     job.jobUuid,
                     JobStepType.COMPILING,
                     async () => {
-                        const { explores, lightdashProjectConfig } =
-                            await this.refreshTablesAndProjectConfig(
-                                user,
-                                projectUuid,
-                                requestMethod,
-                            );
+                        const {
+                            explores,
+                            lightdashProjectConfig,
+                            projectContext,
+                        } = await this.refreshTablesAndProjectConfig(
+                            user,
+                            projectUuid,
+                            requestMethod,
+                        );
 
                         timings.yaml.start = performance.now();
                         await this.replaceYamlTags(
@@ -5888,6 +5978,10 @@ export class ProjectService extends BaseService {
                         await this.projectModel.setTableGroups(
                             projectUuid,
                             lightdashProjectConfig.table_groups,
+                        );
+                        await this.replaceProjectContext(
+                            projectUuid,
+                            projectContext,
                         );
                         timings.parameters.end = performance.now();
                         timings.cacheExplores.start = performance.now();

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -143,6 +143,7 @@ interface ServiceManifest {
     aiAgentReviewClassifierService: unknown;
     aiRouterService: unknown;
     aiOrganizationSettingsService: unknown;
+    projectContextService: unknown;
     scimService: unknown;
     supportService: unknown;
     cacheService: unknown;
@@ -1264,6 +1265,12 @@ export class ServiceRepository
         AppGenerateServiceImplT,
     >(): AppGenerateServiceImplT {
         return this.getService('appGenerateService');
+    }
+
+    public getProjectContextService<
+        ProjectContextServiceImplT,
+    >(): ProjectContextServiceImplT {
+        return this.getService('projectContextService');
     }
 
     public getEmbedService<EmbedServiceImplT>(): EmbedServiceImplT {

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1687,6 +1687,16 @@ export class UserService extends BaseService {
         return this.userModel.findSessionUserByUUID(userUuid);
     }
 
+    async getSessionByUserUuidAndOrg(
+        userUuid: string,
+        organizationUuid: string,
+    ): Promise<SessionUser> {
+        return this.userModel.findSessionUserAndOrgByUuid(
+            userUuid,
+            organizationUuid,
+        );
+    }
+
     async getAccountByUserUuid(userUuid: string): Promise<RegisteredAccount> {
         const sessionUser = await this.getSessionByUserUuid(userUuid);
 

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -4,6 +4,7 @@ import {
     Explore,
     ExploreError,
     LightdashProjectConfig,
+    ProjectContextEntry,
 } from '@lightdash/common';
 import { WarehouseCatalog } from '@lightdash/warehouses';
 
@@ -36,6 +37,8 @@ export interface ProjectAdapter {
     getLightdashProjectConfig(
         trackingParams: TrackingParams | undefined,
     ): Promise<LightdashProjectConfig>;
+
+    getProjectContext(): Promise<ProjectContextEntry[]>;
 }
 
 export interface DbtClient {

--- a/packages/common/src/ee/AiAgent/projectContext.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.ts
@@ -157,7 +157,7 @@ export const loadProjectContextFile = (
         loaded = yaml.load(yamlContents);
     } catch (e) {
         throw new ParseError(
-            `Invalid project_context.yml: ${
+            `Invalid lightdash.project_context.yml: ${
                 e instanceof Error ? e.message : 'failed to parse YAML'
             }`,
         );
@@ -179,7 +179,7 @@ export const loadProjectContextFile = (
             { indent: 2 },
         );
         throw new ParseError(
-            `Invalid project_context.yml with errors:\n${errors}`,
+            `Invalid lightdash.project_context.yml with errors:\n${errors}`,
         );
     }
 

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -104,6 +104,7 @@ export const SCHEDULER_TASKS = {
     CLEAN_DEPLOY_SESSIONS: 'cleanDeploySessions',
     MANAGED_AGENT_HEARTBEAT: 'managedAgentHeartbeat',
     CLEAN_EXPIRED_PREVIEWS: 'cleanExpiredPreviews',
+    INGEST_PROJECT_CONTEXT: 'ingestProjectContext',
     ...EE_SCHEDULER_TASKS,
 } as const;
 
@@ -146,6 +147,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.CLEAN_DEPLOY_SESSIONS]: TraceTaskBase;
     [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: ManagedAgentHeartbeatPayload;
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: TraceTaskBase;
+    [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;


### PR DESCRIPTION
## What

**Ingests & caches** the project context file. On project compile, the backend fetches `lightdash.project_context.yml` from the GitHub-connected repo, parses it, and caches it as a per-project blob (`project_context_document`). Wires the `INGEST_PROJECT_CONTEXT` scheduler task + EE worker handler.

## Scope / regression analysis

- GitHub-connected projects only; degrades to a **no-op** (never throws) for other dbt connection types or when the GitHub App isn't installed.
- A missing file clears the cache (file is the source of truth); a transient GitHub/parse error is surfaced **without** wiping cached entries.
- Ingestion runs after compile but is inert unless `ai-project-context` is enabled and the file exists. No effect on existing compile behavior otherwise.

_Stack: PR 2 of 6. Depends on PR 1 (entry contract)._

Relates: ZAP-475
