### PR TITLE
fix: filter ENV variables on dbt CLI execution

### DIFF
--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -104,3 +104,42 @@ Object.values(SupportedDbtVersions).map((dbtVersion) => {
         });
     });
 });
+
+describe('DbtCliClient environment filtering', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('only passes allowed dbt environment variables to dbt processes', async () => {
+        execaMock.mockImplementationOnce(cliMockImplementation.success);
+
+        const client = new DbtCliClient({
+            ...cliArgsWithoutVersion,
+            dbtVersion: SupportedDbtVersions.V1_11,
+            environment: {
+                DBT_ENV_CUSTOM_ENV_KEY: 'dbt-value',
+                LIGHTDASH_DBT_PROFILE_VAR_PASSWORD: 'password',
+                AWS_ACCESS_KEY_ID: 'aws-key',
+                GIT_SSH_COMMAND: 'touch /tmp/pwned',
+                LD_PRELOAD: '/tmp/payload.so',
+                PYTHONPATH: '/tmp',
+            },
+        });
+
+        await expect(client.installDeps()).resolves.toEqual(undefined);
+
+        expect(execaMock).toHaveBeenCalledTimes(1);
+        expect(execaMock).toHaveBeenCalledWith(
+            client.getDbtExec(),
+            [...expectedDbtOptions, 'deps', ...expectedCommandOptions],
+            expect.objectContaining({
+                env: {
+                    DBT_PARTIAL_PARSE: 'false',
+                    DBT_SEND_ANONYMOUS_USAGE_STATS: 'false',
+                    DBT_ENV_CUSTOM_ENV_KEY: 'dbt-value',
+                    LIGHTDASH_DBT_PROFILE_VAR_PASSWORD: 'password',
+                },
+            }),
+        );
+    });
+});

