### PR TITLE
fix(ai-agents): string filter case sensitivity

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/discoverFields/schema.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/schema.ts
@@ -3,4 +3,5 @@ export {
     discoverFieldsResultSchema,
     type DiscoverFieldsInput,
     type DiscoverFieldsResult,
+    type ToolDiscoverFieldsOutput,
 } from '@lightdash/common';

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
@@ -92,6 +92,7 @@ Then call submitResult with the resolved handoff.
 ## Hard rules
 
 - Never invent fieldIds. Only return fieldIds returned by findFields.
+- Copy selected field attributes from findFields.
 - Never call findFields when the status will be "ambiguous". If two explores are tied, call submitResult with the ambiguous handoff directly.
 - Never return all fields. Always filter.
 - Keep field descriptions short — one sentence max. Many fields should have no description.

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
@@ -49,6 +49,12 @@ const renderResolved = (
                     fieldValueType={f.fieldValueType}
                     fieldFilterType={f.fieldFilterType}
                     isFromJoinedTable={f.isFromJoinedTable}
+                    {...(f.caseSensitiveFilters === 'not_applicable'
+                        ? {}
+                        : {
+                              caseSensitiveFilters:
+                                  f.caseSensitiveFilters === 'true',
+                          })}
                 >
                     {f.description ? (
                         <description>{f.description}</description>

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -59,6 +59,10 @@ If the user mentions any time window ("last 3 months", "this quarter", "past yea
 - Never set the dimension filter \`type\` to \`or\` when the query also has a categorical (or any non-date) filter. \`or\` applies across all dimension filters in the group, so the categorical filter becomes optional and is silently dropped. Only use \`type: or\` with one \`inBetween\` per range when the date ranges are the sole dimension filter and no granularity-aligned \`equals\` rule fits (e.g. arbitrary day ranges like "Mar 1–6 vs Apr 1–6").
 - Use \`limit\` only for explicit "top N" / "show me 10 rows" requests, never to approximate a time window.
 
+## String filter case sensitivity
+
+String dimension metadata has \`caseSensitiveFilters\` when case sensitivity applies. \`true\` means string filters must match casing exactly; \`false\` means string filters ignore casing.
+
 ## Table calculations (when to reach for them)
 
 Use a table calculation when the question requires row-by-row math over query results — anything the metric query alone can't express:

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -188,6 +188,15 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                           "items": {
                             "additionalProperties": false,
                             "properties": {
+                              "caseSensitiveFilters": {
+                                "description": "Use "true" or "false" only when the exact selected findFields result explicitly includes caseSensitiveFilters with that value; otherwise use "not_applicable".",
+                                "enum": [
+                                  "true",
+                                  "false",
+                                  "not_applicable",
+                                ],
+                                "type": "string",
+                              },
                               "description": {
                                 "description": "Short description, only include when needed to distinguish similar fields.",
                                 "type": [
@@ -234,6 +243,7 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                               "fieldType",
                               "fieldValueType",
                               "fieldFilterType",
+                              "caseSensitiveFilters",
                               "isFromJoinedTable",
                               "description",
                             ],

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -1,7 +1,10 @@
 import {
     CatalogField,
     convertToAiHints,
+    DEFAULT_FILTER_CASE_SENSITIVE,
+    DimensionType,
     Explore,
+    FieldType,
     findFieldsToolDefinition,
     getFilterTypeFromItemType,
     getItemId,
@@ -27,6 +30,27 @@ type Dependencies = {
 
 const toolDefinition = findFieldsToolDefinition.for('agent');
 
+const getFieldCaseSensitive = (
+    catalogField: CatalogField,
+    explore?: Explore,
+): boolean | undefined => {
+    if (
+        catalogField.fieldType !== FieldType.DIMENSION ||
+        catalogField.fieldValueType !== DimensionType.STRING
+    ) {
+        return undefined;
+    }
+
+    const dimension =
+        explore?.tables[catalogField.tableName]?.dimensions[catalogField.name];
+
+    return (
+        dimension?.caseSensitive ??
+        explore?.caseSensitive ??
+        DEFAULT_FILTER_CASE_SENSITIVE
+    );
+};
+
 const renderField = (catalogField: CatalogField, explore?: Explore) => {
     const isFromJoinedTable =
         explore &&
@@ -34,6 +58,7 @@ const renderField = (catalogField: CatalogField, explore?: Explore) => {
         explore.joinedTables.some(
             (join) => join.table === catalogField.tableName,
         );
+    const caseSensitiveFilters = getFieldCaseSensitive(catalogField, explore);
 
     const aiHints = convertToAiHints(catalogField.aiHints ?? undefined);
 
@@ -54,6 +79,9 @@ const renderField = (catalogField: CatalogField, explore?: Explore) => {
             chartUsage={catalogField.chartUsage}
             usageInVerifiedCharts={catalogField.verifiedChartUsage ?? 0}
             isFromJoinedTable={isFromJoinedTable}
+            {...(caseSensitiveFilters === undefined
+                ? {}
+                : { caseSensitiveFilters })}
         >
             {isFromJoinedTable && explore && (
                 <note>

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -8,6 +8,7 @@ import {
     convertAiTableCalcsSchemaToTableCalcs,
     CustomMetricBaseTransformed,
     dateFilterSchema,
+    DEFAULT_FILTER_CASE_SENSITIVE,
     DependencyNode,
     detectCircularDependencies,
     Explore,
@@ -275,7 +276,7 @@ function validateFilterRule(
                 WeekDay.SUNDAY,
                 SupportedDbtAdapter.BIGQUERY,
                 'UTC',
-                true, // Default to case sensitive for validation
+                DEFAULT_FILTER_CASE_SENSITIVE,
             );
         }
     } catch (e) {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -7,6 +7,7 @@ import {
     CompiledTableCalculation,
     CompileError,
     createFilterRuleFromModelRequiredFilterRule,
+    DEFAULT_FILTER_CASE_SENSITIVE,
     DimensionType,
     Explore,
     ExploreCompiler,
@@ -1598,7 +1599,8 @@ export class MetricQueryBuilder {
                 startOfWeek,
                 adapterType,
                 timezone,
-                this.args.explore.caseSensitive ?? true,
+                this.args.explore.caseSensitive ??
+                    DEFAULT_FILTER_CASE_SENSITIVE,
                 baseDimensionSql,
                 this.args.useTimezoneAwareDateTrunc,
                 this.columnTimezone,

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -32,6 +32,8 @@ import {
     WeekDay,
 } from '../utils/timeFrames';
 
+export const DEFAULT_FILTER_CASE_SENSITIVE = true;
+
 /**
  * Formats computed Date boundaries for relative date operators (IN_THE_PAST, etc.)
  * by converting UTC back to the project timezone before formatting as YYYY-MM-DD.
@@ -118,7 +120,7 @@ export const renderStringFilterSql = (
     dimensionSql: string,
     filter: FilterRule<FilterOperator, unknown>,
     stringQuoteChar: string,
-    caseSensitive: boolean = true,
+    caseSensitive: boolean = DEFAULT_FILTER_CASE_SENSITIVE,
 ): string => {
     const nonEmptyFilterValues = filter.values?.filter((v) => v !== '');
 
@@ -764,7 +766,7 @@ export const renderFilterRuleSql = (
     startOfWeek: WeekDay | null | undefined,
     adapterType: SupportedDbtAdapter,
     timezone: string = 'UTC',
-    caseSensitive: boolean = true,
+    caseSensitive: boolean = DEFAULT_FILTER_CASE_SENSITIVE,
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
     baseTimeIntervalDimensionType?: DimensionType,
@@ -865,7 +867,7 @@ export const renderFilterRuleSqlFromField = (
     startOfWeek: WeekDay | null | undefined,
     adapterType: SupportedDbtAdapter,
     timezone: string = 'UTC',
-    exploreCaseSensitive: boolean = true,
+    exploreCaseSensitive: boolean = DEFAULT_FILTER_CASE_SENSITIVE,
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
     sourceTimezone?: string,
@@ -878,12 +880,12 @@ export const renderFilterRuleSqlFromField = (
         : field.compiledSql;
 
     // Determine if this filter should be case sensitive
-    // Priority: filter-rule-level override > field-level setting > explore-level setting > default true
+    // Priority: filter-rule-level override > field-level setting > explore-level setting > default
     let caseSensitive: boolean;
     if (filterRule.caseSensitive !== undefined) {
         caseSensitive = filterRule.caseSensitive;
     } else if (isMetric(field)) {
-        caseSensitive = true;
+        caseSensitive = DEFAULT_FILTER_CASE_SENSITIVE;
     } else if ('caseSensitive' in field && field.caseSensitive !== undefined) {
         caseSensitive = field.caseSensitive;
     } else {

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDiscoverFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDiscoverFieldsArgs.ts
@@ -52,6 +52,11 @@ const discoverFieldsFieldSummarySchema = z.object({
             'The value type (e.g. number, string, date, timestamp, boolean).',
         ),
     fieldFilterType: z.string(),
+    caseSensitiveFilters: z
+        .enum(['true', 'false', 'not_applicable'])
+        .describe(
+            'Use "true" or "false" only when the exact selected findFields result explicitly includes caseSensitiveFilters with that value; otherwise use "not_applicable".',
+        ),
     isFromJoinedTable: z.boolean(),
     description: z
         .string()

--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -137,6 +137,12 @@ lightdash set-warehouse --project-dir ./dbt --profiles-dir ./profiles --project 
 
 **CRITICAL**: Never guess filter values. Case mismatches (e.g., `'Payment'` vs `'payment'`) cause charts to silently return no data.
 
+Filters are case-sensitive by default. The `case_sensitive` key can override this in order of priority:
+
+- Dimension metadata
+- Model/explore metadata
+- `lightdash.config.yml` `defaults.case_sensitive`
+
 **Before writing any string filter**, query actual values from the warehouse:
 
 ```bash


### PR DESCRIPTION
## Summary
- inject string filter case-sensitivity guidance into the AI analyst system prompt from resolved explore metadata
- expose effective per-explore `caseSensitive` defaults from findExplores for agent and MCP paths
- document the hierarchy in the repo developing-in-lightdash skill

## Testing
- pnpm -F common run build
- pnpm -F backend run typecheck
- pnpm -F backend test -- systemV2.test.ts agentToolContracts.snapshot.test.ts

Closes: ZAP-465