### PR TITLE
feat(changesets): show chart & dashboard dependencies per change

### DIFF
--- a/packages/backend/src/services/ChangesetService.ts
+++ b/packages/backend/src/services/ChangesetService.ts
@@ -2,18 +2,23 @@ import { subject } from '@casl/ability';
 import {
     Account,
     Change,
-    ChangesetWithChanges,
+    ChangeDependency,
+    ChangesetWithChangesAndDependencies,
     ForbiddenError,
 } from '@lightdash/common';
 import { CatalogModel } from '../models/CatalogModel/CatalogModel';
 import { ChangesetModel } from '../models/ChangesetModel';
+import { DashboardModel } from '../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../models/SavedChartModel';
 import { BaseService } from './BaseService';
 
 type ChangesetServiceArguments = {
     changesetModel: ChangesetModel;
     catalogModel: CatalogModel;
     projectModel: ProjectModel;
+    savedChartModel: SavedChartModel;
+    dashboardModel: DashboardModel;
 };
 
 export class ChangesetService extends BaseService {
@@ -23,17 +28,87 @@ export class ChangesetService extends BaseService {
 
     private readonly projectModel: ProjectModel;
 
+    private readonly savedChartModel: SavedChartModel;
+
+    private readonly dashboardModel: DashboardModel;
+
     constructor(args: ChangesetServiceArguments) {
         super({ serviceName: 'ChangesetService' });
         this.changesetModel = args.changesetModel;
         this.catalogModel = args.catalogModel;
         this.projectModel = args.projectModel;
+        this.savedChartModel = args.savedChartModel;
+        this.dashboardModel = args.dashboardModel;
+    }
+
+    /**
+     * Content that would break if this change is reverted: charts that
+     * reference the field the change provides, and dashboards that embed those
+     * charts (or filter on the field directly). Only `create` changes add a
+     * field, so other change types have no dependencies.
+     */
+    private async getChangeDependencies(
+        projectUuid: string,
+        change: Change,
+        dashboards: Awaited<
+            ReturnType<DashboardModel['findDashboardsForValidation']>
+        >,
+    ): Promise<ChangeDependency[]> {
+        if (change.type !== 'create') {
+            return [];
+        }
+
+        // The explore keys the field under entityName, but the metric's own
+        // name can differ - check both candidate field ids.
+        const fieldIds = Array.from(
+            new Set([
+                `${change.entityTableName}_${change.entityName}`,
+                `${change.entityTableName}_${change.payload.value.name}`,
+            ]),
+        );
+
+        const chartSummaries = (
+            await Promise.all(
+                fieldIds.map((fieldId) =>
+                    this.savedChartModel.getChartSummariesForFieldId(
+                        projectUuid,
+                        fieldId,
+                    ),
+                ),
+            )
+        ).flat();
+
+        const chartDependencies = new Map<string, ChangeDependency>();
+        for (const chart of chartSummaries) {
+            chartDependencies.set(chart.uuid, {
+                type: 'chart',
+                id: chart.uuid,
+                name: chart.name,
+            });
+        }
+        const chartUuids = new Set(chartDependencies.keys());
+
+        const dashboardDependencies = dashboards
+            .filter(
+                (dashboard) =>
+                    dashboard.chartUuids.some((uuid) => chartUuids.has(uuid)) ||
+                    fieldIds.some((fieldId) =>
+                        JSON.stringify(dashboard.filters).includes(fieldId),
+                    ),
+            )
+            .map<ChangeDependency>((dashboard) => ({
+                type: 'dashboard',
+                id: dashboard.dashboardUuid,
+                name: dashboard.name,
+            }));
+
+        return [...chartDependencies.values(), ...dashboardDependencies];
     }
 
     async findActiveChangesetWithChangesByProjectUuid(
         account: Account,
         projectUuid: string,
-    ): Promise<ChangesetWithChanges | undefined> {
+    ): Promise<ChangesetWithChangesAndDependencies | undefined> {
         const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
@@ -49,9 +124,35 @@ export class ChangesetService extends BaseService {
             );
         }
 
-        return this.changesetModel.findActiveChangesetWithChangesByProjectUuid(
-            projectUuid,
+        const changeset =
+            await this.changesetModel.findActiveChangesetWithChangesByProjectUuid(
+                projectUuid,
+            );
+
+        if (!changeset) {
+            return undefined;
+        }
+
+        // Dashboards are only needed to resolve dependencies of `create`
+        // changes; skip the lookup entirely otherwise.
+        const dashboards = changeset.changes.some(
+            (change) => change.type === 'create',
+        )
+            ? await this.dashboardModel.findDashboardsForValidation(projectUuid)
+            : [];
+
+        const changes = await Promise.all(
+            changeset.changes.map(async (change) => ({
+                ...change,
+                dependencies: await this.getChangeDependencies(
+                    projectUuid,
+                    change,
+                    dashboards,
+                ),
+            })),
         );
+
+        return { ...changeset, changes };
     }
 
     async getChange(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1109,6 +1109,8 @@ export class ServiceRepository
                     changesetModel: this.models.getChangesetModel(),
                     catalogModel: this.models.getCatalogModel(),
                     projectModel: this.models.getProjectModel(),
+                    savedChartModel: this.models.getSavedChartModel(),
+                    dashboardModel: this.models.getDashboardModel(),
                 }),
         );
     }

