### PR TITLE
fix: conditional formatting works with hidden metrics in pivot tables

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1,6 +1,7 @@
 import { type ItemsMap } from '../types/field';
 import { type PivotData } from '../types/pivot';
 import { type ResultRow } from '../types/results';
+import { getPivotRowContextKey } from '../utils/conditionalFormatting';
 import {
     SortByDirection,
     VizAggregationOptions,
@@ -1063,5 +1064,148 @@ describe('passthrough dimensions (PROD-7873)', () => {
                 columnType: 'passthrough',
             },
         ]);
+    });
+});
+
+describe('hidden-metric conditional-formatting side-channel (PROD-2372)', () => {
+    // One index dim (year), one pivot dim (payment method), two metrics where
+    // one is hidden. The hidden metric is filtered out of the visible output,
+    // but its pivoted values must be stashed on `hiddenContextValues` keyed by
+    // the displayed dimension context so a CF rule referencing it still resolves.
+    const rows: ResultRow[] = [
+        {
+            orders_order_date_year: {
+                value: { raw: '2025-01-01T00:00:00Z', formatted: '2025' },
+            },
+            payments_total_revenue_any_bank_transfer: {
+                value: { raw: 100, formatted: '100' },
+            },
+            orders_total_order_amount_any_bank_transfer: {
+                value: { raw: 200, formatted: '200' },
+            },
+        },
+        {
+            orders_order_date_year: {
+                value: { raw: '2024-01-01T00:00:00Z', formatted: '2024' },
+            },
+            payments_total_revenue_any_bank_transfer: {
+                value: { raw: 50, formatted: '50' },
+            },
+            orders_total_order_amount_any_bank_transfer: {
+                value: { raw: 75, formatted: '75' },
+            },
+        },
+    ];
+
+    const pivotDetails = {
+        totalColumnCount: 1,
+        valuesColumns: [
+            {
+                aggregation: VizAggregationOptions.ANY,
+                pivotValues: [
+                    {
+                        value: 'bank_transfer',
+                        referenceField: 'payments_payment_method',
+                    },
+                ],
+                referenceField: 'payments_total_revenue',
+                pivotColumnName: 'payments_total_revenue_any_bank_transfer',
+            },
+            {
+                aggregation: VizAggregationOptions.ANY,
+                pivotValues: [
+                    {
+                        value: 'bank_transfer',
+                        referenceField: 'payments_payment_method',
+                    },
+                ],
+                referenceField: 'orders_total_order_amount',
+                pivotColumnName: 'orders_total_order_amount_any_bank_transfer',
+            },
+        ],
+        indexColumn: [
+            {
+                type: VizIndexType.TIME,
+                reference: 'orders_order_date_year',
+            },
+        ],
+        groupByColumns: [{ reference: 'payments_payment_method' }],
+        sortBy: [
+            {
+                direction: SortByDirection.DESC,
+                reference: 'orders_order_date_year',
+            },
+        ],
+        originalColumns: {},
+    };
+
+    it('stashes the hidden metric value keyed by index + header dims, without changing the visible output shape', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows,
+            pivotDetails,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: false,
+                columnOrder: [
+                    'orders_order_date_year',
+                    'payments_payment_method',
+                    'payments_total_revenue',
+                    'orders_total_order_amount',
+                ],
+                hiddenMetricFieldIds: ['orders_total_order_amount'],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        // Visible output only carries the one visible metric (revenue): one
+        // pivot column group, so dataValues has exactly one column per row.
+        expect(result.dataColumnCount).toBe(1);
+        result.dataValues.forEach((row) => {
+            expect(row).toHaveLength(1);
+        });
+
+        expect(result.hiddenContextValues).toBeDefined();
+
+        const key2025 = getPivotRowContextKey({
+            orders_order_date_year: '2025-01-01T00:00:00Z',
+            payments_payment_method: 'bank_transfer',
+        });
+        expect(result.hiddenContextValues![key2025]).toEqual({
+            orders_total_order_amount: { raw: 200, formatted: '200' },
+        });
+
+        const key2024 = getPivotRowContextKey({
+            orders_order_date_year: '2024-01-01T00:00:00Z',
+            payments_payment_method: 'bank_transfer',
+        });
+        expect(result.hiddenContextValues![key2024]).toEqual({
+            orders_total_order_amount: { raw: 75, formatted: '75' },
+        });
+    });
+
+    it('omits hiddenContextValues entirely when no metric is hidden', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows,
+            pivotDetails,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: false,
+                columnOrder: [
+                    'orders_order_date_year',
+                    'payments_payment_method',
+                    'payments_total_revenue',
+                    'orders_total_order_amount',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        expect(result.hiddenContextValues).toBeUndefined();
     });
 });

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -18,6 +18,7 @@ import {
 import { type ResultRow, type ResultValue } from '../types/results';
 import { TimeFrames } from '../types/timeFrames';
 import { getArrayValue } from '../utils/accessors';
+import { getPivotRowContextKey } from '../utils/conditionalFormatting';
 import {
     formatItemValue,
     formatTemporalCellForSpreadsheet,
@@ -1208,6 +1209,54 @@ export const convertSqlPivotedRowsToPivotData = ({
                     return enriched;
                 },
             );
+    }
+
+    // Hidden-metric side-channel for conditional formatting (PROD-2372).
+    // Hidden metrics are dropped from `filteredValuesColumns`, so their pivoted
+    // values never reach `dataValues` and a CF rule that references a hidden
+    // metric renders nothing. Stash each hidden metric's pivoted cell value,
+    // keyed by the same displayed-dimension context the renderer rebuilds
+    // (visible index dims + visible header/pivot dims) via the shared
+    // `getPivotRowContextKey` helper, so producer and consumer keys cannot drift.
+    const hiddenValuesColumns = pivotDetails.valuesColumns.filter(
+        ({ referenceField }) => !isMetricVisibleInPivot(referenceField),
+    );
+    if (hiddenValuesColumns.length > 0) {
+        const visiblePivotDimRefs = new Set(
+            (pivotDetails.groupByColumns ?? []).map((c) => c.reference),
+        );
+        const hiddenContextValues: Record<
+            string,
+            Record<string, ResultValue>
+        > = {};
+        rows.forEach((row) => {
+            hiddenValuesColumns.forEach((col) => {
+                const cell = row[col.pivotColumnName];
+                if (!cell?.value) return;
+                const dimValues: Record<string, unknown> = {};
+                // Visible index (row) dims — match the renderer, which keys on
+                // displayed index dims only (hidden index dims are excluded).
+                indexColumns.forEach((ref) => {
+                    dimValues[ref] = row[ref]?.value?.raw;
+                });
+                // Visible header (pivot) dims for this column group. Hidden
+                // sort-only pivot dims never appear in `groupByColumns`, so they
+                // are excluded here too — keeping the key aligned with the
+                // renderer's `headerInfo`.
+                col.pivotValues.forEach((pv) => {
+                    if (visiblePivotDimRefs.has(pv.referenceField)) {
+                        dimValues[pv.referenceField] = pv.value;
+                    }
+                });
+                const key = getPivotRowContextKey(dimValues);
+                const perField = hiddenContextValues[key] ?? {};
+                perField[col.referenceField] = cell.value;
+                hiddenContextValues[key] = perField;
+            });
+        });
+        if (Object.keys(hiddenContextValues).length > 0) {
+            retrofitted.hiddenContextValues = hiddenContextValues;
+        }
     }
 
     return retrofitted;

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -114,5 +114,12 @@ export type PivotData = {
         allCombinedData: ResultRow[];
         pivotColumnInfo: PivotColumn[];
     };
+    /**
+     * Raw values for metrics that are hidden from the pivot output but are
+     * still referenced by conditional-formatting rules (PROD-2372). Keyed by
+     * `getPivotRowContextKey(dimValues)` → (hidden metric fieldId → value).
+     * Absent when no metrics are hidden.
+     */
+    hiddenContextValues?: Record<string, Record<string, ResultValue>>;
     groupedSubtotals?: Record<string, Record<string, number>[]>;
 };

