### PR TITLE
feat(ai-writeback): surface "View preview" in Slack writeback threads (PROD-8083)

### DIFF
--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -6,11 +6,34 @@ import {
     EE_SCHEDULER_TASKS,
     EmbedArtifactVersionJobPayload,
     GenerateArtifactQuestionJobPayload,
+    PollWritebackPreviewJobPayload,
     SlackPromptJobPayload,
 } from '@lightdash/common';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 
 export class CommercialSchedulerClient extends SchedulerClient {
+    /**
+     * Enqueue (or re-enqueue) a poll for a write-back PR's preview URL. Keyed by
+     * prompt so a re-enqueue replaces the pending poll rather than stacking. Pass
+     * a future `runAt` to delay the next poll.
+     */
+    async pollWritebackPreview(
+        payload: PollWritebackPreviewJobPayload,
+        runAt: Date = new Date(),
+    ) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.POLL_WRITEBACK_PREVIEW,
+            payload,
+            {
+                runAt,
+                maxAttempts: 1,
+                jobKey: `poll-writeback-preview:${payload.promptUuid}`,
+            },
+        );
+        return { jobId };
+    }
+
     async slackAiPrompt(payload: SlackPromptJobPayload) {
         const graphileClient = await this.graphileUtils;
         const now = new Date();

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -96,6 +96,12 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     payload.slackPromptUuid,
                 );
             },
+            [EE_SCHEDULER_TASKS.POLL_WRITEBACK_PREVIEW]: async (
+                payload,
+                _helpers,
+            ) => {
+                await this.aiAgentService.pollSlackWritebackPreview(payload);
+            },
             [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: async (
                 payload,
                 _helpers,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -50,11 +50,13 @@ import {
     derivePivotConfigurationFromChart,
     Explore,
     ExploreCompiler,
+    extractPreviewUrlFromComments,
     FeatureFlags,
     filterExploreByTags,
     followUpToolsText,
     ForbiddenError,
     getContentAsCodePathFromLtreePath,
+    getErrorMessage,
     getGroupByDimensions,
     getItemId,
     getItemMap,
@@ -77,6 +79,7 @@ import {
     OpenIdIdentityIssuerType,
     ParameterError,
     parseVizConfig,
+    PollWritebackPreviewJobPayload,
     ProjectType,
     QueryExecutionContext,
     QueryHistoryStatus,
@@ -141,7 +144,10 @@ import {
     LightdashAnalytics,
 } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
-import { getInstallationToken } from '../../../clients/github/Github';
+import {
+    getInstallationToken,
+    getPullRequestComments,
+} from '../../../clients/github/Github';
 import { type SlackClient } from '../../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
@@ -268,6 +274,7 @@ import {
     getReferencedArtifactsBlocks,
     getTextBlocks,
     getThinkingBlocks,
+    getWritebackPreviewReplyBlocks,
 } from '../ai/utils/getSlackBlocks';
 import { llmAsAJudge } from '../ai/utils/llmAsAJudge';
 import {
@@ -5973,6 +5980,34 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         );
                     });
             }
+            // If the repo deploys Lightdash previews, kick off a background poll
+            // that adds a "View preview" follow-up in the Slack thread once the
+            // preview URL is published on the PR. Best-effort — never blocks the
+            // writeback result.
+            if (result.prUrl && isSlackPrompt(prompt)) {
+                try {
+                    const ciStatus =
+                        await this.aiWritebackService.getProjectCiStatus(
+                            user,
+                            projectUuid,
+                        );
+                    if (ciStatus?.hasPreviewDeployWorkflow) {
+                        await this.schedulerClient.pollWritebackPreview({
+                            organizationUuid,
+                            projectUuid,
+                            userUuid: user.userUuid,
+                            promptUuid: prompt.promptUuid,
+                            prUrl: result.prUrl,
+                            startedAt: Date.now(),
+                        });
+                    }
+                } catch (err) {
+                    Logger.debug(
+                        'Failed to schedule writeback preview poll:',
+                        err,
+                    );
+                }
+            }
             return result;
         };
 
@@ -6819,6 +6854,106 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         }
 
         return [uuid, createdThread];
