### PR TITLE
feat(ai): default Slack aiRequireOAuth to true (PROD-8072)

### DIFF
--- a/packages/backend/src/database/migrations/20260602130000_slack_ai_require_oauth_default_true.ts
+++ b/packages/backend/src/database/migrations/20260602130000_slack_ai_require_oauth_default_true.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+// Make AI agents in Slack require OAuth by default. This only changes the
+// column DEFAULT for NEW Slack installations — existing rows keep whatever
+// value they already have, so current installs are not silently flipped.
+// Requiring OAuth means each Slack user resolves to their real Lightdash
+// identity, so per-user permissions and user-attribute access controls apply
+// (otherwise the agent acts as the workspace installer).
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(
+        'ALTER TABLE slack_auth_tokens ALTER COLUMN ai_require_oauth SET DEFAULT true',
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(
+        'ALTER TABLE slack_auth_tokens ALTER COLUMN ai_require_oauth SET DEFAULT false',
+    );
+}

--- a/packages/backend/src/ee/models/CommercialSlackAuthenticationModel.ts
+++ b/packages/backend/src/ee/models/CommercialSlackAuthenticationModel.ts
@@ -140,7 +140,7 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
                     notification_channel: notificationChannel,
                     app_profile_photo_url: appProfilePhotoUrl,
                     ai_thread_access_consent: aiThreadAccessConsent ?? false,
-                    ai_require_oauth: aiRequireOAuth ?? false,
+                    ai_require_oauth: aiRequireOAuth ?? true,
                     ai_multi_agent_channel_id: aiMultiAgentChannelId ?? null,
                     unfurls_enabled: unfurlsEnabled,
                 })

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -100,7 +100,7 @@ const SlackSettingsPanel: FC = () => {
             appProfilePhotoUrl: null,
             slackChannelProjectMappings: [],
             aiThreadAccessConsent: false,
-            aiRequireOAuth: false,
+            aiRequireOAuth: true,
             aiMultiAgentChannelId: undefined,
             aiMultiAgentProjectUuids: null,
             unfurlsEnabled: true,
@@ -120,7 +120,7 @@ const SlackSettingsPanel: FC = () => {
                 slackInstallation.slackChannelProjectMappings ?? [],
             aiThreadAccessConsent:
                 slackInstallation.aiThreadAccessConsent ?? false,
-            aiRequireOAuth: slackInstallation.aiRequireOAuth ?? false,
+            aiRequireOAuth: slackInstallation.aiRequireOAuth ?? true,
             aiMultiAgentChannelId:
                 slackInstallation.aiMultiAgentChannelId ?? undefined,
             aiMultiAgentProjectUuids:


### PR DESCRIPTION
Closes: PROD-8072

### Description

Follow-up to #23787 (semantic-layer search + writeback). Hardens the Slack AI-agent permission model.

**Why:** A Slack AI agent only resolves to the real Lightdash user — and therefore applies that user's permissions and **user-attribute access controls** — when `aiRequireOAuth` is enabled. With it off, the agent acts as the **workspace installer**: per-agent access checks are bypassed (`getAvailableAgents` returns all agents) and reads (incl. the new `searchSemanticLayer`) are scoped to the installer's visibility, not the asker's. (Write/SQL tools already fail closed in that mode.)

Making OAuth required by default means the agent — including semantic-layer search and writeback — is governed per-user out of the box.

**What changed:**
- Migration flips `slack_auth_tokens.ai_require_oauth` column **DEFAULT** to `true`. **New installs only** — existing rows are **not** backfilled, so current installs keep their setting and are not silently changed.
- Align the settings-save fallback (`CommercialSlackAuthenticationModel`) and the Slack settings UI initial/display defaults to `true`.

**Non-breaking:** existing Slack installations are unaffected; admins can still toggle the setting off on the Slack integration settings page.

### Testing
- Ran the migration locally (EE): `slack_auth_tokens.ai_require_oauth` default flips `false → true`; existing rows unchanged.
- backend + frontend typecheck clean. No tests assert the old default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)