### PR TITLE
fix(embed): apply embed theme without overriding the viewer's theme

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import {
     CommercialWebAppRoutes,
 } from './ee/CommercialRoutes';
 import { AiAgentsGlobalProvider } from './ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider';
+import { parseEmbedThemeParams } from './ee/providers/Embed/parseEmbedThemeParams';
 import ErrorBoundary from './features/errorBoundary/ErrorBoundary';
 import { SourceCodeEditorProvider } from './features/sourceCodeEditor';
 import ChartColorMappingContextProvider from './hooks/useChartColorConfig/ChartColorMappingContextProvider';
@@ -32,6 +33,14 @@ import Routes from './Routes';
 const isMobile = window.innerWidth < 768;
 
 const isMinimalPage = window.location.pathname.startsWith('/minimal');
+
+// On embed routes, force the color scheme from the ?theme= URL param without
+// persisting it to localStorage. This keeps the embed in its configured theme
+// while never overriding the viewer's own (shared, cross-tab) theme preference.
+// `undefined` everywhere else, so non-embed routes are unaffected.
+const embedForcedColorScheme = window.location.pathname.startsWith('/embed')
+    ? parseEmbedThemeParams().theme
+    : undefined;
 
 // Sentry wrapper for createBrowserRouter
 const sentryCreateBrowserRouter =
@@ -78,8 +87,13 @@ const App = () => (
         <DocumentTitle />
 
         <ReactQueryProvider>
-            <MantineProvider withGlobalStyles withNormalizeCSS withCSSVariables>
-                <Mantine8Provider>
+            <MantineProvider
+                withGlobalStyles
+                withNormalizeCSS
+                withCSSVariables
+                forceColorScheme={embedForcedColorScheme}
+            >
+                <Mantine8Provider forceColorScheme={embedForcedColorScheme}>
                     <ModalsProvider>
                         <RouterProvider router={router} />
                     </ModalsProvider>

--- a/packages/frontend/src/ee/features/embed/EmbeddedApp.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbeddedApp.tsx
@@ -1,21 +1,20 @@
 import { type SavedChart } from '@lightdash/common';
-import { useMantineColorScheme } from '@mantine/core';
 import { useEffect, useState, type FC } from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router';
 import EmbedProvider from '../../providers/Embed/EmbedProvider';
 import useEmbed from '../../providers/Embed/useEmbed';
 
 /**
- * Syncs the embed theme URL params with the Mantine color scheme
- * and applies a custom background color if provided.
+ * Applies the embed's custom background color if provided.
+ *
+ * The color scheme itself is forced at the app root (see App.tsx) from the
+ * ?theme= URL param, so the embed never writes to the viewer's shared
+ * (cross-tab) theme preference.
  */
-const EmbedThemeSync: FC<React.PropsWithChildren> = ({ children }) => {
-    const { theme, backgroundColor } = useEmbed();
-    const { toggleColorScheme } = useMantineColorScheme();
-
-    useEffect(() => {
-        toggleColorScheme(theme);
-    }, [theme, toggleColorScheme]);
+const EmbedBackgroundColorSync: FC<React.PropsWithChildren> = ({
+    children,
+}) => {
+    const { backgroundColor } = useEmbed();
 
     useEffect(() => {
         if (backgroundColor) {
@@ -58,9 +57,9 @@ const EmbeddedApp: FC = () => {
             onExplore={handleExplore}
             onBackToDashboard={handleBackToDashboard}
         >
-            <EmbedThemeSync>
+            <EmbedBackgroundColorSync>
                 <Outlet />
-            </EmbedThemeSync>
+            </EmbedBackgroundColorSync>
         </EmbedProvider>
     );
 };

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -12,29 +12,8 @@ import { type SdkFilter } from '../../features/embed/EmbedDashboard/types';
 import { LightdashEventType } from '../../features/embed/events/types';
 import { useEmbedEventEmitter } from '../../features/embed/hooks/useEmbedEventEmitter';
 import EmbedProviderContext from './context';
-import {
-    EMBED_KEY,
-    type EmbedMode,
-    type EmbedTheme,
-    type InMemoryEmbed,
-} from './types';
-
-const HEX_COLOR_REGEX = /^[0-9a-fA-F]{3,8}$/;
-
-function parseEmbedThemeParams(): {
-    theme: EmbedTheme;
-    backgroundColor: string | null;
-} {
-    const params = new URLSearchParams(window.location.search);
-    const themeParam = params.get('theme');
-    const theme: EmbedTheme =
-        themeParam === 'light' || themeParam === 'dark' ? themeParam : 'light';
-    const bgParam = params.get('backgroundColor');
-    // Accept bare hex codes (e.g. "121212") and prepend "#"
-    const backgroundColor =
-        bgParam && HEX_COLOR_REGEX.test(bgParam) ? `#${bgParam}` : null;
-    return { theme, backgroundColor };
-}
+import { parseEmbedThemeParams } from './parseEmbedThemeParams';
+import { EMBED_KEY, type EmbedMode, type InMemoryEmbed } from './types';
 
 type Props = {
     embedToken?: string;

--- a/packages/frontend/src/ee/providers/Embed/parseEmbedThemeParams.ts
+++ b/packages/frontend/src/ee/providers/Embed/parseEmbedThemeParams.ts
@@ -1,0 +1,23 @@
+import { type EmbedTheme } from './types';
+
+const HEX_COLOR_REGEX = /^[0-9a-fA-F]{3,8}$/;
+
+/**
+ * Parses the embed theme params from the current URL query string.
+ * Used both at the app root (to force the color scheme without persisting it)
+ * and inside the EmbedProvider (to expose them on the embed context).
+ */
+export function parseEmbedThemeParams(): {
+    theme: EmbedTheme;
+    backgroundColor: string | null;
+} {
+    const params = new URLSearchParams(window.location.search);
+    const themeParam = params.get('theme');
+    const theme: EmbedTheme =
+        themeParam === 'light' || themeParam === 'dark' ? themeParam : 'light';
+    const bgParam = params.get('backgroundColor');
+    // Accept bare hex codes (e.g. "121212") and prepend "#"
+    const backgroundColor =
+        bgParam && HEX_COLOR_REGEX.test(bgParam) ? `#${bgParam}` : null;
+    return { theme, backgroundColor };
+}


### PR DESCRIPTION
### Description:
The embed view applied its ?theme= URL param by calling the global toggleColorScheme, which persists to the shared `color-scheme` localStorage key. That polluted the viewer's own theme and, because useLocalStorage broadcasts across tabs, caused a manual theme switch in the main app to be reverted by any embed open in a background tab.

Instead, force the color scheme from the URL param at the app root for /embed routes (forceColorScheme on both Mantine providers) without persisting it, and drop the toggleColorScheme effect from EmbeddedApp. The embed renders in its configured theme while the viewer's global, cross-tab theme preference is left untouched. forceColorScheme is undefined on every non-embed route, so the rest of the app is unchanged.

Verified in-browser: a dark embed no longer writes localStorage; switching the main app to light while a dark embed is open in the background now sticks; embed renders correctly for theme=light and theme=dark.
