### PR TITLE
fix(ai-agents): widen evaluation form modal

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalFormModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalFormModal.tsx
@@ -184,7 +184,7 @@ export const EvalFormModal: FC<Props> = ({
             onClose={handleClose}
             icon={IconSettings}
             title={modalTitle}
-            size="full"
+            size="lg"
             cancelDisabled={isLoading || isDeleting}
             leftActions={
                 mode === 'edit' && onDelete ? (


### PR DESCRIPTION
## Summary
- widen the shared evaluation form modal with an explicit responsive width
- covers both create and edit evaluation flows
- leaves the smaller add-to-evaluation picker at its current width

## Validation
- pnpm --dir packages/frontend run linter src/ee/features/aiCopilot/components/Evals/EvalFormModal.tsx
- pnpm --filter @lightdash/frontend typecheck