### PR TITLE
fix(embed): match current app theme in preview and copied URL

### DIFF
--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewChartForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewChartForm.tsx
@@ -21,6 +21,7 @@ import {
     TextInput,
     Title,
 } from '@mantine-8/core';
+import { useMantineColorScheme } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconEye, IconLink, IconPlus, IconTrash } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
@@ -76,6 +77,7 @@ const EmbedPreviewChartForm: FC<{
 }> = ({ projectUuid, siteUrl, charts }) => {
     const { mutateAsync: createEmbedUrl } =
         useEmbedUrlCreateMutation(projectUuid);
+    const { colorScheme } = useMantineColorScheme();
     const { data: user } = useUser(true);
     const [embedMethod, setEmbedMethod] = useState<EmbedMethod>('iframe');
 
@@ -148,15 +150,32 @@ const EmbedPreviewChartForm: FC<{
         const data = await createEmbedUrl(
             convertFormValuesToCreateEmbedJwt(formValues, true),
         );
-        window.open(data.url, '_blank');
-    }, [formValues, form, convertFormValuesToCreateEmbedJwt, createEmbedUrl]);
+        // Open data.url in a new tab, matching the current app color scheme
+        const previewUrl = new URL(data.url);
+        previewUrl.searchParams.set('theme', colorScheme);
+        window.open(previewUrl.toString(), '_blank');
+    }, [
+        formValues,
+        form,
+        convertFormValuesToCreateEmbedJwt,
+        createEmbedUrl,
+        colorScheme,
+    ]);
 
     const generateUrl = useCallback(async () => {
         const data = await createEmbedUrl(
             convertFormValuesToCreateEmbedJwt(form.values),
         );
-        return data.url;
-    }, [convertFormValuesToCreateEmbedJwt, createEmbedUrl, form.values]);
+        // Match the current app color scheme
+        const url = new URL(data.url);
+        url.searchParams.set('theme', colorScheme);
+        return url.toString();
+    }, [
+        convertFormValuesToCreateEmbedJwt,
+        createEmbedUrl,
+        form.values,
+        colorScheme,
+    ]);
 
     const { handleCopy } = useAsyncClipboard(generateUrl);
     const handleCopySubmit = onSubmit(handleCopy);

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -26,6 +26,7 @@ import {
     Title,
     Tooltip,
 } from '@mantine-8/core';
+import { useMantineColorScheme } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import {
     IconEye,
@@ -94,6 +95,7 @@ const EmbedPreviewDashboardForm: FC<{
 }> = ({ projectUuid, siteUrl, dashboards }) => {
     const { mutateAsync: createEmbedUrl } =
         useEmbedUrlCreateMutation(projectUuid);
+    const { colorScheme } = useMantineColorScheme();
     const { data: user } = useUser(true);
     const [embedMethod, setEmbedMethod] = useState<EmbedMethod>('iframe');
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
@@ -191,16 +193,32 @@ const EmbedPreviewDashboardForm: FC<{
         const data = await createEmbedUrl(
             convertFormValuesToCreateEmbedJwt(formValues, true),
         );
-        //Open data.url on new tab
-        window.open(data.url, '_blank');
-    }, [formValues, form, convertFormValuesToCreateEmbedJwt, createEmbedUrl]);
+        // Open data.url in a new tab, matching the current app color scheme
+        const previewUrl = new URL(data.url);
+        previewUrl.searchParams.set('theme', colorScheme);
+        window.open(previewUrl.toString(), '_blank');
+    }, [
+        formValues,
+        form,
+        convertFormValuesToCreateEmbedJwt,
+        createEmbedUrl,
+        colorScheme,
+    ]);
 
     const generateUrl = useCallback(async () => {
         const data = await createEmbedUrl(
             convertFormValuesToCreateEmbedJwt(form.values),
         );
-        return data.url;
-    }, [convertFormValuesToCreateEmbedJwt, createEmbedUrl, form.values]);
+        // Match the current app color scheme
+        const url = new URL(data.url);
+        url.searchParams.set('theme', colorScheme);
+        return url.toString();
+    }, [
+        convertFormValuesToCreateEmbedJwt,
+        createEmbedUrl,
+        form.values,
+        colorScheme,
+    ]);
 
     const { handleCopy } = useAsyncClipboard(generateUrl);
     const handleCopySubmit = onSubmit(handleCopy);


### PR DESCRIPTION
### Description:
The embed config "Preview" and "Generate & copy URL" actions built the embed URL without a theme param, so the embedded view always defaulted to light. Append the current Mantine color scheme as ?theme=light|dark so the embed opens/copies in whatever theme the user is currently using.