### PR TITLE
fix(frontend): correct floating sidebar z-index

### DIFF
--- a/packages/frontend/src/components/common/Page/Sidebar.module.css
+++ b/packages/frontend/src/components/common/Page/Sidebar.module.css
@@ -8,15 +8,15 @@
     height: calc(100% - 1px);
     max-height: 100%;
     flex-shrink: 0;
-    z-index: var(--mantine-z-index-popover);
+    z-index: var(--mantine-z-index-app);
     transition: width var(--sidebar-reveal-duration) var(--sidebar-ease-reveal);
     top: 1px;
     width: var(--sidebar-width);
 }
 
-/* Collapsed: drop out of the page flow so content reclaims the space. */
 .floatContainer:has(.floatingPanel[data-collapsed='true']) {
     width: 0;
+    z-index: calc(var(--mantine-z-index-popover) + 1);
 }
 
 .floatingPanel {
@@ -24,7 +24,7 @@
     top: 0;
     bottom: 0;
     left: 0;
-    z-index: var(--mantine-z-index-popover);
+    z-index: 2;
     display: flex;
     flex-direction: column;
     overflow: hidden;


### PR DESCRIPTION
## Problem

After the Page Mantine 8 migration (#23818), the collapsible **Settings sidebar**'s `z-index` clashed with overlays:

- The floating sidebar sat at `--mantine-z-index-popover` (300), the **same level as dropdowns/Select/Menu** → content menus and the sidebar fought for the top, clipping each other.
- 300 is also **above** `--mantine-z-index-modal` (200), so the sidebar poked **through modal overlays** instead of being covered by them.

## Fix

A single static `z-index` can't satisfy both cases, because the sidebar needs opposite ordering depending on its state — and Mantine's scale puts `modal` (200) *below* `popover` (300). So the `z-index` is scoped by the panel's `data-collapsed` state on `.floatContainer` (the stacking-context root):

| State | `data-collapsed` | z-index | Behaviour |
|---|---|---|---|
| **Pinned / expanded** (in-layout chrome) | `false` | `--mantine-z-index-app` (100) | modals & popovers correctly cover it |
| **Unpinned / floating** (overlay) | `true` | `popover + 1` (301) | overlays content dropdowns/menus |

`.floatingPanel` gets a small local `z-index: 2` — it's capped inside `.floatContainer`'s stacking context, so it only needs to outrank the edge/collapse triggers (`z-index: 1`), not match the root.

This works because the pinned sidebar is in-layout (content sits beside it, not under it), so it doesn't need to beat content popovers — only the floating overlay state does.

## Testing

- Pinned + modal: the modal overlay now dims and covers the sidebar (verified in-app).
- Unpinned + content dropdown: the floating sidebar overlays the dropdown (`.floatContainer` computes to 301 vs the dropdown's 300, with no trapping ancestor stacking context).
- `pnpm -F frontend typecheck`, oxlint, oxfmt all pass.

## Notes

- Builds on the merged migration (#23818); the diff is 3 lines in `Sidebar.module.css`.
- Known edge case: a modal opened while the sidebar is *unpinned and actively hover-revealed* (301) would still sit above the modal — rare, since the collapsed panel is off-screen unless hovered. Making that airtight would require raising `MantineModal` above 301 **and** in-modal popovers above that (Mantine deliberately puts `modal` < `popover`), a broader change left out here.
- No Linear ticket — self-initiated follow-up to the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)