### PR TITLE
fix(metrics-explorer): render segmented chart by requesting SQL pivot

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
@@ -2,9 +2,11 @@ import {
     buildPopAdditionalMetric,
     CartesianSeriesType,
     ChartType,
+    derivePivotConfigurationFromChart,
     FilterOperator,
     getDefaultDateRangeFromInterval,
     getFieldIdForDateDimension,
+    getFieldsFromMetricQuery,
     getItemId,
     getPopPeriodLabel,
     isCompleteLayout,
@@ -20,6 +22,7 @@ import {
     type MetricExplorerDateRange,
     type MetricQuery,
     type MetricWithAssociatedTimeDimension,
+    type PivotConfiguration,
     type Series,
     type TimeDimensionConfig,
 } from '@lightdash/common';
@@ -343,6 +346,51 @@ export function useMetricVisualization({
         compareMetric,
     ]);
 
+    /**
+     * When segmenting, request a SQL pivot so the backend emits pivotDetails.
+     * The series logic (getExpectedSeriesMap) requires pivotDetails to expand
+     * pivoted series — without it a segmented chart renders no series.
+     *
+     * Derived from the pre-execution metricQuery (not executedMetricQuery): it
+     * feeds queryArgs, so a per-response reference would loop the query.
+     */
+    const pivotConfiguration = useMemo<PivotConfiguration | undefined>(() => {
+        if (
+            !segmentDimensionId ||
+            !metricQuery ||
+            !exploreQuery.data ||
+            !metricFieldQuery.data
+        ) {
+            return undefined;
+        }
+
+        // Reuse buildLineChartConfig so the pivot's layout (xField/yField) stays
+        // the single source of truth and can't drift from the rendered chart.
+        const chartConfigForPivot = buildLineChartConfig(
+            metricQuery,
+            metricFieldQuery.data.label,
+            comparison,
+            compareMetric?.label ?? undefined,
+        );
+        const fields = getFieldsFromMetricQuery(metricQuery, exploreQuery.data);
+
+        return derivePivotConfigurationFromChart(
+            {
+                chartConfig: chartConfigForPivot,
+                pivotConfig: { columns: [segmentDimensionId] },
+            },
+            metricQuery,
+            fields,
+        );
+    }, [
+        segmentDimensionId,
+        metricQuery,
+        exploreQuery.data,
+        metricFieldQuery.data,
+        comparison,
+        compareMetric,
+    ]);
+
     const queryArgs = useMemo<QueryResultsProps | null>(() => {
         if (!projectUuid || !tableName || !metricQuery) return null;
         return {
@@ -350,8 +398,9 @@ export function useMetricVisualization({
             tableId: tableName,
             query: metricQuery,
             context: QueryExecutionContext.METRICS_EXPLORER,
+            pivotConfiguration,
         };
-    }, [projectUuid, tableName, metricQuery]);
+    }, [projectUuid, tableName, metricQuery, pivotConfiguration]);
 
     const [{ query: createQuery, queryResults }] = useQueryExecutor(
         queryArgs,


### PR DESCRIPTION
Metrics Explorer rendered a blank chart (no series) when segmenting by a dimension. The fix derives a `PivotConfiguration` when a segment dimension is set and passes it through the query so the backend returns a SQL pivot, restoring the segmented series.

**Before**

https://github.com/user-attachments/assets/c0f45eec-80f6-4425-b41e-09c45d310e60

**After**

https://github.com/user-attachments/assets/2f0b7fbb-8952-45b5-9bc4-3a6297c5f836

Closes: [PROD-8092](https://linear.app/lightdash/issue/PROD-8092/metrics-explorer-segmenting-renders-a-blank-chart-no-series-since)<br>[PROD-8092](https://linear.app/lightdash/issue/PROD-8092/metrics-explorer-segmenting-renders-a-blank-chart-no-series-since)