### PR TITLE
docs: clarify dashboard tab semantics

### DIFF
--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-reference.md
@@ -257,6 +257,61 @@ Organize tiles into multiple views:
 }
 ```
 
+**IMPORTANT:** Tab rendering depends on `tabs` and tile `tabUuid` values:
+
+- If no tabs are defined, all tiles render in a single untabbed dashboard view.
+- If tabs are defined, tiles with `"tabUuid": null` render on the default/first tab.
+- Avoid relying on this defaulting behavior. When using tabs, set each tile's `tabUuid` explicitly.
+
+Example: no tabs, so both tiles render together in one untabbed view.
+
+```json
+{
+    "tabs": [],
+    "tiles": [
+        {
+            "tabUuid": null,
+            "type": "saved_chart"
+        },
+        {
+            "tabUuid": null,
+            "type": "saved_chart"
+        }
+    ]
+}
+```
+
+Example: tabs are defined, so the `null` tile renders on `"Overview"` and the other tile renders on `"Details"`.
+
+```json
+{
+    "tabs": [
+        {
+            "hidden": false,
+            "name": "Overview",
+            "order": 0,
+            "uuid": "b3f1a2c4-d5e6-4f78-9abc-def012345678"
+        },
+        {
+            "hidden": false,
+            "name": "Details",
+            "order": 1,
+            "uuid": "c4d2b3e5-f6a7-4089-bcde-f12345678901"
+        }
+    ],
+    "tiles": [
+        {
+            "tabUuid": null,
+            "type": "saved_chart"
+        },
+        {
+            "tabUuid": "c4d2b3e5-f6a7-4089-bcde-f12345678901",
+            "type": "saved_chart"
+        }
+    ]
+}
+```
+
 ## Dashboard Filters
 
 ### Dimension Filters

--- a/skills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/skills/developing-in-lightdash/resources/dashboard-reference.md
@@ -212,6 +212,44 @@ tiles:
     y: 0
 ```
 
+**IMPORTANT:** Tab rendering depends on `tabs` and tile `tabUuid` values:
+
+- If no tabs are defined, all tiles render in a single untabbed dashboard view.
+- If tabs are defined, tiles with `tabUuid: null` render on the default/first tab.
+- Avoid relying on this defaulting behavior. When using tabs, set each tile's `tabUuid` explicitly.
+
+Example: no tabs, so both tiles render together in one untabbed view.
+
+```yaml
+tabs: []
+
+tiles:
+  - tabUuid: null
+    type: saved_chart
+  - tabUuid: null
+    type: saved_chart
+```
+
+Example: tabs are defined, so the `null` tile renders on "Overview" and the other tile renders on "Details".
+
+```yaml
+tabs:
+  - name: "Overview"
+    hidden: false
+    order: 0
+    uuid: "b3f1a2c4-d5e6-4f78-9abc-def012345678"
+  - name: "Details"
+    hidden: false
+    order: 1
+    uuid: "c4d2b3e5-f6a7-4089-bcde-f12345678901"
+
+tiles:
+  - tabUuid: null
+    type: saved_chart
+  - tabUuid: "c4d2b3e5-f6a7-4089-bcde-f12345678901"
+    type: saved_chart
+```
+
 ## Dashboard Filters
 
 ### Dimension Filters


### PR DESCRIPTION
### Description
- Clarifies dashboard tab rendering semantics in AI content skill dashboard references.
- Documents how untabbed dashboards and `tabUuid: null` tiles render.
- Instructs agents to set tile `tabUuid` explicitly when using tabs.

Closes: ZAP-459