### PR TITLE
fix(frontend): retry transient network failures before surfacing errors

### DIFF
--- a/packages/frontend/src/providers/ReactQuery/createQueryClient.test.ts
+++ b/packages/frontend/src/providers/ReactQuery/createQueryClient.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { getQueryRetryDelay, shouldRetryQuery } from './createQueryClient';
+
+const networkError = { error: { name: 'NetworkError', statusCode: 500 } };
+const serverError = {
+    error: { name: 'UnexpectedServerError', statusCode: 500 },
+};
+const synthesizedQueryError = { error: { name: 'Error', statusCode: 500 } };
+const notFound = { error: { name: 'NotFoundError', statusCode: 404 } };
+
+describe('shouldRetryQuery', () => {
+    it('retries transient NetworkError up to 5 times', () => {
+        expect(shouldRetryQuery(0, networkError)).toBe(true);
+        expect(shouldRetryQuery(4, networkError)).toBe(true);
+        expect(shouldRetryQuery(5, networkError)).toBe(false);
+    });
+
+    it('does not retry real server errors, synthesized query failures or 4xx', () => {
+        expect(shouldRetryQuery(0, serverError)).toBe(false);
+        expect(shouldRetryQuery(0, synthesizedQueryError)).toBe(false);
+        expect(shouldRetryQuery(0, notFound)).toBe(false);
+    });
+
+    it('does not retry malformed errors', () => {
+        expect(shouldRetryQuery(0, undefined)).toBe(false);
+        expect(shouldRetryQuery(0, {})).toBe(false);
+    });
+});
+
+describe('getQueryRetryDelay', () => {
+    it('backs off exponentially capped at 8s', () => {
+        expect(getQueryRetryDelay(0)).toBe(1000);
+        expect(getQueryRetryDelay(1)).toBe(2000);
+        expect(getQueryRetryDelay(2)).toBe(4000);
+        expect(getQueryRetryDelay(3)).toBe(8000);
+        expect(getQueryRetryDelay(4)).toBe(8000);
+    });
+});

--- a/packages/frontend/src/providers/ReactQuery/createQueryClient.ts
+++ b/packages/frontend/src/providers/ReactQuery/createQueryClient.ts
@@ -1,10 +1,27 @@
+import { type ApiError } from '@lightdash/common';
 import { QueryClient, type DefaultOptions } from '@tanstack/react-query';
+
+const MAX_QUERY_RETRIES = 5;
+
+// Retry transient transport failures (dropped/misrouted requests during
+// rollouts, brief gateway timeouts) so a single blip doesn't surface an error.
+// Real API errors and synthesized terminal query failures still surface at once.
+export const shouldRetryQuery = (
+    failureCount: number,
+    error: unknown,
+): boolean =>
+    (error as Partial<ApiError>)?.error?.name === 'NetworkError' &&
+    failureCount < MAX_QUERY_RETRIES;
+
+export const getQueryRetryDelay = (attemptIndex: number): number =>
+    Math.min(1000 * 2 ** attemptIndex, 8000);
 
 export const createQueryClient = (options?: DefaultOptions) => {
     const queryClient = new QueryClient({
         defaultOptions: {
             queries: {
-                retry: false,
+                retry: shouldRetryQuery,
+                retryDelay: getQueryRetryDelay,
                 staleTime: 30000, // 30 seconds
                 refetchOnWindowFocus: false,
                 onError: async (result) => {


### PR DESCRIPTION
Closes: SPK-464

### Description:

Transient HTTP failures (requests dropped or misrouted during rollouts, brief gateway timeouts) were surfacing an "unable to reach the Lightdash server" error toast even though the backend was up and still processing requests. This sets the global React Query default to retry transient `NetworkError` transport failures (up to 5 attempts, exponential backoff capped at 8s) so a single blip recovers silently. Real API errors (4xx/5xx) and synthesized terminal query failures still surface immediately, and the ~40 hooks that opt out with `retry: false` are unchanged. Adds unit tests for the retry predicate and backoff.