### PR TITLE
fix(ai-project-context): format-preserving writeback for minimal PR diffs

### DIFF
--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
@@ -1,11 +1,10 @@
 import { subject } from '@casl/ability';
 import {
+    applyProjectContextWriteback,
     DbtProjectType,
     ForbiddenError,
     loadProjectContextFile,
-    mergeProjectContextEntry,
     NotFoundError,
-    serializeProjectContextFile,
     type AiAgentJudgeProjectContextEntry,
     type DbtProjectConfig,
     type SessionUser,
@@ -242,11 +241,11 @@ export class ProjectContextService extends BaseService {
             }
         }
 
-        const { entries, entryId, op } = mergeProjectContextEntry(
-            loadProjectContextFile(existingContent),
-            args.entry,
-        );
-        const serialized = serializeProjectContextFile(entries);
+        const {
+            content: serialized,
+            entryId,
+            op,
+        } = applyProjectContextWriteback(existingContent, args.entry);
 
         const lastCommit = await getLastCommit({
             owner,

--- a/packages/common/src/ee/AiAgent/projectContext.test.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.test.ts
@@ -1,5 +1,6 @@
 import { ParseError } from '../../types/errors';
 import {
+    applyProjectContextWriteback,
     loadProjectContextFile,
     mergeProjectContextEntry,
     serializeProjectContextFile,
@@ -293,5 +294,87 @@ entries:
     content: '"HR" = high-risk cohort.'
 `;
         expect(() => loadProjectContextFile(yaml)).toThrow(ParseError);
+    });
+});
+
+describe('applyProjectContextWriteback', () => {
+    test('creates a canonical file from empty content', () => {
+        const { content, entryId, op } = applyProjectContextWriteback('', {
+            op: 'create',
+            id: null,
+            kind: 'definition',
+            content: 'MRR means monthly recurring revenue.',
+            terms: ['MRR'],
+            objects: [],
+        });
+        expect(op).toBe('create');
+        expect(entryId).toBe('mrr');
+        expect(content).toContain('version: 1');
+        expect(loadProjectContextFile(content)).toEqual([
+            {
+                id: 'mrr',
+                kind: 'definition',
+                content: 'MRR means monthly recurring revenue.',
+                terms: ['MRR'],
+                objects: [],
+            },
+        ]);
+    });
+
+    test('appends a new entry, preserving existing comments and entries verbatim', () => {
+        const existing = `version: 1
+entries:
+  # Curated by the data team — do not reorder.
+  - id: hr
+    kind: definition
+    content: '"HR" = high-risk cohort.'
+    terms: [HR]
+    objects: []
+`;
+        const { content, op } = applyProjectContextWriteback(existing, {
+            op: 'create',
+            id: null,
+            kind: 'definition',
+            content: 'MRR means monthly recurring revenue.',
+            terms: ['MRR'],
+            objects: [],
+        });
+        expect(op).toBe('create');
+        // The human comment, the original quoting and the entry content all
+        // survive — this is the whole point: a minimal, reviewable diff rather
+        // than a full-file rewrite. (Flow seqs are re-spaced, e.g. [HR] →
+        // [ HR ], which is the one cosmetic cost vs js-yaml nuking everything.)
+        expect(content).toContain('# Curated by the data team');
+        expect(content).toContain(`content: '"HR" = high-risk cohort.'`);
+        expect(content).toContain('id: hr');
+        expect(content).toContain('id: mrr');
+        expect(loadProjectContextFile(content)).toHaveLength(2);
+    });
+
+    test('updates an existing entry in place by id', () => {
+        const existing = `version: 1
+entries:
+  - id: mrr
+    kind: definition
+    content: old
+    terms: [MRR]
+    objects: []
+`;
+        const { content, entryId, op } = applyProjectContextWriteback(
+            existing,
+            {
+                op: 'update',
+                id: 'mrr',
+                kind: 'definition',
+                content: 'MRR means monthly recurring revenue.',
+                terms: ['MRR'],
+                objects: [],
+            },
+        );
+        expect(op).toBe('update');
+        expect(entryId).toBe('mrr');
+        const entries = loadProjectContextFile(content);
+        expect(entries).toHaveLength(1);
+        expect(entries[0].content).toBe('MRR means monthly recurring revenue.');
     });
 });

--- a/packages/common/src/ee/AiAgent/projectContext.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.ts
@@ -2,6 +2,7 @@ import Ajv from 'ajv';
 import AjvErrors from 'ajv-errors';
 import betterAjvErrors from 'better-ajv-errors';
 import * as yaml from 'js-yaml';
+import { isMap, isSeq, parseDocument } from 'yaml';
 import { z } from 'zod';
 import lightdashProjectContextSchema from '../../schemas/json/lightdash-project-context-1.0.json';
 import { ParseError } from '../../types/errors';
@@ -206,4 +207,51 @@ export const loadProjectContextFile = (
         entries.push({ ...entry, id, terms, objects });
     }
     return entries;
+};
+
+/**
+ * Apply a judge-emitted entry and return the new file contents, the entry id,
+ * and whether it created or updated. For a canonical `{ version, entries }`
+ * file this edits the parsed YAML document in place — appending the new entry
+ * (or replacing the one matching `id`) — so the resulting diff is just the
+ * touched entry, with comments, quoting and key order in the rest of the file
+ * preserved. Empty or legacy (bare-array) files fall back to a fresh canonical
+ * serialization.
+ */
+export const applyProjectContextWriteback = (
+    existingContent: string,
+    judgeEntry: ProjectContextWritebackEntry,
+): { content: string; entryId: string; op: 'create' | 'update' } => {
+    const { entries, entryId, op } = mergeProjectContextEntry(
+        loadProjectContextFile(existingContent),
+        judgeEntry,
+    );
+
+    if (existingContent.trim() !== '') {
+        const doc = parseDocument(existingContent);
+        const entriesNode = doc.get('entries');
+        if (doc.errors.length === 0 && isSeq(entriesNode)) {
+            if (doc.get('version') === undefined) {
+                doc.set('version', PROJECT_CONTEXT_FILE_VERSION);
+            }
+            const node = doc.createNode({
+                id: entryId,
+                kind: judgeEntry.kind,
+                content: judgeEntry.content,
+                terms: judgeEntry.terms,
+                objects: judgeEntry.objects,
+            });
+            const index = entriesNode.items.findIndex(
+                (item) => isMap(item) && item.get('id') === entryId,
+            );
+            if (index >= 0) {
+                entriesNode.set(index, node);
+            } else {
+                entriesNode.add(node);
+            }
+            return { content: doc.toString({ lineWidth: 0 }), entryId, op };
+        }
+    }
+
+    return { content: serializeProjectContextFile(entries), entryId, op };
 };


### PR DESCRIPTION
## What & why

Creating a PR to update `lightdash.project_context.yml` round-tripped the **entire** file through `js-yaml` (`yaml.dump`), which strips comments, re-quotes strings and re-indents. So adding a single entry showed up as a full-file rewrite in the PR diff — hard to review, and it silently deleted any human-authored comments.

## Change

New `applyProjectContextWriteback(existingContent, judgeEntry)` in `packages/common/src/ee/AiAgent/projectContext.ts` edits the parsed [`yaml`](https://eemeli.org/yaml/) (eemeli) **Document** in place — append the new entry node, or replace the one matching `id` — then `stringify`. `ProjectContextService.writebackEntry` calls it instead of `mergeProjectContextEntry` + `serializeProjectContextFile`.

This follows the existing `DbtSchemaEditor` precedent (already on the `yaml` package — no new dependency).

## Behaviour / regression analysis

- **Canonical `{ version, entries }` files (the normal case):** untouched entries keep their comments, quoting and key order → the PR diff is just the added/updated entry. The one cosmetic change is that **flow** sequences are re-spaced (`[HR]` → `[ HR ]`) by the serializer; block sequences and everything else are byte-preserved.
- **Empty / legacy bare-array files:** fall back to a fresh canonical serialization (a one-time rewrite — same as the old behaviour).
- **Update path:** matches the existing entry by explicit `id`; if it can't be found it appends (op still reported correctly).
- Still fully **deterministic** — no sandbox / LLM. The `semantic_layer` writeback path is unchanged.

## Tests

`projectContext.test.ts`: creates a canonical file from empty content; appends a new entry while preserving existing comments + quoting; updates an entry in place by id. Existing `ProjectContextService` writeback tests still pass (create-when-missing, update-when-present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)