### PR TITLE
fix: enforce statement_timeout on Postgres/Redshift cursor queries

### DIFF
--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -23,7 +23,13 @@ jest.mock('pg', () => ({
             callback(
                 null,
                 {
-                    query: jest.fn(() => {
+                    query: jest.fn((arg: unknown) => {
+                        // Session statements (SET statement_timeout / timezone)
+                        // are issued as plain string queries and must return a
+                        // thenable, not a stream.
+                        if (typeof arg === 'string') {
+                            return Promise.resolve({ rows: [], fields: [] });
+                        }
                         const mockedStream = new PassThrough();
                         setTimeout(() => {
                             mockedStream.emit('data', {
@@ -59,7 +65,13 @@ describe('PostgresWarehouseClient', () => {
                     callback(
                         null,
                         {
-                            query: jest.fn(() => {
+                            query: jest.fn((arg: unknown) => {
+                                if (typeof arg === 'string') {
+                                    return Promise.resolve({
+                                        rows: [],
+                                        fields: [],
+                                    });
+                                }
                                 const mockedStream = new PassThrough();
                                 setTimeout(() => {
                                     mockedStream.emit('data', {
@@ -83,7 +95,13 @@ describe('PostgresWarehouseClient', () => {
                     callback(
                         null,
                         {
-                            query: jest.fn(() => {
+                            query: jest.fn((arg: unknown) => {
+                                if (typeof arg === 'string') {
+                                    return Promise.resolve({
+                                        rows: [],
+                                        fields: [],
+                                    });
+                                }
                                 const mockedStream = new PassThrough();
                                 setTimeout(() => {
                                     columns.forEach((column) => {
@@ -111,6 +129,85 @@ describe('PostgresWarehouseClient', () => {
     it('expect empty catalog when dbt project has no references', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
         expect(await warehouse.getCatalog([])).toEqual({});
+    });
+});
+
+describe('PostgresWarehouseClient statement timeout', () => {
+    const mockPoolWithQuery = (queryMock: jest.Mock) => {
+        (pg.Pool as unknown as jest.Mock).mockImplementationOnce(() => ({
+            connect: jest.fn((callback) => {
+                callback(null, { query: queryMock, on: jest.fn() }, jest.fn());
+            }),
+            end: jest.fn(async () => undefined),
+            on: jest.fn(),
+        }));
+    };
+
+    const respondingQueryMock = () =>
+        jest.fn((arg: unknown) => {
+            if (typeof arg === 'string') {
+                return Promise.resolve({ rows: [], fields: [] });
+            }
+            const stream = new PassThrough();
+            setTimeout(() => {
+                stream.emit('data', {
+                    row: expectedRow,
+                    fields: queryColumnsMock,
+                });
+                stream.end();
+            }, 10);
+            return stream;
+        });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('sets a server-side statement_timeout using the 9-minute default ceiling', async () => {
+        const queryMock = respondingQueryMock();
+        mockPoolWithQuery(queryMock);
+        const warehouse = new PostgresWarehouseClient(credentials);
+        await warehouse.runQuery('select 1');
+        const sessionStatement = queryMock.mock.calls
+            .map((call) => call[0])
+            .find((arg) => typeof arg === 'string');
+        expect(sessionStatement).toContain('SET statement_timeout = 540000');
+    });
+
+    it('honors a configured timeoutSeconds for the statement_timeout', async () => {
+        const queryMock = respondingQueryMock();
+        mockPoolWithQuery(queryMock);
+        const warehouse = new PostgresWarehouseClient({
+            ...credentials,
+            timeoutSeconds: 120,
+        });
+        await warehouse.runQuery('select 1');
+        const sessionStatement = queryMock.mock.calls
+            .map((call) => call[0])
+            .find((arg) => typeof arg === 'string');
+        expect(sessionStatement).toContain('SET statement_timeout = 120000');
+    });
+
+    it('rejects with a timeout error when a query stalls past the client backstop', async () => {
+        jest.useFakeTimers();
+        const queryMock = jest.fn((arg: unknown) => {
+            if (typeof arg === 'string') {
+                return Promise.resolve({ rows: [], fields: [] });
+            }
+            // A stream that never emits or ends — simulates a stalled cursor.
+            return new PassThrough();
+        });
+        mockPoolWithQuery(queryMock);
+        const warehouse = new PostgresWarehouseClient(credentials);
+        const resultPromise = warehouse.runQuery('select pg_sleep(9999)');
+        // Attach the rejection handler before advancing the clock so the
+        // rejection is never momentarily unhandled.
+        const assertion = expect(resultPromise).rejects.toThrow(
+            'Query timed out after 570s',
+        );
+        // 9-minute statement_timeout + 30s client buffer = 570s
+        await jest.advanceTimersByTimeAsync(570 * 1000 + 1000);
+        await assertion;
     });
 });
 

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -115,6 +115,20 @@ const mapFieldType = (type: string): DimensionType => {
 const { builtins } = pg.types;
 const POSTGRES_NAME_TOO_LONG_SQLSTATE = '42622';
 
+// Server-side ceiling for a single streamed query, bounded just under the
+// 10-min scheduler job timeout so a stalled cursor fails clearly instead of
+// hanging the whole job. The pool's `query_timeout` does not fire on the
+// cursor (pg-cursor) path, so the ceiling is enforced via `statement_timeout`
+// plus a client-side wall-clock backstop. Overridable per-connection via
+// `timeoutSeconds`.
+const DEFAULT_STATEMENT_TIMEOUT_MS = 1000 * 60 * 9; // 9 minutes
+
+// The client-side backstop fires this long after the server-side
+// statement_timeout, so the server's cancellation error wins the race and
+// surfaces a clear message; the client backstop only triggers if the server
+// never reports back (e.g. a dead SSH tunnel socket).
+const CLIENT_STATEMENT_TIMEOUT_BUFFER_MS = 1000 * 30; // 30 seconds
+
 const convertDataTypeIdToDimensionType = (
     dataTypeId: number,
 ): DimensionType => {
@@ -245,8 +259,30 @@ export class PostgresClient<
         let pool: pg.Pool | undefined;
         let closeClient: (() => void) | undefined;
         let activeStream: QueryStream | undefined;
+        let queryTimeout: ReturnType<typeof setTimeout> | undefined;
+
+        // The pool's `query_timeout` does not fire on the cursor (pg-cursor)
+        // path, so we enforce the ceiling ourselves: a server-side
+        // `statement_timeout` (set below) plus this client-side wall-clock
+        // backstop that fires shortly after, in case the server never reports
+        // back (e.g. a stalled SSH tunnel socket).
+        const statementTimeoutMs = this.credentials.timeoutSeconds
+            ? this.credentials.timeoutSeconds * 1000
+            : DEFAULT_STATEMENT_TIMEOUT_MS;
+        const clientTimeoutMs =
+            statementTimeoutMs + CLIENT_STATEMENT_TIMEOUT_BUFFER_MS;
 
         return new Promise<void>((resolve, reject) => {
+            queryTimeout = setTimeout(() => {
+                const timeoutError = new WarehouseQueryError(
+                    `Query timed out after ${Math.round(
+                        clientTimeoutMs / 1000,
+                    )}s`,
+                );
+                activeStream?.destroy(timeoutError);
+                reject(timeoutError);
+            }, clientTimeoutMs);
+
             pool = new pg.Pool({
                 ...this.config,
                 connectionTimeoutMillis: 30000,
@@ -372,19 +408,29 @@ export class PostgresClient<
                     });
                 };
 
-                if (options?.timezone) {
-                    console.debug(
-                        `Setting postgres session timezone ${options?.timezone}`,
-                    );
-                    client
-                        .query(`SET timezone TO '${options?.timezone}';`)
-                        .then(() => {
-                            runQuery();
-                        })
-                        .catch((sessionError) => {
-                            reject(sessionError);
-                        });
-                } else runQuery();
+                // Always enforce a server-side statement timeout — the pool's
+                // query_timeout is ineffective on the cursor path. Issued as
+                // its own single statement (followed by the optional timezone)
+                // to stay portable across Postgres and Redshift.
+                client
+                    .query(`SET statement_timeout = ${statementTimeoutMs}`)
+                    .then(() => {
+                        if (options?.timezone) {
+                            console.debug(
+                                `Setting postgres session timezone ${options?.timezone}`,
+                            );
+                            return client.query(
+                                `SET timezone TO '${options?.timezone}'`,
+                            );
+                        }
+                        return undefined;
+                    })
+                    .then(() => {
+                        runQuery();
+                    })
+                    .catch((sessionError) => {
+                        reject(sessionError);
+                    });
             });
         })
             .catch((e) => {
@@ -395,6 +441,9 @@ export class PostgresClient<
                 throw this.parseError(error, sql);
             })
             .finally(async () => {
+                if (queryTimeout) {
+                    clearTimeout(queryTimeout);
+                }
                 // Release the client first, then end the pool
                 if (closeClient) {
                     try {


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/PROD-8075/scheduled-sql-chart-google-sheets-sync-hangs-in-column-discovery-until

### Description:
The pg pool query_timeout does not fire on the cursor (pg-cursor) path, so a stalled or pathologically-planned query could hang until the 10-minute job timeout and surface as "Connection terminated unexpectedly". Add a server-side statement_timeout (honoring timeoutSeconds, default 9 min) plus a client-side wall-clock backstop, matching Snowflake STATEMENT_TIMEOUT_IN_SECONDS.
