### PR TITLE
feat: full-row conditional formatting based on a single column's value

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4409,7 +4409,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ConditionalFormattingColorApplyTo: {
         dataType: 'refEnum',
-        enums: ['cell', 'text'],
+        enums: ['cell', 'text', 'row'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ConditionalFormattingConfigWithSingleColor: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5051,7 +5051,7 @@
                 ]
             },
             "ConditionalFormattingColorApplyTo": {
-                "enum": ["cell", "text"],
+                "enum": ["cell", "text", "row"],
                 "type": "string"
             },
             "ConditionalFormattingConfigWithSingleColor": {

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -529,7 +529,7 @@
             "type": "string"
         },
         "ConditionalFormattingColorApplyTo": {
-            "enum": ["cell", "text"],
+            "enum": ["cell", "text", "row"],
             "type": "string"
         },
         "ConditionalFormattingColorRange": {

--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -120,6 +120,7 @@ export enum ConditionalFormattingComparisonType {
 export enum ConditionalFormattingColorApplyTo {
     CELL = 'cell',
     TEXT = 'text',
+    ROW = 'row',
 }
 
 export type ConditionalRuleLabel = {

--- a/packages/common/src/utils/conditionalFormatting.test.ts
+++ b/packages/common/src/utils/conditionalFormatting.test.ts
@@ -1,9 +1,11 @@
+import { ConditionalFormattingColorApplyTo } from '../types/conditionalFormatting';
 import { DimensionType, FieldType } from '../types/field';
 import { FilterOperator } from '../types/filter';
 import {
     createConditionalFormattingConfigWithSingleColor,
     createConditionalFormattingRuleWithValues,
     getPivotRowContextKey,
+    getRowConditionalFormattingColor,
     hasMatchingConditionalRules,
 } from './conditionalFormatting';
 
@@ -196,5 +198,110 @@ describe('getPivotRowContextKey', () => {
         expect(getPivotRowContextKey({ dim_a: null })).toEqual(
             getPivotRowContextKey({ dim_a: undefined }),
         );
+    });
+});
+
+describe('getRowConditionalFormattingColor', () => {
+    // Reuse the same numeric field fixture used by hasMatchingConditionalRules tests
+    const triggerField = {
+        name: 'status',
+        table: 'orders',
+        type: DimensionType.NUMBER,
+        fieldType: FieldType.DIMENSION,
+        sql: 'status',
+        tableLabel: 'Orders',
+        label: 'Status',
+        hidden: false,
+    };
+    const fieldId = 'orders_status';
+    const target = { fieldId };
+
+    const makeMatchingConfig = (color: string) => {
+        const config = createConditionalFormattingConfigWithSingleColor(
+            color,
+            target,
+        );
+        const rule = createConditionalFormattingRuleWithValues();
+        rule.operator = FilterOperator.EQUALS;
+        rule.values = [42];
+        config.rules = [rule];
+        config.applyTo = ConditionalFormattingColorApplyTo.ROW;
+        return config;
+    };
+
+    const rowFields = {
+        [fieldId]: { field: triggerField, value: 42 },
+    };
+
+    it('returns the configured color when trigger field matches', () => {
+        const config = makeMatchingConfig('#ff0000');
+        const result = getRowConditionalFormattingColor({
+            conditionalFormattings: [config],
+            rowFields,
+            minMaxMap: {},
+        });
+        expect(result).toBe('#ff0000');
+    });
+
+    it('returns null when trigger field value does not match', () => {
+        const config = makeMatchingConfig('#ff0000');
+        const nonMatchingRowFields = {
+            [fieldId]: { field: triggerField, value: 99 },
+        };
+        const result = getRowConditionalFormattingColor({
+            conditionalFormattings: [config],
+            rowFields: nonMatchingRowFields,
+            minMaxMap: {},
+        });
+        expect(result).toBeNull();
+    });
+
+    it('ignores configs with applyTo: CELL even when rule would match', () => {
+        const config = makeMatchingConfig('#00ff00');
+        config.applyTo = ConditionalFormattingColorApplyTo.CELL;
+        const result = getRowConditionalFormattingColor({
+            conditionalFormattings: [config],
+            rowFields,
+            minMaxMap: {},
+        });
+        expect(result).toBeNull();
+    });
+
+    it('returns null when config target is null', () => {
+        const config = createConditionalFormattingConfigWithSingleColor(
+            '#0000ff',
+            null,
+        );
+        const rule = createConditionalFormattingRuleWithValues();
+        rule.operator = FilterOperator.EQUALS;
+        rule.values = [42];
+        config.rules = [rule];
+        config.applyTo = ConditionalFormattingColorApplyTo.ROW;
+        const result = getRowConditionalFormattingColor({
+            conditionalFormattings: [config],
+            rowFields,
+            minMaxMap: {},
+        });
+        expect(result).toBeNull();
+    });
+
+    it('returns null when conditionalFormattings is undefined', () => {
+        const result = getRowConditionalFormattingColor({
+            conditionalFormattings: undefined,
+            rowFields,
+            minMaxMap: {},
+        });
+        expect(result).toBeNull();
+    });
+
+    it('returns color of first matching ROW config when multiple exist', () => {
+        const first = makeMatchingConfig('#aaaaaa');
+        const second = makeMatchingConfig('#bbbbbb');
+        const result = getRowConditionalFormattingColor({
+            conditionalFormattings: [first, second],
+            rowFields,
+            minMaxMap: {},
+        });
+        expect(result).toBe('#aaaaaa');
     });
 });

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -736,6 +736,46 @@ export const getConditionalFormattingColor = ({
 };
 
 /**
+ * Row-level conditional formatting (PROD-8058): returns the background color to
+ * paint across an entire row when a single `applyTo: ROW` rule's trigger field
+ * matches. Evaluated once per row, independent of the cell being drawn.
+ * Returns null when no ROW rule matches.
+ */
+export const getRowConditionalFormattingColor = ({
+    conditionalFormattings,
+    rowFields,
+    minMaxMap = {},
+}: {
+    conditionalFormattings: ConditionalFormattingConfig[] | undefined;
+    rowFields: ConditionalFormattingRowFields;
+    minMaxMap: ConditionalFormattingMinMaxMap | undefined;
+}): string | null => {
+    if (!conditionalFormattings) return null;
+
+    const match = conditionalFormattings.find((config) => {
+        if (config.applyTo !== ConditionalFormattingColorApplyTo.ROW) {
+            return false;
+        }
+        const targetFieldId = config.target?.fieldId;
+        if (!targetFieldId) return false;
+        const trigger = rowFields[targetFieldId];
+        if (!trigger) return false;
+        return hasMatchingConditionalRules(
+            trigger.field,
+            trigger.value,
+            minMaxMap,
+            config,
+            rowFields,
+        );
+    });
+
+    if (!match) return null;
+    return isConditionalFormattingConfigWithSingleColor(match)
+        ? match.color
+        : null;
+};
+
+/**
  * Canonical key for a pivot cell's dimension context (index + header dims).
  * Used by both pivotQueryResults (to store hidden values) and the pivot
  * renderer (to look them up), so the keys cannot drift. Entries are sorted by

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -475,6 +475,19 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                         value: ConditionalFormattingColorApplyTo.TEXT,
                                         label: 'Text',
                                     },
+                                    // Row fill only applies to single-color rules;
+                                    // color-range (gradient) rules ignore ROW, so
+                                    // don't offer a dead option for them.
+                                    ...(isConditionalFormattingConfigWithSingleColor(
+                                        config,
+                                    )
+                                        ? [
+                                              {
+                                                  value: ConditionalFormattingColorApplyTo.ROW,
+                                                  label: 'Row',
+                                              },
+                                          ]
+                                        : []),
                                 ]}
                                 value={
                                     config.applyTo ??

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -5,6 +5,7 @@ import {
     getConditionalFormattingColor,
     getConditionalFormattingConfig,
     getConditionalFormattingDescription,
+    getRowConditionalFormattingColor,
     getItemId,
     getPivotRowContextKey,
     isDimension,
@@ -1535,6 +1536,39 @@ const PivotTable: FC<PivotTableProps> = ({
 
                     const toggleExpander = row.getToggleExpandedHandler();
 
+                    // Row-level conditional formatting (PROD-8058): evaluate
+                    // once per row using a representative data column's pivot
+                    // context, then paint every cell in the row.
+                    const representativeHeaderInfo = row
+                        .getVisibleCells()
+                        .find((c) => {
+                            const m = c.column.columnDef.meta;
+                            return (
+                                c.column.id !== ROW_NUMBER_COLUMN_ID &&
+                                m?.type !== 'indexValue' &&
+                                m?.type !== 'label' &&
+                                m?.type !== 'rowTotal'
+                            );
+                        })?.column.columnDef.meta?.headerInfo;
+
+                    const rowLevelFields = representativeHeaderInfo
+                        ? data.pivotConfig.metricsAsRows
+                            ? buildRowFieldsForMetricsAsRows(
+                                  rowIndex,
+                                  representativeHeaderInfo,
+                              )
+                            : buildRowFieldsFromVisibleCells(
+                                  row,
+                                  representativeHeaderInfo,
+                              )
+                        : buildRowFieldsFromVisibleCells(row, undefined);
+
+                    const rowBackgroundColor = getRowConditionalFormattingColor({
+                        conditionalFormattings,
+                        rowFields: rowLevelFields,
+                        minMaxMap,
+                    });
+
                     return (
                         <Table.Row
                             key={`row-${rowIndex}-${data.pivotConfig.metricsAsRows}`}
@@ -1723,21 +1757,33 @@ const PivotTable: FC<PivotTableProps> = ({
                                             getConditionalRuleLabelFromItem,
                                         );
 
+                                    // No cell-level result → fall back to the row fill (if any).
                                     if (
                                         !conditionalFormattingResult ||
                                         !isHexCodeColor(
                                             conditionalFormattingResult.color,
                                         )
                                     ) {
-                                        return undefined;
+                                        return rowBackgroundColor
+                                            ? {
+                                                  tooltipContent,
+                                                  color: readableColor(
+                                                      rowBackgroundColor,
+                                                  ),
+                                                  backgroundColor:
+                                                      rowBackgroundColor,
+                                              }
+                                            : undefined;
                                     }
 
-                                    // When applying to text, set color directly without background
-                                    // When applying to cell, set background and calculate readable text color
+                                    // Cell-level result present: cell wins. Keep the row fill as the background
+                                    // under a TEXT rule so the row stays continuous; a CELL rule overrides bg.
                                     return applyToText
                                         ? {
                                               tooltipContent,
                                               color: conditionalFormattingResult.color,
+                                              backgroundColor:
+                                                  rowBackgroundColor ?? undefined,
                                           }
                                         : {
                                               tooltipContent,

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -1563,11 +1563,13 @@ const PivotTable: FC<PivotTableProps> = ({
                               )
                         : buildRowFieldsFromVisibleCells(row, undefined);
 
-                    const rowBackgroundColor = getRowConditionalFormattingColor({
-                        conditionalFormattings,
-                        rowFields: rowLevelFields,
-                        minMaxMap,
-                    });
+                    const rowBackgroundColor = getRowConditionalFormattingColor(
+                        {
+                            conditionalFormattings,
+                            rowFields: rowLevelFields,
+                            minMaxMap,
+                        },
+                    );
 
                     return (
                         <Table.Row
@@ -1783,7 +1785,8 @@ const PivotTable: FC<PivotTableProps> = ({
                                               tooltipContent,
                                               color: conditionalFormattingResult.color,
                                               backgroundColor:
-                                                  rowBackgroundColor ?? undefined,
+                                                  rowBackgroundColor ??
+                                                  undefined,
                                           }
                                         : {
                                               tooltipContent,

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -5,6 +5,7 @@ import {
     getConditionalFormattingDescription,
     getItemId,
     getReadableTextColor,
+    getRowConditionalFormattingColor,
     isNumericItem,
     type ConditionalFormattingRowFields,
     type ResultRow,
@@ -100,6 +101,16 @@ const TableRow: FC<TableRowProps> = ({
         [row],
     );
 
+    const rowBackgroundColor = useMemo(
+        () =>
+            getRowConditionalFormattingColor({
+                conditionalFormattings,
+                rowFields,
+                minMaxMap,
+            }),
+        [conditionalFormattings, rowFields, minMaxMap],
+    );
+
     return (
         <Tr $index={index} ref={measureElement} data-index={virtualIndex}>
             {row.getVisibleCells().map((cell) => {
@@ -143,6 +154,8 @@ const TableRow: FC<TableRowProps> = ({
                 let backgroundColor: string | undefined;
                 if (conditionalFormattingResult && !applyToText) {
                     backgroundColor = conditionalFormattingResult.color;
+                } else if (rowBackgroundColor) {
+                    backgroundColor = rowBackgroundColor;
                 } else if (meta?.frozen) {
                     backgroundColor = FROZEN_COLUMN_BACKGROUND;
                 }
@@ -164,6 +177,8 @@ const TableRow: FC<TableRowProps> = ({
                         : getReadableTextColor(
                               conditionalFormattingResult.color,
                           );
+                } else if (rowBackgroundColor) {
+                    fontColor = getReadableTextColor(rowBackgroundColor);
                 }
 
                 const suppressContextMenu =


### PR DESCRIPTION
## Summary

Adds a **Row** option to conditional formatting so a rule can paint an entire row's background when its single trigger column matches — e.g. highlight whole subtotal/total rows in a P&L by the value of a row-type column.

- New `ROW` value on `ConditionalFormattingColorApplyTo` + a pure `getRowConditionalFormattingColor` evaluator (single-color rules only).
- Applied in both the flat table and the pivot table; in pivots the fill spans **all** column groups, including the leftmost label/index column.
- **Precedence:** a cell that independently matches a Cell/Text rule keeps its own styling — cell rules paint over the row fill; under a Text rule the row background stays continuous.
- Config UI gains a "Row" segment in the apply-to control (offered only for single-color rules).

Out of scope (deferred): column-span, and row-level text colour.

> **Stacked on #23806** (the hidden-metric fix) — the headline use case drives the row highlight from a hidden helper column, which needs that fix to resolve the trigger value in pivots. Review/merge #23806 first.

## Test Plan

- [x] Unit tests: `getRowConditionalFormattingColor` matches only `applyTo: ROW` rules with a target, returns null for gradients, first-match wins, ignores Cell/Text
- [ ] Manual (flat): a Row rule fills the whole row; a Cell rule on another column still overrides its own cell
- [ ] Manual (pivot): hide a row-type helper metric, add a Row rule keyed on it — the whole visual row fills across all pivot column groups (both `metricsAsRows` orientations)

Closes: PROD-8058
Closes: #23750

🤖 Generated with [Claude Code](https://claude.com/claude-code)