--- a/packages/common/src/utils/conditionalFormatting.test.ts
+++ b/packages/common/src/utils/conditionalFormatting.test.ts
@@ -3,6 +3,7 @@ import { FilterOperator } from '../types/filter';
 import {
     createConditionalFormattingConfigWithSingleColor,
     createConditionalFormattingRuleWithValues,
+    getPivotRowContextKey,
     hasMatchingConditionalRules,
 } from './conditionalFormatting';
 
@@ -169,5 +170,31 @@ describe('hasMatchingConditionalRules', () => {
 
             expect(result).toBe(true);
         });
+    });
+});
+
+describe('getPivotRowContextKey', () => {
+    it('is stable regardless of key insertion order', () => {
+        const a = getPivotRowContextKey({ dim_b: 'y', dim_a: 'x' });
+        const b = getPivotRowContextKey({ dim_a: 'x', dim_b: 'y' });
+        expect(a).toEqual(b);
+    });
+
+    it('distinguishes different values', () => {
+        expect(getPivotRowContextKey({ dim_a: 'x' })).not.toEqual(
+            getPivotRowContextKey({ dim_a: 'z' }),
+        );
+    });
+
+    it('distinguishes different fields with equal values', () => {
+        expect(getPivotRowContextKey({ dim_a: 'x' })).not.toEqual(
+            getPivotRowContextKey({ dim_b: 'x' }),
+        );
+    });
+
+    it('normalizes null/undefined consistently', () => {
+        expect(getPivotRowContextKey({ dim_a: null })).toEqual(
+            getPivotRowContextKey({ dim_a: undefined }),
+        );
     });
 });

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -734,3 +734,22 @@ export const getConditionalFormattingColor = ({
         getColorFromRange,
     });
 };
