### PR TITLE
feat(ai-project-context): writeback — review finding opens a project_context PR

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -215,7 +215,8 @@ export class AiAgentAdminController extends BaseController {
     }
 
     /**
-     * Open a writeback pull request for a semantic-layer review item
+     * Open a writeback pull request for a review item (semantic-layer or
+     * project-context root cause)
      * @summary Create AI agent review item writeback PR
      */
     @Middlewares([

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -225,6 +225,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectModel: models.getProjectModel(),
                     aiWritebackService:
                         repository.getAiWritebackService<AiWritebackService>(),
+                    projectContextService:
+                        repository.getProjectContextService<ProjectContextService>(),
+                    pullRequestsModel: models.getPullRequestsModel(),
                     githubAppInstallationsModel:
                         models.getGithubAppInstallationsModel(),
                     schedulerClient:

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -17,6 +17,8 @@ import {
     MissingConfigError,
     NotFoundError,
     ParameterError,
+    PullRequestProvider,
+    PullRequestSource,
     UpdateAiAgentReviewItemStatus,
     type SessionUser,
 } from '@lightdash/common';
@@ -28,6 +30,7 @@ import {
 import { type LightdashConfig } from '../../config/parseConfig';
 import { type GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { type PullRequestsModel } from '../../models/PullRequestsModel';
 import { type UserModel } from '../../models/UserModel';
 import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
@@ -39,6 +42,7 @@ import {
     planReviewWriteback,
 } from './ai/reviewWriteback/buildReviewWritebackPrompt';
 import { type AiWritebackService } from './AiWritebackService/AiWritebackService';
+import { type ProjectContextService } from './ProjectContextService/ProjectContextService';
 
 type AiAgentAdminServiceDependencies = {
     aiAgentModel: AiAgentModel;
@@ -46,6 +50,8 @@ type AiAgentAdminServiceDependencies = {
     featureFlagService: FeatureFlagService;
     projectModel: ProjectModel;
     aiWritebackService: AiWritebackService;
+    projectContextService: ProjectContextService;
+    pullRequestsModel: PullRequestsModel;
     githubAppInstallationsModel: GithubAppInstallationsModel;
     schedulerClient: CommercialSchedulerClient;
     userModel: UserModel;
@@ -64,6 +70,24 @@ const parsePullRequestUrl = (
 
 // Longer than the worker's 30-min job timeout — past this, a queued/running writeback has lost its worker and is treated as failed so the UI recovers and retries.
 const WRITEBACK_STALE_MS = 35 * 60 * 1000;
+
+// Root causes that can open a writeback PR (both also require a GitHub-connected
+// project). project_context additionally needs the judge-emitted entry.
+const hasWritebackStrategy = (
+    item: AiAgentReviewItemSummary,
+    { projectContextEnabled }: { projectContextEnabled: boolean },
+): boolean => {
+    if (item.primaryRootCause === 'semantic_layer') {
+        return true;
+    }
+    if (item.primaryRootCause === 'project_context') {
+        return (
+            projectContextEnabled &&
+            item.latestFinding?.projectContextEntry != null
+        );
+    }
+    return false;
+};
 
 const isWritebackStale = (
     item: AiAgentReviewItemSummary,
@@ -98,6 +122,10 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly aiWritebackService: AiWritebackService;
 
+    private readonly projectContextService: ProjectContextService;
+
+    private readonly pullRequestsModel: PullRequestsModel;
+
     private readonly githubAppInstallationsModel: GithubAppInstallationsModel;
 
     private readonly schedulerClient: CommercialSchedulerClient;
@@ -112,6 +140,8 @@ export class AiAgentAdminService extends BaseService {
         this.featureFlagService = dependencies.featureFlagService;
         this.projectModel = dependencies.projectModel;
         this.aiWritebackService = dependencies.aiWritebackService;
+        this.projectContextService = dependencies.projectContextService;
+        this.pullRequestsModel = dependencies.pullRequestsModel;
         this.githubAppInstallationsModel =
             dependencies.githubAppInstallationsModel;
         this.schedulerClient = dependencies.schedulerClient;
@@ -205,19 +235,25 @@ export class AiAgentAdminService extends BaseService {
             statuses,
         });
 
+        const [writebackEnabled, projectContextEnabled] = await Promise.all([
+            this.isWritebackFeatureEnabled(user),
+            this.isProjectContextFeatureEnabled(user),
+        ]);
         const overrides = await this.reconcileLinkedPullRequests(
+            user.userUuid,
             organizationUuid,
             items,
+            { projectContextEnabled },
         );
 
-        const writebackEnabled = await this.isWritebackFeatureEnabled(user);
         const githubProjects = writebackEnabled
             ? await this.getGithubProjectUuids(
                   items
                       .filter(
                           (item) =>
-                              item.primaryRootCause === 'semantic_layer' &&
-                              item.projectUuid !== null,
+                              hasWritebackStrategy(item, {
+                                  projectContextEnabled,
+                              }) && item.projectUuid !== null,
                       )
                       .map((item) => item.projectUuid as string),
               )
@@ -228,7 +264,7 @@ export class AiAgentAdminService extends BaseService {
             const override = overrides.get(item.fingerprint);
             const writebackEligible =
                 writebackEnabled &&
-                item.primaryRootCause === 'semantic_layer' &&
+                hasWritebackStrategy(item, { projectContextEnabled }) &&
                 item.projectUuid !== null &&
                 githubProjects.has(item.projectUuid);
             return withStaleWritebackOverride(
@@ -268,6 +304,24 @@ export class AiAgentAdminService extends BaseService {
         return classifier.enabled && engine.enabled;
     }
 
+    private async isProjectContextFeatureEnabled(
+        user: SessionUser,
+    ): Promise<boolean> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            return false;
+        }
+        const flag = await this.featureFlagService.get({
+            featureFlagId: FeatureFlags.AiProjectContext,
+            user: {
+                userUuid: user.userUuid,
+                organizationUuid,
+                organizationName: user.organizationName ?? '',
+            },
+        });
+        return flag.enabled;
+    }
+
     private async getGithubProjectUuids(
         projectUuids: string[],
     ): Promise<Set<string>> {
@@ -293,8 +347,14 @@ export class AiAgentAdminService extends BaseService {
      * re-opened. Best effort — a GitHub failure for one item is skipped.
      */
     private async reconcileLinkedPullRequests(
+        userUuid: string,
         organizationUuid: string,
         items: AiAgentReviewItemSummary[],
+        {
+            projectContextEnabled,
+        }: {
+            projectContextEnabled: boolean;
+        },
     ): Promise<
         Map<
             string,
@@ -358,6 +418,20 @@ export class AiAgentAdminService extends BaseService {
                         },
                     );
                     overrides.set(item.fingerprint, { status, prState });
+                    // Loop closure: a merged project_context PR changed the file,
+                    // so re-ingest to refresh the cache for future agent turns.
+                    if (
+                        pr.merged &&
+                        projectContextEnabled &&
+                        item.primaryRootCause === 'project_context' &&
+                        item.projectUuid
+                    ) {
+                        await this.schedulerClient.ingestProjectContext({
+                            projectUuid: item.projectUuid,
+                            organizationUuid,
+                            userUuid,
+                        });
+                    }
                 } catch (error) {
                     this.logger.warn(
                         `Failed to reconcile PR state for review item ${item.fingerprint}: ${error}`,
@@ -500,18 +574,6 @@ export class AiAgentAdminService extends BaseService {
             throw new ForbiddenError('AI writeback is not enabled');
         }
 
-        // Fail fast at the click rather than queue → run → fail on the worker.
-        if (!this.lightdashConfig.appRuntime.e2bApiKey) {
-            throw new MissingConfigError(
-                'E2B API key is not configured (E2B_API_KEY)',
-            );
-        }
-        if (!this.lightdashConfig.aiWriteback.anthropicApiKey) {
-            throw new MissingConfigError(
-                'Anthropic API key is not configured (AI_WRITEBACK_ANTHROPIC_API_KEY)',
-            );
-        }
-
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
                 organizationUuid,
@@ -520,10 +582,30 @@ export class AiAgentAdminService extends BaseService {
         if (!reviewItem) {
             throw new NotFoundError('Review item not found');
         }
-        if (reviewItem.primaryRootCause !== 'semantic_layer') {
+        const projectContextEnabled =
+            reviewItem.primaryRootCause === 'project_context'
+                ? await this.isProjectContextFeatureEnabled(user)
+                : false;
+        if (!hasWritebackStrategy(reviewItem, { projectContextEnabled })) {
             throw new ParameterError(
-                'Writeback is only supported for semantic-layer review items',
+                'Writeback is not available for this review item',
             );
+        }
+        // The semantic_layer strategy runs in the e2b sandbox with Claude Code,
+        // so fail fast at the click rather than queue → run → fail on the
+        // worker. project_context uses a deterministic GitHub merge — no sandbox,
+        // no Anthropic key — so these checks don't apply to it.
+        if (reviewItem.primaryRootCause === 'semantic_layer') {
+            if (!this.lightdashConfig.appRuntime.e2bApiKey) {
+                throw new MissingConfigError(
+                    'E2B API key is not configured (E2B_API_KEY)',
+                );
+            }
+            if (!this.lightdashConfig.aiWriteback.anthropicApiKey) {
+                throw new MissingConfigError(
+                    'Anthropic API key is not configured (AI_WRITEBACK_ANTHROPIC_API_KEY)',
+                );
+            }
         }
         if (reviewItem.linkedPrUrl && reviewItem.prState === 'open') {
             throw new ParameterError(
@@ -638,23 +720,59 @@ export class AiAgentAdminService extends BaseService {
                 reviewItem,
                 buildYmlPathByModel(Object.values(explores)),
             );
-            const result = await this.aiWritebackService.run({
-                user,
-                projectUuid,
-                prompt: plan.promptText,
-                source: 'admin_review',
-                onProgress: (message) => {
-                    void setProgress(message);
-                },
-            });
 
-            if (result.prUrl) {
+            let prUrl: string | null;
+            if (plan.strategy === 'project_context') {
+                await setProgress('Updating project context…');
+                const finding = reviewItem.latestFinding;
+                const sourceThread = finding
+                    ? {
+                          threadUrl: `${this.lightdashConfig.siteUrl}/projects/${finding.projectUuid}/ai-agents/${finding.agentUuid}/threads/${finding.threadUuid}`,
+                          promptUuid: finding.promptUuid,
+                          threadUuid: finding.threadUuid,
+                      }
+                    : null;
+                const writeback =
+                    await this.projectContextService.writebackEntry({
+                        projectUuid,
+                        entry: plan.entry,
+                        branchTimestamp: Date.now(),
+                        sourceThread,
+                    });
+                prUrl = writeback.prUrl;
+                // Surface the PR in the project's Pull Requests list with
+                // AI_AGENT provenance, same as the semantic_layer writeback.
+                await this.pullRequestsModel.findOrCreate({
+                    organizationUuid,
+                    projectUuid,
+                    createdByUserUuid: userUuid,
+                    provider: PullRequestProvider.GITHUB,
+                    source: PullRequestSource.AI_AGENT,
+                    owner: writeback.owner,
+                    repo: writeback.repo,
+                    prNumber: writeback.prNumber,
+                    prUrl: writeback.prUrl,
+                });
+            } else {
+                const result = await this.aiWritebackService.run({
+                    user,
+                    projectUuid,
+                    prompt: plan.promptText,
+                    source: 'admin_review',
+                    onProgress: (message) => {
+                        void setProgress(message);
+                    },
+                });
+                prUrl = result.prUrl;
+            }
+
+            if (prUrl) {
                 await this.aiAgentReviewClassifierModel.setReviewItemPrLink({
                     fingerprint,
                     organizationUuid,
                     projectUuid,
                     agentUuid,
-                    linkedPrUrl: result.prUrl,
+                    linkedPrUrl: prUrl,
                     prState: 'open',
                 });
                 await setTerminal('completed', 'Opened pull request');
@@ -697,10 +815,13 @@ export class AiAgentAdminService extends BaseService {
             throw new NotFoundError('Review item not found');
         }
 
-        const writebackEnabled = await this.isWritebackFeatureEnabled(user);
+        const [writebackEnabled, projectContextEnabled] = await Promise.all([
+            this.isWritebackFeatureEnabled(user),
+            this.isProjectContextFeatureEnabled(user),
+        ]);
         const writebackEligible =
             writebackEnabled &&
-            reviewItem.primaryRootCause === 'semantic_layer' &&
+            hasWritebackStrategy(reviewItem, { projectContextEnabled }) &&
             reviewItem.projectUuid !== null &&
             (await this.getGithubProjectUuids([reviewItem.projectUuid])).has(
                 reviewItem.projectUuid,

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
@@ -8,8 +8,12 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import {
+    createBranch,
+    createPullRequest,
+    createSignedCommitOnBranch,
     getFileContent,
     getInstallationToken,
+    getLastCommit,
 } from '../../../clients/github/Github';
 import type { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import type { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
@@ -22,10 +26,18 @@ import {
 jest.mock('../../../clients/github/Github', () => ({
     getFileContent: jest.fn(),
     getInstallationToken: jest.fn(),
+    getLastCommit: jest.fn(),
+    createBranch: jest.fn(),
+    createSignedCommitOnBranch: jest.fn(),
+    createPullRequest: jest.fn(),
 }));
 
 const mockGetFileContent = getFileContent as jest.Mock;
 const mockGetInstallationToken = getInstallationToken as jest.Mock;
+const mockGetLastCommit = getLastCommit as jest.Mock;
+const mockCreateBranch = createBranch as jest.Mock;
+const mockCreateSignedCommitOnBranch = createSignedCommitOnBranch as jest.Mock;
+const mockCreatePullRequest = createPullRequest as jest.Mock;
 
 const PROJECT_UUID = '00000000-0000-0000-0000-000000000001';
 const ORG_UUID = '00000000-0000-0000-0000-000000000002';
@@ -219,5 +231,131 @@ describe('ProjectContextService.ingestProjectContext', () => {
             service.ingestProjectContext(userWithIngestAccess(), PROJECT_UUID),
         ).rejects.toThrow('500 from GitHub');
         expect(getCachedEntries()).toEqual(existingEntries());
+    });
+});
+
+describe('ProjectContextService.writebackEntry', () => {
+    const judgeEntry = {
+        op: 'create' as const,
+        id: null,
+        kind: 'definition' as const,
+        content: '"HR" = high-risk cohort.',
+        terms: ['HR'],
+        objects: [],
+    };
+
+    beforeEach(() => {
+        mockGetLastCommit.mockResolvedValue({ sha: 'base-sha' });
+        mockCreateBranch.mockResolvedValue({});
+        mockCreateSignedCommitOnBranch.mockResolvedValue({
+            oid: 'commit-sha',
+            url: 'https://github.com/acme/analytics/commit/commit-sha',
+        });
+        mockCreatePullRequest.mockResolvedValue({
+            html_url: 'https://github.com/acme/analytics/pull/7',
+            number: 7,
+        });
+    });
+
+    test('creates the file and opens a PR when it does not yet exist', async () => {
+        mockGetFileContent.mockRejectedValue(new NotFoundError('missing'));
+        const { service } = makeService({});
+
+        const result = await service.writebackEntry({
+            projectUuid: PROJECT_UUID,
+            entry: judgeEntry,
+            branchTimestamp: 1000,
+            sourceThread: null,
+        });
+
+        expect(result).toEqual({
+            prUrl: 'https://github.com/acme/analytics/pull/7',
+            prNumber: 7,
+            owner: 'acme',
+            repo: 'analytics',
+            op: 'create',
+            entryId: 'hr',
+        });
+        expect(mockCreateSignedCommitOnBranch).toHaveBeenCalledTimes(1);
+        const commitArgs = mockCreateSignedCommitOnBranch.mock.calls[0][0];
+        expect(commitArgs).toMatchObject({
+            branch: 'lightdash-project-context/hr-1000',
+            expectedHeadOid: 'base-sha',
+        });
+        expect(commitArgs.fileChanges.additions[0].path).toBe(
+            'lightdash.project_context.yml',
+        );
+        expect(mockCreateBranch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sha: 'base-sha',
+                branch: 'lightdash-project-context/hr-1000',
+            }),
+        );
+    });
+
+    test('updates the existing file when present and reports op=update', async () => {
+        mockGetFileContent.mockResolvedValue({
+            content: `
+- id: hr
+  kind: definition
+  content: old
+  terms: [HR]
+`,
+            sha: 'file-sha',
+        });
+        const { service } = makeService({});
+
+        const result = await service.writebackEntry({
+            projectUuid: PROJECT_UUID,
+            entry: { ...judgeEntry, op: 'update', id: 'hr' },
+            branchTimestamp: 2000,
+            sourceThread: null,
+        });
+
+        expect(result.op).toBe('update');
+        // op=update is decided by merging into the existing entry, not by a
+        // file SHA — the signed commit overwrites the file either way.
+        const commitArgs = mockCreateSignedCommitOnBranch.mock.calls[0][0];
+        const updated = Buffer.from(
+            commitArgs.fileChanges.additions[0].contents,
+            'base64',
+        ).toString('utf-8');
+        expect(updated).toContain('"HR" = high-risk cohort.');
+        expect(updated).not.toContain('content: old');
+    });
+
+    test('throws when the project has no GitHub access', async () => {
+        const { service } = makeService({ installationId: undefined });
+        await expect(
+            service.writebackEntry({
+                projectUuid: PROJECT_UUID,
+                entry: judgeEntry,
+                branchTimestamp: 1,
+                sourceThread: null,
+            }),
+        ).rejects.toThrow(NotFoundError);
+    });
+
+    test('links the originating agent thread in the PR body', async () => {
+        mockGetFileContent.mockRejectedValue(new NotFoundError('missing'));
+        const { service } = makeService({});
+
+        await service.writebackEntry({
+            projectUuid: PROJECT_UUID,
+            entry: judgeEntry,
+            branchTimestamp: 1000,
+            sourceThread: {
+                threadUrl:
+                    'https://app.lightdash.com/projects/p/ai-agents/a/threads/t',
+                promptUuid: 'prompt-123',
+                threadUuid: 't',
+            },
+        });
+
+        const body = mockCreatePullRequest.mock.calls[0][0].body as string;
+        expect(body).toContain(
+            'https://app.lightdash.com/projects/p/ai-agents/a/threads/t',
+        );
+        expect(body).toContain('prompt-123');
     });
 });

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
@@ -3,13 +3,20 @@ import {
     DbtProjectType,
     ForbiddenError,
     loadProjectContextFile,
+    mergeProjectContextEntry,
     NotFoundError,
+    serializeProjectContextFile,
+    type AiAgentJudgeProjectContextEntry,
     type DbtProjectConfig,
     type SessionUser,
 } from '@lightdash/common';
 import {
+    createBranch,
+    createPullRequest,
+    createSignedCommitOnBranch,
     getFileContent,
     getInstallationToken,
+    getLastCommit,
 } from '../../../clients/github/Github';
 import type { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import type { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
@@ -36,6 +43,15 @@ export const projectContextFilePath = (projectSubPath: string): string => {
 export type ProjectContextIngestResult =
     | { ingested: true; entryCount: number }
     | { ingested: false; reason: string };
+
+export type ProjectContextWritebackResult = {
+    prUrl: string;
+    prNumber: number;
+    owner: string;
+    repo: string;
+    op: 'create' | 'update';
+    entryId: string;
+};
 
 type GithubAccess = {
     owner: string;
@@ -179,5 +195,140 @@ export class ProjectContextService extends BaseService {
             entries,
         );
         return { ingested: true, entryCount: entries.length };
+    }
+
+    /**
+     * Deterministic GitHub-API writeback for a judge-emitted project_context
+     * entry: fetch the current file, apply the entry by id, and open a PR on a
+     * fresh branch. No sandbox (distinct from the semantic_layer strategy).
+     * `branchTimestamp` keys the PR branch name (caller supplies it so the
+     * method stays free of wall-clock reads).
+     */
+    async writebackEntry(args: {
+        projectUuid: string;
+        entry: AiAgentJudgeProjectContextEntry;
+        branchTimestamp: number;
+        // The agent thread that motivated this entry, linked from the PR body
+        // so a reviewer can trace it back. Null when the source is unknown.
+        sourceThread: {
+            threadUrl: string;
+            promptUuid: string;
+            threadUuid: string;
+        } | null;
+    }): Promise<ProjectContextWritebackResult> {
+        const access = await this.resolveGithubAccess(args.projectUuid);
+        if (!access) {
+            throw new NotFoundError(
+                'Project is not connected to GitHub or the GitHub App is not installed',
+            );
+        }
+        const { owner, repo, branch, installationId, token } = access;
+        const fileName = projectContextFilePath(access.projectSubPath);
+
+        let existingContent = '';
+        try {
+            const file = await getFileContent({
+                fileName,
+                owner,
+                repo,
+                branch,
+                installationId,
+                token,
+            });
+            existingContent = file.content;
+        } catch (error) {
+            if (!(error instanceof NotFoundError)) {
+                throw error;
+            }
+        }
+
+        const { entries, entryId, op } = mergeProjectContextEntry(
+            loadProjectContextFile(existingContent),
+            args.entry,
+        );
+        const serialized = serializeProjectContextFile(entries);
+
+        const lastCommit = await getLastCommit({
+            owner,
+            repo,
+            branch,
+            installationId,
+            token,
+        });
+        const headBranch = `lightdash-project-context/${entryId}-${args.branchTimestamp}`;
+        await createBranch({
+            owner,
+            repo,
+            sha: lastCommit.sha,
+            branch: headBranch,
+            installationId,
+            token,
+        });
+
+        const commitMessage = `${
+            op === 'create' ? 'Add' : 'Update'
+        } project context: ${entryId}`;
+        // Reuse the writeback infra's signed-commit helper (GitHub GraphQL
+        // createCommitOnBranch) so the commit is server-side "Verified", like
+        // the semantic_layer writeback — a single addition overwrites the file
+        // whether it already exists or not.
+        await createSignedCommitOnBranch({
+            owner,
+            repo,
+            branch: headBranch,
+            expectedHeadOid: lastCommit.sha,
+            headline: commitMessage,
+            body: '',
+            fileChanges: {
+                additions: [
+                    {
+                        path: fileName,
+                        contents: Buffer.from(serialized, 'utf-8').toString(
+                            'base64',
+                        ),
+                    },
+                ],
+                deletions: [],
+            },
+            installationId,
+            token,
+        });
+
+        const bodyLines = [
+            `This PR ${
+                op === 'create' ? 'adds a new' : 'updates an'
+            } project context entry from an AI agent review finding.`,
+            `- id: \`${entryId}\``,
+            `- kind: \`${args.entry.kind}\``,
+            '',
+            args.entry.content,
+        ];
+        if (args.sourceThread) {
+            bodyLines.push(
+                '',
+                '---',
+                `[View the agent thread that motivated this entry](${args.sourceThread.threadUrl}) (prompt \`${args.sourceThread.promptUuid}\`).`,
+            );
+        }
+
+        const pr = await createPullRequest({
+            owner,
+            repo,
+            title: commitMessage,
+            body: bodyLines.join('\n'),
+            head: headBranch,
+            base: branch,
+            installationId,
+            token,
+        });
+
+        return {
+            prUrl: pr.html_url,
+            prNumber: pr.number,
+            owner,
+            repo,
+            op,
+            entryId,
+        };
     }
 }

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -57,17 +57,26 @@ const baseItem = (
             rationale: 'Disambiguate it from total_order_amount.',
             targetRefs: [],
         },
-        createdAt: new Date('2026-05-26T00:00:00.000Z'),
         projectContextEntry: null,
+        createdAt: new Date('2026-05-26T00:00:00.000Z'),
     },
     ...overrides,
 });
 
+const expectPromptPlan = (plan: ReturnType<typeof planReviewWriteback>) => {
+    if (plan.strategy !== 'prompt') {
+        throw new Error(`expected a prompt plan, got ${plan.strategy}`);
+    }
+    return plan;
+};
+
 describe('planReviewWriteback', () => {
     it('builds a deterministic one-shot prompt for semantic_layer items', () => {
-        const plan = planReviewWriteback(
-            baseItem(),
-            new Map([['orders', 'models/orders.yml']]),
+        const plan = expectPromptPlan(
+            planReviewWriteback(
+                baseItem(),
+                new Map([['orders', 'models/orders.yml']]),
+            ),
         );
 
         expect(plan.aggregationKey).toBeNull();
@@ -86,17 +95,41 @@ describe('planReviewWriteback', () => {
     });
 
     it('omits the yaml path when the model is not in the resolved map', () => {
-        const plan = planReviewWriteback(baseItem());
+        const plan = expectPromptPlan(planReviewWriteback(baseItem()));
 
         expect(plan.promptText).toContain('metric "orders.average_order_size"');
         expect(plan.promptText).not.toContain('(yaml:');
     });
 
-    it('throws for unsupported root causes', () => {
+    it('returns a project_context plan when the finding carries an entry', () => {
+        const item = baseItem({ primaryRootCause: 'project_context' });
+        const entry = {
+            op: 'create' as const,
+            id: null,
+            kind: 'definition' as const,
+            content: '"HR" = high-risk cohort.',
+            terms: ['HR'],
+            objects: [],
+        };
+        if (item.latestFinding) {
+            item.latestFinding.projectContextEntry = entry;
+        }
+
+        const plan = planReviewWriteback(item);
+        expect(plan).toEqual({ strategy: 'project_context', entry });
+    });
+
+    it('throws for a project_context item with no entry', () => {
         expect(() =>
             planReviewWriteback(
                 baseItem({ primaryRootCause: 'project_context' }),
             ),
+        ).toThrow('requires a projectContextEntry');
+    });
+
+    it('throws for unsupported root causes', () => {
+        expect(() =>
+            planReviewWriteback(baseItem({ primaryRootCause: 'data_gap' })),
         ).toThrow('not supported');
     });
 });

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     isExploreError,
+    type AiAgentJudgeProjectContextEntry,
     type AiAgentReviewItemSummary,
     type AiAgentSemanticTargetRef,
     type AiAgentTargetRef,
@@ -9,14 +10,23 @@ import {
 } from '@lightdash/common';
 
 /**
- * Output of a review-writeback strategy. `aggregationKey` is null for one-shot
- * PRs (semantic_layer) and set for cumulative living-document flows that resume
- * an existing writeback thread (e.g. project_context).
+ * Output of a review-writeback strategy. Two execution shapes:
+ * - `prompt`: a natural-language prompt run in the e2b/Claude Code sandbox
+ *   (semantic_layer). `aggregationKey` is null for one-shot PRs and set for
+ *   cumulative living-document flows that resume an existing writeback thread.
+ * - `project_context`: a structured entry applied by a deterministic
+ *   GitHub-API merge of lightdash.project_context.yml — no sandbox.
  */
-export type ReviewWritebackPlan = {
-    promptText: string;
-    aggregationKey: string | null;
-};
+export type ReviewWritebackPlan =
+    | {
+          strategy: 'prompt';
+          promptText: string;
+          aggregationKey: string | null;
+      }
+    | {
+          strategy: 'project_context';
+          entry: AiAgentJudgeProjectContextEntry;
+      };
 
 // Resolves each model's dbt YAML path from compiled explores so the writeback agent edits the right file (the judge only gives names).
 export const buildYmlPathByModel = (
@@ -102,15 +112,17 @@ const buildSemanticLayerWritebackPrompt = (
     ].filter((section): section is string => section !== null);
 
     return {
+        strategy: 'prompt',
         promptText: sections.join('\n\n'),
         aggregationKey: null,
     };
 };
 
 /**
- * Per-root-cause strategy dispatcher. Only semantic_layer is implemented today;
- * other root causes (e.g. project_context living document) plug in here with
- * their own prompt + aggregationKey without touching the bridge.
+ * Per-root-cause strategy dispatcher. Two strategies are implemented:
+ * `semantic_layer` → a sandbox prompt, and `project_context` → a structured
+ * entry for the deterministic GitHub-API merge. Other root causes throw until
+ * they plug in here with their own strategy.
  */
 export const planReviewWriteback = (
     item: AiAgentReviewItemSummary,
@@ -118,6 +130,15 @@ export const planReviewWriteback = (
 ): ReviewWritebackPlan => {
     if (item.primaryRootCause === 'semantic_layer') {
         return buildSemanticLayerWritebackPrompt(item, ymlPathByModel);
+    }
+    if (item.primaryRootCause === 'project_context') {
+        const entry = item.latestFinding?.projectContextEntry ?? null;
+        if (!entry) {
+            throw new Error(
+                'Writeback for project_context requires a projectContextEntry on the finding',
+            );
+        }
+        return { strategy: 'project_context', entry };
     }
     throw new Error(
         `Writeback is not supported for root cause "${item.primaryRootCause}"`,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12278,6 +12278,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['generateBarVizConfig'] },
                 { dataType: 'enum', enums: ['generateTableVizConfig'] },
                 { dataType: 'enum', enums: ['generateTimeSeriesVizConfig'] },
+                { dataType: 'enum', enums: ['generateHashes'] },
                 { dataType: 'enum', enums: ['generateUuids'] },
                 { dataType: 'enum', enums: ['listContent'] },
                 { dataType: 'enum', enums: ['findExplores'] },
@@ -12296,6 +12297,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['listProjects'] },
                 { dataType: 'enum', enums: ['getProjectInfo'] },
                 { dataType: 'enum', enums: ['loadSkill'] },
+                { dataType: 'enum', enums: ['loadProjectContext'] },
                 { dataType: 'enum', enums: ['proposeWriteback'] },
                 { dataType: 'enum', enums: ['setupPreviewDeploy'] },
                 { dataType: 'enum', enums: ['runQuery'] },
@@ -12944,6 +12946,25 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -13058,12 +13079,6 @@ const models: TsoaRoute.Models = {
                                                                         'nestedObjectLiteral',
                                                                     nestedProperties:
                                                                         {
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -13072,6 +13087,12 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -13107,6 +13128,12 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -13127,23 +13154,6 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -13165,6 +13175,17 @@ const models: TsoaRoute.Models = {
                                                                                                     ],
                                                                                                 },
                                                                                             ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
                                                                                         required: true,
                                                                                     },
                                                                                 label: {
@@ -13209,17 +13230,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -13348,17 +13369,17 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                    required: true,
+                                                },
                                                 uuid: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
                                                     dataType: 'string',
-                                                    required: true,
-                                                },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -13390,11 +13411,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13529,11 +13550,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13548,11 +13569,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13575,11 +13596,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13596,6 +13617,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13676,25 +13716,6 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 type: {
                                                                     dataType:
                                                                         'union',
@@ -13737,11 +13758,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -24451,6 +24472,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['cleanDeploySessions'] },
                 { dataType: 'enum', enums: ['managedAgentHeartbeat'] },
                 { dataType: 'enum', enums: ['cleanExpiredPreviews'] },
+                { dataType: 'enum', enums: ['ingestProjectContext'] },
             ],
             validators: {},
         },
@@ -27324,7 +27346,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27334,7 +27356,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27344,7 +27366,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -27357,7 +27379,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -28012,7 +28034,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28022,7 +28044,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28032,7 +28054,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28045,7 +28067,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13848,6 +13848,7 @@
                     "generateBarVizConfig",
                     "generateTableVizConfig",
                     "generateTimeSeriesVizConfig",
+                    "generateHashes",
                     "generateUuids",
                     "listContent",
                     "findExplores",
@@ -13866,6 +13867,7 @@
                     "listProjects",
                     "getProjectInfo",
                     "loadSkill",
+                    "loadProjectContext",
                     "proposeWriteback",
                     "setupPreviewDeploy",
                     "runQuery",
@@ -14268,14 +14270,14 @@
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -14285,8 +14287,8 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "baseTable",
                                                                             "joinedTables",
+                                                                            "baseTable",
                                                                             "label",
                                                                             "name"
                                                                         ],
@@ -14301,18 +14303,12 @@
                                                                                 "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
                                                                                 },
                                                                                 "fieldType": {
                                                                                     "type": "string",
@@ -14320,6 +14316,12 @@
                                                                                         "metric",
                                                                                         "dimension"
                                                                                     ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "label": {
                                                                                     "type": "string"
@@ -14331,11 +14333,11 @@
                                                                             "required": [
                                                                                 "isFromJoinedTable",
                                                                                 "fieldValueType",
-                                                                                "description",
                                                                                 "fieldFilterType",
-                                                                                "fieldId",
-                                                                                "table",
+                                                                                "description",
                                                                                 "fieldType",
+                                                                                "table",
+                                                                                "fieldId",
                                                                                 "label",
                                                                                 "name"
                                                                             ],
@@ -14367,10 +14369,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -14378,8 +14380,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "reason",
                                                                                 "exploreLabel",
+                                                                                "reason",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -14465,16 +14467,16 @@
                                                     "slug": {
                                                         "type": "string"
                                                     },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
+                                                    },
                                                     "uuid": {
                                                         "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
-                                                    },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
@@ -14482,9 +14484,9 @@
                                                     "warnings",
                                                     "href",
                                                     "slug",
+                                                    "status",
                                                     "uuid",
-                                                    "name",
-                                                    "status"
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14533,8 +14535,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
+                                                            "success",
                                                             "rejected",
                                                             "timeout"
                                                         ]
@@ -14547,6 +14549,10 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -14583,10 +14589,6 @@
                                                                 },
                                                                 "type": "array"
                                                             },
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
@@ -14598,8 +14600,8 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "fields",
                                                             "searchQuery",
+                                                            "fields",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -14607,8 +14609,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -25134,7 +25136,8 @@
                     "checkForStuckJobs",
                     "cleanDeploySessions",
                     "managedAgentHeartbeat",
-                    "cleanExpiredPreviews"
+                    "cleanExpiredPreviews",
+                    "ingestProjectContext"
                 ]
             },
             "BaseSchedulerLog": {
@@ -28211,22 +28214,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -28786,22 +28789,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -37687,7 +37690,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3081.1",
+        "version": "0.3082.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -44450,7 +44453,7 @@
                         }
                     }
                 },
-                "description": "Open a writeback pull request for a semantic-layer review item",
+                "description": "Open a writeback pull request for a review item (semantic-layer or\nproject-context root cause)",
                 "summary": "Create AI agent review item writeback PR",
                 "security": [],
                 "parameters": [


### PR DESCRIPTION
## What

**Writeback**: a `project_context` review finding opens a GitHub PR that adds/updates the entry in `lightdash.project_context.yml`, via a deterministic GitHub-API merge by `id` — **no sandbox** (distinct from the `semantic_layer` strategy, which uses e2b/Claude Code). Routed through the existing admin review-item writeback seam.

## Reuse of the existing AI-writeback infrastructure

This intentionally builds on the writeback infra rather than reinventing it:
- Commits via `createSignedCommitOnBranch` → the commit is server-side **"Verified"**, same as semantic_layer.
- Records the opened PR via `PullRequestsModel.findOrCreate` (`GITHUB` / `AI_AGENT` provenance), so it appears in the project's **Pull requests** list — parity with semantic_layer.
- Reuses PR-state reconciliation: merged → triggers re-ingest of the cached context (loop closure).
- Correctly **skips** the e2b sandbox + `ai_writeback_thread` resume machinery — review-item writebacks are one-shot and deterministic, so those don't apply.

## Scope / regression analysis

- Gated by `ai-project-context` + the existing writeback flag; the `semantic_layer` writeback path is untouched (shared dispatcher, separate branch).
- Adds a `pullRequestsModel` dependency to `AiAgentAdminService`; no controller signature change (worker-job only), so no API regen.

_Stack: PR 4 of 6. Depends on PR 1–3._

Relates: ZAP-475
