### PR TITLE
feat(ai-project-context): surface project_context items in the review queue

### DIFF
--- a/packages/frontend/src/components/common/CategoryBadge/CategoryBadge.module.css
+++ b/packages/frontend/src/components/common/CategoryBadge/CategoryBadge.module.css
@@ -1,0 +1,31 @@
+.dotBadge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-4));
+}
+
+.dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+/* Bordered chip — shadcn style, shared with the Autopilot activity feed. */
+.bordered {
+    padding: 2px 10px;
+    border-radius: 8px;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-6)
+    );
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    transition: box-shadow 150ms ease;
+}

--- a/packages/frontend/src/components/common/CategoryBadge/CategoryBadge.tsx
+++ b/packages/frontend/src/components/common/CategoryBadge/CategoryBadge.tsx
@@ -1,0 +1,69 @@
+import { Badge, Box, Tooltip } from '@mantine-8/core';
+import { type FC } from 'react';
+import classes from './CategoryBadge.module.css';
+
+export type CategoryBadgeProps = {
+    label: string;
+    /**
+     * A Mantine color reference for the accent dot. A name ('violet'), shade
+     * ('orange.5') or raw CSS var all work.
+     */
+    color: string;
+    tooltip?: string;
+    /**
+     * `dot` = colored dot + label in a shadcn-style chip (Autopilot/review
+     * style). `token` = light filled pill.
+     */
+    variant?: 'dot' | 'token';
+    /** Wrap the `dot` variant in a bordered chip. Defaults to true. */
+    bordered?: boolean;
+    /** Extra class for the chip — e.g. parent-driven hover/disabled states. */
+    className?: string;
+};
+
+/**
+ * Shared color-coded category badge used across the Autopilot activity feed and
+ * the AI agent review queue.
+ */
+export const CategoryBadge: FC<CategoryBadgeProps> = ({
+    label,
+    color,
+    tooltip,
+    variant = 'dot',
+    bordered = true,
+    className,
+}) => {
+    const content =
+        variant === 'token' ? (
+            <Badge
+                size="sm"
+                radius="sm"
+                variant="light"
+                color={color}
+                className={className}
+            >
+                {label}
+            </Badge>
+        ) : (
+            <Box
+                className={[
+                    classes.dotBadge,
+                    bordered && classes.bordered,
+                    className,
+                ]
+                    .filter(Boolean)
+                    .join(' ')}
+            >
+                <Box className={classes.dot} bg={color} />
+                {label}
+            </Box>
+        );
+
+    if (!tooltip) return content;
+
+    return (
+        <Tooltip label={tooltip} withArrow openDelay={300}>
+            {content}
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/components/common/CategoryBadge/index.ts
+++ b/packages/frontend/src/components/common/CategoryBadge/index.ts
@@ -1,0 +1,2 @@
+export { CategoryBadge } from './CategoryBadge';
+export type { CategoryBadgeProps } from './CategoryBadge';

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.module.css
@@ -1,46 +1,3 @@
-.categoryToken {
-    display: inline-flex;
-    align-items: center;
-    min-height: 18px;
-    padding: 1px 6px;
-    border: 1px solid
-        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-dark-4));
-    border-radius: 4px;
-    background: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-dark-6)
-    );
-    line-height: 1;
-    white-space: nowrap;
-}
-
-.categoryTokenText,
-.categoryTokenSecondaryText {
-    white-space: nowrap;
-}
-
-.categoryTokenText {
-    color: light-dark(
-        var(--mantine-color-ldGray-8),
-        var(--mantine-color-dark-0)
-    );
-}
-
-.categoryTokenSecondary {
-    background: transparent;
-    border-color: light-dark(
-        var(--mantine-color-ldGray-3),
-        var(--mantine-color-dark-5)
-    );
-}
-
-.categoryTokenSecondaryText {
-    color: light-dark(
-        var(--mantine-color-ldGray-8),
-        var(--mantine-color-dark-1)
-    );
-}
-
 .expandableText {
     cursor: zoom-in;
 }
@@ -88,6 +45,19 @@
     cursor: help;
 }
 
