### PR TITLE
fix(ai-agents): move suggestion chips below input and remove loading states

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -170,26 +170,37 @@
     margin: 0;
 }
 
-/* ------------------------------------------------------------------ *
- *  Chip reveal wrapper. Chips are present whenever the agent has      *
- *  something to suggest, but we hide them while the user is scrolled  *
- *  up reading history — they only feel useful when the input is in    *
- *  view. Animates opacity + collapse to keep the transition calm.     *
- * ------------------------------------------------------------------ */
 .chipReveal {
+    display: grid;
+    grid-template-rows: 1fr;
     transition:
         opacity 360ms cubic-bezier(0.22, 1, 0.36, 1),
-        max-height 420ms cubic-bezier(0.22, 1, 0.36, 1),
+        grid-template-rows 420ms cubic-bezier(0.22, 1, 0.36, 1),
         transform 360ms cubic-bezier(0.22, 1, 0.36, 1);
-    max-height: 80px;
+}
+
+.chipReveal > * {
+    min-height: 0;
     overflow: hidden;
 }
 
 .chipHidden {
     opacity: 0;
-    max-height: 0;
-    transform: translateY(6px);
+    grid-template-rows: 0fr;
+    transform: translateY(-6px);
     pointer-events: none;
+}
+
+/* Full (empty-state) layout: the composer lives in a vertically centered
+ * stack, so any chip row added in normal flow re-centers the block and nudges
+ * the input. Take the row out of flow instead — absolute with no `top` keeps
+ * it at its static position (directly below the input) while carrying zero
+ * layout height, so the input holds still no matter how many lines the chips
+ * wrap to. `.container` is the positioning context. */
+.chipFloat {
+    position: absolute;
+    left: 0;
+    right: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -410,12 +410,10 @@ export const AgentChatInput = ({
         if (!emptyStateMode && !postResponseMode) return null;
         if (suggestionsQuery.isError) return null;
         const chips = suggestionsQuery.data?.chips ?? [];
-        if (!suggestionsQuery.isLoading && chips.length === 0) return null;
+        if (chips.length === 0) return null;
         return (
             <AgentSuggestionChips
                 chips={chips}
-                isLoading={suggestionsQuery.isLoading}
-                loadingVariant={postResponseMode ? 'follow-up' : 'skeleton'}
                 onChipClick={handleChipClick}
                 onImpression={handleImpression}
             />
@@ -424,11 +422,22 @@ export const AgentChatInput = ({
         emptyStateMode,
         postResponseMode,
         suggestionsQuery.isError,
-        suggestionsQuery.isLoading,
         suggestionsQuery.data,
         handleChipClick,
         handleImpression,
     ]);
+
+    const renderChipRow = (extraClassName = '') =>
+        chipRow && (
+            <Box
+                className={`${styles.chipReveal} ${extraClassName} ${
+                    chipsNearBottom ? '' : styles.chipHidden
+                }`}
+                aria-hidden={!chipsNearBottom}
+            >
+                {chipRow}
+            </Box>
+        );
 
     if (isMinimalMode) {
         return (
@@ -438,16 +447,7 @@ export const AgentChatInput = ({
                 }`}
                 ref={rootRef}
             >
-                {chipRow && (
-                    <Box
-                        className={`${styles.chipReveal} ${
-                            chipsNearBottom ? '' : styles.chipHidden
-                        }`}
-                        aria-hidden={!chipsNearBottom}
-                    >
-                        {chipRow}
-                    </Box>
-                )}
+                {renderChipRow()}
 
                 <Box
                     className={`${styles.minimalInputWrapper} ${
@@ -537,17 +537,6 @@ export const AgentChatInput = ({
                 showDisabledBanner ? styles.disabledBannerVisible : ''
             }`}
         >
-            {chipRow && (
-                <Box
-                    className={`${styles.chipReveal} ${
-                        chipsNearBottom ? '' : styles.chipHidden
-                    }`}
-                    aria-hidden={!chipsNearBottom}
-                >
-                    {chipRow}
-                </Box>
-            )}
-
             <Box
                 className={`${styles.inputCard} ${
                     sqlMode ? styles.sqlModeActive : ''
@@ -702,6 +691,8 @@ export const AgentChatInput = ({
                     </Group>
                 </Box>
             </Box>
+
+            {renderChipRow(styles.chipFloat)}
 
             {showDisabledBanner && (
                 <Paper className={styles.disabledBanner} px="md" py="xs">

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
@@ -2,15 +2,9 @@
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
-    padding: 0 var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    padding: var(--mantine-spacing-xs);
 }
 
-/* ------------------------------------------------------------------ *
- *  Chips live inside the input chrome — designed to read as soft      *
- *  labels attached to the input rather than free-floating buttons.    *
- *  Resting state matches the input bg with a subtle tint; hover       *
- *  reveals a clear card affordance.                                   *
- * ------------------------------------------------------------------ */
 .chip {
     height: 22px;
     min-height: 22px;
@@ -95,88 +89,19 @@
     }
 }
 
-.skeleton {
-    height: 22px;
-    border-radius: 6px;
-}
-
-.followUpLoader {
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    padding: 0 var(--mantine-spacing-xs) var(--mantine-spacing-sm);
-    min-height: 30px;
-    animation: chipFadeIn 220ms cubic-bezier(0.22, 1, 0.36, 1) both;
-}
-
-.loaderText {
-    font-weight: 500;
-
-    @mixin light {
-        color: var(--mantine-color-ldGray-6);
-    }
-
-    @mixin dark {
-        color: var(--mantine-color-ldDark-2);
-    }
-}
-
-.loaderDots {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding-top: 1px;
-
-    span {
-        width: 3px;
-        height: 3px;
-        border-radius: 999px;
-        animation: loaderDotPulse 950ms ease-in-out infinite;
-
-        @mixin light {
-            background-color: var(--mantine-color-ldGray-5);
-        }
-
-        @mixin dark {
-            background-color: var(--mantine-color-ldDark-2);
-        }
-    }
-
-    span:nth-child(2) {
-        animation-delay: 120ms;
-    }
-
-    span:nth-child(3) {
-        animation-delay: 240ms;
-    }
-}
-
 .fadeIn {
-    animation: chipFadeIn 320ms cubic-bezier(0.22, 1, 0.36, 1) both;
-    animation-delay: calc(var(--chip-idx, 0) * 40ms);
+    animation: chipCascade 340ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-delay: calc(var(--chip-idx, 0) * 45ms);
 }
 
-@keyframes chipFadeIn {
+@keyframes chipCascade {
     from {
         opacity: 0;
-        transform: translateY(6px);
+        transform: translateY(-7px) scale(0.97);
     }
     to {
         opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes loaderDotPulse {
-    0%,
-    70%,
-    100% {
-        opacity: 0.35;
-        transform: translateY(0);
-    }
-    35% {
-        opacity: 1;
-        transform: translateY(-1px);
+        transform: translateY(0) scale(1);
     }
 }
 
@@ -188,14 +113,6 @@
     .fadeIn {
         animation: chipFadeInReduced 120ms ease-out both;
         animation-delay: 0ms;
-    }
-
-    .followUpLoader {
-        animation: none;
-    }
-
-    .loaderDots span {
-        animation: none;
     }
 
     @keyframes chipFadeInReduced {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.tsx
@@ -1,5 +1,5 @@
 import type { AgentSuggestion } from '@lightdash/common';
-import { Box, Button, Skeleton, Text } from '@mantine-8/core';
+import { Box, Button } from '@mantine-8/core';
 import { IconArrowUpRight } from '@tabler/icons-react';
 import { useEffect, useRef } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -7,13 +7,9 @@ import styles from './AgentSuggestionChips.module.css';
 
 type Props = {
     chips: AgentSuggestion[];
-    isLoading: boolean;
-    loadingVariant?: 'skeleton' | 'follow-up';
     onChipClick: (chip: AgentSuggestion, index: number) => void;
     onImpression?: (chipCount: number) => void;
 };
-
-const SKELETON_COUNT = 4;
 
 const chipKey = (chip: AgentSuggestion, idx: number) =>
     chip.kind === 'navigate'
@@ -27,55 +23,18 @@ const renderLeftIcon = (chip: AgentSuggestion) => {
 
 export const AgentSuggestionChips = ({
     chips,
-    isLoading,
-    loadingVariant = 'skeleton',
     onChipClick,
     onImpression,
 }: Props) => {
     const impressedRef = useRef<string | null>(null);
 
     useEffect(() => {
-        if (isLoading) return;
         if (chips.length === 0) return;
         const fingerprint = chips.map((c, i) => chipKey(c, i)).join('|');
         if (impressedRef.current === fingerprint) return;
         impressedRef.current = fingerprint;
         onImpression?.(chips.length);
-    }, [chips, isLoading, onImpression]);
-
-    if (isLoading) {
-        if (loadingVariant === 'follow-up') {
-            return (
-                <Box className={styles.followUpLoader}>
-                    <Text
-                        component="span"
-                        size="xs"
-                        className={styles.loaderText}
-                    >
-                        Finding good follow-ups
-                    </Text>
-                    <Box className={styles.loaderDots} aria-hidden>
-                        <span />
-                        <span />
-                        <span />
-                    </Box>
-                </Box>
-            );
-        }
-
-        return (
-            <Box className={styles.row}>
-                {Array.from({ length: SKELETON_COUNT }).map((_, idx) => (
-                    <Skeleton
-                        // eslint-disable-next-line react/no-array-index-key
-                        key={idx}
-                        className={styles.skeleton}
-                        width={idx % 2 === 0 ? 180 : 220}
-                    />
-                ))}
-            </Box>
-        );
-    }
+    }, [chips, onImpression]);
 
     if (chips.length === 0) return null;
 


### PR DESCRIPTION
### Description

Tidies up how AI agent suggestion chips are presented in the chat input.

**Move chips below the input**
- In the empty-state (landing) layout, the chip row now renders **below** the composer instead of above it. It's taken out of normal flow (`.chipFloat`, absolutely positioned) so adding/wrapping chips never re-centers the vertically-centered composer or nudges the input.
- Chip rendering for both layouts is consolidated into a single `renderChipRow()` helper, so the minimal (existing-thread) and full (landing) branches share one render path.
- Reveal/hide animation flipped to match the new placement (chips slide down from above rather than up from below).

**Remove loading states**
- Dropped the skeleton placeholder chips and the animated "Finding good follow-ups" loader (and the `isLoading` / `loadingVariant` props, `loaderDots` / `loaderText` / `skeleton` styles, and `loaderDotPulse` keyframes that backed them). Chips now simply appear once they're ready instead of showing a loading placeholder.

**Other**
- Refreshed the chip entrance animation (`chipFadeIn` → `chipCascade`, slight cascade timing/scale tweak) and normalised the chip row padding.

### How to test
1. Open a new AI agent thread (landing/empty state) — confirm suggestion chips appear **below** the input and that the composer stays put as chips load/wrap.
2. Send a message — confirm follow-up chips show in an existing thread without any skeleton/loader flashing in first.
