### PR TITLE
fix(rename): make model rename idempotent when new name extends old

### DIFF
--- a/packages/backend/src/services/RenameService/rename.test.ts
+++ b/packages/backend/src/services/RenameService/rename.test.ts
@@ -1564,3 +1564,82 @@ describe('getNameChanges', () => {
         });
     });
 });
+
+describe('idempotent model rename (new name extends old, e.g. orders -> orders_restricted)', () => {
+    const nameChanges = {
+        from: 'orders',
+        to: 'orders_restricted',
+        fromReference: 'orders',
+        toReference: 'orders_restricted',
+        fromFieldName: undefined,
+        toFieldName: undefined,
+    };
+    const factory = createRenameFactory({ ...nameChanges, isPrefix: true });
+
+    test('replaceId renames bare ids but is a no-op on already-renamed ids', () => {
+        expect(factory.replaceId('orders_status')).toBe(
+            'orders_restricted_status',
+        );
+        // already renamed -> unchanged (previously doubled to orders_restricted_restricted_status)
+        expect(factory.replaceId('orders_restricted_status')).toBe(
+            'orders_restricted_status',
+        );
+    });
+
+    test('replaceString is a no-op on already-renamed ids', () => {
+        expect(factory.replaceString('orders_status')).toBe(
+            'orders_restricted_status',
+        );
+        expect(factory.replaceString('orders_restricted_status')).toBe(
+            'orders_restricted_status',
+        );
+    });
+
+    test('replaceFull renames the bare model but is a no-op on the renamed model', () => {
+        expect(factory.replaceFull('orders')).toBe('orders_restricted');
+        expect(factory.replaceFull('orders_restricted')).toBe(
+            'orders_restricted',
+        );
+    });
+
+    test('renameSavedChart is idempotent: applying the rename twice equals applying it once', () => {
+        const once = renameSavedChart({
+            type: RenameType.MODEL,
+            chart: chartMocked,
+            nameChanges,
+            validate: false,
+        }).updatedChart;
+        const twice = renameSavedChart({
+            type: RenameType.MODEL,
+            chart: once,
+            nameChanges,
+            validate: false,
+        }).updatedChart;
+
+        expect(twice).toEqual(once);
+        // sanity: the first rename happened and did not double anything
+        expect(once.tableName).toBe('orders_restricted');
+        expect(once.metricQuery.exploreName).toBe('orders_restricted');
+        expect(once.metricQuery.dimensions).toEqual([
+            'orders_restricted_status',
+            'orders_restricted_order_date_week',
+        ]);
+        expect(JSON.stringify(twice)).not.toContain(
+            'orders_restricted_restricted',
+        );
+    });
+
+    test('a normal rename (new name does not extend old) is unaffected by the guard', () => {
+        const normal = createRenameFactory({
+            from: 'payment',
+            to: 'invoice',
+            fromReference: 'payment',
+            toReference: 'invoice',
+            fromFieldName: undefined,
+            toFieldName: undefined,
+            isPrefix: true,
+        });
+        expect(normal.replaceId('payment_amount')).toBe('invoice_amount');
+        expect(normal.replaceFull('payment')).toBe('invoice');
+    });
+});

--- a/packages/backend/src/services/RenameService/rename.ts
+++ b/packages/backend/src/services/RenameService/rename.ts
@@ -53,16 +53,32 @@ export const createRenameFactory = ({
     let replaceFieldReference: (str: string) => string;
     let replaceFieldName: (str: string) => string;
     let replaceDotFieldId: (str: string) => string;
+    // When the new model name extends the old one (e.g. `orders` -> `orders_restricted`),
+    // a naive prefix replace re-matches its own output, so re-running the rename stacks
+    // the suffix (`orders_restricted_restricted_...`). Guard the prefix replacers below so
+    // they skip already-renamed values, keeping model renames idempotent.
+    const newNameExtendsOld = isPrefix && to.startsWith(`${from}_`);
     if (isPrefix) {
         replaceId = (str: string) =>
-            str.replace(new RegExp(`^${from}_`, 'g'), `${to}_`); // table prefix (eg: payment_)
+            newNameExtendsOld && str.startsWith(`${to}_`)
+                ? str // already renamed
+                : str.replace(new RegExp(`^${from}_`, 'g'), `${to}_`); // table prefix (eg: payment_)
         replaceReference = (str: string) =>
             str.replace(
                 new RegExp(`\\$\\{${fromReference}\\.`, 'g'),
                 `\${${toReference}.`,
             ); // SQL normally uses "." on references
         replaceString = (str: string) =>
-            str.replace(new RegExp(`${from}_`, 'g'), `${to}_`);
+            str.replace(
+                newNameExtendsOld
+                    ? // skip occurrences already followed by the new suffix (already renamed)
+                      new RegExp(
+                          `${from}_(?!${to.slice(from.length + 1)}_)`,
+                          'g',
+                      )
+                    : new RegExp(`${from}_`, 'g'),
+                `${to}_`,
+            );
         replaceDotFieldId = (str: string) =>
             str.replace(new RegExp(`^${from}\\.`, 'g'), `${to}.`);
         replaceFieldReference = (str: string) => str; // table prefix (eg: payment_)
@@ -121,7 +137,10 @@ export const createRenameFactory = ({
             });
             return Object.assign({}, ...keyValues);
         },
-        replaceFull: (str: string) => str.replaceAll(from, to), // Full name replace, used in tables
+        replaceFull: (str: string) =>
+            newNameExtendsOld && str === to
+                ? str // already renamed
+                : str.replaceAll(from, to), // Full name replace, used in tables
         replaceList: (list: string[]) => list.map((item) => replaceId(item)),
         replaceOptionalList: (list: string[] | undefined) =>
             list ? list.map((item) => replaceId(item)) : undefined,


### PR DESCRIPTION
Closes: PROD-8098
Relates: #16961

### Description

Renaming a model to a name that **contains the old name as a prefix** (e.g. `orders` → `orders_restricted`) was not idempotent. The prefix replacers re-matched their own output, so re-running the same rename stacked the suffix (`orders_restricted_restricted_…`).

Field IDs doubled (via the `^from_` regex) while `tableName` stayed correct (it has an exact-match guard) — leaving charts internally inconsistent: the table resolves but every field under it breaks. Combined with a separate CLI bug that made a successful rename look like a failure, users retried and compounded the corruption.

Affects **both** the CLI `lightdash rename` and the validator "Fix" UI, which share the rename engine.

### Fix

Guard the three prefix replacers so they skip already-renamed values, but **only when the new name literally extends the old one** (i.e. `to` starts with `from_`):

- `replaceId` — no-op if the id already starts with the new prefix
- `replaceString` — negative lookahead skips occurrences already followed by the new suffix
- `replaceFull` — no-op if the value already equals the new name (this was doubling `exploreName` / `table`)

Normal renames (e.g. `payment` → `invoice`) take the exact original path — no behaviour change.

### Tradeoff

A field literally named `restricted_*` on the original model (id `orders_restricted_foo`) is treated as already-renamed and skipped on a first `orders → orders_restricted` rename. Rare, and far preferable to the compounding corruption.

### Tests

Adds regression tests to `rename.test.ts`: idempotency (`renameTwice === renameOnce` on a full chart), per-replacer no-op-on-already-renamed, and that a normal rename is unaffected. All 55 RenameService tests pass; backend typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