+.threadButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 10px;
+    font-size: 12px;
+    font-weight: 600;
+    color: light-dark(
+        var(--mantine-color-indigo-6),
+        var(--mantine-color-indigo-4)
+    );
+}
+
 .threadIcon {
     opacity: 0;
     transition: opacity 120ms ease-out;
@@ -96,4 +66,94 @@
 .bodyRow:hover .threadIcon,
 .threadIcon:focus-visible {
     opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .threadIcon,
+    .reasoningToggle,
+    .threadLink {
+        transition: none;
+    }
+}
+
+.reasoningToggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    width: fit-content;
+    margin-top: 2px;
+    font-size: 12px;
+    font-weight: 600;
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-dark-2)
+    );
+    transition: color 120ms ease;
+}
+
+.reasoningToggle:hover {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-dark-0)
+    );
+}
+
+.reasoning {
+    margin-top: 8px;
+    padding: 10px 12px;
+    border-radius: var(--mantine-radius-md);
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-dark-6)
+    );
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-dark-4));
+}
+
+.reasoningLabel {
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    color: light-dark(
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-dark-3)
+    );
+    margin-bottom: 4px;
+}
+
+.statusDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.threadLink {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 10px;
+    font-size: 12px;
+    font-weight: 600;
+    color: light-dark(
+        var(--mantine-color-indigo-6),
+        var(--mantine-color-indigo-4)
+    );
+    transition: color 120ms ease;
+}
+
+.threadLink:hover {
+    color: light-dark(
+        var(--mantine-color-indigo-7),
+        var(--mantine-color-indigo-3)
+    );
+}
+
+.countPill {
+    display: flex;
+    align-items: center;
+    height: 32px;
+    padding: 0 var(--mantine-spacing-sm);
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-ldGray-1);
+    color: var(--mantine-color-ldGray-9);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -563,6 +563,7 @@ const AiAgentAdminReviewItemsTable = ({
                 agent?.name,
                 project?.name,
                 reviewItem.latestFinding?.recommendation?.title,
+                reviewItem.latestFinding?.projectContextEntry?.content,
             ]
                 .filter(Boolean)
                 .some((value) => value?.toLowerCase().includes(searchLower));
@@ -913,6 +914,11 @@ const AiAgentAdminReviewItemsTable = ({
                     const reviewItem = row.original;
                     const subcategory =
                         reviewItem.latestFinding?.subcategories[0];
+                    // project_context findings carry the structured entry the
+                    // writeback PR will create/update — preview it so the admin
+                    // sees the exact fact and kind, not the generic rationale.
+                    const contextEntry =
+                        reviewItem.latestFinding?.projectContextEntry ?? null;
                     return (
                         <Stack gap={4}>
                             <Group gap={4} wrap="nowrap">
@@ -923,17 +929,29 @@ const AiAgentAdminReviewItemsTable = ({
                                         ]
                                     }
                                 </CategoryToken>
-                                {subcategory && (
+                                {contextEntry ? (
                                     <CategoryToken secondary>
-                                        {subcategory.replaceAll('_', ' ')}
+                                        {contextEntry.kind}
                                     </CategoryToken>
+                                ) : (
+                                    subcategory && (
+                                        <CategoryToken secondary>
+                                            {subcategory.replaceAll('_', ' ')}
+                                        </CategoryToken>
+                                    )
                                 )}
                                 <SuggestedStep>
                                     {getSuggestedNextStep(reviewItem)}
                                 </SuggestedStep>
                             </Group>
                             <ExpandableText lineClamp={1}>
-                                {getWhyText(reviewItem)}
+                                {contextEntry
+                                    ? `${
+                                          contextEntry.op === 'update'
+                                              ? 'Updates'
+                                              : 'Adds'
+                                      } project context: ${contextEntry.content}`
+                                    : getWhyText(reviewItem)}
                             </ExpandableText>
                         </Stack>
                     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -9,26 +9,30 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
-    Anchor,
-    Badge,
     Box,
     Button,
+    Collapse,
     Divider,
     Group,
     Loader,
+    Menu,
     Paper,
     SegmentedControl,
     Stack,
     Text,
     Tooltip,
+    UnstyledButton,
     useMantineTheme,
 } from '@mantine-8/core';
 import {
     IconArrowRight,
     IconBox,
+    IconChevronDown,
+    IconChevronRight,
     IconCircleCheck,
     IconCircleDashed,
     IconClock,
+    IconDots,
     IconExternalLink,
     IconFilterX,
     IconGitPullRequest,
@@ -41,8 +45,16 @@ import {
     IconTriangle,
     IconX,
 } from '@tabler/icons-react';
-import { useCallback, useDeferredValue, useMemo, useState } from 'react';
+import {
+    useCallback,
+    useDeferredValue,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
+import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import {
     ContentTable,
     useContentTable,
@@ -51,6 +63,7 @@ import {
 import FilterFacet, {
     type FilterFacetOption,
 } from '../../../../../components/common/FilterFacet';
+import LinkButton from '../../../../../components/common/LinkButton';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useProjects } from '../../../../../hooks/useProjects';
 import {
@@ -82,6 +95,18 @@ const rootCauseLabels: Record<AiAgentRootCause, string> = {
     feedback_quality: 'Feedback',
     not_a_failure: 'Not failure',
     ambiguous: 'Ambiguous',
+};
+
+const rootCauseColors: Record<AiAgentRootCause, string> = {
+    semantic_layer: 'indigo',
+    project_context: 'violet',
+    agent_configuration: 'cyan',
+    data_gap: 'orange',
+    product_capability: 'grape',
+    runtime_reliability: 'red',
+    feedback_quality: 'teal',
+    not_a_failure: 'gray',
+    ambiguous: 'gray',
 };
 
 const signalLabels: Record<AiAgentTurnSignal, string> = {
@@ -278,32 +303,6 @@ const getConfidenceIcon = (
     }
 };
 
-const CategoryToken = ({
-    children,
-    secondary = false,
-}: {
-    children: string;
-    secondary?: boolean;
-}) => (
-    <Box
-        className={`${styles.categoryToken} ${
-            secondary ? styles.categoryTokenSecondary : ''
-        }`}
-    >
-        <Text
-            fz="xs"
-            fw={500}
-            className={
-                secondary
-                    ? styles.categoryTokenSecondaryText
-                    : styles.categoryTokenText
-            }
-        >
-            {children}
-        </Text>
-    </Box>
-);
-
 const ExpandableText = ({
     children,
     lineClamp = 2,
@@ -318,10 +317,27 @@ const ExpandableText = ({
     weight?: number;
 }) => {
     const [expanded, setExpanded] = useState(false);
-    const canExpand = children.length > lineClamp * 72;
+    const [isOverflowing, setIsOverflowing] = useState(false);
+    const textRef = useRef<HTMLParagraphElement>(null);
+
+    // Detect real truncation (which is width-dependent) instead of guessing
+    // from character count, so a narrow column expands the same as a wide one.
+    useEffect(() => {
+        const element = textRef.current;
+        if (!element) return;
+        const measure = () =>
+            setIsOverflowing(element.scrollHeight - element.clientHeight > 1);
+        measure();
+        const observer = new ResizeObserver(measure);
+        observer.observe(element);
+        return () => observer.disconnect();
+    }, [children]);
+
+    const canExpand = expanded || isOverflowing;
 
     return (
         <Text
+            ref={textRef}
             fz={size}
             c={color}
             fw={weight}
@@ -332,7 +348,13 @@ const ExpandableText = ({
                 event.stopPropagation();
                 setExpanded((isExpanded) => !isExpanded);
             }}
-            title={canExpand ? 'Click to expand' : undefined}
+            title={
+                canExpand
+                    ? expanded
+                        ? 'Click to collapse'
+                        : 'Click to expand'
+                    : undefined
+            }
         >
             {children}
         </Text>
@@ -372,11 +394,96 @@ const ReviewConceptHelp = () => (
 );
 
 const statusColors: Record<AiAgentReviewItemStatus, string> = {
-    open: 'blue',
+    open: 'gray',
     in_progress: 'yellow',
     resolved: 'green',
     dismissed: 'gray',
     duplicate: 'gray',
+};
+
+const FindingCell = ({
+    reviewItem,
+    onPreview,
+}: {
+    reviewItem: AiAgentReviewItemSummary;
+    onPreview: (() => void) | null;
+}) => {
+    const [showReasoning, setShowReasoning] = useState(false);
+    const contextEntry = reviewItem.latestFinding?.projectContextEntry ?? null;
+    const reasoning = contextEntry
+        ? `${
+              contextEntry.op === 'update' ? 'Updates' : 'Adds'
+          } project context: ${contextEntry.content}`
+        : getWhyText(reviewItem);
+
+    return (
+        <Stack gap={2} miw={0}>
+            <Text fw={600} fz="sm" c="ldGray.9" lineClamp={1}>
+                {getIssueTitle(reviewItem)}
+            </Text>
+            <ExpandableText lineClamp={1}>
+                {getWhatHappened(reviewItem)}
+            </ExpandableText>
+            <Group justify="space-between" wrap="nowrap" gap="xs" mt={2}>
+                <UnstyledButton
+                    className={styles.reasoningToggle}
+                    onClick={(event) => {
+                        event.stopPropagation();
+                        setShowReasoning((shown) => !shown);
+                    }}
+                >
+                    <MantineIcon
+                        icon={
+                            showReasoning ? IconChevronDown : IconChevronRight
+                        }
+                        size="xs"
+                    />
+                    Agent&rsquo;s reasoning
+                </UnstyledButton>
+                <Group gap={6} wrap="nowrap">
+                    <Box
+                        className={styles.statusDot}
+                        bg={statusColors[reviewItem.status]}
+                    />
+                    <Text fz="xs" c="ldGray.5" tt="capitalize">
+                        {reviewItem.status.replaceAll('_', ' ')} ·{' '}
+                        {formatLastSeenDate(reviewItem.lastSeenAt)}
+                    </Text>
+                </Group>
+            </Group>
+            <Collapse in={showReasoning}>
+                <Box className={styles.reasoning}>
+                    <Text className={styles.reasoningLabel}>
+                        Why this was flagged
+                    </Text>
+                    <Text fz="xs" c="ldGray.7">
+                        {reasoning}
+                    </Text>
+                    <Group justify="flex-end">
+                        {onPreview && (
+                            <Button
+                                size="compact-xs"
+                                variant="subtle"
+                                color="gray"
+                                leftSection={
+                                    <MantineIcon
+                                        icon={IconMessages}
+                                        size="sm"
+                                    />
+                                }
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    onPreview();
+                                }}
+                            >
+                                Open AI thread
+                            </Button>
+                        )}
+                    </Group>
+                </Box>
+            </Collapse>
+        </Stack>
+    );
 };
 
 const ReviewItemActionsCell = ({
@@ -390,8 +497,7 @@ const ReviewItemActionsCell = ({
     const propInFlight =
         reviewItem.prWritebackStatus === 'queued' ||
         reviewItem.prWritebackStatus === 'running';
-    // While a writeback runs on the worker, poll the single item so the live
-    // phase messages ("Starting sandbox", "Discovering models"…) surface here.
+    // Poll the single item while writeback runs so live phase messages surface.
     const { data: polled } = useAiAgentAdminReviewItem(reviewItem.fingerprint, {
         enabled: propInFlight,
         refetchInterval: propInFlight ? 2500 : false,
@@ -410,91 +516,109 @@ const ReviewItemActionsCell = ({
         !isWritebackInFlight;
 
     if (isWritebackInFlight) {
+        const phase = current.prWritebackMessage ?? 'Opening pull request…';
         return (
-            <Group gap="xs" wrap="nowrap" justify="flex-end">
-                <Loader size="xs" color="violet" />
-                <Text fz="xs" c="ldGray.7" lineClamp={1} maw={170}>
-                    {current.prWritebackMessage ?? 'Working…'}
-                </Text>
-            </Group>
+            <Tooltip label={phase} withArrow openDelay={300}>
+                <Group gap={8} wrap="nowrap" maw={180}>
+                    <Loader size={12} color="ldGray.5" />
+                    <Text fz="xs" c="ldGray.6" lineClamp={1}>
+                        {phase}
+                    </Text>
+                </Group>
+            </Tooltip>
         );
     }
 
     return (
-        <Group gap="xs" wrap="nowrap" justify="flex-end">
-            <Badge
-                size="sm"
-                radius="sm"
-                variant="light"
-                color={statusColors[current.status]}
-            >
-                {current.status.replaceAll('_', ' ')}
-            </Badge>
+        <Stack gap={6} align="flex-start">
+            <Group gap="xs" wrap="nowrap">
+                {current.linkedPrUrl && (
+                    <LinkButton
+                        href={current.linkedPrUrl}
+                        target="_blank"
+                        onClick={(event) => event.stopPropagation()}
+                        leftIcon={IconExternalLink}
+                        size="compact-xs"
+                        fz="xs"
+                        loading={createWriteback.isLoading}
+                    >
+                        View PR
+                    </LinkButton>
+                )}
 
-            {current.linkedPrUrl && (
-                <Anchor
-                    href={current.linkedPrUrl}
-                    target="_blank"
-                    onClick={(event) => event.stopPropagation()}
-                >
-                    <Group gap={4} wrap="nowrap">
-                        <MantineIcon icon={IconExternalLink} size="xs" />
-                        <Text fz="xs" fw={500}>
-                            View PR
-                        </Text>
-                    </Group>
-                </Anchor>
-            )}
+                {canCreatePr && (
+                    <Tooltip
+                        label="Open a pull request against the dbt project (runs in the background, may take a few minutes)"
+                        withArrow
+                        multiline
+                        maw={260}
+                    >
+                        <Button
+                            size="compact-xs"
+                            radius="md"
+                            variant="default"
+                            loading={createWriteback.isLoading}
+                            leftSection={
+                                <MantineIcon icon={IconGitPullRequest} />
+                            }
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                createWriteback.mutate(current.fingerprint);
+                            }}
+                        >
+                            Create PR
+                        </Button>
+                    </Tooltip>
+                )}
+
+                {!isTerminal && (
+                    <Menu position="bottom-end" withinPortal>
+                        <Menu.Target>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                size="sm"
+                                aria-label="More actions"
+                                loading={updateStatus.isLoading}
+                                onClick={(event) => event.stopPropagation()}
+                            >
+                                <MantineIcon icon={IconDots} />
+                            </ActionIcon>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            <Menu.Item
+                                leftSection={<MantineIcon icon={IconX} />}
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    updateStatus.mutate({
+                                        fingerprint: current.fingerprint,
+                                        body: {
+                                            status: 'dismissed',
+                                            dismissedReason: 'not_actionable',
+                                        },
+                                    });
+                                }}
+                            >
+                                Dismiss finding
+                            </Menu.Item>
+                        </Menu.Dropdown>
+                    </Menu>
+                )}
+            </Group>
 
             {canCreatePr && (
-                <Tooltip
-                    label="Open a pull request against the dbt project (runs in the background, may take a few minutes)"
-                    withArrow
-                    multiline
-                    maw={260}
-                >
-                    <Button
-                        size="compact-xs"
-                        radius="md"
-                        variant="light"
-                        loading={createWriteback.isLoading}
-                        leftSection={
-                            <MantineIcon icon={IconGitPullRequest} size="xs" />
-                        }
-                        onClick={(event) => {
-                            event.stopPropagation();
-                            createWriteback.mutate(current.fingerprint);
-                        }}
-                    >
-                        Create PR
-                    </Button>
-                </Tooltip>
+                <Group gap={4} wrap="nowrap">
+                    <MantineIcon
+                        icon={IconArrowRight}
+                        size="xs"
+                        className={styles.suggestedStepArrow}
+                    />
+                    <Text fz="xs" c="ldGray.6" fw={500} lineClamp={1}>
+                        {getSuggestedNextStep(current)}
+                    </Text>
+                </Group>
             )}
-
-            {!isTerminal && (
-                <Tooltip label="Dismiss this finding" withArrow>
-                    <ActionIcon
-                        variant="subtle"
-                        color="gray"
-                        size="sm"
-                        aria-label="Dismiss finding"
-                        loading={updateStatus.isLoading}
-                        onClick={(event) => {
-                            event.stopPropagation();
-                            updateStatus.mutate({
-                                fingerprint: current.fingerprint,
-                                body: {
-                                    status: 'dismissed',
-                                    dismissedReason: 'not_actionable',
-                                },
-                            });
-                        }}
-                    >
-                        <MantineIcon icon={IconX} />
-                    </ActionIcon>
-                </Tooltip>
-            )}
-        </Group>
+        </Stack>
     );
 };
 
@@ -757,17 +881,14 @@ const AiAgentAdminReviewItemsTable = ({
     }) => {
         const pluralised = visibleCount === 1 ? noun : `${noun}s`;
         const countLabel = toolbarLoading
-            ? 'Loading...'
+            ? 'Loading…'
             : hasActiveFilters && visibleCount !== totalCount
               ? `${visibleCount} of ${totalCount} ${pluralised}`
               : `${visibleCount} ${pluralised}`;
 
         return (
             <Box>
-                <Group
-                    p={`${theme.spacing.lg} ${theme.spacing.xl}`}
-                    justify="space-between"
-                >
+                <Group py="lg" px="xl" justify="space-between">
                     <Group gap="xs" wrap="wrap">
                         <SearchFilter
                             search={search}
@@ -775,14 +896,7 @@ const AiAgentAdminReviewItemsTable = ({
                             placeholder="Search reviews"
                         />
 
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <SegmentedControl
                             size="xs"
                             radius="md"
@@ -851,17 +965,7 @@ const AiAgentAdminReviewItemsTable = ({
                         )}
                     </Group>
 
-                    <Box
-                        bg="ldGray.1"
-                        c="ldGray.9"
-                        style={{
-                            borderRadius: 6,
-                            padding: `${theme.spacing.sm} ${theme.spacing.xs}`,
-                            height: 32,
-                            display: 'flex',
-                            alignItems: 'center',
-                        }}
-                    >
+                    <Box className={styles.countPill}>
                         <Text fz="sm" fw={500}>
                             {countLabel}
                         </Text>
@@ -875,10 +979,57 @@ const AiAgentAdminReviewItemsTable = ({
     const columns: MRT_ColumnDef<AiAgentReviewItemSummary>[] = useMemo(
         () => [
             {
-                accessorKey: 'title',
-                header: 'Issue',
+                accessorKey: 'primaryRootCause',
+                header: 'Type',
                 enableSorting: false,
-                size: 330,
+                size: 220,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconTag} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const reviewItem = row.original;
+                    const subcategory =
+                        reviewItem.latestFinding?.subcategories[0];
+                    const contextEntry =
+                        reviewItem.latestFinding?.projectContextEntry ?? null;
+                    return (
+                        <Stack gap={7} align="flex-start">
+                            <CategoryBadge
+                                variant="dot"
+                                label={
+                                    rootCauseLabels[reviewItem.primaryRootCause]
+                                }
+                                color={
+                                    rootCauseColors[reviewItem.primaryRootCause]
+                                }
+                            />
+                            {contextEntry ? (
+                                <CategoryBadge
+                                    variant="dot"
+                                    label={contextEntry.kind}
+                                    color="gray"
+                                />
+                            ) : (
+                                subcategory && (
+                                    <CategoryBadge
+                                        variant="dot"
+                                        label={subcategory.replaceAll('_', ' ')}
+                                        color="gray"
+                                    />
+                                )
+                            )}
+                        </Stack>
+                    );
+                },
+            },
+            {
+                accessorKey: 'title',
+                header: 'Finding',
+                enableSorting: false,
+                size: 650,
                 Header: ({ column }) => (
                     <Group gap="two">
                         <MantineIcon icon={IconListCheck} color="ldGray.6" />
@@ -887,73 +1038,25 @@ const AiAgentAdminReviewItemsTable = ({
                 ),
                 Cell: ({ row }) => {
                     const reviewItem = row.original;
+                    const latestFinding = reviewItem.latestFinding;
                     return (
-                        <Stack gap={2}>
-                            <Text fw={600} fz="sm" c="ldGray.9" lineClamp={1}>
-                                {getIssueTitle(reviewItem)}
-                            </Text>
-                            <ExpandableText lineClamp={1}>
-                                {getWhatHappened(reviewItem)}
-                            </ExpandableText>
-                        </Stack>
-                    );
-                },
-            },
-            {
-                accessorKey: 'primaryRootCause',
-                header: 'Review note',
-                enableSorting: false,
-                size: 380,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconInfoCircle} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
-                Cell: ({ row }) => {
-                    const reviewItem = row.original;
-                    const subcategory =
-                        reviewItem.latestFinding?.subcategories[0];
-                    // project_context findings carry the structured entry the
-                    // writeback PR will create/update — preview it so the admin
-                    // sees the exact fact and kind, not the generic rationale.
-                    const contextEntry =
-                        reviewItem.latestFinding?.projectContextEntry ?? null;
-                    return (
-                        <Stack gap={4}>
-                            <Group gap={4} wrap="nowrap">
-                                <CategoryToken>
-                                    {
-                                        rootCauseLabels[
-                                            reviewItem.primaryRootCause
-                                        ]
-                                    }
-                                </CategoryToken>
-                                {contextEntry ? (
-                                    <CategoryToken secondary>
-                                        {contextEntry.kind}
-                                    </CategoryToken>
-                                ) : (
-                                    subcategory && (
-                                        <CategoryToken secondary>
-                                            {subcategory.replaceAll('_', ' ')}
-                                        </CategoryToken>
-                                    )
-                                )}
-                                <SuggestedStep>
-                                    {getSuggestedNextStep(reviewItem)}
-                                </SuggestedStep>
-                            </Group>
-                            <ExpandableText lineClamp={1}>
-                                {contextEntry
-                                    ? `${
-                                          contextEntry.op === 'update'
-                                              ? 'Updates'
-                                              : 'Adds'
-                                      } project context: ${contextEntry.content}`
-                                    : getWhyText(reviewItem)}
-                            </ExpandableText>
-                        </Stack>
+                        <FindingCell
+                            reviewItem={reviewItem}
+                            onPreview={
+                                latestFinding
+                                    ? () =>
+                                          onReviewItemSelect?.({
+                                              projectUuid:
+                                                  latestFinding.projectUuid,
+                                              agentUuid:
+                                                  latestFinding.agentUuid,
+                                              threadUuid:
+                                                  latestFinding.threadUuid,
+                                              reviewItemUuid: reviewItem.uuid,
+                                          })
+                                    : null
+                            }
+                        />
                     );
                 },
             },
@@ -961,7 +1064,7 @@ const AiAgentAdminReviewItemsTable = ({
                 accessorKey: 'agentUuid',
                 header: 'Agent',
                 enableSorting: false,
-                size: 140,
+                size: 150,
                 Header: ({ column }) => (
                     <Group gap="two">
                         <MantineIcon icon={IconRobotFace} color="ldGray.6" />
@@ -982,31 +1085,25 @@ const AiAgentAdminReviewItemsTable = ({
                     const project = projectUuid
                         ? projectsMap.get(projectUuid)
                         : undefined;
+                    const projectName = project?.name ?? 'Organization';
 
                     if (agent) {
                         return (
                             <Tooltip
-                                label={project?.name ?? 'Organization'}
+                                label={projectName}
                                 withArrow
                                 disabled={!project}
                             >
-                                <Paper px="xs" w="fit-content" maw="100%">
-                                    <Group gap="two" wrap="nowrap">
-                                        <LightdashUserAvatar
-                                            size={16}
-                                            name={agent.name}
-                                            src={agent.imageUrl}
-                                        />
-                                        <Text
-                                            fz="sm"
-                                            fw={600}
-                                            c="ldGray.9"
-                                            truncate
-                                        >
-                                            {agent.name}
-                                        </Text>
-                                    </Group>
-                                </Paper>
+                                <Group gap="xs" wrap="nowrap">
+                                    <LightdashUserAvatar
+                                        size={20}
+                                        name={agent.name}
+                                        src={agent.imageUrl}
+                                    />
+                                    <Text fz="sm" c="ldGray.9" truncate>
+                                        {agent.name}
+                                    </Text>
+                                </Group>
                             </Tooltip>
                         );
                     }
@@ -1019,68 +1116,17 @@ const AiAgentAdminReviewItemsTable = ({
                                 size="sm"
                             />
                             <Text fz="sm" c="ldGray.9" lineClamp={1}>
-                                {project?.name ?? 'Organization'}
+                                {projectName}
                             </Text>
-                        </Group>
-                    );
-                },
-            },
-            {
-                accessorKey: 'lastSeenAt',
-                header: 'Last seen',
-                enableSorting: true,
-                size: 120,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconClock} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
-                Cell: ({ row }) => {
-                    const reviewItem = row.original;
-                    const latestFinding = reviewItem.latestFinding;
-                    return (
-                        <Group gap="xs" wrap="nowrap" justify="space-between">
-                            <Text fz="xs" c="ldGray.7" fw={500}>
-                                {formatLastSeenDate(reviewItem.lastSeenAt)}
-                            </Text>
-                            {latestFinding && (
-                                <Tooltip
-                                    label="Open AI thread preview"
-                                    withArrow
-                                >
-                                    <ActionIcon
-                                        variant="subtle"
-                                        color="gray"
-                                        size="sm"
-                                        aria-label="Open AI thread preview"
-                                        className={styles.threadIcon}
-                                        onClick={(event) => {
-                                            event.stopPropagation();
-                                            onReviewItemSelect?.({
-                                                projectUuid:
-                                                    latestFinding.projectUuid,
-                                                agentUuid:
-                                                    latestFinding.agentUuid,
-                                                threadUuid:
-                                                    latestFinding.threadUuid,
-                                                reviewItemUuid: reviewItem.uuid,
-                                            });
-                                        }}
-                                    >
-                                        <MantineIcon icon={IconMessages} />
-                                    </ActionIcon>
-                                </Tooltip>
-                            )}
                         </Group>
                     );
                 },
             },
             {
                 accessorKey: 'status',
-                header: 'Status',
+                header: 'Action',
                 enableSorting: false,
-                size: 220,
+                size: 260,
                 Header: ({ column }) => (
                     <Group gap="two">
                         <MantineIcon
@@ -1116,9 +1162,17 @@ const AiAgentAdminReviewItemsTable = ({
                     const ConfidenceIcon = getConfidenceIcon(signal.confidence);
                     return (
                         <Group gap={4} wrap="nowrap">
-                            <CategoryToken>
-                                {getSignalResultLabel(signal)}
-                            </CategoryToken>
+                            <CategoryBadge
+                                variant="dot"
+                                label={getSignalResultLabel(signal)}
+                                color={
+                                    signal.finding
+                                        ? rootCauseColors[
+                                              signal.finding.primaryRootCause
+                                          ]
+                                        : 'gray'
+                                }
+                            />
                             <Tooltip
                                 label={`${signal.confidence} confidence`}
                                 withArrow
@@ -1139,7 +1193,7 @@ const AiAgentAdminReviewItemsTable = ({
                 accessorKey: 'signal',
                 header: 'Signal',
                 enableSorting: false,
-                size: 340,
+                size: 300,
                 Header: ({ column }) => (
                     <Group gap="two">
                         <MantineIcon icon={IconInfoCircle} color="ldGray.6" />
@@ -1153,13 +1207,17 @@ const AiAgentAdminReviewItemsTable = ({
                     return (
                         <Stack gap={4}>
                             <Group gap={4} wrap="nowrap">
-                                <CategoryToken>
-                                    {signalLabels[signal.signal]}
-                                </CategoryToken>
+                                <CategoryBadge
+                                    variant="dot"
+                                    label={signalLabels[signal.signal]}
+                                    color="gray"
+                                />
                                 {subcategory && (
-                                    <CategoryToken secondary>
-                                        {subcategory.replaceAll('_', ' ')}
-                                    </CategoryToken>
+                                    <CategoryBadge
+                                        variant="dot"
+                                        label={subcategory.replaceAll('_', ' ')}
+                                        color="gray"
+                                    />
                                 )}
                                 <SuggestedStep>
                                     {getSignalActionText(signal)}
@@ -1203,7 +1261,7 @@ const AiAgentAdminReviewItemsTable = ({
                 accessorKey: 'agentUuid',
                 header: 'Agent',
                 enableSorting: false,
-                size: 140,
+                size: 100,
                 Header: ({ column }) => (
                     <Group gap="two">
                         <MantineIcon icon={IconRobotFace} color="ldGray.6" />
@@ -1261,7 +1319,7 @@ const AiAgentAdminReviewItemsTable = ({
                 accessorKey: 'createdAt',
                 header: 'Reviewed',
                 enableSorting: true,
-                size: 120,
+                size: 150,
                 Header: ({ column }) => (
                     <Group gap="two">
                         <MantineIcon icon={IconClock} color="ldGray.6" />
@@ -1347,6 +1405,7 @@ const AiAgentAdminReviewItemsTable = ({
                 borderLeft: 'none',
                 borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
                 borderTop: 'none',
+                verticalAlign: 'top',
             },
         },
         mantineTableBodyRowProps: ({ row, table: mantineTable }) => {
@@ -1381,7 +1440,7 @@ const AiAgentAdminReviewItemsTable = ({
         },
         mantineLoadingOverlayProps: {
             loaderProps: {
-                color: 'violet',
+                color: 'gray',
             },
         },
     });
@@ -1429,6 +1488,7 @@ const AiAgentAdminReviewItemsTable = ({
                 borderLeft: 'none',
                 borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
                 borderTop: 'none',
+                verticalAlign: 'top',
             },
         },
         mantineTableBodyRowProps: ({ row, table: mantineTable }) => {
@@ -1464,7 +1524,7 @@ const AiAgentAdminReviewItemsTable = ({
         },
         mantineLoadingOverlayProps: {
             loaderProps: {
-                color: 'violet',
+                color: 'gray',
             },
         },
     });

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -217,27 +217,8 @@
     max-width: 100%;
 }
 
-/* Action pill — shadcn style */
-.actionPill {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 11px;
-    font-weight: 500;
-    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-4));
-    white-space: nowrap;
-    padding: 2px 10px;
-    border-radius: 8px;
-    border: 1px solid
-        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
-    background-color: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-dark-6)
-    );
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-    transition: box-shadow 150ms var(--ease-out-quart);
-}
-
+/* Action pill base styling now lives in the shared CategoryBadge; these
+   selectors only add the parent-row-driven hover/reversed states. */
 .row:hover .actionPill {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -67,6 +67,7 @@ import {
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
+import { CategoryBadge } from '../../../components/common/CategoryBadge';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
 import InfoRow from '../../../components/common/PageHeader/InfoRow';
@@ -920,15 +921,13 @@ const DetailSidebar: FC<{
             {/* Header */}
             <Stack gap={2} className={classes.sidebarHeader}>
                 <Group justify="space-between" align="center">
-                    <Group gap={6}>
-                        <Box
-                            className={classes.dot}
-                            style={{ backgroundColor: config.dotColor }}
-                        />
-                        <Text fz="xs" c="dimmed">
-                            {config.label}
-                        </Text>
-                    </Group>
+                    <CategoryBadge
+                        variant="dot"
+                        bordered={false}
+                        label={config.label}
+                        color={config.dotColor}
+                        tooltip={config.tooltip}
+                    />
                     <Group gap={2}>
                         <Menu position="bottom-end" withinPortal>
                             <Menu.Target>
@@ -1478,25 +1477,13 @@ const ActionRow: FC<{
             onClick={() => onSelect(action)}
         >
             <Table.Td w={100}>
-                {config.tooltip ? (
-                    <Tooltip label={config.tooltip} withinPortal>
-                        <span className={classes.actionPill}>
-                            <Box
-                                className={classes.dot}
-                                style={{ backgroundColor: config.dotColor }}
-                            />
-                            {config.label}
-                        </span>
-                    </Tooltip>
-                ) : (
-                    <span className={classes.actionPill}>
-                        <Box
-                            className={classes.dot}
-                            style={{ backgroundColor: config.dotColor }}
-                        />
-                        {config.label}
-                    </span>
-                )}
+                <CategoryBadge
+                    variant="dot"
+                    label={config.label}
+                    color={config.dotColor}
+                    tooltip={config.tooltip}
+                    className={classes.actionPill}
+                />
             </Table.Td>
             <Table.Td w={250}>
                 <Group gap={6} wrap="nowrap">


### PR DESCRIPTION
## What

Surfaces `project_context` items in the **admin review queue** — shows the entry `kind` / preview so a reviewer can scan what a writeback PR would add before creating it.

## Project context lifecycle

```mermaid
flowchart LR
  file["lightdash.project_context.yml"] --> ingest["compile triggers ingest"]
  ingest --> service["ProjectContextService"]
  service --> cache["ProjectContextModel cache"]

  cache --> agent["AiAgentService turn setup"]
  agent --> tool["load_project_context tool"]
  tool --> answer["agent field/model selection"]

  answer --> judge["review classifier judge"]
  judge --> finding["projectContextEntry on finding"]
  finding --> admin["admin review queue"]
  admin --> writeback["project_context writeback PR"]
  writeback --> file
  writeback --> ingest

  flag["ai-project-context flag"] -. gates .-> ingest
  flag -. gates .-> agent
  flag -. gates .-> finding
  flag -. gates .-> writeback
```

## Scope / regression analysis

- Frontend-only; gated by `ai-project-context` (no project_context items appear when off).
- No change to existing review-queue rows for other root causes.

_Stack: PR 5 of 6. Depends on PR 1–4._

Closes: ZAP-475