--- a/packages/common/src/types/changeset.ts
+++ b/packages/common/src/types/changeset.ts
@@ -102,9 +102,25 @@ export type Changeset = z.infer<typeof ChangesetSchema>;
 export type ChangesetWithChanges = z.infer<typeof ChangesetWithChangesSchema>;
 export type Change = z.infer<typeof ChangeSchema>;
 
+// Content that would break if a change is reverted (i.e. references the field
+// the change provides). Only `create` changes can have dependencies.
+export type ChangeDependency = {
+    type: 'chart' | 'dashboard';
+    id: string;
+    name: string;
+};
+
+export type ChangeWithDependencies = Change & {
+    dependencies: ChangeDependency[];
+};
+
+export type ChangesetWithChangesAndDependencies = Changeset & {
+    changes: ChangeWithDependencies[];
+};
+
 export type ApiChangesetsResponse = {
     status: 'ok';
-    results: ChangesetWithChanges;
+    results: ChangesetWithChangesAndDependencies;
 };
 
 export type ApiGetChangeResponse = {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8104/show-changeset-dependencies

## Summary

Extends the changeset list endpoint so each change reports the content that would break if it were reverted. `GET /api/v1/projects/{projectUuid}/changesets` now returns a `dependencies` array on every change: the charts that reference the field the change provides, plus the dashboards that embed those charts (or filter on the field directly).

Only `create` changes add a field to the semantic layer, so only they can have dependencies. Cosmetic `update` changes (description / label) return an empty list — reverting them restores text without removing anything.

## API shape

```ts
GET /api/v1/projects/{projectUuid}/changesets

{
  "status": "ok",
  "results": {
    "changesetUuid": "...",
    "name": "...",
    "changes": [
      {
        "type": "create",
        "entityType": "metric",
        "entityName": "net_revenue",
        "dependencies": [
          { "type": "chart",     "id": "<uuid>", "name": "Revenue by month" },
          { "type": "dashboard", "id": "<uuid>", "name": "Finance overview" }
        ]
      },
      { "type": "update", "entityName": "orders", "dependencies": [] }
    ]
  }
}
```

## How it works

```
change (create) ──> field ids: table_entityName  +  table_payload.name
                         │
       ┌─────────────────┴─────────────────┐
       ▼                                    ▼
getChartSummariesForFieldId           findDashboardsForValidation
  → charts referencing the field        → dashboards whose chartUuids
                                           include a breaking chart (transitive)
                                           OR whose view filters name the field
       └──────────────► dependencies: [{chart…}, {dashboard…}] ◄──┘
```

`ChangesetService.getChangeDependencies` reuses existing model methods rather than adding new queries: `getChartSummariesForFieldId` for charts, and `findDashboardsForValidation` (which already returns each dashboard's `chartUuids` + `filters`) for both the transitive and direct-filter dashboard paths. The dashboard lookup is skipped entirely when a changeset has no `create` changes.

The field id is derived from both `entityName` and the metric's payload `name`, since the overlay keys a created metric under `entityName` while its own `name` can differ.

## Notes

- No OpenAPI change: `getChange`/list already return the zod-inferred change as a loose `Record<string, unknown>` (TSOA can't type it), so `dependencies` rides inside that object. `ChangeDependency` is exported from `@lightdash/common` for the frontend.
- Coverage is fields + sorts (via the chart-summary path). References that live only in JSONB — a metric used solely in a chart's filters, table calc, or chart config — are not yet detected; follow-up.

## Test plan

- [x] `pnpm -F common typecheck`, `pnpm -F backend typecheck` pass
- [x] Seeded 3 projects, each with an active changeset of 5 changes (2 with dependents, 3 empty) + 3 charts + 1 dashboard, and verified via the endpoint:
  - `create` referenced by 2 charts → returns both charts
  - `create` whose chart sits in a dashboard → returns the chart **and** the dashboard (transitive)
  - orphan `create` (nothing references it) → `[]`
  - cosmetic `update` (description / label / table) → `[]`
- [x] A control chart referencing a different field was correctly **excluded** (no over-reporting)
- [ ] Authorization unchanged: `manage` on `Explore` for the project still required