### PR TITLE
ci: add timeout to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: build-and-test
     concurrency: ${{ github.ref }}
     permissions:


### PR DESCRIPTION
### Description
Adds a 20-minute timeout to the `release` job in the GitHub Actions release workflow to prevent indefinite hangs.

E.g. https://github.com/lightdash/lightdash/actions/runs/26880221681/job/79278516365

No ticket.