--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -118,7 +118,10 @@ describe('DbtCliClient environment filtering', () => {
             dbtVersion: SupportedDbtVersions.V1_11,
             environment: {
                 DBT_ENV_CUSTOM_ENV_KEY: 'dbt-value',
+                DBT_PARTIAL_PARSE: 'true',
+                DBT_SEND_ANONYMOUS_USAGE_STATS: 'true',
                 LIGHTDASH_DBT_PROFILE_VAR_PASSWORD: 'password',
+                LIGHTDASH_API_KEY: 'lightdash-api-key',
                 AWS_ACCESS_KEY_ID: 'aws-key',
                 GIT_SSH_COMMAND: 'touch /tmp/pwned',
                 LD_PRELOAD: '/tmp/payload.so',

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -5,6 +5,7 @@ import {
     DbtLog,
     DbtPackages,
     DbtRpcGetManifestResults,
+    filterDbtEnvironment,
     getErrorMessage,
     isDbtLog,
     isDbtPackages,
@@ -209,7 +210,7 @@ export class DbtCliClient implements DbtClient {
                 env: {
                     DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
                     DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
-                    ...this.environment,
+                    ...filterDbtEnvironment(this.environment),
                 },
             });
             return {

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -208,9 +208,9 @@ export class DbtCliClient implements DbtClient {
                 all: true,
                 stdio: ['pipe', 'pipe', process.stderr],
                 env: {
+                    ...filterDbtEnvironment(this.environment),
                     DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
                     DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
-                    ...filterDbtEnvironment(this.environment),
                 },
             });
             return {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -74,6 +74,7 @@ import {
     getErrorMessage,
     getFields,
     getIntrinsicUserAttributes,
+    getInvalidDbtEnvironmentVariableKeys,
     getItemId,
     getMetricOverridesWithPopInheritance,
     getMetrics,
@@ -2101,6 +2102,7 @@ export class ProjectService extends BaseService {
         await this.validateProjectCreationPermissions(user, data);
 
         const newProjectData = data;
+        ProjectService.validateDbtEnvironmentVariables(newProjectData);
 
         // If type preview and has upstream project, we first link the preview to the same organization warehouse credentials (if exists)
         if (
@@ -2324,6 +2326,7 @@ export class ProjectService extends BaseService {
         }
 
         await this.validateProjectCreationPermissions(user, data);
+        ProjectService.validateDbtEnvironmentVariables(data);
 
         let encryptedData: string;
         try {
@@ -2438,6 +2441,7 @@ export class ProjectService extends BaseService {
                 user.userUuid,
                 user.organizationUuid,
             );
+            ProjectService.validateDbtEnvironmentVariables(createProject);
 
             await this.jobModel.update(jobUuid, {
                 jobStatus: JobStatusType.RUNNING,
@@ -2713,6 +2717,24 @@ export class ProjectService extends BaseService {
         }
     }
 
+    static validateDbtEnvironmentVariables(
+        project: Pick<CreateProjectOptionalCredentials, 'dbtConnection'>,
+    ) {
+        const invalidKeys = getInvalidDbtEnvironmentVariableKeys(
+            'environment' in project.dbtConnection
+                ? project.dbtConnection.environment
+                : undefined,
+        );
+
+        if (invalidKeys.length > 0) {
+            throw new ParameterError(
+                `Invalid dbt environment variable keys: ${invalidKeys.join(
+                    ', ',
+                )}. dbt environment variable keys must be uppercase and start with DBT_.`,
+            );
+        }
+    }
+
     async updateAndScheduleAsyncWork(
         projectUuid: string,
         account: Account,
@@ -2759,6 +2781,7 @@ export class ProjectService extends BaseService {
         );
 
         this.validateConfigSecrets(updatedProject);
+        ProjectService.validateDbtEnvironmentVariables(updatedProject);
 
         await this.projectModel.update(projectUuid, updatedProject);
 

--- a/packages/common/src/types/projects.test.ts
+++ b/packages/common/src/types/projects.test.ts
@@ -66,6 +66,7 @@ describe('dbt environment variables', () => {
                 '': 'ignored-empty-row',
                 DBT_ENV_CUSTOM_ENV_KEY: 'dbt-value',
                 LIGHTDASH_DBT_PROFILE_VAR_PASSWORD: 'password',
+                LIGHTDASH_API_KEY: 'lightdash-api-key',
                 AWS_ACCESS_KEY_ID: 'aws-key',
                 GIT_SSH_COMMAND: 'touch /tmp/pwned',
             }),

--- a/packages/common/src/types/projects.test.ts
+++ b/packages/common/src/types/projects.test.ts
@@ -1,0 +1,77 @@
+import {
+    filterDbtEnvironment,
+    getInvalidDbtEnvironmentVariableKeys,
+    isAllowedDbtEnvironmentVariableKey,
+} from './projects';
+
+describe('dbt environment variables', () => {
+    it('allows blank keys for empty UI rows and documented dbt variables', () => {
+        expect(isAllowedDbtEnvironmentVariableKey('')).toEqual(true);
+        expect(isAllowedDbtEnvironmentVariableKey('DBT_PROFILES_DIR')).toEqual(
+            true,
+        );
+        expect(
+            isAllowedDbtEnvironmentVariableKey('DBT_ENV_CUSTOM_ENV_KEY'),
+        ).toEqual(true);
+        expect(
+            isAllowedDbtEnvironmentVariableKey('DBT_ENV_SECRET_TOKEN'),
+        ).toEqual(true);
+        expect(isAllowedDbtEnvironmentVariableKey('DBT_CLOUD_RUN_ID')).toEqual(
+            true,
+        );
+    });
+
+    it('rejects non-dbt variables', () => {
+        expect(
+            getInvalidDbtEnvironmentVariableKeys([
+                { key: 'LIGHTDASH_DBT_PROFILE_VAR_PASSWORD', value: 'secret' },
+                { key: 'AWS_ACCESS_KEY_ID', value: 'aws-key' },
+                {
+                    key: 'GOOGLE_APPLICATION_CREDENTIALS',
+                    value: '/tmp/credentials.json',
+                },
+                { key: 'DATABRICKS_HOST', value: 'databricks-host' },
+                { key: 'DBT_ENV_CUSTOM_key', value: 'lowercase-key' },
+                { key: 'GIT_SSH_COMMAND', value: 'touch /tmp/pwned' },
+                { key: 'GIT_CONFIG_COUNT', value: '1' },
+                { key: 'LD_PRELOAD', value: '/tmp/payload.so' },
+                { key: 'DYLD_INSERT_LIBRARIES', value: '/tmp/payload.dylib' },
+                { key: 'PYTHONPATH', value: '/tmp' },
+                { key: 'NODE_OPTIONS', value: '--require /tmp/payload.js' },
+                { key: 'BASH_ENV', value: '/tmp/payload.sh' },
+                { key: 'SSH_ASKPASS', value: '/tmp/payload.sh' },
+                { key: 'BASH_FUNC_x%%', value: '() { ignored; }' },
+            ]),
+        ).toEqual([
+            'LIGHTDASH_DBT_PROFILE_VAR_PASSWORD',
+            'AWS_ACCESS_KEY_ID',
+            'GOOGLE_APPLICATION_CREDENTIALS',
+            'DATABRICKS_HOST',
+            'DBT_ENV_CUSTOM_key',
+            'GIT_SSH_COMMAND',
+            'GIT_CONFIG_COUNT',
+            'LD_PRELOAD',
+            'DYLD_INSERT_LIBRARIES',
+            'PYTHONPATH',
+            'NODE_OPTIONS',
+            'BASH_ENV',
+            'SSH_ASKPASS',
+            'BASH_FUNC_x%%',
+        ]);
+    });
+
+    it('filters environment records before spawning dbt', () => {
+        expect(
+            filterDbtEnvironment({
+                '': 'ignored-empty-row',
+                DBT_ENV_CUSTOM_ENV_KEY: 'dbt-value',
+                LIGHTDASH_DBT_PROFILE_VAR_PASSWORD: 'password',
+                AWS_ACCESS_KEY_ID: 'aws-key',
+                GIT_SSH_COMMAND: 'touch /tmp/pwned',
+            }),
+        ).toEqual({
+            DBT_ENV_CUSTOM_ENV_KEY: 'dbt-value',
+            LIGHTDASH_DBT_PROFILE_VAR_PASSWORD: 'password',
+        });
+    });
+});

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -631,6 +631,33 @@ export type DbtProjectEnvironmentVariable = {
     value: string;
 };
 
+const DBT_ENVIRONMENT_VARIABLE_KEY_REGEX = /^[A-Z_][A-Z0-9_]*$/;
+
+export const isAllowedDbtEnvironmentVariableKey = (key: string): boolean =>
+    key.length === 0 ||
+    (DBT_ENVIRONMENT_VARIABLE_KEY_REGEX.test(key) && key.startsWith('DBT_'));
+
+const isAllowedDbtProcessEnvironmentVariableKey = (key: string): boolean =>
+    isAllowedDbtEnvironmentVariableKey(key) || key.startsWith('LIGHTDASH_');
+
+export const getInvalidDbtEnvironmentVariableKeys = (
+    environment: DbtProjectEnvironmentVariable[] | undefined,
+): string[] =>
+    (environment ?? [])
+        .map(({ key }) => key)
+        .filter((key) => !isAllowedDbtEnvironmentVariableKey(key));
+
+export const filterDbtEnvironment = (
+    environment: Record<string, string> | undefined,
+): Record<string, string> =>
+    Object.fromEntries(
+        Object.entries(environment ?? {}).filter(
+            ([key]) =>
+                key.length > 0 &&
+                isAllowedDbtProcessEnvironmentVariableKey(key),
+        ),
+    );
+
 export enum SupportedDbtVersions {
     V1_4 = 'v1.4',
     V1_5 = 'v1.5',

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -631,14 +631,16 @@ export type DbtProjectEnvironmentVariable = {
     value: string;
 };
 
-const DBT_ENVIRONMENT_VARIABLE_KEY_REGEX = /^[A-Z_][A-Z0-9_]*$/;
+const DBT_ENVIRONMENT_VARIABLE_KEY_REGEX = /^DBT_[A-Z0-9_]*$/;
+const LIGHTDASH_DBT_PROFILE_ENVIRONMENT_VARIABLE_KEY_REGEX =
+    /^LIGHTDASH_DBT_PROFILE_VAR_[A-Z0-9_]+$/;
 
 export const isAllowedDbtEnvironmentVariableKey = (key: string): boolean =>
-    key.length === 0 ||
-    (DBT_ENVIRONMENT_VARIABLE_KEY_REGEX.test(key) && key.startsWith('DBT_'));
+    key.length === 0 || DBT_ENVIRONMENT_VARIABLE_KEY_REGEX.test(key);
 
 const isAllowedDbtProcessEnvironmentVariableKey = (key: string): boolean =>
-    isAllowedDbtEnvironmentVariableKey(key) || key.startsWith('LIGHTDASH_');
+    DBT_ENVIRONMENT_VARIABLE_KEY_REGEX.test(key) ||
+    LIGHTDASH_DBT_PROFILE_ENVIRONMENT_VARIABLE_KEY_REGEX.test(key);
 
 export const getInvalidDbtEnvironmentVariableKeys = (
     environment: DbtProjectEnvironmentVariable[] | undefined,

--- a/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
+++ b/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
@@ -3,6 +3,7 @@ import {
     DbtProjectType,
     DbtProjectTypeLabels,
     ProjectType,
+    getInvalidDbtEnvironmentVariableKeys,
     type ApiError,
     type DbtProjectEnvironmentVariable,
 } from '@lightdash/common';
@@ -71,6 +72,7 @@ type EnvironmentVariablesInputProps = {
     disabled?: boolean;
     documentationUrl?: string;
     labelHelp?: string | React.ReactNode;
+    error?: string;
 };
 
 const EnvironmentVariablesInput: FC<EnvironmentVariablesInputProps> = ({
@@ -80,6 +82,7 @@ const EnvironmentVariablesInput: FC<EnvironmentVariablesInputProps> = ({
     disabled,
     documentationUrl,
     labelHelp,
+    error,
 }) => {
     const [isLabelInfoOpen, setIsLabelInfoOpen] = useState<boolean>(false);
 
@@ -136,6 +139,7 @@ const EnvironmentVariablesInput: FC<EnvironmentVariablesInputProps> = ({
                 </>
             }
             description={isLabelInfoOpen && labelHelp}
+            error={error}
         >
             <Stack>
                 {value.map((variable, index) => (
@@ -214,6 +218,7 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
     const [environment, setEnvironment] = useState<
         DbtProjectEnvironmentVariable[]
     >([]);
+    const [environmentError, setEnvironmentError] = useState<string>('');
     const [manifestJson, setManifestJson] = useState<string>('');
     const [manifestError, setManifestError] = useState<string>('');
 
@@ -361,6 +366,18 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
         if (manifestJson.trim() && !validateManifest(manifestJson)) {
             return;
         }
+
+        const invalidEnvironmentKeys =
+            getInvalidDbtEnvironmentVariableKeys(environment);
+        if (invalidEnvironmentKeys.length > 0) {
+            setEnvironmentError(
+                `Environment variable keys must be uppercase and start with DBT_. Invalid keys: ${invalidEnvironmentKeys.join(
+                    ', ',
+                )}`,
+            );
+            return;
+        }
+        setEnvironmentError('');
 
         // Reduce manifest size by removing unnecessary keys
         const finalManifest = manifestJson.trim()
@@ -539,10 +556,12 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
                                 <EnvironmentVariablesInput
                                     label="Environment Variables"
                                     value={environment}
-                                    onChange={(newVariables) =>
-                                        setEnvironment(newVariables)
-                                    }
+                                    onChange={(newVariables) => {
+                                        setEnvironment(newVariables);
+                                        setEnvironmentError('');
+                                    }}
                                     disabled={isPreviewCreating}
+                                    error={environmentError}
                                 />
 
                                 <Textarea

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/validators.ts
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/validators.ts
@@ -1,4 +1,8 @@
-import { validateDbtSelector } from '@lightdash/common';
+import {
+    getInvalidDbtEnvironmentVariableKeys,
+    validateDbtSelector,
+    type DbtProjectEnvironmentVariable,
+} from '@lightdash/common';
 import {
     everyValidator,
     hasNoWhiteSpaces,
@@ -13,9 +17,21 @@ const selectorValidator = (value?: string) => {
     return 'dbt selector is invalid';
 };
 
+const environmentValidator = (
+    value?: DbtProjectEnvironmentVariable[],
+): string | undefined => {
+    const invalidKeys = getInvalidDbtEnvironmentVariableKeys(value);
+    if (invalidKeys.length === 0) return undefined;
+
+    return `Environment variable keys must be uppercase and start with DBT_. Invalid keys: ${invalidKeys.join(
+        ', ',
+    )}`;
+};
+
 export const dbtFormValidators = {
     api_key: hasNoWhiteSpaces('API Key'),
     environment_id: hasNoWhiteSpaces('Environment ID'),
+    environment: environmentValidator,
     selector: selectorValidator,
     // TODO :: improve this for github to detect the prefix
     // @mantine/form@7.5.2 doesn't support replacing validators after initialization

--- a/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
@@ -32,6 +32,7 @@ export const MultiKeyValuePairsInput = ({
 
     const values: { id: string; key: string; value: string }[] =
         get(form.values, name) ?? [];
+    const error = form.errors[name];
 
     const addValue = () => {
         form.insertListItem(name, {
@@ -79,6 +80,7 @@ export const MultiKeyValuePairsInput = ({
                 </>
             }
             description={isLabelInfoOpen && labelHelp}
+            error={error}
         >
             <Stack>
                 {values.map((value, index) => (


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-8109/command-injection-via-unsanitized-dbt-environment-variables](https://linear.app/lightdash/issue/PROD-8109/command-injection-via-unsanitized-dbt-environment-variables)

![CleanShot 2026-06-04 at 09.35.10.png](https://app.graphite.com/user-attachments/assets/8041cfc9-215b-4b46-8e86-a46f71473967.png)





### Description:

Adds validation and filtering of dbt environment variables