### PR TITLE
feat(metrics-catalog): support default_segment and default_filter in metric spotlight config

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -145,6 +145,15 @@ models:
                 type: count_distinct
                 spotlight:
                   categories: ["revenue_growth"]
+                  # Curate the default Metrics Explorer view: open already
+                  # segmented by status and filtered to completed orders.
+                  segment_by:
+                    - status
+                  filter_by:
+                    - status
+                  default_segment: status
+                  default_filter:
+                    status: completed
               completed_order_count:
                 label: Completed order count
                 description: Total number of completed orders

--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -145,13 +145,24 @@ models:
                 type: count_distinct
                 spotlight:
                   categories: ["revenue_growth"]
-                  # Curate the default Metrics Explorer view: open already
-                  # segmented by status and filtered to completed orders.
+                  # Curate the default Metrics Explorer view: open segmented by
+                  # order source and pre-filtered to completed orders. Engineers
+                  # can switch to any of the other allowlisted dimensions.
                   segment_by:
+                    - order_source
                     - status
+                    - shipping_method
+                    - order_priority
+                    - fulfillment_center
+                    - is_completed
                   filter_by:
                     - status
-                  default_segment: status
+                    - order_source
+                    - shipping_method
+                    - order_priority
+                    - fulfillment_center
+                    - is_completed
+                  default_segment: order_source
                   default_filter:
                     status: completed
               completed_order_count:

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3352,6 +3352,8 @@ const models: TsoaRoute.Models = {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
                     owner: { dataType: 'string' },
+                    defaultFilter: { ref: 'MetricFilterRule' },
+                    defaultSegment: { dataType: 'string' },
                     segmentBy: {
                         dataType: 'array',
                         array: { dataType: 'string' },
@@ -33038,6 +33040,8 @@ const models: TsoaRoute.Models = {
                             ],
                             required: true,
                         },
+                        spotlightDefaultFilter: { ref: 'MetricFilterRule' },
+                        spotlightDefaultSegment: { dataType: 'string' },
                         spotlightSegmentBy: {
                             dataType: 'array',
                             array: { dataType: 'string' },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12335,11 +12335,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12397,11 +12397,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12438,11 +12438,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12947,11 +12947,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13075,40 +13075,6 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
-                                                                explore: {
-                                                                    dataType:
-                                                                        'nestedObjectLiteral',
-                                                                    nestedProperties:
-                                                                        {
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            joinedTables:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                    },
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                        },
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13117,6 +13083,26 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
                                                                                 isFromJoinedTable:
                                                                                     {
                                                                                         dataType:
@@ -13153,49 +13139,18 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
                                                                                 fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldId:
+                                                                                fieldValueType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -13206,17 +13161,28 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'metric',
+                                                                                                        'dimension',
                                                                                                     ],
                                                                                                 },
                                                                                                 {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'dimension',
+                                                                                                        'metric',
                                                                                                     ],
                                                                                                 },
                                                                                             ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
                                                                                         required: true,
                                                                                     },
                                                                                 label: {
@@ -13231,6 +13197,40 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                explore: {
+                                                                    dataType:
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                        },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -13562,11 +13562,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13627,11 +13627,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13808,11 +13808,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13827,11 +13827,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13846,11 +13846,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -27435,7 +27435,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27445,7 +27445,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27455,7 +27455,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -27468,7 +27468,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3702,6 +3702,12 @@
                             "owner": {
                                 "type": "string"
                             },
+                            "defaultFilter": {
+                                "$ref": "#/components/schemas/MetricFilterRule"
+                            },
+                            "defaultSegment": {
+                                "type": "string"
+                            },
                             "segmentBy": {
                                 "items": {
                                     "type": "string"
@@ -33661,6 +33667,12 @@
                                     }
                                 ],
                                 "nullable": true
+                            },
+                            "spotlightDefaultFilter": {
+                                "$ref": "#/components/schemas/MetricFilterRule"
+                            },
+                            "spotlightDefaultSegment": {
+                                "type": "string"
                             },
                             "spotlightSegmentBy": {
                                 "items": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13900,8 +13900,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13959,8 +13959,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13984,19 +13984,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -14216,6 +14203,19 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "contentSizeBytes": {
                                                         "type": "number",
                                                         "format": "double"
@@ -14273,35 +14273,13 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
-                                                                    "explore": {
-                                                                        "properties": {
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "joinedTables": {
-                                                                                "items": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "type": "array"
-                                                                            },
-                                                                            "label": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "name": {
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "baseTable",
-                                                                            "joinedTables",
-                                                                            "label",
-                                                                            "name"
-                                                                        ],
-                                                                        "type": "object"
-                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
                                                                                 "isFromJoinedTable": {
                                                                                     "type": "boolean"
                                                                                 },
@@ -14313,28 +14291,24 @@
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
+                                                                                "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldType": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
+                                                                                        "dimension",
+                                                                                        "metric"
                                                                                     ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "label": {
                                                                                     "type": "string"
@@ -14344,20 +14318,46 @@
                                                                                 }
                                                                             },
                                                                             "required": [
+                                                                                "description",
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
-                                                                                "fieldValueType",
-                                                                                "description",
                                                                                 "fieldFilterType",
-                                                                                "fieldId",
-                                                                                "table",
+                                                                                "fieldValueType",
                                                                                 "fieldType",
+                                                                                "table",
+                                                                                "fieldId",
                                                                                 "label",
                                                                                 "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
+                                                                    },
+                                                                    "explore": {
+                                                                        "properties": {
+                                                                            "joinedTables": {
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "label": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "joinedTables",
+                                                                            "baseTable",
+                                                                            "label",
+                                                                            "name"
+                                                                        ],
+                                                                        "type": "object"
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -14369,8 +14369,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "explore",
                                                                     "fields",
+                                                                    "explore",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -28291,22 +28291,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -37779,7 +37779,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3090.0",
+        "version": "0.3091.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -65,6 +65,12 @@ const parseFieldFromMetricOrDimension = (
     ...(isMetric(field) && field.spotlight?.segmentBy
         ? { spotlightSegmentBy: field.spotlight.segmentBy }
         : {}),
+    ...(isMetric(field) && field.spotlight?.defaultSegment
+        ? { spotlightDefaultSegment: field.spotlight.defaultSegment }
+        : {}),
+    ...(isMetric(field) && field.spotlight?.defaultFilter
+        ? { spotlightDefaultFilter: field.spotlight.defaultFilter }
+        : {}),
 });
 
 export const parseFieldsFromCompiledTable = (

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -485,6 +485,103 @@ describe('Compile metrics with filters', () => {
     });
 });
 
+describe('compileMetric spotlight defaults validation', () => {
+    const baseMetric = tablesWithMetricsWithFilters.table1.metrics.metric1;
+
+    test('accepts a valid default_segment and default_filter', () => {
+        const metric = {
+            ...baseMetric,
+            spotlight: {
+                visibility: 'show' as const,
+                segmentBy: ['shared'],
+                defaultSegment: 'shared',
+                defaultFilter: {
+                    id: 'x',
+                    target: { fieldRef: 'shared' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['foo'],
+                },
+            },
+        };
+        expect(() =>
+            compiler.compileMetric(metric, tablesWithMetricsWithFilters, []),
+        ).not.toThrow();
+    });
+
+    test('does not throw for a metric with no spotlight defaults (no regression)', () => {
+        expect(() =>
+            compiler.compileMetric(
+                baseMetric,
+                tablesWithMetricsWithFilters,
+                [],
+            ),
+        ).not.toThrow();
+    });
+
+    test('throws when default_segment is not in the segment_by allowlist', () => {
+        const metric = {
+            ...baseMetric,
+            spotlight: {
+                visibility: 'show' as const,
+                segmentBy: ['shared'],
+                defaultSegment: 'dim1',
+            },
+        };
+        expect(() =>
+            compiler.compileMetric(metric, tablesWithMetricsWithFilters, []),
+        ).toThrowError(/default_segment 'dim1' must be one of segment_by/);
+    });
+
+    test('throws when default_segment dimension is not segmentable', () => {
+        const metric = {
+            ...baseMetric,
+            spotlight: {
+                visibility: 'show' as const,
+                defaultSegment: 'dim1',
+            },
+        };
+        expect(() =>
+            compiler.compileMetric(metric, tablesWithMetricsWithFilters, []),
+        ).toThrowError(/default_segment 'dim1' .* segmentable/);
+    });
+
+    test('throws when default_filter references an unknown dimension', () => {
+        const metric = {
+            ...baseMetric,
+            spotlight: {
+                visibility: 'show' as const,
+                defaultFilter: {
+                    id: 'x',
+                    target: { fieldRef: 'does_not_exist' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['foo'],
+                },
+            },
+        };
+        expect(() =>
+            compiler.compileMetric(metric, tablesWithMetricsWithFilters, []),
+        ).toThrowError(/default_filter references an unknown dimension/);
+    });
+
+    test('throws when default_filter uses an unsupported operator', () => {
+        const metric = {
+            ...baseMetric,
+            spotlight: {
+                visibility: 'show' as const,
+                defaultFilter: {
+                    id: 'x',
+                    target: { fieldRef: 'shared' },
+                    operator: FilterOperator.GREATER_THAN,
+                    values: [4],
+                },
+            },
+        };
+        expect(() =>
+            compiler.compileMetric(metric, tablesWithMetricsWithFilters, []),
+        ).toThrowError(/default_filter uses operator .* not supported/);
+    });
+});
+
 describe('Parse dimension reference', () => {
     test('should parse dimensions', () => {
         expect(parseAllReferences('${dimension} == 1', 'table')).toStrictEqual([

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -508,6 +508,24 @@ describe('compileMetric spotlight defaults validation', () => {
         ).not.toThrow();
     });
 
+    test('accepts a joined (cross-table) default_filter reference', () => {
+        const metric = {
+            ...baseMetric,
+            spotlight: {
+                visibility: 'show' as const,
+                defaultFilter: {
+                    id: 'x',
+                    target: { fieldRef: 'table2.dim2' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['v'],
+                },
+            },
+        };
+        expect(() =>
+            compiler.compileMetric(metric, tablesWithMetricsWithFilters, []),
+        ).not.toThrow();
+    });
+
     test('does not throw for a metric with no spotlight defaults (no regression)', () => {
         expect(() =>
             compiler.compileMetric(

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -58,78 +58,6 @@ import {
 export const lightdashVariablePattern =
     /\$\{((?!(lightdash|ld)\.)[a-zA-Z0-9_.]+)\}/g;
 
-// The Metrics Explorer filter UI can only render "is" / "is not"
-const EXPLORER_SUPPORTED_DEFAULT_FILTER_OPERATORS = new Set<FilterOperator>([
-    FilterOperator.EQUALS,
-    FilterOperator.NOT_EQUALS,
-]);
-
-/**
- * Validate metric spotlight `default_segment` / `default_filter` at compile time.
- * Stricter than the segment_by/filter_by allowlists: a wrong default silently
- * produces a wrong landing view in the Metrics Explorer, so we hard-fail.
- * Only runs when the optional fields are present — existing configs are untouched.
- */
-const validateSpotlightDefaults = (
-    metric: Metric,
-    tables: Record<string, Table>,
-): void => {
-    const { spotlight } = metric;
-    if (!spotlight) return;
-
-    const tableDimensions = tables[metric.table]?.dimensions ?? {};
-
-    if (spotlight.defaultSegment !== undefined) {
-        const name = spotlight.defaultSegment;
-        if (spotlight.segmentBy && !spotlight.segmentBy.includes(name)) {
-            throw new CompileError(
-                `Metric "${metric.name}": default_segment '${name}' must be one of segment_by: [${spotlight.segmentBy.join(
-                    ', ',
-                )}]`,
-            );
-        }
-        const dimension = tableDimensions[name];
-        const isSegmentable =
-            dimension !== undefined &&
-            !dimension.timeIntervalBaseDimensionName &&
-            (dimension.type === DimensionType.STRING ||
-                dimension.type === DimensionType.BOOLEAN);
-        if (!isSegmentable) {
-            throw new CompileError(
-                `Metric "${metric.name}": default_segment '${name}' must reference an existing dimension that is segmentable (string or boolean)`,
-            );
-        }
-    }
-
-    if (spotlight.defaultFilter !== undefined) {
-        const { fieldRef } = spotlight.defaultFilter.target;
-        const name = fieldRef.includes('.')
-            ? fieldRef.split('.').slice(-1)[0]
-            : fieldRef;
-        if (spotlight.filterBy && !spotlight.filterBy.includes(name)) {
-            throw new CompileError(
-                `Metric "${metric.name}": default_filter dimension '${name}' must be one of filter_by: [${spotlight.filterBy.join(
-                    ', ',
-                )}]`,
-            );
-        }
-        if (tableDimensions[name] === undefined) {
-            throw new CompileError(
-                `Metric "${metric.name}": default_filter references an unknown dimension '${name}'`,
-            );
-        }
-        if (
-            !EXPLORER_SUPPORTED_DEFAULT_FILTER_OPERATORS.has(
-                spotlight.defaultFilter.operator,
-            )
-        ) {
-            throw new CompileError(
-                `Metric "${metric.name}": default_filter uses operator '${spotlight.defaultFilter.operator}' which is not supported in the Metrics Explorer (use 'is' or 'is not')`,
-            );
-        }
-    }
-};
-
 type Reference = {
     refTable: string;
     refName: string;
@@ -255,6 +183,90 @@ export const getParsedReference = (
     const refName = split.length === 1 ? split[0] : split[1];
 
     return { refTable, refName };
+};
+
+// The Metrics Explorer filter UI can only render "is" / "is not"
+const EXPLORER_SUPPORTED_DEFAULT_FILTER_OPERATORS = new Set<FilterOperator>([
+    FilterOperator.EQUALS,
+    FilterOperator.NOT_EQUALS,
+]);
+
+/**
+ * Validate metric spotlight `default_segment` / `default_filter` at compile time.
+ * Stricter than the segment_by/filter_by allowlists: a wrong default silently
+ * produces a wrong landing view in the Metrics Explorer, so we hard-fail.
+ * Only runs when the optional fields are present — existing configs are untouched.
+ */
+const validateSpotlightDefaults = (
+    metric: Metric,
+    tables: Record<string, Table>,
+): void => {
+    const { spotlight } = metric;
+    if (!spotlight) return;
+
+    // Resolve a default's reference exactly like metric.filters does, so
+    // bare ("status") and joined ("customers.first_name") refs both work.
+    const resolveDimension = (ref: string): Dimension | undefined => {
+        const { refTable, refName } = getParsedReference(ref, metric.table);
+        return getReferencedDimensionCaseInsensitive(refTable, refName, tables);
+    };
+
+    // Allowlists store bare dimension names (matched against dimension.name in
+    // the explorer), but accept the fully-qualified ref too.
+    const isInAllowlist = (allowlist: string[], ref: string): boolean => {
+        const { refName } = getParsedReference(ref, metric.table);
+        return allowlist.includes(ref) || allowlist.includes(refName);
+    };
+
+    if (spotlight.defaultSegment !== undefined) {
+        const ref = spotlight.defaultSegment;
+        if (spotlight.segmentBy && !isInAllowlist(spotlight.segmentBy, ref)) {
+            throw new CompileError(
+                `Metric "${metric.name}": default_segment '${ref}' must be one of segment_by: [${spotlight.segmentBy.join(
+                    ', ',
+                )}]`,
+            );
+        }
+        const dimension = resolveDimension(ref);
+        const isSegmentable =
+            dimension !== undefined &&
+            !dimension.timeIntervalBaseDimensionName &&
+            (dimension.type === DimensionType.STRING ||
+                dimension.type === DimensionType.BOOLEAN);
+        if (!isSegmentable) {
+            throw new CompileError(
+                `Metric "${metric.name}": default_segment '${ref}' must reference an existing dimension that is segmentable (string or boolean)`,
+            );
+        }
+    }
+
+    if (spotlight.defaultFilter !== undefined) {
+        const { fieldRef } = spotlight.defaultFilter.target;
+        if (
+            spotlight.filterBy &&
+            !isInAllowlist(spotlight.filterBy, fieldRef)
+        ) {
+            throw new CompileError(
+                `Metric "${metric.name}": default_filter dimension '${fieldRef}' must be one of filter_by: [${spotlight.filterBy.join(
+                    ', ',
+                )}]`,
+            );
+        }
+        if (resolveDimension(fieldRef) === undefined) {
+            throw new CompileError(
+                `Metric "${metric.name}": default_filter references an unknown dimension '${fieldRef}'`,
+            );
+        }
+        if (
+            !EXPLORER_SUPPORTED_DEFAULT_FILTER_OPERATORS.has(
+                spotlight.defaultFilter.operator,
+            )
+        ) {
+            throw new CompileError(
+                `Metric "${metric.name}": default_filter uses operator '${spotlight.defaultFilter.operator}' which is not supported in the Metrics Explorer (use 'is' or 'is not')`,
+            );
+        }
+    }
 };
 
 const getDimensionFromRequiredFilter = ({

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -10,7 +10,6 @@ import {
     type Table,
 } from '../types/explore';
 import {
-    DimensionType,
     friendlyName,
     isCustomBinDimension,
     isNonAggregateMetric,
@@ -26,8 +25,12 @@ import {
     type FieldCompilationError,
     type Metric,
 } from '../types/field';
-import { FilterOperator, type ModelRequiredFilterRule } from '../types/filter';
+import { type ModelRequiredFilterRule } from '../types/filter';
 import { type LightdashProjectConfig } from '../types/lightdashProjectConfig';
+import {
+    isMetricsExplorerCompatibleDimension,
+    METRICS_EXPLORER_FILTER_OPERATORS,
+} from '../types/metricsExplorer';
 import { type PreAggregateDef } from '../types/preAggregate';
 import {
     dateGranularityToTimeFrameMap,
@@ -185,12 +188,6 @@ export const getParsedReference = (
     return { refTable, refName };
 };
 
-// The Metrics Explorer filter UI can only render "is" / "is not"
-const EXPLORER_SUPPORTED_DEFAULT_FILTER_OPERATORS = new Set<FilterOperator>([
-    FilterOperator.EQUALS,
-    FilterOperator.NOT_EQUALS,
-]);
-
 /**
  * Validate metric spotlight `default_segment` / `default_filter` at compile time.
  * Stricter than the segment_by/filter_by allowlists: a wrong default silently
@@ -230,9 +227,7 @@ const validateSpotlightDefaults = (
         const dimension = resolveDimension(ref);
         const isSegmentable =
             dimension !== undefined &&
-            !dimension.timeIntervalBaseDimensionName &&
-            (dimension.type === DimensionType.STRING ||
-                dimension.type === DimensionType.BOOLEAN);
+            isMetricsExplorerCompatibleDimension(dimension);
         if (!isSegmentable) {
             throw new CompileError(
                 `Metric "${metric.name}": default_segment '${ref}' must reference an existing dimension that is segmentable (string or boolean)`,
@@ -258,7 +253,7 @@ const validateSpotlightDefaults = (
             );
         }
         if (
-            !EXPLORER_SUPPORTED_DEFAULT_FILTER_OPERATORS.has(
+            !METRICS_EXPLORER_FILTER_OPERATORS.includes(
                 spotlight.defaultFilter.operator,
             )
         ) {

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -10,6 +10,7 @@ import {
     type Table,
 } from '../types/explore';
 import {
+    DimensionType,
     friendlyName,
     isCustomBinDimension,
     isNonAggregateMetric,
@@ -25,7 +26,7 @@ import {
     type FieldCompilationError,
     type Metric,
 } from '../types/field';
-import { type ModelRequiredFilterRule } from '../types/filter';
+import { FilterOperator, type ModelRequiredFilterRule } from '../types/filter';
 import { type LightdashProjectConfig } from '../types/lightdashProjectConfig';
 import { type PreAggregateDef } from '../types/preAggregate';
 import {
@@ -56,6 +57,78 @@ import {
 // exclude lightdash prefix from variable pattern
 export const lightdashVariablePattern =
     /\$\{((?!(lightdash|ld)\.)[a-zA-Z0-9_.]+)\}/g;
+
+// The Metrics Explorer filter UI can only render "is" / "is not"
+const EXPLORER_SUPPORTED_DEFAULT_FILTER_OPERATORS = new Set<FilterOperator>([
+    FilterOperator.EQUALS,
+    FilterOperator.NOT_EQUALS,
+]);
+
+/**
+ * Validate metric spotlight `default_segment` / `default_filter` at compile time.
+ * Stricter than the segment_by/filter_by allowlists: a wrong default silently
+ * produces a wrong landing view in the Metrics Explorer, so we hard-fail.
+ * Only runs when the optional fields are present — existing configs are untouched.
+ */
+const validateSpotlightDefaults = (
+    metric: Metric,
+    tables: Record<string, Table>,
+): void => {
+    const { spotlight } = metric;
+    if (!spotlight) return;
+
+    const tableDimensions = tables[metric.table]?.dimensions ?? {};
+
+    if (spotlight.defaultSegment !== undefined) {
+        const name = spotlight.defaultSegment;
+        if (spotlight.segmentBy && !spotlight.segmentBy.includes(name)) {
+            throw new CompileError(
+                `Metric "${metric.name}": default_segment '${name}' must be one of segment_by: [${spotlight.segmentBy.join(
+                    ', ',
+                )}]`,
+            );
+        }
+        const dimension = tableDimensions[name];
+        const isSegmentable =
+            dimension !== undefined &&
+            !dimension.timeIntervalBaseDimensionName &&
+            (dimension.type === DimensionType.STRING ||
+                dimension.type === DimensionType.BOOLEAN);
+        if (!isSegmentable) {
+            throw new CompileError(
+                `Metric "${metric.name}": default_segment '${name}' must reference an existing dimension that is segmentable (string or boolean)`,
+            );
+        }
+    }
+
+    if (spotlight.defaultFilter !== undefined) {
+        const { fieldRef } = spotlight.defaultFilter.target;
+        const name = fieldRef.includes('.')
+            ? fieldRef.split('.').slice(-1)[0]
+            : fieldRef;
+        if (spotlight.filterBy && !spotlight.filterBy.includes(name)) {
+            throw new CompileError(
+                `Metric "${metric.name}": default_filter dimension '${name}' must be one of filter_by: [${spotlight.filterBy.join(
+                    ', ',
+                )}]`,
+            );
+        }
+        if (tableDimensions[name] === undefined) {
+            throw new CompileError(
+                `Metric "${metric.name}": default_filter references an unknown dimension '${name}'`,
+            );
+        }
+        if (
+            !EXPLORER_SUPPORTED_DEFAULT_FILTER_OPERATORS.has(
+                spotlight.defaultFilter.operator,
+            )
+        ) {
+            throw new CompileError(
+                `Metric "${metric.name}": default_filter uses operator '${spotlight.defaultFilter.operator}' which is not supported in the Metrics Explorer (use 'is' or 'is not')`,
+            );
+        }
+    }
+};
 
 type Reference = {
     refTable: string;
@@ -912,6 +985,8 @@ export class ExploreCompiler {
             parameterReferences,
             availableParameters,
         );
+
+        validateSpotlightDefaults(metric, tables);
 
         return {
             ...metric,

--- a/packages/common/src/compiler/lightdashProjectConfig.test.ts
+++ b/packages/common/src/compiler/lightdashProjectConfig.test.ts
@@ -1,0 +1,43 @@
+import { FilterOperator, type MetricFilterRule } from '../types/filter';
+import { getSpotlightConfigurationForResource } from './lightdashProjectConfig';
+
+describe('getSpotlightConfigurationForResource defaults', () => {
+    it('threads defaultSegment and a parsed defaultFilter into spotlight', () => {
+        const defaultFilter: MetricFilterRule = {
+            id: 'test-id',
+            target: { fieldRef: 'status' },
+            operator: FilterOperator.EQUALS,
+            values: ['active'],
+        };
+        const result = getSpotlightConfigurationForResource({
+            visibility: 'show',
+            segmentBy: ['region'],
+            defaultSegment: 'region',
+            defaultFilter,
+        });
+        expect(result).toEqual({
+            spotlight: {
+                visibility: 'show',
+                categories: undefined,
+                segmentBy: ['region'],
+                defaultSegment: 'region',
+                defaultFilter,
+            },
+        });
+    });
+
+    it('omits defaults when not provided (no regression for existing configs)', () => {
+        const result = getSpotlightConfigurationForResource({
+            visibility: 'show',
+        });
+        expect(result).toEqual({
+            spotlight: { visibility: 'show', categories: undefined },
+        });
+    });
+
+    it('returns an empty object when visibility is undefined', () => {
+        expect(
+            getSpotlightConfigurationForResource({ defaultSegment: 'region' }),
+        ).toEqual({});
+    });
+});

--- a/packages/common/src/compiler/lightdashProjectConfig.ts
+++ b/packages/common/src/compiler/lightdashProjectConfig.ts
@@ -1,6 +1,7 @@
 import { ParseError } from '../types/errors';
 import type { Explore } from '../types/explore';
 import type { Metric } from '../types/field';
+import type { MetricFilterRule } from '../types/filter';
 import type { LightdashProjectConfig } from '../types/lightdashProjectConfig';
 
 type SpotlightConfigArgs = {
@@ -8,6 +9,8 @@ type SpotlightConfigArgs = {
     categories?: string[];
     filterBy?: string[];
     segmentBy?: string[];
+    defaultSegment?: string;
+    defaultFilter?: MetricFilterRule;
     owner?: string;
 };
 
@@ -30,6 +33,8 @@ export const getSpotlightConfigurationForResource = ({
     categories,
     filterBy,
     segmentBy,
+    defaultSegment,
+    defaultFilter,
     owner,
 }: SpotlightConfigArgs):
     | Pick<Explore, 'spotlight'>
@@ -46,6 +51,8 @@ export const getSpotlightConfigurationForResource = ({
             categories,
             ...(filterBy ? { filterBy } : {}),
             ...(segmentBy ? { segmentBy } : {}),
+            ...(defaultSegment ? { defaultSegment } : {}),
+            ...(defaultFilter ? { defaultFilter } : {}),
             ...(validatedOwner ? { owner: validatedOwner } : {}),
         },
     };

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -325,6 +325,16 @@
                                         },
                                         "description": "An array of dimension names that are allowed for segmenting this metric in the Metrics Explorer"
                                     },
+                                    "default_segment": {
+                                        "type": "string",
+                                        "description": "A dimension name pre-selected in the Segment by picker when this metric is opened in the Metrics Explorer. Must be one of segment_by (if set) and a segmentable dimension."
+                                    },
+                                    "default_filter": {
+                                        "type": "object",
+                                        "description": "A single filter pre-applied when this metric is opened in the Metrics Explorer, e.g. { status: active } or { status: [active, pending] }. Uses the metric filter syntax; only is / is not operators are supported here.",
+                                        "additionalProperties": true,
+                                        "maxProperties": 1
+                                    },
                                     "owner": {
                                         "type": "string",
                                         "description": "Email of the metric owner"
@@ -733,6 +743,16 @@
                                                 "type": "string"
                                             },
                                             "description": "An array of dimension names that are allowed for segmenting this metric in the Metrics Explorer"
+                                        },
+                                        "default_segment": {
+                                            "type": "string",
+                                            "description": "A dimension name pre-selected in the Segment by picker when this metric is opened in the Metrics Explorer. Must be one of segment_by (if set) and a segmentable dimension."
+                                        },
+                                        "default_filter": {
+                                            "type": "object",
+                                            "description": "A single filter pre-applied when this metric is opened in the Metrics Explorer, e.g. { status: active } or { status: [active, pending] }. Uses the metric filter syntax; only is / is not operators are supported here.",
+                                            "additionalProperties": true,
+                                            "maxProperties": 1
                                         },
                                         "owner": {
                                             "type": "string",
@@ -1322,6 +1342,16 @@
                                                 "type": "string"
                                             },
                                             "description": "An array of dimension names that are allowed for segmenting this metric in the Metrics Explorer"
+                                        },
+                                        "default_segment": {
+                                            "type": "string",
+                                            "description": "A dimension name pre-selected in the Segment by picker when this metric is opened in the Metrics Explorer. Must be one of segment_by (if set) and a segmentable dimension."
+                                        },
+                                        "default_filter": {
+                                            "type": "object",
+                                            "description": "A single filter pre-applied when this metric is opened in the Metrics Explorer, e.g. { status: active } or { status: [active, pending] }. Uses the metric filter syntax; only is / is not operators are supported here.",
+                                            "additionalProperties": true,
+                                            "maxProperties": 1
                                         },
                                         "owner": {
                                             "type": "string",

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -10,6 +10,7 @@ import {
     type FieldType,
     type Metric,
 } from './field';
+import { type MetricFilterRule } from './filter';
 import type { KnexPaginatedData } from './knex-paginate';
 import { type ChartSummary } from './savedCharts';
 import { type TraceTaskBase } from './scheduler';
@@ -95,6 +96,8 @@ export type CatalogField = Pick<
         searchRank?: number;
         spotlightFilterBy?: string[]; // dimension IDs allowlist (metrics only)
         spotlightSegmentBy?: string[]; // dimension IDs allowlist (metrics only)
+        spotlightDefaultSegment?: string; // default segment dimension name (metrics only)
+        spotlightDefaultFilter?: MetricFilterRule; // default filter (metrics only)
         owner: CatalogOwner | null; // resolved metric owner
     };
 

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -285,6 +285,8 @@ export type DbtColumnLightdashMetric = {
         categories?: string[]; // yaml_reference
         filter_by?: string[]; // dimension IDs allowlist
         segment_by?: string[]; // dimension IDs allowlist
+        default_segment?: string; // dimension name pre-selected in Segment by
+        default_filter?: Record<string, AnyType>; // { dimension: value | value[] }, metric filter DSL
         owner?: string; // metric owner email
     };
     drivers?: string[]; // metrics that drive this metric (same-table: 'name', cross-table: 'table.name')

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -629,6 +629,11 @@ export const convertModelMetric = ({
 
     // Metric owner takes precedence over model owner
     const owner = metric.spotlight?.owner ?? modelOwner;
+    const [defaultFilter] = parseFilters(
+        metric.spotlight?.default_filter
+            ? [metric.spotlight.default_filter]
+            : undefined,
+    );
 
     return {
         fieldType: FieldType.METRIC,
@@ -680,6 +685,8 @@ export const convertModelMetric = ({
             categories: spotlightCategories,
             filterBy: metric.spotlight?.filter_by,
             segmentBy: metric.spotlight?.segment_by,
+            defaultSegment: metric.spotlight?.default_segment,
+            defaultFilter,
             owner,
         }),
         ...(metric.drivers ? { drivers: metric.drivers } : {}),

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -629,11 +629,15 @@ export const convertModelMetric = ({
 
     // Metric owner takes precedence over model owner
     const owner = metric.spotlight?.owner ?? modelOwner;
-    const [defaultFilter] = parseFilters(
+    const [parsedDefaultFilter] = parseFilters(
         metric.spotlight?.default_filter
             ? [metric.spotlight.default_filter]
             : undefined,
     );
+    // A spotlight default filter is pre-applied but removable, i.e. non-required.
+    const defaultFilter = parsedDefaultFilter
+        ? { ...parsedDefaultFilter, required: false }
+        : undefined;
 
     return {
         fieldType: FieldType.METRIC,

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -907,6 +907,8 @@ export interface Metric extends Field {
         categories?: string[]; // yaml_reference
         filterBy?: string[]; // dimension IDs allowlist
         segmentBy?: string[]; // dimension IDs allowlist
+        defaultSegment?: string; // dimension name pre-selected in Segment by
+        defaultFilter?: MetricFilterRule; // parsed single default filter
         owner?: string; // metric owner email
     };
     drivers?: string[]; // metrics that drive this metric (same-table: 'name', cross-table: 'table.name')

--- a/packages/common/src/types/metricsExplorer.ts
+++ b/packages/common/src/types/metricsExplorer.ts
@@ -1,5 +1,27 @@
 import { type MetricWithAssociatedTimeDimension } from './catalog';
-import type { Dimension, ItemsMap } from './field';
+import { DimensionType, type Dimension, type ItemsMap } from './field';
+import { FilterOperator } from './filter';
+
+/**
+ * Operators the Metrics Explorer filter UI can render (see getOperatorOptions).
+ * The compile-time validation of a metric's spotlight `default_filter` and the
+ * explorer's operator dropdown both read from this single list.
+ */
+export const METRICS_EXPLORER_FILTER_OPERATORS: readonly FilterOperator[] = [
+    FilterOperator.EQUALS,
+    FilterOperator.NOT_EQUALS,
+];
+
+/**
+ * A dimension whose type can be used to segment or filter in the Metrics
+ * Explorer: a string or boolean that is not a time-derived dimension.
+ */
+export const isMetricsExplorerCompatibleDimension = (
+    dimension: Pick<Dimension, 'type' | 'timeIntervalBaseDimensionName'>,
+): boolean =>
+    !dimension.timeIntervalBaseDimensionName &&
+    (dimension.type === DimensionType.STRING ||
+        dimension.type === DimensionType.BOOLEAN);
 
 export enum MetricExplorerComparison {
     NONE = 'none',

--- a/packages/common/src/utils/metricsExplorer.test.ts
+++ b/packages/common/src/utils/metricsExplorer.test.ts
@@ -1,6 +1,30 @@
 import dayjs from 'dayjs';
+import type { CatalogField } from '../types/catalog';
+import {
+    DimensionType,
+    FieldType,
+    type CompiledDimension,
+} from '../types/field';
+import { FilterOperator } from '../types/filter';
 import { TimeFrames } from '../types/timeFrames';
-import { getDateCalcUtils } from './metricsExplorer';
+import {
+    getDateCalcUtils,
+    getInitialDefaultFilterRule,
+    getInitialDefaultSegment,
+} from './metricsExplorer';
+
+const dimRegion: CompiledDimension = {
+    name: 'region',
+    table: 'orders',
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    label: 'Region',
+    sql: '${TABLE}.region',
+    compiledSql: '"orders".region',
+    tablesReferences: ['orders'],
+    tableLabel: 'Orders',
+    hidden: false,
+};
 
 const formatDate = (date: Date) => dayjs(date).format('YYYY-MM-DD');
 
@@ -41,5 +65,88 @@ describe('getDateCalcUtils', () => {
         const { back } = getDateCalcUtils(TimeFrames.YEAR, TimeFrames.YEAR);
         const leap = new Date('2024-02-29T00:00:00Z');
         expect(formatDate(back(leap))).toBe('2023-02-28');
+    });
+});
+
+describe('getInitialDefaultSegment', () => {
+    test('returns the default segment when present in available dimensions', () => {
+        expect(
+            getInitialDefaultSegment(
+                { spotlightDefaultSegment: 'region' } as CatalogField,
+                [dimRegion],
+            ),
+        ).toBe('region');
+    });
+
+    test('returns null when the default segment is not available', () => {
+        expect(
+            getInitialDefaultSegment(
+                { spotlightDefaultSegment: 'missing' } as CatalogField,
+                [dimRegion],
+            ),
+        ).toBeNull();
+    });
+
+    test('returns null when no default is set', () => {
+        expect(
+            getInitialDefaultSegment({} as CatalogField, [dimRegion]),
+        ).toBeNull();
+    });
+});
+
+describe('getInitialDefaultFilterRule', () => {
+    test('builds a FilterRule targeting the available dimension fieldId', () => {
+        const rule = getInitialDefaultFilterRule(
+            {
+                spotlightDefaultFilter: {
+                    id: 'x',
+                    target: { fieldRef: 'region' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['EMEA'],
+                },
+            } as CatalogField,
+            [dimRegion],
+        );
+        expect(rule?.operator).toBe(FilterOperator.EQUALS);
+        expect(rule?.values).toEqual(['EMEA']);
+        expect(rule?.target.fieldId).toBe('orders_region');
+    });
+
+    test('resolves a table-qualified fieldRef to the dimension name', () => {
+        const rule = getInitialDefaultFilterRule(
+            {
+                spotlightDefaultFilter: {
+                    id: 'x',
+                    target: { fieldRef: 'orders.region' },
+                    operator: FilterOperator.NOT_EQUALS,
+                    values: ['EMEA'],
+                },
+            } as CatalogField,
+            [dimRegion],
+        );
+        expect(rule?.target.fieldId).toBe('orders_region');
+        expect(rule?.operator).toBe(FilterOperator.NOT_EQUALS);
+    });
+
+    test('returns undefined when the filter dimension is unavailable', () => {
+        expect(
+            getInitialDefaultFilterRule(
+                {
+                    spotlightDefaultFilter: {
+                        id: 'x',
+                        target: { fieldRef: 'missing' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['v'],
+                    },
+                } as CatalogField,
+                [dimRegion],
+            ),
+        ).toBeUndefined();
+    });
+
+    test('returns undefined when no default filter is set', () => {
+        expect(
+            getInitialDefaultFilterRule({} as CatalogField, [dimRegion]),
+        ).toBeUndefined();
     });
 });

--- a/packages/common/src/utils/metricsExplorer.test.ts
+++ b/packages/common/src/utils/metricsExplorer.test.ts
@@ -69,19 +69,37 @@ describe('getDateCalcUtils', () => {
 });
 
 describe('getInitialDefaultSegment', () => {
-    test('returns the default segment when present in available dimensions', () => {
+    test('resolves the default segment to the available dimension fieldId', () => {
         expect(
             getInitialDefaultSegment(
-                { spotlightDefaultSegment: 'region' } as CatalogField,
+                {
+                    spotlightDefaultSegment: 'region',
+                    tableName: 'orders',
+                } as CatalogField,
                 [dimRegion],
             ),
-        ).toBe('region');
+        ).toBe('orders_region');
+    });
+
+    test('resolves a joined (table-qualified) default segment fieldId', () => {
+        expect(
+            getInitialDefaultSegment(
+                {
+                    spotlightDefaultSegment: 'orders.region',
+                    tableName: 'metrics',
+                } as CatalogField,
+                [dimRegion],
+            ),
+        ).toBe('orders_region');
     });
 
     test('returns null when the default segment is not available', () => {
         expect(
             getInitialDefaultSegment(
-                { spotlightDefaultSegment: 'missing' } as CatalogField,
+                {
+                    spotlightDefaultSegment: 'missing',
+                    tableName: 'orders',
+                } as CatalogField,
                 [dimRegion],
             ),
         ).toBeNull();
@@ -89,7 +107,9 @@ describe('getInitialDefaultSegment', () => {
 
     test('returns null when no default is set', () => {
         expect(
-            getInitialDefaultSegment({} as CatalogField, [dimRegion]),
+            getInitialDefaultSegment({ tableName: 'orders' } as CatalogField, [
+                dimRegion,
+            ]),
         ).toBeNull();
     });
 });
@@ -98,6 +118,7 @@ describe('getInitialDefaultFilterRule', () => {
     test('builds a FilterRule targeting the available dimension fieldId', () => {
         const rule = getInitialDefaultFilterRule(
             {
+                tableName: 'orders',
                 spotlightDefaultFilter: {
                     id: 'x',
                     target: { fieldRef: 'region' },
@@ -112,9 +133,10 @@ describe('getInitialDefaultFilterRule', () => {
         expect(rule?.target.fieldId).toBe('orders_region');
     });
 
-    test('resolves a table-qualified fieldRef to the dimension name', () => {
+    test('resolves a joined (table-qualified) fieldRef to its fieldId', () => {
         const rule = getInitialDefaultFilterRule(
             {
+                tableName: 'metrics',
                 spotlightDefaultFilter: {
                     id: 'x',
                     target: { fieldRef: 'orders.region' },
@@ -132,6 +154,7 @@ describe('getInitialDefaultFilterRule', () => {
         expect(
             getInitialDefaultFilterRule(
                 {
+                    tableName: 'orders',
                     spotlightDefaultFilter: {
                         id: 'x',
                         target: { fieldRef: 'missing' },
@@ -146,7 +169,10 @@ describe('getInitialDefaultFilterRule', () => {
 
     test('returns undefined when no default filter is set', () => {
         expect(
-            getInitialDefaultFilterRule({} as CatalogField, [dimRegion]),
+            getInitialDefaultFilterRule(
+                { tableName: 'orders' } as CatalogField,
+                [dimRegion],
+            ),
         ).toBeUndefined();
     });
 });

--- a/packages/common/src/utils/metricsExplorer.test.ts
+++ b/packages/common/src/utils/metricsExplorer.test.ts
@@ -124,6 +124,7 @@ describe('getInitialDefaultFilterRule', () => {
                     target: { fieldRef: 'region' },
                     operator: FilterOperator.EQUALS,
                     values: ['EMEA'],
+                    required: false,
                 },
             } as CatalogField,
             [dimRegion],
@@ -131,6 +132,7 @@ describe('getInitialDefaultFilterRule', () => {
         expect(rule?.operator).toBe(FilterOperator.EQUALS);
         expect(rule?.values).toEqual(['EMEA']);
         expect(rule?.target.fieldId).toBe('orders_region');
+        expect(rule?.required).toBe(false);
     });
 
     test('resolves a joined (table-qualified) fieldRef to its fieldId', () => {

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -29,6 +29,7 @@ import {
     type FilterRule,
 } from '../types/filter';
 import {
+    isMetricsExplorerCompatibleDimension,
     MetricExplorerComparison,
     type MetricExploreDataPoint,
     type MetricExplorerDateRange,
@@ -38,6 +39,7 @@ import { type WarehouseTypes } from '../types/projects';
 import type { ResultRow } from '../types/results';
 import { TimeFrames, type DefaultTimeDimension } from '../types/timeFrames';
 import assertUnreachable from './assertUnreachable';
+import { createFilterRuleFromModelRequiredFilterRule } from './filters';
 import { getItemId } from './item';
 
 dayjs.extend(isoWeek);
@@ -587,13 +589,7 @@ export const getAvailableTimeDimensionsFromTables = (
 export const getTypeValidFilterDimensions = (
     dimensions: CompiledDimension[],
 ): CompiledDimension[] =>
-    dimensions.filter((d) => {
-        // Exclude date-derived dimensions (month name, day name, etc.) even though they're strings
-        if (d.timeIntervalBaseDimensionName) return false;
-        return (
-            d.type === DimensionType.STRING || d.type === DimensionType.BOOLEAN
-        );
-    });
+    dimensions.filter(isMetricsExplorerCompatibleDimension);
 
 /**
  * Filters dimensions for a specific metric, applying metric's spotlight allowlist.
@@ -620,13 +616,7 @@ export const getFilterDimensionsForMetric = (
 export const getTypeValidSegmentDimensions = (
     dimensions: CompiledDimension[],
 ): CompiledDimension[] =>
-    dimensions.filter((d) => {
-        // Exclude date-derived dimensions (month name, day name, etc.) even though they're strings
-        if (d.timeIntervalBaseDimensionName) return false;
-        return (
-            d.type === DimensionType.STRING || d.type === DimensionType.BOOLEAN
-        );
-    });
+    dimensions.filter(isMetricsExplorerCompatibleDimension);
 
 /**
  * Filters dimensions for a specific metric, applying metric's spotlight allowlist.
@@ -668,10 +658,8 @@ export const getInitialDefaultSegment = (
 
 /**
  * Build the Metrics Explorer `FilterRule` from the metric's spotlight
- * `default_filter`. The stored rule (a `MetricFilterRule`) targets a dimension
- * by fieldRef; the explorer needs the resolved fieldId — the same fieldRef→fieldId
- * conversion model/required filters use (`createFilterRuleFromModelRequiredFilterRule`).
- * Returns undefined when there is no default or the dimension is not available.
+ * `default_filter`. Returns undefined when there is no default or the dimension
+ * is not available to filter by.
  */
 export const getInitialDefaultFilterRule = (
     metric:
@@ -681,19 +669,17 @@ export const getInitialDefaultFilterRule = (
 ): FilterRule | undefined => {
     const defaultFilter = metric?.spotlightDefaultFilter;
     if (!defaultFilter) return undefined;
-    const fieldId = convertFieldRefToFieldId(
-        defaultFilter.target.fieldRef,
+    // A spotlight default filter is a non-required, pre-applied filter — the
+    // same shape as a model default filter — so reuse that loader to resolve
+    // fieldRef→fieldId and carry `required` through unchanged.
+    const filterRule = createFilterRuleFromModelRequiredFilterRule(
+        defaultFilter,
         metric.tableName,
     );
     const isAvailable = availableFilterDimensions.some(
-        (d) => getItemId(d) === fieldId,
+        (d) => getItemId(d) === filterRule.target.fieldId,
     );
-    if (!isAvailable) return undefined;
-    const { target, ...rest } = defaultFilter;
-    return {
-        ...rest,
-        target: { fieldId },
-    };
+    return isAvailable ? filterRule : undefined;
 };
 
 export const getAvailableCompareMetrics = (

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -13,6 +13,7 @@ import type {
 } from '../types/catalog';
 import { type CompiledTable } from '../types/explore';
 import {
+    convertFieldRefToFieldId,
     CustomDimensionType,
     DimensionType,
     MetricType,
@@ -645,44 +646,53 @@ export const getSegmentDimensionsForMetric = (
     });
 
 /**
- * Resolve the metric's spotlight `default_segment` to a segment dimension name,
- * but only if it is one of the dimensions currently available to segment by.
+ * Resolve the metric's spotlight `default_segment` (a dimension ref, bare or
+ * joined like "customers.first_name") to the explorer's fieldId, but only if it
+ * is one of the dimensions currently available to segment by.
  * Returns null when there is no default or it is not available.
  */
 export const getInitialDefaultSegment = (
-    metric: Pick<CatalogField, 'spotlightDefaultSegment'> | undefined,
+    metric:
+        | Pick<CatalogField, 'spotlightDefaultSegment' | 'tableName'>
+        | undefined,
     availableSegmentDimensions: CompiledDimension[],
 ): string | null => {
-    const name = metric?.spotlightDefaultSegment;
-    if (!name) return null;
-    const isAvailable = availableSegmentDimensions.some((d) => d.name === name);
-    return isAvailable ? name : null;
+    const ref = metric?.spotlightDefaultSegment;
+    if (!ref) return null;
+    const fieldId = convertFieldRefToFieldId(ref, metric.tableName);
+    const isAvailable = availableSegmentDimensions.some(
+        (d) => getItemId(d) === fieldId,
+    );
+    return isAvailable ? fieldId : null;
 };
 
 /**
- * Build the Metrics Explorer `FilterRule` (targeting a resolved fieldId) from the
- * metric's spotlight `default_filter` (which targets a dimension by fieldRef),
- * but only if that dimension is currently available to filter by.
- * Returns undefined when there is no default or it is not available.
+ * Build the Metrics Explorer `FilterRule` from the metric's spotlight
+ * `default_filter`. The stored rule (a `MetricFilterRule`) targets a dimension
+ * by fieldRef; the explorer needs the resolved fieldId — the same fieldRef→fieldId
+ * conversion model/required filters use (`createFilterRuleFromModelRequiredFilterRule`).
+ * Returns undefined when there is no default or the dimension is not available.
  */
 export const getInitialDefaultFilterRule = (
-    metric: Pick<CatalogField, 'spotlightDefaultFilter'> | undefined,
+    metric:
+        | Pick<CatalogField, 'spotlightDefaultFilter' | 'tableName'>
+        | undefined,
     availableFilterDimensions: CompiledDimension[],
 ): FilterRule | undefined => {
     const defaultFilter = metric?.spotlightDefaultFilter;
     if (!defaultFilter) return undefined;
-    const { fieldRef } = defaultFilter.target;
-    const name = fieldRef.includes('.')
-        ? fieldRef.split('.').slice(-1)[0]
-        : fieldRef;
-    const dimension = availableFilterDimensions.find((d) => d.name === name);
-    if (!dimension) return undefined;
-    // MetricFilterRule is a FilterRule that targets by fieldRef; the explorer
-    // needs the resolved fieldId, so carry the rule over and swap the target.
+    const fieldId = convertFieldRefToFieldId(
+        defaultFilter.target.fieldRef,
+        metric.tableName,
+    );
+    const isAvailable = availableFilterDimensions.some(
+        (d) => getItemId(d) === fieldId,
+    );
+    if (!isAvailable) return undefined;
     const { target, ...rest } = defaultFilter;
     return {
         ...rest,
-        target: { fieldId: getItemId(dimension) },
+        target: { fieldId },
     };
 };
 

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -644,6 +644,48 @@ export const getSegmentDimensionsForMetric = (
         return d.spotlight?.segmentBy !== false;
     });
 
+/**
+ * Resolve the metric's spotlight `default_segment` to a segment dimension name,
+ * but only if it is one of the dimensions currently available to segment by.
+ * Returns null when there is no default or it is not available.
+ */
+export const getInitialDefaultSegment = (
+    metric: Pick<CatalogField, 'spotlightDefaultSegment'> | undefined,
+    availableSegmentDimensions: CompiledDimension[],
+): string | null => {
+    const name = metric?.spotlightDefaultSegment;
+    if (!name) return null;
+    const isAvailable = availableSegmentDimensions.some((d) => d.name === name);
+    return isAvailable ? name : null;
+};
+
+/**
+ * Build the Metrics Explorer `FilterRule` (targeting a resolved fieldId) from the
+ * metric's spotlight `default_filter` (which targets a dimension by fieldRef),
+ * but only if that dimension is currently available to filter by.
+ * Returns undefined when there is no default or it is not available.
+ */
+export const getInitialDefaultFilterRule = (
+    metric: Pick<CatalogField, 'spotlightDefaultFilter'> | undefined,
+    availableFilterDimensions: CompiledDimension[],
+): FilterRule | undefined => {
+    const defaultFilter = metric?.spotlightDefaultFilter;
+    if (!defaultFilter) return undefined;
+    const { fieldRef } = defaultFilter.target;
+    const name = fieldRef.includes('.')
+        ? fieldRef.split('.').slice(-1)[0]
+        : fieldRef;
+    const dimension = availableFilterDimensions.find((d) => d.name === name);
+    if (!dimension) return undefined;
+    // MetricFilterRule is a FilterRule that targets by fieldRef; the explorer
+    // needs the resolved fieldId, so carry the rule over and swap the target.
+    const { target, ...rest } = defaultFilter;
+    return {
+        ...rest,
+        target: { fieldId: getItemId(dimension) },
+    };
+};
+
 export const getAvailableCompareMetrics = (
     metrics: MetricWithAssociatedTimeDimension[],
 ): MetricWithAssociatedTimeDimension[] =>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
@@ -261,9 +261,29 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
         [segmentDimensionsQuery.data, currentMetric],
     );
 
-    // Seed the metric's YAML spotlight defaults (default_segment / default_filter)
-    // once the dimension allowlists have loaded. Guarded by seededMetricRef so it
-    // runs at most once per metric and is not a server-state-into-effect mirror.
+    // The metric's YAML spotlight defaults, resolved against the loaded
+    // dimension allowlists (null/undefined when absent or unavailable).
+    const defaultSegment = useMemo(
+        () =>
+            getInitialDefaultSegment(
+                currentMetric,
+                availableSegmentByDimensions,
+            ),
+        [currentMetric, availableSegmentByDimensions],
+    );
+    const defaultFilterRule = useMemo(
+        () =>
+            getInitialDefaultFilterRule(
+                currentMetric,
+                availableFilterByDimensions,
+            ),
+        [currentMetric, availableFilterByDimensions],
+    );
+
+    // Seed the defaults into query state once the dimension allowlists have
+    // loaded. Guarded by seededMetricRef so it runs at most once per metric and
+    // is not a server-state-into-effect mirror. The filter UI is seeded
+    // separately via MetricExploreFilter's initial value (it is uncontrolled).
     const dimensionsReady =
         !segmentDimensionsQuery.isLoading && !filterDimensionsQuery.isLoading;
     const currentMetricId = currentMetric
@@ -276,14 +296,6 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
         seededMetricRef.current !== currentMetricId
     ) {
         seededMetricRef.current = currentMetricId;
-        const defaultSegment = getInitialDefaultSegment(
-            currentMetric,
-            availableSegmentByDimensions,
-        );
-        const defaultFilterRule = getInitialDefaultFilterRule(
-            currentMetric,
-            availableFilterByDimensions,
-        );
         if (defaultSegment !== null) {
             setQuery({
                 comparison: MetricExplorerComparison.NONE,
@@ -529,7 +541,11 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
                                 <MetricExploreFilter
                                     dimensions={availableFilterByDimensions}
                                     onFilterApply={handleFilterApply}
-                                    key={`${tableName}-${metricName}`}
+                                    initialFilterRule={defaultFilterRule}
+                                    key={`${tableName}-${metricName}-${
+                                        defaultFilterRule?.target.fieldId ??
+                                        'none'
+                                    }`}
                                 />
 
                                 <MetricExploreSegmentationPicker

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
@@ -33,14 +33,7 @@ import {
     IconChevronUp,
     IconInfoCircle,
 } from '@tabler/icons-react';
-import {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-    type FC,
-} from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import LightdashVisualization from '../../../../components/LightdashVisualization';
@@ -134,32 +127,30 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
         MetricExplorerDateRange | undefined
     >();
 
-    const [filterRule, setFilterRule] = useState<FilterRule | undefined>();
+    // The user's explicit filter for this metric view. undefined = pristine
+    // (derive from the metric's spotlight default), null = explicitly cleared.
+    const [userFilterRule, setUserFilterRule] = useState<
+        FilterRule | null | undefined
+    >(undefined);
 
-    const [query, setQuery] = useState<MetricExplorerQuery>({
-        comparison: MetricExplorerComparison.NONE,
-        segmentDimension: null,
-    });
-
-    const segmentDimensionId = useMemo(() => {
-        return 'segmentDimension' in query ? query.segmentDimension : null;
-    }, [query]);
-
-    // Tracks the metric whose YAML spotlight defaults have already been applied,
-    // so the defaults seed once per metric and never clobber later user edits.
-    const seededMetricRef = useRef<string | null>(null);
+    // The user's explicit query for this metric view. undefined = pristine
+    // (derive from the metric's spotlight default segment).
+    const [userQuery, setUserQuery] = useState<MetricExplorerQuery | undefined>(
+        undefined,
+    );
 
     // Reset override when navigating to a different metric
     const resetQueryState = useCallback(() => {
-        seededMetricRef.current = null;
         setTimeDimensionOverride(undefined);
         setDateRange(undefined);
-        setFilterRule(undefined);
-        setQuery({
-            comparison: MetricExplorerComparison.NONE,
-            segmentDimension: null,
-        });
-    }, [setTimeDimensionOverride, setDateRange, setFilterRule, setQuery]);
+        setUserFilterRule(undefined);
+        setUserQuery(undefined);
+    }, [
+        setTimeDimensionOverride,
+        setDateRange,
+        setUserFilterRule,
+        setUserQuery,
+    ]);
 
     // Update navigateToMetric to reset state
     const navigateToMetricWithReset = useCallback(
@@ -187,35 +178,6 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
         onClose();
     }, [navigate, onClose, projectUuid, location.search]);
 
-    // All data fetching, query execution, and config building in one hook
-    const {
-        metricField,
-        explore,
-        metricQuery,
-        timeDimensionConfig,
-        effectiveDateRange,
-        chartConfig,
-        resultsData,
-        columnOrder,
-        computedSeries,
-        unsavedChartVersion,
-        isLoading,
-        hasData,
-    } = useMetricVisualization({
-        projectUuid,
-        tableName,
-        metricName,
-        timeDimensionOverride,
-        segmentDimensionId,
-        filterRule,
-        dateRange,
-        comparison: query.comparison,
-        compareMetric:
-            query.comparison === MetricExplorerComparison.DIFFERENT_METRIC
-                ? query.metric
-                : null,
-    });
-
     const filterDimensionsQuery = useCatalogFilterDimensions({
         projectUuid,
         tableName,
@@ -229,15 +191,6 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
         tableName,
         options: {
             enabled: !!projectUuid && !!tableName,
-        },
-    });
-
-    const metricsWithTimeDimensionsQuery = useCatalogMetricsWithTimeDimensions({
-        projectUuid,
-        tableName,
-        options: {
-            enabled:
-                query.comparison === MetricExplorerComparison.DIFFERENT_METRIC,
         },
     });
 
@@ -280,32 +233,64 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
         [currentMetric, availableFilterByDimensions],
     );
 
-    // Seed the defaults into query state once the dimension allowlists have
-    // loaded. Guarded by seededMetricRef so it runs at most once per metric and
-    // is not a server-state-into-effect mirror. The filter UI is seeded
-    // separately via MetricExploreFilter's initial value (it is uncontrolled).
-    const dimensionsReady =
-        !segmentDimensionsQuery.isLoading && !filterDimensionsQuery.isLoading;
-    const currentMetricId = currentMetric
-        ? `${currentMetric.tableName}.${currentMetric.name}`
-        : null;
-    if (
-        dimensionsReady &&
-        currentMetric &&
-        currentMetricId !== null &&
-        seededMetricRef.current !== currentMetricId
-    ) {
-        seededMetricRef.current = currentMetricId;
-        if (defaultSegment !== null) {
-            setQuery({
+    // Effective query/filter: the user's explicit choice once made, otherwise
+    // derived from the metric's spotlight defaults (which resolve whenever the
+    // dimension lists load — no seeding, so they can never be missed or leak
+    // across metrics).
+    const query = useMemo<MetricExplorerQuery>(
+        () =>
+            userQuery ?? {
                 comparison: MetricExplorerComparison.NONE,
                 segmentDimension: defaultSegment,
-            });
-        }
-        if (defaultFilterRule !== undefined) {
-            setFilterRule(defaultFilterRule);
-        }
-    }
+            },
+        [userQuery, defaultSegment],
+    );
+    const filterRule: FilterRule | undefined =
+        userFilterRule === undefined
+            ? defaultFilterRule
+            : (userFilterRule ?? undefined);
+
+    const segmentDimensionId = useMemo(() => {
+        return 'segmentDimension' in query ? query.segmentDimension : null;
+    }, [query]);
+
+    // All data fetching, query execution, and config building in one hook
+    const {
+        metricField,
+        explore,
+        metricQuery,
+        timeDimensionConfig,
+        effectiveDateRange,
+        chartConfig,
+        resultsData,
+        columnOrder,
+        computedSeries,
+        unsavedChartVersion,
+        isLoading,
+        hasData,
+    } = useMetricVisualization({
+        projectUuid,
+        tableName,
+        metricName,
+        timeDimensionOverride,
+        segmentDimensionId,
+        filterRule,
+        dateRange,
+        comparison: query.comparison,
+        compareMetric:
+            query.comparison === MetricExplorerComparison.DIFFERENT_METRIC
+                ? query.metric
+                : null,
+    });
+
+    const metricsWithTimeDimensionsQuery = useCatalogMetricsWithTimeDimensions({
+        projectUuid,
+        tableName,
+        options: {
+            enabled:
+                query.comparison === MetricExplorerComparison.DIFFERENT_METRIC,
+        },
+    });
 
     // Keyboard navigation
     useHotkeys([
@@ -315,7 +300,7 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
 
     const handleSegmentDimensionChange = useCallback(
         (value: string | null) => {
-            setQuery({
+            setUserQuery({
                 comparison: MetricExplorerComparison.NONE,
                 segmentDimension: value,
             });
@@ -333,7 +318,7 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
             });
         },
         [
-            setQuery,
+            setUserQuery,
             track,
             userUuid,
             organizationUuid,
@@ -345,9 +330,11 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
 
     const handleFilterApply = useCallback(
         (nextFilterRule: FilterRule | undefined) => {
-            setFilterRule(nextFilterRule);
+            // Store null (not undefined) on clear so it records an explicit
+            // choice and the metric's default filter is not re-derived.
+            setUserFilterRule(nextFilterRule ?? null);
         },
-        [setFilterRule],
+        [setUserFilterRule],
     );
 
     const handleTimeIntervalChange = useCallback(
@@ -578,7 +565,7 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
                                                 MetricExplorerComparison.NONE
                                             }
                                             onClick={() =>
-                                                setQuery({
+                                                setUserQuery({
                                                     comparison:
                                                         MetricExplorerComparison.NONE,
                                                     segmentDimension: null,
@@ -592,7 +579,7 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
                                     <MetricExploreComparisonSection
                                         baseMetricLabel={metricField?.label}
                                         query={query}
-                                        onQueryChange={setQuery}
+                                        onQueryChange={setUserQuery}
                                         metricsWithTimeDimensionsQuery={
                                             metricsWithTimeDimensionsQuery
                                         }

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
@@ -2,6 +2,8 @@ import {
     ECHARTS_DEFAULT_COLORS,
     getDefaultDateRangeFromInterval,
     getFilterDimensionsForMetric,
+    getInitialDefaultFilterRule,
+    getInitialDefaultSegment,
     getSegmentDimensionsForMetric,
     MetricExplorerComparison,
     type CatalogField,
@@ -31,7 +33,14 @@ import {
     IconChevronUp,
     IconInfoCircle,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import LightdashVisualization from '../../../../components/LightdashVisualization';
@@ -136,8 +145,13 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
         return 'segmentDimension' in query ? query.segmentDimension : null;
     }, [query]);
 
+    // Tracks the metric whose YAML spotlight defaults have already been applied,
+    // so the defaults seed once per metric and never clobber later user edits.
+    const seededMetricRef = useRef<string | null>(null);
+
     // Reset override when navigating to a different metric
     const resetQueryState = useCallback(() => {
+        seededMetricRef.current = null;
         setTimeDimensionOverride(undefined);
         setDateRange(undefined);
         setFilterRule(undefined);
@@ -246,6 +260,40 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
             ),
         [segmentDimensionsQuery.data, currentMetric],
     );
+
+    // Seed the metric's YAML spotlight defaults (default_segment / default_filter)
+    // once the dimension allowlists have loaded. Guarded by seededMetricRef so it
+    // runs at most once per metric and is not a server-state-into-effect mirror.
+    const dimensionsReady =
+        !segmentDimensionsQuery.isLoading && !filterDimensionsQuery.isLoading;
+    const currentMetricId = currentMetric
+        ? `${currentMetric.tableName}.${currentMetric.name}`
+        : null;
+    if (
+        dimensionsReady &&
+        currentMetric &&
+        currentMetricId !== null &&
+        seededMetricRef.current !== currentMetricId
+    ) {
+        seededMetricRef.current = currentMetricId;
+        const defaultSegment = getInitialDefaultSegment(
+            currentMetric,
+            availableSegmentByDimensions,
+        );
+        const defaultFilterRule = getInitialDefaultFilterRule(
+            currentMetric,
+            availableFilterByDimensions,
+        );
+        if (defaultSegment !== null) {
+            setQuery({
+                comparison: MetricExplorerComparison.NONE,
+                segmentDimension: defaultSegment,
+            });
+        }
+        if (defaultFilterRule !== undefined) {
+            setFilterRule(defaultFilterRule);
+        }
+    }
 
     // Keyboard navigation
     useHotkeys([

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
@@ -23,6 +23,7 @@ import { MetricExploreFilterAutoComplete } from './MetricExploreFilterAutoComple
 type Props = {
     dimensions: CompiledDimension[] | undefined;
     onFilterApply: (filterRule: FilterRule | undefined) => void;
+    initialFilterRule?: FilterRule;
 };
 
 interface FilterState {
@@ -32,20 +33,40 @@ interface FilterState {
     values: string[];
 }
 
+const EMPTY_FILTER_STATE: FilterState = {
+    dimension: null,
+    fieldId: null,
+    operator: null,
+    values: [],
+};
+
 export const MetricExploreFilter: FC<Props> = ({
     dimensions,
     onFilterApply,
+    initialFilterRule,
 }) => {
     const { classes: filterSelectClasses, theme } = useFilterSelectStyles();
     const { classes: operatorSelectClasses } = useOperatorSelectStyles();
 
-    const [filterState, setFilterState] = useState<FilterState>({
-        dimension: null,
-        fieldId: null,
-        operator: null,
-        values: [],
-    });
-    const [activeFilter, setActiveFilter] = useState<FilterRule | undefined>();
+    // Seed from the metric's default filter on mount. The parent remounts this
+    // component (via key) per metric, so this initializer re-runs on switch.
+    const [filterState, setFilterState] = useState<FilterState>(() =>
+        initialFilterRule
+            ? {
+                  fieldId: initialFilterRule.target.fieldId,
+                  dimension:
+                      dimensions?.find(
+                          (d) =>
+                              getItemId(d) === initialFilterRule.target.fieldId,
+                      )?.name ?? null,
+                  operator: initialFilterRule.operator,
+                  values: (initialFilterRule.values ?? []) as string[],
+              }
+            : EMPTY_FILTER_STATE,
+    );
+    const [activeFilter, setActiveFilter] = useState<FilterRule | undefined>(
+        initialFilterRule,
+    );
 
     const selectedDimension = dimensions?.find(
         (d) => getItemId(d) === filterState.fieldId,
@@ -93,12 +114,7 @@ export const MetricExploreFilter: FC<Props> = ({
 
     const handleClearFilter = () => {
         setActiveFilter(undefined);
-        setFilterState({
-            dimension: null,
-            fieldId: null,
-            operator: null,
-            values: [],
-        });
+        setFilterState(EMPTY_FILTER_STATE);
         onFilterApply(undefined);
     };
 

--- a/packages/frontend/src/features/metricsCatalog/utils/metricExploreFilter.ts
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricExploreFilter.ts
@@ -3,6 +3,7 @@ import {
     FilterOperator,
     getFilterRuleFromFieldWithDefaultValue,
     getItemId,
+    METRICS_EXPLORER_FILTER_OPERATORS,
     type CompiledDimension,
     type FilterRule,
 } from '@lightdash/common';
@@ -16,25 +17,13 @@ export interface FilterOperatorOption {
 export const getOperatorOptions = (
     dimension?: CompiledDimension,
 ): FilterOperatorOption[] => {
-    const baseOperators = [
-        {
-            value: FilterOperator.EQUALS,
-            label: 'is',
-        },
-        {
-            value: FilterOperator.NOT_EQUALS,
-            label: 'is not',
-        },
-    ];
-
-    if (dimension?.type === DimensionType.BOOLEAN) {
-        return baseOperators.map((op) => ({
-            ...op,
-            label: op.value === FilterOperator.EQUALS ? 'is true' : 'is false',
-        }));
-    }
-
-    return baseOperators;
+    const isBoolean = dimension?.type === DimensionType.BOOLEAN;
+    return METRICS_EXPLORER_FILTER_OPERATORS.map((value) => {
+        if (value === FilterOperator.EQUALS) {
+            return { value, label: isBoolean ? 'is true' : 'is' };
+        }
+        return { value, label: isBoolean ? 'is false' : 'is not' };
+    });
 };
 
 export const doesDimensionRequireValues = (dimension: CompiledDimension) =>


### PR DESCRIPTION
### Description

Lets data engineers curate the default Metrics Explorer view for a metric via YAML. Two new optional fields on the metric-level `spotlight` block:

- `default_segment: <dimension>` — pre-selected in the "Segment by" picker when the metric is opened.
- `default_filter: { <dimension>: <value | [values]> }` — a single filter pre-applied on open, using the existing metric filter syntax (`is` / `is one of` / `is not`).

```yaml
metrics:
  unique_order_count:
    type: count_distinct
    spotlight:
      segment_by: [order_source, status]
      filter_by: [status]
      default_segment: order_source
      default_filter:
        status: completed
```

### Changes

- **Types/schema**: new fields on the dbt YAML metric `spotlight` type, parsed `Metric.spotlight` (`defaultSegment`/`defaultFilter`), and `lightdash-dbt-2.0.json` (all three metric copies).
- **Converter**: `default_filter` parsed via the existing metric filter DSL (`parseFilters`) into a non-required `MetricFilterRule`.
- **Compile-time validation** (`CompileError`, per-metric under partial compilation): `default_segment` must be in `segment_by` (if set) and segmentable; `default_filter` must reference a real dimension in `filter_by` (if set) and use an operator the explorer can render (`is`/`is not` only).
- **API**: `spotlightDefaultSegment`/`spotlightDefaultFilter` on `CatalogField`, derived at read time from the cached explore — no DB migration.
- **Frontend**: the Metrics Explorer derives its initial segment/filter from the metric's defaults at render time; explicit user choices (including clearing) always take precedence and defaults re-apply on a fresh open.
- Demo example on the jaffle shop `unique_order_count` metric.

**Example**

```yaml
        config:
          meta:
            metrics:
              unique_order_count:
                type: count_distinct
                spotlight:
                  categories: ["revenue_growth"]
                  segment_by:
                    - order_source
                    - status
                    - shipping_method
                    - order_priority
                    - fulfillment_center
                    - is_completed
                  filter_by:
                    - status
                    - order_source
                    - shipping_method
                    - order_priority
                    - fulfillment_center
                    - is_completed
                  default_segment: order_source
                  default_filter:
                    status: completed
```


https://github.com/user-attachments/assets/f02d25ad-632f-4c10-927f-243f3e78c0ba



Closes: https://linear.app/lightdash/issue/PROD-8084/metrics-catalog-support-default-segment-and-default-filter-in-metric