### PR TITLE
fix(export): fall back to flat export when pivot details are missing (PROD-8090)

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -3,6 +3,7 @@ import {
     AnyType,
     CreateWarehouseCredentials,
     DimensionType,
+    DownloadFileType,
     ExecuteAsyncQueryRequestParams,
     ExploreType,
     FeatureFlags,
@@ -1689,6 +1690,148 @@ describe('AsyncQueryService', () => {
             );
 
             // THEN: Test completed successfully - all critical behaviors verified
+        });
+    });
+
+    describe('download pivot routing', () => {
+        const pivotConfig = {
+            pivotDimensions: ['order_date'],
+            metricsAsRows: false,
+        };
+
+        const baseReadyQueryHistory = (
+            overrides: Partial<QueryHistory>,
+        ): QueryHistory =>
+            ({
+                createdAt: new Date(),
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                createdByUserUuid: sessionAccount.user.id,
+                createdBy: sessionAccount.user.id,
+                createdByAccount: null,
+                createdByActorType: 'session',
+                queryUuid: 'test-query-uuid',
+                projectUuid,
+                status: QueryHistoryStatus.READY,
+                error: null,
+                erroredAt: null,
+                metricQuery: metricQueryMock,
+                context: QueryExecutionContext.EXPLORE,
+                fields: validExplore.tables.a.dimensions,
+                compiledSql: 'SELECT * FROM test.table',
+                warehouseQueryId: 'test-warehouse-query-id',
+                warehouseQueryMetadata: null,
+                requestParameters: {} as ExecuteAsyncQueryRequestParams,
+                totalRowCount: 10,
+                warehouseExecutionTimeMs: 1500,
+                defaultPageSize: 10,
+                cacheKey: 'test-cache-key',
+                pivotConfiguration: null,
+                pivotTotalColumnCount: null,
+                pivotValuesColumns: null,
+                resultsFileName: 'results-file-name.json',
+                resultsCreatedAt: new Date(),
+                resultsUpdatedAt: new Date(),
+                resultsExpiresAt: new Date(Date.now() + 60_000),
+                columns: expectedColumns,
+                originalColumns: {},
+                preAggregateCompiledSql: null,
+                processingStartedAt: null,
+                ...overrides,
+            }) as QueryHistory;
+
+        it('falls back to a flat CSV export when a pivotConfig is requested but the query stored no pivot details', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            service.queryHistoryModel.get = jest
+                .fn()
+                .mockResolvedValue(baseReadyQueryHistory({}));
+
+            const pivotSpy = jest
+                .spyOn(service.pivotTableService, 'downloadAsyncPivotTableCsv')
+                .mockResolvedValue({
+                    fileUrl: 'should-not-be-used',
+                    truncated: false,
+                });
+            const flatSpy = jest
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .spyOn(
+                    service as any,
+                    'downloadAsyncQueryResultsAsFormattedFile',
+                )
+                .mockResolvedValue({ fileUrl: 'flat-url', truncated: false });
+
+            await expect(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (service as any).downloadAsyncQueryResults({
+                    account: sessionAccount,
+                    projectUuid,
+                    queryUuid: 'test-query-uuid',
+                    type: DownloadFileType.CSV,
+                    pivotConfig,
+                    exportPivotedData: true,
+                }),
+            ).resolves.toMatchObject({ fileUrl: 'flat-url' });
+
+            expect(pivotSpy).not.toHaveBeenCalled();
+            expect(flatSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('uses the pivot CSV export when the query stored pivot details', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            service.queryHistoryModel.get = jest.fn().mockResolvedValue(
+                baseReadyQueryHistory({
+                    pivotConfiguration: {
+                        indexColumn: {
+                            reference: 'user_id',
+                            type: VizIndexType.CATEGORY,
+                        },
+                        valuesColumns: [
+                            {
+                                reference: 'amount',
+                                aggregation: VizAggregationOptions.SUM,
+                            },
+                        ],
+                        groupByColumns: [{ reference: 'order_date' }],
+                        sortBy: [],
+                    },
+                    pivotTotalColumnCount: 5,
+                    pivotValuesColumns: {
+                        amount_sum_2021: {
+                            referenceField: 'amount',
+                            pivotColumnName: 'amount_sum_2021',
+                            aggregation: VizAggregationOptions.SUM,
+                            pivotValues: [
+                                { referenceField: 'order_date', value: '2021' },
+                            ],
+                        },
+                    } as AnyType,
+                }),
+            );
+
+            const pivotSpy = jest
+                .spyOn(service.pivotTableService, 'downloadAsyncPivotTableCsv')
+                .mockResolvedValue({ fileUrl: 'pivot-url', truncated: false });
+            const flatSpy = jest
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .spyOn(
+                    service as any,
+                    'downloadAsyncQueryResultsAsFormattedFile',
+                )
+                .mockResolvedValue({ fileUrl: 'flat-url', truncated: false });
+
+            await expect(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (service as any).downloadAsyncQueryResults({
+                    account: sessionAccount,
+                    projectUuid,
+                    queryUuid: 'test-query-uuid',
+                    type: DownloadFileType.CSV,
+                    pivotConfig,
+                    exportPivotedData: true,
+                }),
+            ).resolves.toMatchObject({ fileUrl: 'pivot-url' });
+
+            expect(pivotSpy).toHaveBeenCalledTimes(1);
+            expect(flatSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -96,6 +96,7 @@ import {
     type PreAggregateStrategy,
 } from './PreAggregateStrategy';
 import type {
+    DownloadAsyncQueryResultsArgs,
     ExecuteAsyncQueryReturn,
     RunAsyncWarehouseQueryArgs,
 } from './types';
@@ -1694,6 +1695,18 @@ describe('AsyncQueryService', () => {
     });
 
     describe('download pivot routing', () => {
+        // Typed view onto the private download methods exercised by these tests.
+        type DownloadInternals = {
+            downloadAsyncQueryResults: (
+                args: DownloadAsyncQueryResultsArgs,
+            ) => Promise<{ fileUrl: string; truncated: boolean }>;
+            downloadAsyncQueryResultsAsFormattedFile: (
+                ...args: unknown[]
+            ) => Promise<{ fileUrl: string; truncated: boolean }>;
+        };
+        const asInternals = (service: AsyncQueryService) =>
+            service as unknown as DownloadInternals;
+
         const pivotConfig = {
             pivotDimensions: ['order_date'],
             metricsAsRows: false,
@@ -1741,6 +1754,7 @@ describe('AsyncQueryService', () => {
 
         it('falls back to a flat CSV export when a pivotConfig is requested but the query stored no pivot details', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const internals = asInternals(service);
             service.queryHistoryModel.get = jest
                 .fn()
                 .mockResolvedValue(baseReadyQueryHistory({}));
@@ -1752,16 +1766,11 @@ describe('AsyncQueryService', () => {
                     truncated: false,
                 });
             const flatSpy = jest
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .spyOn(
-                    service as any,
-                    'downloadAsyncQueryResultsAsFormattedFile',
-                )
+                .spyOn(internals, 'downloadAsyncQueryResultsAsFormattedFile')
                 .mockResolvedValue({ fileUrl: 'flat-url', truncated: false });
 
             await expect(
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (service as any).downloadAsyncQueryResults({
+                internals.downloadAsyncQueryResults({
                     account: sessionAccount,
                     projectUuid,
                     queryUuid: 'test-query-uuid',
@@ -1777,6 +1786,7 @@ describe('AsyncQueryService', () => {
 
         it('uses the pivot CSV export when the query stored pivot details', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const internals = asInternals(service);
             service.queryHistoryModel.get = jest.fn().mockResolvedValue(
                 baseReadyQueryHistory({
                     pivotConfiguration: {
@@ -1811,16 +1821,11 @@ describe('AsyncQueryService', () => {
                 .spyOn(service.pivotTableService, 'downloadAsyncPivotTableCsv')
                 .mockResolvedValue({ fileUrl: 'pivot-url', truncated: false });
             const flatSpy = jest
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .spyOn(
-                    service as any,
-                    'downloadAsyncQueryResultsAsFormattedFile',
-                )
+                .spyOn(internals, 'downloadAsyncQueryResultsAsFormattedFile')
                 .mockResolvedValue({ fileUrl: 'flat-url', truncated: false });
 
             await expect(
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (service as any).downloadAsyncQueryResults({
+                internals.downloadAsyncQueryResults({
                     account: sessionAccount,
                     projectUuid,
                     queryUuid: 'test-query-uuid',

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1348,21 +1348,27 @@ export class AsyncQueryService extends ProjectService {
                   )
                 : fields;
         const downloadPivotConfig = exportPivotedData ? pivotConfig : undefined;
+        // The export only pivots when the underlying query stored pivot details.
+        // A chart's UI pivot config can be more permissive than the backend's
+        // query-side derivation, so fall back to a flat export when they diverge.
+        const pivotDetails =
+            AsyncQueryService.getPivotDetailsFromQueryHistory(queryHistory);
 
         switch (type) {
             case DownloadFileType.CSV:
                 // Check if this is a pivot table download
-                if (downloadPivotConfig && queryHistory.metricQuery) {
+                if (
+                    downloadPivotConfig &&
+                    pivotDetails &&
+                    queryHistory.metricQuery
+                ) {
                     return this.pivotTableService.downloadAsyncPivotTableCsv({
                         resultsFileName,
                         fields,
                         metricQuery: queryHistory.metricQuery,
                         projectUuid,
                         storageClient: resultsStorageClient,
-                        pivotDetails:
-                            AsyncQueryService.getPivotDetailsFromQueryHistory(
-                                queryHistory,
-                            ),
+                        pivotDetails,
                         options: {
                             onlyRaw,
                             showTableNames,
@@ -1411,7 +1417,9 @@ export class AsyncQueryService extends ProjectService {
             case DownloadFileType.XLSX: {
                 // Check if this is a pivot table download
                 const xlsxResult =
-                    downloadPivotConfig && queryHistory.metricQuery
+                    downloadPivotConfig &&
+                    pivotDetails &&
+                    queryHistory.metricQuery
                         ? await ExcelService.downloadAsyncPivotTableXlsx({
                               resultsFileName,
                               fields,
@@ -1425,10 +1433,7 @@ export class AsyncQueryService extends ProjectService {
                                       organizationUuid,
                                   )
                               ).csvCellsLimit,
-                              pivotDetails:
-                                  AsyncQueryService.getPivotDetailsFromQueryHistory(
-                                      queryHistory,
-                                  ),
+                              pivotDetails,
                               options: {
                                   onlyRaw,
                                   showTableNames,


### PR DESCRIPTION
Closes: PROD-8090
Closes: #23832

### Description:
CSV/XLSX downloads threw `Cannot export pivot table CSV without SQL pivot details` whenever a chart's UI pivot config was sent for export but the underlying query had stored no pivot configuration. This happens because the export trigger (`getPivotConfig`) is more permissive than the query-side derivation (`derivePivotConfigurationFromChart`), so the two can disagree — e.g. a Cartesian chart whose pivot layout doesn't satisfy the backend's validation. This change computes the stored `pivotDetails` once up front and only takes the pivoted export path when they are actually present, falling back to a normal flat export instead of throwing. Verified end-to-end on a local instance: the same download request returns a 500 before the change and a graceful flat CSV after, with unit tests covering both the flat-fallback and the still-pivoted routing.