### PR TITLE
fix(clickhouse): native <=> null-safe joins and array literal syntax

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -81,6 +81,7 @@ export const warehouseClientMock: WarehouseClient = {
     getFieldQuoteChar: () => '"',
     getFloatingType: () => 'FLOAT',
     getNullSafeEqualSql: defaultNullSafeEqualSql,
+    getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
     getAdapterType: () => SupportedDbtAdapter.POSTGRES,
     concatString: (...args) => `(${args.join(' || ')})`,
     getAllTables(
@@ -138,6 +139,7 @@ export const bigqueryClientMock: WarehouseClient = {
     getFieldQuoteChar: () => '`',
     getFloatingType: () => 'FLOAT64',
     getNullSafeEqualSql: defaultNullSafeEqualSql,
+    getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
     getCatalog: async () => ({
         default: {
             public: {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -2746,9 +2746,11 @@ export class MetricQueryBuilder {
                             return `CROSS JOIN ${metricCte.name}`;
                         }
                         return `INNER JOIN ${metricCte.name} ON ${dimensionAlias
-                            .map(
-                                (alias) =>
-                                    `( ${unaffectedMetricsCteName}.${alias} = ${metricCte.name}.${alias} OR ( ${unaffectedMetricsCteName}.${alias} IS NULL AND ${metricCte.name}.${alias} IS NULL ) )`,
+                            .map((alias) =>
+                                warehouseSqlBuilder.getNullSafeEqualJoinSql(
+                                    `${unaffectedMetricsCteName}.${alias}`,
+                                    `${metricCte.name}.${alias}`,
+                                ),
                             )
                             .join(' AND ')}`;
                     }),
@@ -2780,7 +2782,10 @@ export class MetricQueryBuilder {
                                     )})`;
                                 }
                                 // default to joining on all dimensions
-                                return `( ${unaffectedMetricsCteName}.${alias} = ${popMetricCte.name}.${alias} OR ( ${unaffectedMetricsCteName}.${alias} IS NULL AND ${popMetricCte.name}.${alias} IS NULL ) )`;
+                                return warehouseSqlBuilder.getNullSafeEqualJoinSql(
+                                    `${unaffectedMetricsCteName}.${alias}`,
+                                    `${popMetricCte.name}.${alias}`,
+                                );
                             })
                             .join(' AND ')}`;
                     }),
@@ -2954,9 +2959,11 @@ export class MetricQueryBuilder {
                 } else {
                     ddJoins.push(
                         `INNER JOIN ${ddCteName} ON ${outerKeyAliases
-                            .map(
-                                (alias) =>
-                                    `( ${baseCteName}.${alias} = ${ddCteName}.${alias} OR ( ${baseCteName}.${alias} IS NULL AND ${ddCteName}.${alias} IS NULL ) )`,
+                            .map((alias) =>
+                                warehouseSqlBuilder.getNullSafeEqualJoinSql(
+                                    `${baseCteName}.${alias}`,
+                                    `${ddCteName}.${alias}`,
+                                ),
                             )
                             .join(' AND ')}`,
                     );
@@ -3452,9 +3459,11 @@ export class MetricQueryBuilder {
             } else {
                 naJoins.push(
                     `INNER JOIN ${naResultsCteName} ON ${dimensionAlias
-                        .map(
-                            (alias) =>
-                                `( ${baseCteName}.${alias} = ${naResultsCteName}.${alias} OR ( ${baseCteName}.${alias} IS NULL AND ${naResultsCteName}.${alias} IS NULL ) )`,
+                        .map((alias) =>
+                            warehouseSqlBuilder.getNullSafeEqualJoinSql(
+                                `${baseCteName}.${alias}`,
+                                `${naResultsCteName}.${alias}`,
+                            ),
                         )
                         .join(' AND ')}`,
                 );
@@ -3484,7 +3493,10 @@ export class MetricQueryBuilder {
                         .trim()
                         .replace(/\s+AS\s+.*$/i, '')
                         .trim();
-                    return `( ${expr} = ${naCteName}.${qId} OR ( ${expr} IS NULL AND ${naCteName}.${qId} IS NULL ) )`;
+                    return warehouseSqlBuilder.getNullSafeEqualJoinSql(
+                        expr,
+                        `${naCteName}.${qId}`,
+                    );
                 },
             );
             const cteJoinClause =
@@ -3517,9 +3529,11 @@ export class MetricQueryBuilder {
             } else {
                 naJoins.push(
                     `INNER JOIN ${naMixedCteName} ON ${dimensionAlias
-                        .map(
-                            (alias) =>
-                                `( ${baseCteName}.${alias} = ${naMixedCteName}.${alias} OR ( ${baseCteName}.${alias} IS NULL AND ${naMixedCteName}.${alias} IS NULL ) )`,
+                        .map((alias) =>
+                            warehouseSqlBuilder.getNullSafeEqualJoinSql(
+                                `${baseCteName}.${alias}`,
+                                `${naMixedCteName}.${alias}`,
+                            ),
                         )
                         .join(' AND ')}`,
                 );
@@ -3942,9 +3956,11 @@ export class MetricQueryBuilder {
             );
             if (nonPivotDimIds.length > 0) {
                 const joinCondition = nonPivotDimIds
-                    .map(
-                        (dimId) =>
-                            `(${opts.currentCteName}.${fieldQuoteChar}${dimId}${fieldQuoteChar} = row_totals.${fieldQuoteChar}${dimId}${fieldQuoteChar} OR (${opts.currentCteName}.${fieldQuoteChar}${dimId}${fieldQuoteChar} IS NULL AND row_totals.${fieldQuoteChar}${dimId}${fieldQuoteChar} IS NULL))`,
+                    .map((dimId) =>
+                        this.args.warehouseSqlBuilder.getNullSafeEqualJoinSql(
+                            `${opts.currentCteName}.${fieldQuoteChar}${dimId}${fieldQuoteChar}`,
+                            `row_totals.${fieldQuoteChar}${dimId}${fieldQuoteChar}`,
+                        ),
                     )
                     .join(' AND ');
                 joinClauses.push(`LEFT JOIN row_totals ON ${joinCondition}`);
@@ -4260,7 +4276,10 @@ export class MetricQueryBuilder {
                                     true,
                                 )})`;
                             }
-                            return `( ${baseCteName}.${alias} = ${popCteName}.${alias} OR ( ${baseCteName}.${alias} IS NULL AND ${popCteName}.${alias} IS NULL ) )`;
+                            return this.args.warehouseSqlBuilder.getNullSafeEqualJoinSql(
+                                `${baseCteName}.${alias}`,
+                                `${popCteName}.${alias}`,
+                            );
                         })
                         .join(' AND ')}`,
                 );

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -27,6 +27,7 @@ const mockWarehouseSqlBuilder = {
     getAdapterType: () => SupportedDbtAdapter.POSTGRES,
     getStartOfWeek: () => WeekDay.MONDAY,
     getNullSafeEqualSql: defaultNullSafeEqualSql,
+    getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
     getStringQuoteChar: () => "'",
     // Mirrors WarehouseBaseSqlBuilder.escapeString: double quotes, strip SQL
     // comments, escape backslashes, drop null bytes.
@@ -1650,6 +1651,7 @@ SELECT * FROM group_by_query LIMIT 50`);
                 getFieldQuoteChar: () => '`',
                 getAdapterType: () => SupportedDbtAdapter.BIGQUERY,
                 getNullSafeEqualSql: defaultNullSafeEqualSql,
+                getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
             } as unknown as WarehouseSqlBuilder;
 
             const pivotConfiguration = {
@@ -1682,6 +1684,7 @@ SELECT * FROM group_by_query LIMIT 50`);
                 getFieldQuoteChar: () => '`',
                 getAdapterType: () => SupportedDbtAdapter.DATABRICKS,
                 getNullSafeEqualSql: defaultNullSafeEqualSql,
+                getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
             } as unknown as WarehouseSqlBuilder;
 
             const pivotConfiguration = {
@@ -3503,6 +3506,7 @@ SELECT * FROM group_by_query LIMIT 50`);
                 getAdapterType: () => SupportedDbtAdapter.BIGQUERY,
                 getStartOfWeek: () => WeekDay.MONDAY,
                 getNullSafeEqualSql: defaultNullSafeEqualSql,
+                getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
             } as unknown as WarehouseSqlBuilder;
 
             const itemsMap: ItemsMap = {
@@ -3961,6 +3965,7 @@ SELECT * FROM group_by_query LIMIT 50`);
                 getAdapterType: () => SupportedDbtAdapter.BIGQUERY,
                 getStartOfWeek: () => WeekDay.MONDAY,
                 getNullSafeEqualSql: defaultNullSafeEqualSql,
+                getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
             } as unknown as WarehouseSqlBuilder;
 
             const itemsMapWithTc: ItemsMap = {
@@ -4443,6 +4448,7 @@ SELECT * FROM group_by_query LIMIT 50`);
                 getAdapterType: () => SupportedDbtAdapter.DATABRICKS,
                 getStartOfWeek: () => WeekDay.MONDAY,
                 getNullSafeEqualSql: defaultNullSafeEqualSql,
+                getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
             } as unknown as WarehouseSqlBuilder;
 
             const pivotConfiguration = {
@@ -4508,6 +4514,7 @@ SELECT * FROM group_by_query LIMIT 50`);
                 getAdapterType: () => SupportedDbtAdapter.DATABRICKS,
                 getStartOfWeek: () => WeekDay.MONDAY,
                 getNullSafeEqualSql: defaultNullSafeEqualSql,
+                getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
             } as unknown as WarehouseSqlBuilder;
 
             const pivotConfiguration = {
@@ -4996,6 +5003,73 @@ SELECT * FROM group_by_query LIMIT 50`);
             // The downstream CTEs reference the bare names the aliases expose.
             expect(result).toContain(
                 'distinct_groups AS (SELECT DISTINCT "status" FROM filtered_rows)',
+            );
+        });
+
+        test('Metric sort: ClickHouse uses the native `<=>` operator in JOIN ON, but keeps the OR form in the row-anchor CASE WHEN (#23711)', () => {
+            // https://github.com/lightdash/lightdash/issues/23711
+            // ClickHouse's analyzer cannot determine join keys from the generic
+            // `a = b OR (a IS NULL AND b IS NULL)` form in the deep pivot CTE
+            // chain. Its native `<=>` operator is accepted as a join key, but is
+            // unsupported in the SELECT list — so the row-anchor MAX(CASE WHEN …)
+            // must keep the OR form.
+            const clickhouseSqlBuilder = {
+                getFieldQuoteChar: () => '"',
+                getAdapterType: () => SupportedDbtAdapter.CLICKHOUSE,
+                getStartOfWeek: () => WeekDay.MONDAY,
+                getNullSafeEqualSql: defaultNullSafeEqualSql,
+                getNullSafeEqualJoinSql: (left: string, right: string) =>
+                    `${left} <=> ${right}`,
+                getStringQuoteChar: () => "'",
+                escapeString: (v: string) => v,
+            } as unknown as WarehouseSqlBuilder;
+
+            const pivotConfiguration = {
+                indexColumn: [
+                    { reference: 'order_date', type: VizIndexType.TIME },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'amount',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'status' }],
+                sortBy: [
+                    { reference: 'amount', direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                clickhouseSqlBuilder,
+            );
+
+            const result = replaceWhitespace(builder.toSql());
+
+            // JOIN ON conditions use the native `<=>` operator.
+            expect(result).toContain(
+                'LEFT JOIN row_ranking rr ON g."order_date" <=> rr."order_date"',
+            );
+            expect(result).toContain(
+                'LEFT JOIN column_ranking cr ON g."status" <=> cr."status"',
+            );
+            // Anchor CTE joins also use `<=>`.
+            expect(result).toContain('g."status" <=> "amount_ca"."status"');
+            expect(result).toContain(
+                'g."order_date" <=> "amount_ra"."order_date"',
+            );
+
+            // No JOIN ON falls back to the OR form on ClickHouse.
+            expect(result).not.toContain(
+                'ON (g."status" = "amount_ca"."status" OR',
+            );
+
+            // The row-anchor MAX(CASE WHEN …) projection keeps the OR form,
+            // since `<=>` is unsupported in the SELECT list.
+            expect(result).toContain(
+                'MAX(CASE WHEN (q."status" = ac."anchor_status" OR (q."status" IS NULL AND ac."anchor_status" IS NULL)) THEN',
             );
         });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -833,7 +833,7 @@ export class PivotQueryBuilder {
         Object.values(columnAnchorCTEs).forEach(({ cteName }) => {
             const joinConditions = groupByColumns
                 .map((col) =>
-                    this.warehouseSqlBuilder.getNullSafeEqualSql(
+                    this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
                         `g.${q}${col.reference}${q}`,
                         `${q}${cteName}${q}.${q}${col.reference}${q}`,
                     ),
@@ -1246,7 +1246,7 @@ export class PivotQueryBuilder {
         Object.values(rowAnchorQueries).forEach(({ cteName }) => {
             const joinConditions = indexColumns
                 .map((col) =>
-                    this.warehouseSqlBuilder.getNullSafeEqualSql(
+                    this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
                         `g.${q}${col.reference}${q}`,
                         `${q}${cteName}${q}.${q}${col.reference}${q}`,
                     ),
@@ -1321,7 +1321,7 @@ export class PivotQueryBuilder {
             if (indexColumns.length > 0) {
                 const rowRankJoinConditions = indexColumns
                     .map((col) =>
-                        this.warehouseSqlBuilder.getNullSafeEqualSql(
+                        this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
                             `g.${q}${col.reference}${q}`,
                             `rr.${q}${col.reference}${q}`,
                         ),
@@ -1334,7 +1334,7 @@ export class PivotQueryBuilder {
 
             const colRankJoinConditions = groupByColumns
                 .map((col) =>
-                    this.warehouseSqlBuilder.getNullSafeEqualSql(
+                    this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
                         `g.${q}${col.reference}${q}`,
                         `cr.${q}${col.reference}${q}`,
                     ),
@@ -1367,7 +1367,7 @@ export class PivotQueryBuilder {
                 if (indexColumns.length > 0) {
                     const joinConditions = indexColumns
                         .map((col) =>
-                            this.warehouseSqlBuilder.getNullSafeEqualSql(
+                            this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
                                 `g.${q}${col.reference}${q}`,
                                 `${q}${cteName}${q}.${q}${col.reference}${q}`,
                             ),
@@ -1381,7 +1381,7 @@ export class PivotQueryBuilder {
                 // Join on group columns for column anchor CTEs
                 const joinConditions = groupByColumns
                     .map((col) =>
-                        this.warehouseSqlBuilder.getNullSafeEqualSql(
+                        this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
                             `g.${q}${col.reference}${q}`,
                             `${q}${cteName}${q}.${q}${col.reference}${q}`,
                         ),

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -57,6 +57,7 @@ export const warehouseClientMock: WarehouseClient = {
     getEscapeStringQuoteChar: () => "'",
     getFloatingType: () => 'FLOAT',
     getNullSafeEqualSql: defaultNullSafeEqualSql,
+    getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
     getAdapterType: () => SupportedDbtAdapter.POSTGRES,
     getMetricSql: (sql, metric) => {
         switch (metric.type) {

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -85,6 +85,7 @@ export interface WarehouseSqlBuilder {
     getFieldQuoteChar: () => string;
     getFloatingType: () => string;
     getNullSafeEqualSql: (left: string, right: string) => string;
+    getNullSafeEqualJoinSql: (left: string, right: string) => string;
     getMetricSql: (sql: string, metric: Metric) => string;
     concatString: (...args: string[]) => string;
     escapeString: (value: string) => string;

--- a/packages/common/src/utils/convertCustomDimensionsToYaml.ts
+++ b/packages/common/src/utils/convertCustomDimensionsToYaml.ts
@@ -137,6 +137,7 @@ const warehouseClientMock: WarehouseClient = {
         return 'FLOAT';
     },
     getNullSafeEqualSql: defaultNullSafeEqualSql,
+    getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
     escapeString(value) {
         return value;
     },

--- a/packages/common/src/utils/virtualView.test.ts
+++ b/packages/common/src/utils/virtualView.test.ts
@@ -39,6 +39,7 @@ const fakeWarehouseClient: WarehouseClient = {
     getFieldQuoteChar: () => '"',
     getFloatingType: () => 'FLOAT',
     getNullSafeEqualSql: defaultNullSafeEqualSql,
+    getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
     getMetricSql: () => '',
     concatString: (...args: string[]) => args.join(''),
     getAllTables: async () => [],

--- a/packages/common/src/utils/virtualView.ts
+++ b/packages/common/src/utils/virtualView.ts
@@ -117,6 +117,7 @@ export const createTemporaryVirtualView = (
         getFieldQuoteChar: () => '"',
         getFloatingType: () => 'FLOAT',
         getNullSafeEqualSql: defaultNullSafeEqualSql,
+        getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
         getMetricSql: () => '',
         concatString: (...args) => args.join(''),
         getAllTables: async () => [],

--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.test.ts
@@ -1,8 +1,23 @@
 import { DimensionType } from '@lightdash/common';
 import {
+    ClickhouseSqlBuilder,
     ClickhouseTypes,
     convertDataTypeToDimensionType,
 } from './ClickhouseWarehouseClient';
+
+describe('ClickhouseSqlBuilder', () => {
+    const builder = new ClickhouseSqlBuilder();
+
+    it('builds arrays with [...] syntax, not ARRAY[...] which ClickHouse rejects', () => {
+        expect(builder.buildArray(['1', '2', '3'])).toBe('[1, 2, 3]');
+    });
+
+    it('uses the native <=> operator for null-safe join keys', () => {
+        expect(builder.getNullSafeEqualJoinSql('a."x"', 'b."x"')).toBe(
+            'a."x" <=> b."x"',
+        );
+    });
+});
 
 describe('convertDataTypeToDimensionType', () => {
     // Plain types (no wrappers)

--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
@@ -209,6 +209,18 @@ export class ClickhouseSqlBuilder extends WarehouseBaseSqlBuilder {
         // ClickHouse has a native median function
         return `median(${valueSql})`;
     }
+
+    getNullSafeEqualJoinSql(left: string, right: string): string {
+        // ClickHouse's analyzer can't determine join keys from the generic
+        // `a = b OR (a IS NULL AND b IS NULL)` form in deep CTE chains; its
+        // native `<=>` (isNotDistinctFrom) operator is accepted as a join key.
+        return `${left} <=> ${right}`;
+    }
+
+    buildArray(elements: string[]): string {
+        // ClickHouse rejects the `ARRAY[...]` form; arrays are `[...]`.
+        return `[${elements.join(', ')}]`;
+    }
 }
 
 export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickhouseCredentials> {

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
@@ -51,6 +51,10 @@ export default abstract class WarehouseBaseClient<
         return this.sqlBuilder.getNullSafeEqualSql(left, right);
     }
 
+    getNullSafeEqualJoinSql(left: string, right: string): string {
+        return this.sqlBuilder.getNullSafeEqualJoinSql(left, right);
+    }
+
     buildArrayAgg(expression: string, orderBy?: string): string {
         return this.sqlBuilder.buildArrayAgg(expression, orderBy);
     }

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseSqlBuilder.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseSqlBuilder.ts
@@ -42,6 +42,10 @@ export default abstract class WarehouseBaseSqlBuilder implements WarehouseSqlBui
         return defaultNullSafeEqualSql(left, right);
     }
 
+    getNullSafeEqualJoinSql(left: string, right: string): string {
+        return defaultNullSafeEqualSql(left, right);
+    }
+
     getMetricSql(sql: string, metric: Metric): string {
         return getDefaultMetricSql(sql, metric.type);
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-8082
Closes: #23811

### Description:

ClickHouse pre-25 cannot determine join keys from the generic `a = b OR (a IS NULL AND b IS NULL)` null-safe join form in deep CTE chains (error `INVALID_JOIN_ON_EXPRESSION`), and it rejects the `ARRAY[...]` constructor. This adds a `getNullSafeEqualJoinSql` warehouse-builder method that emits ClickHouse's native `<=>` operator in JOIN ON while other warehouses keep the OR form, and routes every PivotQueryBuilder and MetricQueryBuilder JOIN ON null-safe condition through it; the pivot row-anchor `CASE WHEN` keeps the OR form because `<=>` is unsupported in the SELECT list before 25.10. It also overrides `buildArray` for ClickHouse to emit `[...]` instead of `ARRAY[...]`, fixing the `LIST` / `OFFSET_LIST` / `PIVOT_OFFSET_LIST` table calculations. Verified against ClickHouse 24.8 in Docker: reproduced the original "Cannot determine join keys" error with the old SQL and confirmed the new `<=>` and `[...]` forms execute correctly (NULL group rows preserved).