+
+/**
+ * Canonical key for a pivot cell's dimension context (index + header dims).
+ * Used by both pivotQueryResults (to store hidden values) and the pivot
+ * renderer (to look them up), so the keys cannot drift. Entries are sorted by
+ * fieldId; null and undefined raw values are normalised to the same token.
+ */
+export const getPivotRowContextKey = (
+    dimValues: Record<string, unknown>,
+): string => {
+    const entries = Object.keys(dimValues)
+        .sort()
+        .map((fieldId) => {
+            const raw = dimValues[fieldId];
+            const token = raw === null || raw === undefined ? ' ' : String(raw);
+            return [fieldId, token];
+        });
+    return JSON.stringify(entries);
+};

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -825,15 +825,20 @@ const PivotTable: FC<PivotTableProps> = ({
     // Merge hidden metric values from hiddenContextValues into rowFields
     // for conditional formatting rules that reference hidden metrics
     const mergeHiddenContextValues = useCallback(
-        (dimValues: Record<string, unknown>): ConditionalFormattingRowFields => {
+        (
+            dimValues: Record<string, unknown>,
+        ): ConditionalFormattingRowFields => {
             if (!data.hiddenContextValues) return {};
             const key = getPivotRowContextKey(dimValues);
             const hidden = data.hiddenContextValues[key];
             if (!hidden) return {};
-            return Object.entries(hidden).reduce<ConditionalFormattingRowFields>(
+            return Object.entries(
+                hidden,
+            ).reduce<ConditionalFormattingRowFields>(
                 (acc, [fieldId, resultValue]) => {
                     const field = getField(fieldId);
-                    if (field) acc[fieldId] = { field, value: resultValue?.raw };
+                    if (field)
+                        acc[fieldId] = { field, value: resultValue?.raw };
                     return acc;
                 },
                 {},
@@ -910,9 +915,11 @@ const PivotTable: FC<PivotTableProps> = ({
             // Build dim map for hidden context key lookup:
             // use display index dims (rowDimensionFields) + header dims (headerInfo)
             const dimValuesForKey: Record<string, unknown> = {};
-            Object.entries(rowDimensionFields).forEach(([fieldId, { value }]) => {
-                dimValuesForKey[fieldId] = value;
-            });
+            Object.entries(rowDimensionFields).forEach(
+                ([fieldId, { value }]) => {
+                    dimValuesForKey[fieldId] = value;
+                },
+            );
             if (headerInfo) {
                 Object.entries(headerInfo).forEach(([fieldId, rv]) => {
                     dimValuesForKey[fieldId] = rv?.raw;
@@ -977,7 +984,8 @@ const PivotTable: FC<PivotTableProps> = ({
             // use index dimension cells + header dims (headerInfo)
             const dimValuesForKey: Record<string, unknown> = {};
             Object.values(cellFields).forEach(({ field, value }) => {
-                if (isDimension(field)) dimValuesForKey[getItemId(field)] = value;
+                if (isDimension(field))
+                    dimValuesForKey[getItemId(field)] = value;
             });
             if (headerInfo) {
                 Object.entries(headerInfo).forEach(([fieldId, rv]) => {

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -6,6 +6,7 @@ import {
     getConditionalFormattingConfig,
     getConditionalFormattingDescription,
     getItemId,
+    getPivotRowContextKey,
     isDimension,
     isField,
     isHexCodeColor,
@@ -821,6 +822,26 @@ const PivotTable: FC<PivotTableProps> = ({
         [getField],
     );
 
+    // Merge hidden metric values from hiddenContextValues into rowFields
+    // for conditional formatting rules that reference hidden metrics
+    const mergeHiddenContextValues = useCallback(
+        (dimValues: Record<string, unknown>): ConditionalFormattingRowFields => {
+            if (!data.hiddenContextValues) return {};
+            const key = getPivotRowContextKey(dimValues);
+            const hidden = data.hiddenContextValues[key];
+            if (!hidden) return {};
+            return Object.entries(hidden).reduce<ConditionalFormattingRowFields>(
+                (acc, [fieldId, resultValue]) => {
+                    const field = getField(fieldId);
+                    if (field) acc[fieldId] = { field, value: resultValue?.raw };
+                    return acc;
+                },
+                {},
+            );
+        },
+        [data.hiddenContextValues, getField],
+    );
+
     // Build rowFields for metricsAsRows mode by looking up metric values across rows
     // that share the same index dimension values (same "row group" in the original data)
     const buildRowFieldsForMetricsAsRows = useCallback(
@@ -886,11 +907,24 @@ const PivotTable: FC<PivotTableProps> = ({
                     {},
                 );
 
-            // Merge pivoted dimensions, row dimensions, and metrics
+            // Build dim map for hidden context key lookup:
+            // use display index dims (rowDimensionFields) + header dims (headerInfo)
+            const dimValuesForKey: Record<string, unknown> = {};
+            Object.entries(rowDimensionFields).forEach(([fieldId, { value }]) => {
+                dimValuesForKey[fieldId] = value;
+            });
+            if (headerInfo) {
+                Object.entries(headerInfo).forEach(([fieldId, rv]) => {
+                    dimValuesForKey[fieldId] = rv?.raw;
+                });
+            }
+
+            // Merge pivoted dimensions, row dimensions, metrics, and hidden metric values
             return {
                 ...pivotedDimensionFields,
                 ...rowDimensionFields,
                 ...metricFields,
+                ...mergeHiddenContextValues(dimValuesForKey),
             };
         },
         [
@@ -899,6 +933,7 @@ const PivotTable: FC<PivotTableProps> = ({
             findDataColumnIndex,
             getField,
             buildRowFieldsFromHeaderInfo,
+            mergeHiddenContextValues,
         ],
     );
 
@@ -938,10 +973,26 @@ const PivotTable: FC<PivotTableProps> = ({
                     return acc;
                 }, {});
 
-            // Merge pivoted dimensions with cell fields
-            return { ...pivotedDimensionFields, ...cellFields };
+            // Build dim map for hidden context key lookup:
+            // use index dimension cells + header dims (headerInfo)
+            const dimValuesForKey: Record<string, unknown> = {};
+            Object.values(cellFields).forEach(({ field, value }) => {
+                if (isDimension(field)) dimValuesForKey[getItemId(field)] = value;
+            });
+            if (headerInfo) {
+                Object.entries(headerInfo).forEach(([fieldId, rv]) => {
+                    dimValuesForKey[fieldId] = rv?.raw;
+                });
+            }
+
+            // Merge pivoted dimensions, cell fields, and hidden metric values
+            return {
+                ...pivotedDimensionFields,
+                ...cellFields,
+                ...mergeHiddenContextValues(dimValuesForKey),
+            };
         },
-        [buildRowFieldsFromHeaderInfo],
+        [buildRowFieldsFromHeaderInfo, mergeHiddenContextValues],
     );
 
     const paddingTop = useMemo(() => {


### PR DESCRIPTION
## Summary

In pivot tables, conditional formatting that referenced a **hidden** metric rendered nothing. Hidden metrics are filtered out of the pivot output (`pivotQueryResults`), so their values never reached the conditional-formatting lookup. (Flat tables were unaffected — they build row fields from all cells, including hidden ones.)

This adds a context-keyed side-channel on `PivotData` carrying the raw values of hidden metrics, populated during the pivot data pass and consumed by the pivot `rowFields` builders. A shared `getPivotRowContextKey` helper is used on both the producer and consumer sides so the lookup keys cannot drift (keyed on displayed index + header dimensions).

The pivot output shape is unchanged — `dataValues`, column/row counts, and totals are untouched; the new `PivotData.hiddenContextValues` field is additive and optional.

## Test Plan

- [x] Unit test: `pivotQueryResults` stashes hidden metric values keyed by dimension context without changing the visible output shape
- [x] Unit test: `getPivotRowContextKey` is order-stable and distinguishes fields/values
- [ ] Manual: pivot with 2 dimensions + 2 metrics, hide one metric, add conditional formatting on the visible metric comparing to the hidden one — formatting now renders (both `metricsAsRows` orientations)

Closes: PROD-2372
Closes: #19288

🤖 Generated with [Claude Code](https://claude.com/claude-code)