### PR TITLE
feat(writeback): preview-deploy refinements — answer CI status from the repo + hide non-applicable preview button [PROD-8093]

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -222,6 +222,75 @@ export const getFileContent = async ({
     }
 };
 
+/**
+ * Read every `.github/workflows/*.{yml,yaml}` file from a repo via the GitHub
+ * API — no clone/sandbox. Used to detect a Lightdash preview-deploy workflow on
+ * demand. Reads the repo's default branch when `ref` is omitted. Returns an
+ * empty list when the workflows directory does not exist.
+ */
+export const getRepoWorkflowFiles = async ({
+    owner,
+    repo,
+    ref,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    ref?: string;
+    installationId?: string;
+    token?: string;
+}): Promise<{ path: string; content: string }[]> => {
+    const { octokit, headers } = getOctokit(installationId, token);
+    try {
+        const dirResponse = await octokit.rest.repos.getContent({
+            owner,
+            repo,
+            path: '.github/workflows',
+            ...(ref ? { ref } : {}),
+            headers,
+        });
+        // A directory listing is an array; a single file (unexpected here) is not.
+        if (!Array.isArray(dirResponse.data)) {
+            return [];
+        }
+        const workflowEntries = dirResponse.data.filter(
+            (entry) =>
+                entry.type === 'file' &&
+                (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml')),
+        );
+        return await Promise.all(
+            workflowEntries.map(async (entry) => {
+                const fileResponse = await octokit.rest.repos.getContent({
+                    owner,
+                    repo,
+                    path: entry.path,
+                    ...(ref ? { ref } : {}),
+                    headers,
+                });
+                const content =
+                    'content' in fileResponse.data
+                        ? Buffer.from(
+                              fileResponse.data.content,
+                              'base64',
+                          ).toString('utf-8')
+                        : '';
+                return { path: entry.path, content };
+            }),
+        );
+    } catch (error) {
+        if (
+            error instanceof Error &&
+            `status` in error &&
+            error.status === 404
+        ) {
+            // No `.github/workflows` directory — the repo has no workflows.
+            return [];
+        }
+        throw new UnexpectedGitError(getErrorMessage(error));
+    }
+};
+
 export const createBranch = async ({
     owner,
     repo,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6097,7 +6097,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     hasPreviewDeployWorkflow: boolean;
                     workflowPath: string | null;
                 } | null = null;
-                if (isGitProjectType(dbtConnection)) {
+                // Gate the CI lookup on the same SourceCode permission
+                // getOrScanProjectCiStatus enforces, checked up-front so a user
+                // who can view the project but not its source simply doesn't get
+                // this optional field — no swallowed ForbiddenError. Genuine
+                // operational failures (GitHub API, decryption) are logged at
+                // warn (visible) and still never fail getProjectInfo.
+                const canViewSourceCode = auditedAbility.can(
+                    'view',
+                    subject('SourceCode', { organizationUuid, projectUuid }),
+                );
+                if (isGitProjectType(dbtConnection) && canViewSourceCode) {
                     try {
                         const ciStatus =
                             await this.aiWritebackService.getOrScanProjectCiStatus(
@@ -6112,8 +6122,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                               }
                             : null;
                     } catch (err) {
-                        Logger.debug(
-                            'getProjectInfo: preview-deploy CI lookup failed:',
+                        Logger.warn(
+                            'getProjectInfo: preview-deploy CI lookup failed',
                             err,
                         );
                     }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6088,6 +6088,37 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 const project = await this.projectModel.get(projectUuid);
                 const { dbtConnection } = project;
 
+                // For a git-backed project, look up (and, if not yet known,
+                // scan the connected repo for) its preview-deploy CI status so
+                // the assistant can answer "is preview-deploy CI set up?" by
+                // inspecting the git-backed project. Best-effort — never block
+                // getProjectInfo on it.
+                let previewDeployCi: {
+                    hasPreviewDeployWorkflow: boolean;
+                    workflowPath: string | null;
+                } | null = null;
+                if (isGitProjectType(dbtConnection)) {
+                    try {
+                        const ciStatus =
+                            await this.aiWritebackService.getOrScanProjectCiStatus(
+                                user,
+                                projectUuid,
+                            );
+                        previewDeployCi = ciStatus
+                            ? {
+                                  hasPreviewDeployWorkflow:
+                                      ciStatus.hasPreviewDeployWorkflow,
+                                  workflowPath: ciStatus.workflowPath,
+                              }
+                            : null;
+                    } catch (err) {
+                        Logger.debug(
+                            'getProjectInfo: preview-deploy CI lookup failed:',
+                            err,
+                        );
+                    }
+                }
+
                 return {
                     projectName: project.name,
                     projectType: project.type,
@@ -6102,6 +6133,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                               hostDomain: dbtConnection.host_domain ?? null,
                           }
                         : null,
+                    previewDeployCi,
                 };
             });
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -4,6 +4,7 @@ import {
     DbtProjectType,
     FeatureFlags,
     ForbiddenError,
+    ParameterError,
     PullRequestProvider,
     WarehouseTypes,
     type MemberAbility,
@@ -549,5 +550,53 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
         expect(result).toMatchObject({ exitCode: 0, prUrl: null });
         expect(createPullRequest).not.toHaveBeenCalled();
         expect(sandbox.kill).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('AiWritebackService.setupPreviewDeploy', () => {
+    const userWithManageSourceCode = (): SessionUser => {
+        const { build, can } = new AbilityBuilder<MemberAbility>(Ability);
+        can('manage', 'SourceCode', { organizationUuid: ORG });
+        return {
+            userUuid: 'u1',
+            organizationUuid: ORG,
+            organizationName: 'Acme',
+            organizationCreatedAt: new Date(),
+            role: 'admin',
+            ability: build(),
+        } as AnyType;
+    };
+
+    const gitlabProject = (): AnyType => ({
+        organizationUuid: ORG,
+        name: 'Analytics',
+        dbtConnection: {
+            type: DbtProjectType.GITLAB,
+            personal_access_token: 'pat',
+            repository: 'acme/analytics',
+            branch: 'main',
+            project_sub_path: '/',
+            host_domain: 'gitlab.acme.com',
+        },
+        warehouseConnection: { type: WarehouseTypes.POSTGRES },
+    });
+
+    it('rejects a non-GitHub project — automated GitHub Actions setup is GitHub-only', async () => {
+        const run = jest.fn();
+        const service = buildService({
+            projectModel: {
+                get: jest.fn().mockResolvedValue(gitlabProject()),
+            } as AnyType,
+        });
+        jest.spyOn(service as AnyType, 'run').mockImplementation(run);
+
+        await expect(
+            (service as AnyType).setupPreviewDeploy({
+                user: userWithManageSourceCode(),
+                projectUuid: 'p1',
+            }),
+        ).rejects.toThrow(ParameterError);
+        // The guard fires before any sandbox run is started.
+        expect(run).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -372,6 +372,75 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
+     * Return the project's preview-deploy CI status, scanning the connected repo
+     * via the git host API (no sandbox) when it hasn't been determined yet.
+     *
+     * This lets the assistant answer "is preview-deploy CI set up?" by looking
+     * at the git-backed project on demand, rather than only learning the answer
+     * as a side effect of a full writeback run. A project already recorded as
+     * configured is not re-scanned. Best-effort: returns the last known status
+     * (or null) when the host has no preview-deploy support, the GitHub App
+     * isn't installed, or the scan fails.
+     */
+    async getOrScanProjectCiStatus(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ProjectCiStatus | null> {
+        const project = await this.projectModel.get(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('SourceCode', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const existing =
+            await this.projectCiStatusModel.findByProjectUuid(projectUuid);
+        if (existing?.hasPreviewDeployWorkflow) {
+            // Already configured — don't re-scan (matches the sandbox path).
+            return existing;
+        }
+
+        const provider = this.getGitProvider(project.dbtConnection.type);
+        if (!provider.supportsPreviewDeploy) {
+            return existing;
+        }
+
+        try {
+            const connection = provider.resolveConnection(
+                project.dbtConnection,
+            );
+            const installation = await provider.resolveInstallation(
+                project.organizationUuid,
+            );
+            const files = await provider.readPreviewDeployWorkflowFiles(
+                connection,
+                installation,
+            );
+            const detection = detectPreviewDeployWorkflow(files);
+            return await this.projectCiStatusModel.upsert({
+                projectUuid,
+                hasPreviewDeployWorkflow: detection.hasPreviewDeployWorkflow,
+                workflowPath: detection.workflowPath,
+                detectedCommitSha: null,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `AiWriteback: on-demand preview-deploy scan failed — returning last known status: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            return existing;
+        }
+    }
+
+    /**
      * Secondary task of the writeback agent: while the repo is cloned in the
      * sandbox, detect whether it already deploys Lightdash preview projects via
      * GitHub Actions and persist the result. A project already recorded as set

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -548,6 +548,20 @@ export class AiWritebackService extends BaseService {
             throw new ForbiddenError();
         }
 
+        // This tool auto-generates a Lightdash preview-deploy *GitHub Actions*
+        // workflow, which today only supports GitHub-backed projects
+        // (provider.supportsPreviewDeploy). Preview deploys themselves can be
+        // wired up on any CI by hand — we just can't generate that for
+        // non-GitHub hosts yet. The agent isn't prompted to offer setup for
+        // other hosts (detection is gated on supportsPreviewDeploy), but the
+        // tool can still be reached by a direct ask — guard it explicitly.
+        const provider = this.getGitProvider(project.dbtConnection.type);
+        if (!provider.supportsPreviewDeploy) {
+            throw new ParameterError(
+                `Automated preview-deploy setup currently supports GitHub Actions only, so it can't run for this project's "${project.dbtConnection.type}" connection. Preview deploys can still be set up manually via your own CI.`,
+            );
+        }
+
         const result = await this.run({
             user,
             projectUuid,

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -562,7 +562,7 @@ export class AiWritebackService extends BaseService {
             // Stages can opt out of progress reporting by returning null
             // from progressTextForStage when their label would duplicate
             // the parent tool's heading or otherwise add no signal.
-            const progressText = progressTextForStage(stage);
+            const progressText = progressTextForStage(stage, source);
             if (progressText !== null) {
                 reportProgress(progressText);
             }

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GitProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GitProvider.ts
@@ -2,6 +2,7 @@ import type {
     DbtProjectConfig,
     PullRequestProvider,
     SessionUser,
+    WorkflowFile,
 } from '@lightdash/common';
 import type { Sandbox } from 'e2b';
 import type {
@@ -59,4 +60,16 @@ export interface GitProvider {
     updatePullRequest(args: UpdatePullRequestArgs): Promise<void>;
     /** Validate a pasted PR/MR link before editing it on top of its branch. */
     adoptPullRequest(args: AdoptPullRequestArgs): Promise<AdoptedPullRequest>;
+
+    /**
+     * Read `.github/workflows/*` from the host API (no sandbox) so the service
+     * can detect a preview-deploy workflow on demand — e.g. to answer "is
+     * preview-deploy CI set up?" without running a writeback. Returns an empty
+     * list when the host doesn't support preview deploys or the directory is
+     * absent.
+     */
+    readPreviewDeployWorkflowFiles(
+        connection: GitConnection,
+        installation: GitInstallation,
+    ): Promise<WorkflowFile[]>;
 }

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.ts
@@ -9,6 +9,7 @@ import {
     UnexpectedServerError,
     type DbtProjectConfig,
     type SessionUser,
+    type WorkflowFile,
 } from '@lightdash/common';
 import { randomUUID } from 'crypto';
 import type { Sandbox } from 'e2b';
@@ -21,6 +22,7 @@ import {
     getBranchHeadSha,
     getInstallationToken,
     getPullRequest,
+    getRepoWorkflowFiles,
     updatePullRequest,
 } from '../../../../clients/github/Github';
 import type { GithubAppInstallationsModel } from '../../../../models/GithubAppInstallations/GithubAppInstallationsModel';
@@ -319,6 +321,20 @@ export class GithubProvider implements GitProvider {
             pullNumber: parsed.pullNumber,
             headRef: pr.headRef,
         };
+    }
+
+    async readPreviewDeployWorkflowFiles(
+        connection: GitConnection,
+        installation: GitInstallation,
+    ): Promise<WorkflowFile[]> {
+        const gh = asGithubConnection(connection);
+        // Reads the repo's default branch (no `ref`), matching the in-sandbox
+        // scan which detects on the freshly-cloned default branch.
+        return getRepoWorkflowFiles({
+            owner: gh.owner,
+            repo: gh.repo,
+            ...githubAuth(asGithubInstallation(installation)),
+        });
     }
 
     /**

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GitlabProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GitlabProvider.ts
@@ -10,6 +10,7 @@ import {
     UnexpectedServerError,
     type DbtProjectConfig,
     type SessionUser,
+    type WorkflowFile,
 } from '@lightdash/common';
 import { randomUUID } from 'crypto';
 import type { Sandbox } from 'e2b';
@@ -337,6 +338,12 @@ export class GitlabProvider implements GitProvider {
             pullNumber: mergeRequestIid,
             headRef: mr.sourceBranch,
         };
+    }
+
+    // GitLab has no Lightdash preview-deploy support (`supportsPreviewDeploy`
+    // is false), so there is nothing to scan for.
+    async readPreviewDeployWorkflowFiles(): Promise<WorkflowFile[]> {
+        return [];
     }
 
     /**

--- a/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
@@ -225,6 +225,28 @@ describe('progressTextForStage', () => {
     it('opts pull_request out of progress reporting', () => {
         expect(progressTextForStage('pull_request')).toBeNull();
     });
+
+    it('relabels the model-editing stages for a preview-deploy setup', () => {
+        // The setup run generates a workflow file, it does not edit models.
+        expect(progressTextForStage('agent', 'preview_deploy_setup')).toBe(
+            'Generating preview-deploy workflow',
+        );
+        expect(progressTextForStage('commit', 'preview_deploy_setup')).toBe(
+            'Committing workflow',
+        );
+        // Shared stages keep their generic labels.
+        expect(progressTextForStage('clone', 'preview_deploy_setup')).toBe(
+            'Cloning project',
+        );
+        expect(progressTextForStage('push', 'preview_deploy_setup')).toBe(
+            'Pushing changes',
+        );
+        // Non-setup sources are unaffected.
+        expect(progressTextForStage('agent', 'web')).toBe('Starting sub agent');
+        expect(progressTextForStage('commit', 'slack')).toBe(
+            'Committing changes',
+        );
+    });
 });
 
 describe('extractPrMetadata', () => {

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -204,7 +204,13 @@ export const parsePullNumber = (prUrl: string): number => {
 /** `null` opts a stage out of progress reporting (its label would be noise). */
 export const progressTextForStage = (
     stage: AiWritebackFailureStage,
+    source?: AiWritebackSource,
 ): string | null => {
+    // A preview-deploy setup run shares the writeback pipeline but isn't editing
+    // the user's models — it generates and commits a workflow file. Relabel the
+    // stages whose generic writeback wording ("sub agent", "changes") would
+    // misdescribe what's happening, so the sub-progress reads correctly.
+    const isPreviewDeploySetup = source === 'preview_deploy_setup';
     switch (stage) {
         case 'install':
             return 'Setting up';
@@ -213,9 +219,13 @@ export const progressTextForStage = (
         case 'clone':
             return 'Cloning project';
         case 'agent':
-            return 'Starting sub agent';
+            return isPreviewDeploySetup
+                ? 'Generating preview-deploy workflow'
+                : 'Starting sub agent';
         case 'commit':
-            return 'Committing changes';
+            return isPreviewDeploySetup
+                ? 'Committing workflow'
+                : 'Committing changes';
         case 'push':
             return 'Pushing changes';
         case 'pull_request':

--- a/packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts
@@ -22,7 +22,7 @@ Match the user's intent — don't re-ask for permission they already gave. If th
 
 **Preview-deploy GitHub Actions:**
 
-This project is git-backed, so you can answer questions about its CI directly — never say you "can't verify" whether preview deploys are set up. When the user asks whether the repo has Lightdash preview deploys (a preview project per pull request) configured, call \`getProjectInfo\`: it reports the repo's preview-deploy status (checking the git-backed project's \`.github/workflows\` when not already known). Report what it says. If it reports preview deploys are NOT set up, offer to add them by opening a pull request, and call \`setupPreviewDeploy\` only once the user agrees.
+This project is git-backed, so you can answer questions about its CI directly — never say you "can't verify". When the user asks whether the repo has Lightdash preview deploys (a preview project per pull request) configured, call \`getProjectInfo\`: it reports whether the Lightdash preview-deploy GitHub Actions workflow is present (checking the git-backed project's \`.github/workflows\` when not already known). Report what it says. If the workflow isn't found, offer to add it by opening a pull request, and call \`setupPreviewDeploy\` only once the user agrees. Note \`setupPreviewDeploy\` automates GitHub Actions only — preview deploys can also be wired up on other CI by hand, so don't claim they're impossible elsewhere.
 
 **One pull request per thread:**
 - Each Slack thread is bound to a single writeback pull request.

--- a/packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2AiWriteback.ts
@@ -20,6 +20,10 @@ When a discovery tool — especially \`searchSemanticLayer\` — surfaces proble
 
 Match the user's intent — don't re-ask for permission they already gave. If the user's request already tells you to make the change (e.g. "fix it", "open a PR", "clean these up", "update the descriptions"), go straight to \`proposeWriteback\` — do not stop to ask "want me to go ahead?". Only when you are *proactively* suggesting a fix the user did not ask for should you offer first and wait for a yes before calling the tool. Either way, translate the change into a precise, self-contained instruction for the writeback agent (target model/YAML file and the literal edit — e.g. which metric to update and the exact new description text).
 
+**Preview-deploy GitHub Actions:**
+
+This project is git-backed, so you can answer questions about its CI directly — never say you "can't verify" whether preview deploys are set up. When the user asks whether the repo has Lightdash preview deploys (a preview project per pull request) configured, call \`getProjectInfo\`: it reports the repo's preview-deploy status (checking the git-backed project's \`.github/workflows\` when not already known). Report what it says. If it reports preview deploys are NOT set up, offer to add them by opening a pull request, and call \`setupPreviewDeploy\` only once the user agrees.
+
 **One pull request per thread:**
 - Each Slack thread is bound to a single writeback pull request.
 - The first \`proposeWriteback\` call in a thread opens the PR; later calls update that same PR.

--- a/packages/backend/src/ee/services/ai/tools/getProjectInfo.ts
+++ b/packages/backend/src/ee/services/ai/tools/getProjectInfo.ts
@@ -46,18 +46,20 @@ export const getGetProjectInfo = ({ getProjectInfo }: Dependencies) =>
                     }
                 }
 
-                // Preview-deploy CI status — lets the assistant answer "is
-                // preview-deploy set up?" straight from the git-backed project.
-                // Only meaningful for git projects; null means undeterminable.
+                // Preview-deploy GitHub Actions status — lets the assistant
+                // answer "are preview deploys set up?" from the git-backed repo.
+                // This only detects the Lightdash GitHub Actions workflow (the
+                // only setup the agent automates today); preview deploys wired
+                // via another CI aren't detected. Null when undeterminable.
                 if (info.previewDeployCi) {
                     lines.push(
                         info.previewDeployCi.hasPreviewDeployWorkflow
-                            ? `Preview deploys: configured via GitHub Actions${
+                            ? `Preview-deploy GitHub Actions: configured${
                                   info.previewDeployCi.workflowPath
                                       ? ` (${info.previewDeployCi.workflowPath})`
                                       : ''
                               }`
-                            : 'Preview deploys: NOT set up — no Lightdash preview-deploy GitHub Actions workflow found in the repo. Offer to add one with the `setupPreviewDeploy` tool.',
+                            : 'Preview-deploy GitHub Actions: not found — no Lightdash preview-deploy workflow in the repo. You can offer to add one with the `setupPreviewDeploy` tool (GitHub Actions only).',
                     );
                 }
 

--- a/packages/backend/src/ee/services/ai/tools/getProjectInfo.ts
+++ b/packages/backend/src/ee/services/ai/tools/getProjectInfo.ts
@@ -46,6 +46,21 @@ export const getGetProjectInfo = ({ getProjectInfo }: Dependencies) =>
                     }
                 }
 
+                // Preview-deploy CI status — lets the assistant answer "is
+                // preview-deploy set up?" straight from the git-backed project.
+                // Only meaningful for git projects; null means undeterminable.
+                if (info.previewDeployCi) {
+                    lines.push(
+                        info.previewDeployCi.hasPreviewDeployWorkflow
+                            ? `Preview deploys: configured via GitHub Actions${
+                                  info.previewDeployCi.workflowPath
+                                      ? ` (${info.previewDeployCi.workflowPath})`
+                                      : ''
+                              }`
+                            : 'Preview deploys: NOT set up — no Lightdash preview-deploy GitHub Actions workflow found in the repo. Offer to add one with the `setupPreviewDeploy` tool.',
+                    );
+                }
+
                 return {
                     result: lines.join('\n'),
                     metadata: { status: 'success' as const },

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -418,4 +418,13 @@ export type GetProjectInfoFn = () => Promise<{
         projectSubPath: string;
         hostDomain: string | null;
     } | null;
+    /**
+     * Whether the git-backed repo deploys Lightdash preview projects via GitHub
+     * Actions. Null when it can't be determined (not a git project, GitHub App
+     * not installed, or the host has no preview-deploy support).
+     */
+    previewDeployCi: {
+        hasPreviewDeployWorkflow: boolean;
+        workflowPath: string | null;
+    } | null;
 }>;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -444,15 +444,31 @@ const AssistantBubbleContent: FC<{
     //     slice mirrors AI SDK output-available chunks into each part's
     //     toolResult, which is the full tool return shape {result,metadata}.
     //     We re-shape to the structured `metadata` the card expects.
-    const proposeWritebackMetadata:
-        | ToolProposeWritebackOutput['metadata']
-        | null = (() => {
+    const proposeWritebackResult: {
+        metadata: ToolProposeWritebackOutput['metadata'];
+        // setupPreviewDeploy reuses this card but its PR only adds the preview
+        // workflow — it never previews itself, so the card hides the preview
+        // affordance when this is true.
+        isPreviewDeploySetup: boolean;
+    } | null = (() => {
         // setupPreviewDeploy shares proposeWriteback's output shape and the
         // same PR-button card, so resolve either tool's result here.
-        const persisted =
-            message.toolResults.find(isToolProposeWritebackResult) ??
-            message.toolResults.find(isToolSetupPreviewDeployResult);
-        if (persisted) return persisted.metadata;
+        const writebackResult = message.toolResults.find(
+            isToolProposeWritebackResult,
+        );
+        if (writebackResult)
+            return {
+                metadata: writebackResult.metadata,
+                isPreviewDeploySetup: false,
+            };
+        const setupResult = message.toolResults.find(
+            isToolSetupPreviewDeployResult,
+        );
+        if (setupResult)
+            return {
+                metadata: setupResult.metadata,
+                isPreviewDeploySetup: true,
+            };
 
         const livePart = streamingState?.parts.find(
             (p): p is Extract<StreamPart, { type: 'toolCall' }> =>
@@ -465,7 +481,11 @@ const AssistantBubbleContent: FC<{
         const liveOutput = livePart?.toolResult as
             | ToolProposeWritebackOutput
             | undefined;
-        return liveOutput?.metadata ?? null;
+        if (!liveOutput?.metadata) return null;
+        return {
+            metadata: liveOutput.metadata,
+            isPreviewDeploySetup: livePart?.toolName === 'setupPreviewDeploy',
+        };
     })();
 
     const mcpUnavailableNotices = streamingState?.mcpUnavailableNotices ?? [];
@@ -903,11 +923,14 @@ const AssistantBubbleContent: FC<{
                     toolResult={proposeChangeToolResult}
                 />
             )}
-            {proposeWritebackMetadata && (
+            {proposeWritebackResult && (
                 <AiProposeWritebackToolCall
-                    metadata={proposeWritebackMetadata}
+                    metadata={proposeWritebackResult.metadata}
                     projectUuid={projectUuid}
                     prCreatedAt={message.createdAt}
+                    isPreviewDeploySetup={
+                        proposeWritebackResult.isPreviewDeploySetup
+                    }
                 />
             )}
         </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
@@ -29,6 +29,13 @@ type Props = {
     projectUuid: string;
     /** When the write-back PR was opened — anchors the ~10 min preview wait. */
     prCreatedAt: string;
+    /**
+     * True when this card belongs to a `setupPreviewDeploy` PR (one that adds
+     * the preview-deploy workflow) rather than a data-change `proposeWriteback`
+     * PR. A setup PR never produces a preview of itself, so the preview
+     * affordance is suppressed for it.
+     */
+    isPreviewDeploySetup: boolean;
 };
 
 // Parses "https://github.com/lightdash/jaffle/pull/29" into "lightdash/jaffle #29"
@@ -63,6 +70,7 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
     metadata,
     projectUuid,
     prCreatedAt,
+    isPreviewDeploySetup,
 }) => {
     const prUrl = metadata.status === 'success' ? metadata.prUrl : null;
 
@@ -74,10 +82,13 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
     // Only wait for a preview URL when one is actually expected — poll unless we
     // positively know the repo has no preview workflow (avoids polling forever
     // on repos that never produce a preview). The poll also stops ~10 min after
-    // the PR was opened.
+    // the PR was opened. A preview-deploy *setup* PR never previews itself, so
+    // never poll for one.
     const { data: preview } = usePullRequestPreview(
         projectUuid,
-        previewDeployConfigured === false ? null : prUrl,
+        isPreviewDeploySetup || previewDeployConfigured === false
+            ? null
+            : prUrl,
         prCreatedAt,
     );
     const previewTimedOut = isPreviewWaitTimedOut(prCreatedAt);
@@ -162,7 +173,7 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
                     </Stack>
                 </Group>
                 <Group gap="xs" wrap="nowrap">
-                    {preview?.previewUrl ? (
+                    {isPreviewDeploySetup ? null : preview?.previewUrl ? (
                         <Button
                             component="a"
                             href={preview.previewUrl}


### PR DESCRIPTION
## What & why

Follow-up refinements to the preview-deploy GitHub Actions feature shipped in PROD-8056 (#23746), found while dogfooding the agent on a git-backed project.

**Linear:** [PROD-8093](https://linear.app/lightdash/issue/PROD-8093)

### 1. Answer "is preview-deploy CI set up?" from the git-backed project
When asked whether a project has Lightdash preview deploys configured, the agent had no signal until a full writeback run recorded it, so it disclaimed ("I can't verify"). `getProjectInfo` now reports preview-deploy CI status: it reads the persisted `project_ci_status` and, when unknown, scans the connected repo's `.github/workflows` via the GitHub contents API (no sandbox) and persists the result. The prompt instructs the agent to answer from `getProjectInfo` and offer `setupPreviewDeploy` only when CI is absent.

### 2. Hide the "View preview" affordance on preview-deploy *setup* PRs
`setupPreviewDeploy` reuses the `proposeWriteback` PR card, which renders a preview affordance ("View preview" / "Preparing preview…"). That only makes sense for a data-change writeback PR that triggers a preview deploy — a setup PR merely adds the workflow file and never previews itself. An `isPreviewDeploySetup` flag now suppresses that section (and its polling) for setup PRs; the `proposeWriteback` card is unchanged.

### 3. Preview-deploy-specific sub-step progress labels
A setup run reused the writeback pipeline's generic sub-step labels ("Starting sub agent", "Committing changes"). `progressTextForStage` is now source-aware: a `preview_deploy_setup` run reads "Generating preview-deploy workflow" / "Committing workflow"; shared stages keep their generic labels.

## Testing

Verified end-to-end locally via the web UI (Claude Sonnet 4.6 agent, GitHub-connected project):
- Asking "do we have preview-deploy CI?" → agent calls `getProjectInfo`, answers definitively from the repo (no disclaimer), and persists `project_ci_status`.
- Running `setupPreviewDeploy` → "Setting up preview deploys" with the new "Generating preview-deploy workflow" sub-step; PR card shows only "View pull request".
- Forcing `has_preview_deploy_workflow = true` (which would make the old code render "Preparing preview…") and reloading → the setup-PR card still shows no preview affordance, confirming the `isPreviewDeploySetup` suppression.

Unit tests: `progressTextForStage` source-aware labels added; common detection (14) + writeback suite (124) + utils (64) green. Backend + frontend typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)