+    }
+
+    /**
+     * Background poll (Graphile Worker) that surfaces a write-back PR's Lightdash
+     * preview environment in the Slack thread. The preview URL is published
+     * asynchronously by the dbt repo's CI as a PR comment, so we poll the PR's
+     * comments and, once found, post a "View preview" follow-up in the thread.
+     * Re-enqueues itself every ~25s until the URL appears or the ~10 min window
+     * elapses. Only scheduled when the project's repo deploys previews.
+     */
+    async pollSlackWritebackPreview(
+        payload: PollWritebackPreviewJobPayload,
+    ): Promise<void> {
+        const PREVIEW_POLL_INTERVAL_MS = 25_000;
+        const PREVIEW_WAIT_TIMEOUT_MS = 10 * 60_000;
+        const { promptUuid, prUrl, startedAt, organizationUuid } = payload;
+
+        // Past the wait window — give up (the PR link stays in the message).
+        if (Date.now() - startedAt > PREVIEW_WAIT_TIMEOUT_MS) {
+            Logger.info(
+                `AiAgent: writeback preview poll timed out for prompt ${promptUuid}`,
+            );
+            return;
+        }
+
+        const slackPrompt = await this.aiAgentModel.findSlackPrompt(promptUuid);
+        // Not a Slack prompt (or gone) — nothing to deliver to.
+        if (!slackPrompt) {
+            return;
+        }
+
+        // Wait until the agent's reply is actually posted, then resolve the URL.
+        const previewUrl = slackPrompt.response_slack_ts
+            ? await this.resolveWritebackPreviewUrl(organizationUuid, prUrl)
+            : null;
+
+        if (!previewUrl) {
+            await this.schedulerClient.pollWritebackPreview(
+                payload,
+                new Date(Date.now() + PREVIEW_POLL_INTERVAL_MS),
+            );
+            return;
+        }
+
+        await this.slackClient.postMessage({
+            organizationUuid,
+            channel: slackPrompt.slackChannelId,
+            thread_ts: slackPrompt.slackThreadTs,
+            text: `Preview environment ready: ${previewUrl}`,
+            unfurl_links: false,
+            blocks: [
+                ...getMarkdownBlocks(
+                    ':white_check_mark: Preview environment ready',
+                ),
+                ...getWritebackPreviewReplyBlocks(previewUrl),
+            ],
+        });
+    }
+
+    /**
+     * Resolve the Lightdash preview URL for a write-back PR by reading its
+     * comments via the org's GitHub App installation. Returns null when no
+     * preview comment is present yet, or on any failure — so the caller keeps
+     * polling rather than erroring.
+     */
+    private async resolveWritebackPreviewUrl(
+        organizationUuid: string,
+        prUrl: string,
+    ): Promise<string | null> {
+        try {
+            const url = new URL(prUrl);
+            const [owner, repo, , pullNumberStr] = url.pathname
+                .split('/')
+                .filter(Boolean);
+            const pullNumber = Number(pullNumberStr);
+            if (!owner || !repo || !Number.isInteger(pullNumber)) {
+                return null;
+            }
+            const installationId =
+                await this.githubAppInstallationsModel.getInstallationId(
+                    organizationUuid,
+                );
+            const comments = await getPullRequestComments({
+                owner,
+                repo,
+                pullNumber,
+                installationId,
+            });
+            return extractPreviewUrlFromComments(
+                comments,
+                this.lightdashConfig.siteUrl,
+            );
+        } catch (error) {
+            Logger.warn(
+                `AiAgent: failed to resolve writeback preview URL for ${prUrl}: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            return null;
+        }
     }
 
     // TODO: user permissions

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6869,7 +6869,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     ): Promise<void> {
         const PREVIEW_POLL_INTERVAL_MS = 25_000;
         const PREVIEW_WAIT_TIMEOUT_MS = 10 * 60_000;
-        const { promptUuid, prUrl, startedAt, organizationUuid } = payload;
+        const { promptUuid, prUrl, startedAt, organizationUuid, projectUuid } =
+            payload;
 
         // Past the wait window — give up (the PR link stays in the message).
         if (Date.now() - startedAt > PREVIEW_WAIT_TIMEOUT_MS) {
@@ -6877,6 +6878,22 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 `AiAgent: writeback preview poll timed out for prompt ${promptUuid}`,
             );
             return;
+        }
+
+        // Re-verify the triggering user can still view the project's source code
+        // before delivering — they may have lost access during the wait window.
+        // (Authorize against the project's organization, taken from the payload.)
+        const user = await this.userModel.findSessionUserByUUID(
+            payload.userUuid,
+        );
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('SourceCode', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
         }
 
         const slackPrompt = await this.aiAgentModel.findSlackPrompt(promptUuid);

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -508,6 +508,33 @@ export function getProposeWritebackBlocks(
     ];
 }
 
+/**
+ * Block for the threaded "preview ready" follow-up posted once a write-back
+ * PR's preview environment has been published (the URL is discovered async from
+ * the PR comments by a background poll).
+ */
+export function getWritebackPreviewReplyBlocks(
+    previewUrl: string,
+): (Block | KnownBlock)[] {
+    return [
+        {
+            type: 'actions',
+            elements: [
+                {
+                    type: 'button',
+                    url: previewUrl,
+                    style: 'primary',
+                    action_id: 'actions.view_preview_button_click',
+                    text: {
+                        type: 'plain_text',
+                        text: 'View preview',
+                    },
+                },
+            ],
+        },
+    ];
+}
+
 export function getAgentSelectionBlocks(
     agents: AiAgent[],
     channelId: string,

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -171,6 +171,12 @@ const getTagsForTask: {
         'user.uuid': payload.userUuid,
     }),
 
+    [SCHEDULER_TASKS.POLL_WRITEBACK_PREVIEW]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid,
+    }),
+
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -161,6 +161,15 @@ export type SlackPromptJobPayload = TraceTaskBase & {
     slackPromptUuid: string;
 };
 
+export type PollWritebackPreviewJobPayload = TraceTaskBase & {
+    /** The AI prompt that triggered the write-back; resolves the Slack message. */
+    promptUuid: string;
+    /** The opened pull request URL whose comments we poll for a preview URL. */
+    prUrl: string;
+    /** Epoch ms when polling first started — bounds the ~10 min wait window. */
+    startedAt: number;
+};
+
 export type AiAgentEvalRunJobPayload = TraceTaskBase & {
     evalRunResultUuid: string;
     evalRunUuid: string;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -8,6 +8,7 @@ import {
     type DataAppTemplate,
     type EmbedArtifactVersionJobPayload,
     type GenerateArtifactQuestionJobPayload,
+    type PollWritebackPreviewJobPayload,
     type SlackPromptJobPayload,
 } from '../ee';
 import { type SchedulerIndexCatalogJobPayload } from './catalog';
@@ -68,6 +69,7 @@ export const EE_SCHEDULER_TASKS = {
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
     SWEEP_STALE_APP_LOCKS: 'sweepStaleAppLocks',
+    POLL_WRITEBACK_PREVIEW: 'pollWritebackPreview',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -155,6 +157,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
+    [SCHEDULER_TASKS.POLL_WRITEBACK_PREVIEW]: PollWritebackPreviewJobPayload;
 }
 
 export interface EETaskPayloadMap {
@@ -166,6 +169,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
     [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
+    [EE_SCHEDULER_TASKS.POLL_WRITEBACK_PREVIEW]: PollWritebackPreviewJobPayload;
 }
 
 export type SchedulerTaskName =


### PR DESCRIPTION
## What & why

Follow-up to PROD-8055 (which added the **View preview** button to the *web* AI chat). Slack writeback messages are server-rendered and static — there's no client to poll — so they never surfaced the preview. This adds a server-side mechanism.

Closes PROD-8083 (https://linear.app/lightdash/issue/PROD-8083).

## How it works

When a **Slack-sourced** write-back opens a PR **and** the project's repo deploys Lightdash previews (`ProjectCiStatus.hasPreviewDeployWorkflow`), a Graphile Worker job polls the PR's comments and, once the preview URL is published, posts a **"View preview"** follow-up in the thread. It re-enqueues every ~25s until the URL appears or a ~10 min deadline — mirroring the web's wait window.

Reuses the discovery primitives from PROD-8055 (`getPullRequestComments` + `extractPreviewUrlFromComments`) — no duplication.

## Changes

- **common**: `EE_SCHEDULER_TASKS.POLL_WRITEBACK_PREVIEW` + `PollWritebackPreviewJobPayload`.
- **EE `SchedulerClient.pollWritebackPreview(payload, runAt)`** — delayed `addJob`, `jobKey`-deduped per prompt (re-enqueue replaces the pending poll).
- **`AiAgentService.pollSlackWritebackPreview`** — resolves the Slack message via `findSlackPrompt`, reads PR comments through the GitHub App installation, extracts the preview URL; delivers a threaded reply, re-enqueues, or stops at the deadline.
- **Enqueue** from the `proposeWriteback` Slack path, gated on `hasPreviewDeployWorkflow` (no wasted polling on repos without previews).
- **`getWritebackPreviewReplyBlocks`** for the button; trace + EE worker handler wired.

## Design note

v1 posts a **threaded reply** ("✅ Preview environment ready → View preview") rather than editing the original message in place — `chat.update` replaces the whole message, so edit-in-place would require reconstructing all of its blocks. Edit-in-place (and a "preview didn't appear" note on timeout, for web parity) are noted as follow-ups.

## Testing

- Typecheck + lint + backend tests (38, incl. snapshots) green.
- Full Slack E2E needs a live workspace + a Slack-sourced write-back; covered here by types/lint/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)