### PR TITLE
feat(changesets): add a dependencies column to the changesets table

### DIFF
--- a/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
+++ b/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
@@ -1,7 +1,8 @@
 import {
     assertUnreachable,
     type Change,
-    type ChangesetWithChanges,
+    type ChangeDependency,
+    type ChangeWithDependencies,
 } from '@lightdash/common';
 import {
     Alert,
@@ -9,19 +10,26 @@ import {
     Badge,
     Box,
     Button,
+    Divider,
     Group,
+    HoverCard,
     Loader,
+    ScrollArea,
     Stack,
     Text,
     Title,
     Tooltip,
+    UnstyledButton,
     useMantineTheme,
 } from '@mantine-8/core';
 import { modals } from '@mantine/modals';
 import {
     IconAlertCircle,
+    IconAlertTriangle,
     IconArrowBackUp,
+    IconChartBar,
     IconClock,
+    IconLayoutDashboard,
     IconTable,
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
@@ -103,6 +111,125 @@ const getUserDisplayName = (
     return user.firstName && user.lastName
         ? `${user.firstName} ${user.lastName}`
         : user.email;
+};
+
+const getDependencyMeta = (
+    dependency: ChangeDependency,
+    projectUuid: string,
+) => {
+    switch (dependency.type) {
+        case 'chart':
+            return {
+                icon: IconChartBar,
+                color: 'blue',
+                to: `/projects/${projectUuid}/saved/${dependency.id}`,
+            };
+        case 'dashboard':
+            return {
+                icon: IconLayoutDashboard,
+                color: 'grape',
+                to: `/projects/${projectUuid}/dashboards/${dependency.id}`,
+            };
+        default:
+            return assertUnreachable(
+                dependency.type,
+                `Unknown dependency type`,
+            );
+    }
+};
+
+const DependenciesCell: FC<{
+    dependencies: ChangeDependency[];
+    projectUuid: string;
+}> = ({ dependencies, projectUuid }) => {
+    if (dependencies.length === 0) {
+        return null;
+    }
+
+    return (
+        <HoverCard
+            withinPortal
+            position="bottom-start"
+            offset={4}
+            withArrow
+            shadow="md"
+            radius="md"
+            openDelay={100}
+            closeDelay={150}
+        >
+            <HoverCard.Target>
+                <UnstyledButton>
+                    <Group gap={6} wrap="nowrap">
+                        <MantineIcon icon={IconAlertTriangle} color="red.6" />
+                        <Text fz="xs" fw={500} c="red.6">
+                            {dependencies.length}{' '}
+                            {dependencies.length === 1
+                                ? 'dependency'
+                                : 'dependencies'}
+                        </Text>
+                    </Group>
+                </UnstyledButton>
+            </HoverCard.Target>
+            <HoverCard.Dropdown p={0}>
+                <Group justify="space-between" gap="lg" px="sm" py="xs">
+                    <Text fz={10} fw={600} c="dimmed" tt="uppercase">
+                        Breaks if reverted
+                    </Text>
+                    <Badge color="red" variant="light" size="xs" radius="sm">
+                        {dependencies.length}
+                    </Badge>
+                </Group>
+                <Divider color="ldGray.2" />
+                <ScrollArea.Autosize mah={260} type="auto">
+                    <Stack gap={1} p={4} miw={248}>
+                        {dependencies.map((dependency) => {
+                            const { icon, color, to } = getDependencyMeta(
+                                dependency,
+                                projectUuid,
+                            );
+                            return (
+                                <Group
+                                    key={`${dependency.type}-${dependency.id}`}
+                                    gap="md"
+                                    wrap="nowrap"
+                                    justify="space-between"
+                                    px="xs"
+                                    py={4}
+                                >
+                                    <Group gap={8} wrap="nowrap" miw={0}>
+                                        <MantineIcon
+                                            icon={icon}
+                                            size={14}
+                                            color={`${color}.6`}
+                                        />
+                                        <Anchor
+                                            href={to}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            fz="xs"
+                                            fw={500}
+                                            lineClamp={1}
+                                        >
+                                            {dependency.name}
+                                        </Anchor>
+                                    </Group>
+                                    <Badge
+                                        color={color}
+                                        variant="light"
+                                        size="xs"
+                                        radius="sm"
+                                        tt="capitalize"
+                                    >
+                                        {dependency.type}
+                                    </Badge>
+                                </Group>
+                            );
+                        })}
+                    </Stack>
+                </ScrollArea.Autosize>
+            </HoverCard.Dropdown>
+        </HoverCard>
+    );
 };
 
 export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
@@ -194,141 +321,145 @@ export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
         });
     };
 
-    const columns: MRT_ColumnDef<ChangesetWithChanges['changes'][0]>[] =
-        useMemo(
-            () => [
-                {
-                    accessorKey: 'entityName',
-                    header: '',
-                    enableSorting: false,
-                    size: 150,
-                    Cell: ({ row }) => {
-                        const change = row.original;
-                        return (
-                            <Tooltip
-                                withinPortal
-                                label={
-                                    <Group gap="xs">
-                                        <MantineIcon
-                                            icon={IconTable}
-                                            size={16}
-                                        />
-                                        <Text size="sm">
-                                            {change.entityTableName}
-                                        </Text>
-                                    </Group>
-                                }
+    const columns: MRT_ColumnDef<ChangeWithDependencies>[] = useMemo(
+        () => [
+            {
+                accessorKey: 'entityName',
+                header: '',
+                enableSorting: false,
+                size: 150,
+                Cell: ({ row }) => {
+                    const change = row.original;
+                    return (
+                        <Tooltip
+                            withinPortal
+                            label={
+                                <Group gap="xs">
+                                    <MantineIcon icon={IconTable} size={16} />
+                                    <Text size="sm">
+                                        {change.entityTableName}
+                                    </Text>
+                                </Group>
+                            }
+                        >
+                            <Text
+                                fw={500}
+                                fz="sm"
+                                truncate
+                                style={{ cursor: 'help' }}
                             >
-                                <Text
-                                    fw={500}
-                                    fz="sm"
-                                    truncate
-                                    style={{ cursor: 'help' }}
-                                >
-                                    {change.entityName}
-                                </Text>
-                            </Tooltip>
-                        );
-                    },
+                                {change.entityName}
+                            </Text>
+                        </Tooltip>
+                    );
                 },
-                {
-                    accessorKey: 'change',
-                    header: 'Change',
-                    enableSorting: false,
-                    size: 200,
+            },
+            {
+                accessorKey: 'change',
+                header: 'Change',
+                enableSorting: false,
+                size: 200,
 
-                    Cell: ({ row }) => {
-                        const isTruncated = useIsTruncated<HTMLDivElement>();
-                        const change = row.original;
-                        const changeValue = extractChangeValue(change);
+                Cell: ({ row }) => {
+                    const isTruncated = useIsTruncated<HTMLDivElement>();
+                    const change = row.original;
+                    const changeValue = extractChangeValue(change);
 
-                        return (
-                            <Group gap="xs" align="center">
-                                <Badge
-                                    {...getChangeTypeBadgeProps(change.type)}
-                                    radius="sm"
-                                    size="sm"
-                                    fw={400}
-                                    tt="capitalize"
-                                >
-                                    {change.type}
-                                </Badge>
-                                {typeof changeValue === 'string' ? (
-                                    <Text fz="xs">{changeValue}</Text>
-                                ) : (
-                                    <>
-                                        <Tooltip
-                                            withinPortal
-                                            label={changeValue.map((patch) => (
-                                                <Text key={patch.path} fz="xs">
+                    return (
+                        <Group gap="xs" align="center">
+                            <Badge
+                                {...getChangeTypeBadgeProps(change.type)}
+                                radius="sm"
+                                size="sm"
+                                fw={400}
+                                tt="capitalize"
+                            >
+                                {change.type}
+                            </Badge>
+                            {typeof changeValue === 'string' ? (
+                                <Text fz="xs">{changeValue}</Text>
+                            ) : (
+                                <>
+                                    <Tooltip
+                                        withinPortal
+                                        label={changeValue.map((patch) => (
+                                            <Text key={patch.path} fz="xs">
+                                                {patch.value}
+                                            </Text>
+                                        ))}
+                                        disabled={!isTruncated.isTruncated}
+                                    >
+                                        <Box>
+                                            {changeValue.map((patch) => (
+                                                <Text
+                                                    key={patch.path}
+                                                    fz="xs"
+                                                    maw={280}
+                                                    truncate
+                                                    ref={isTruncated.ref}
+                                                >
+                                                    <Text fw={500} fz="xs" span>
+                                                        {patch.path}:{' '}
+                                                    </Text>
                                                     {patch.value}
                                                 </Text>
                                             ))}
-                                            disabled={!isTruncated.isTruncated}
-                                        >
-                                            <Box>
-                                                {changeValue.map((patch) => (
-                                                    <Text
-                                                        key={patch.path}
-                                                        fz="xs"
-                                                        maw={280}
-                                                        truncate
-                                                        ref={isTruncated.ref}
-                                                    >
-                                                        <Text
-                                                            fw={500}
-                                                            fz="xs"
-                                                            span
-                                                        >
-                                                            {patch.path}:{' '}
-                                                        </Text>
-                                                        {patch.value}
-                                                    </Text>
-                                                ))}
-                                            </Box>
-                                        </Tooltip>
-                                    </>
-                                )}
-                            </Group>
-                        );
-                    },
+                                        </Box>
+                                    </Tooltip>
+                                </>
+                            )}
+                        </Group>
+                    );
                 },
-                {
-                    accessorKey: 'createdByUserUuid',
-                    header: 'Created By',
-                    enableSorting: false,
-                    size: 200,
-                    Cell: ({ row }) => {
-                        const change = row.original;
-                        const userName = getUserDisplayName(
-                            change.createdByUserUuid,
-                            organizationUsers,
-                        );
+            },
+            {
+                accessorKey: 'createdByUserUuid',
+                header: 'Created By',
+                enableSorting: false,
+                size: 200,
+                Cell: ({ row }) => {
+                    const change = row.original;
+                    const userName = getUserDisplayName(
+                        change.createdByUserUuid,
+                        organizationUsers,
+                    );
 
-                        return (
-                            <Group gap="xs" align="center">
-                                <Tooltip
-                                    withinPortal
-                                    label={formatDateTime(change.createdAt)}
-                                >
-                                    <Box style={{ cursor: 'help' }}>
-                                        <MantineIcon
-                                            icon={IconClock}
-                                            size={16}
-                                            color="ldGray.6"
-                                        />
-                                    </Box>
-                                </Tooltip>
-                                <Text fz="sm" truncate>
-                                    {userName}
-                                </Text>
-                            </Group>
-                        );
-                    },
+                    return (
+                        <Group gap="xs" align="center">
+                            <Tooltip
+                                withinPortal
+                                label={formatDateTime(change.createdAt)}
+                            >
+                                <Box style={{ cursor: 'help' }}>
+                                    <MantineIcon
+                                        icon={IconClock}
+                                        size={16}
+                                        color="ldGray.6"
+                                    />
+                                </Box>
+                            </Tooltip>
+                            <Text fz="sm" truncate>
+                                {userName}
+                            </Text>
+                        </Group>
+                    );
                 },
-            ],
-            [organizationUsers],
-        );
+            },
+            {
+                id: 'dependencies',
+                header: 'Dependencies',
+                enableSorting: false,
+                size: 160,
+                Cell: ({ row }) => (
+                    <DependenciesCell
+                        dependencies={row.original.dependencies}
+                        projectUuid={projectUuid}
+                    />
+                ),
+            },
+        ],
+        [organizationUsers, projectUuid],
+    );
 
     const table = useContentTable({
         columns,


### PR DESCRIPTION
## Summary

PR 2 of 2 for [PROD-8104](https://linear.app/lightdash/issue/PROD-8104/show-changeset-dependencies). Surfaces per-change dependencies in the changesets settings table: a new **Dependencies** column shows which charts and dashboards would break if a change were reverted.

Stacks on top of PR 1 ([#23851](https://github.com/lightdash/lightdash/pull/23851)), which added the `dependencies` array to the `GET /projects/{projectUuid}/changesets` response. No new data fetching here — the existing `useActiveChangesets` hook already carries it.

Closes: https://linear.app/lightdash/issue/PROD-8104/show-changeset-dependencies

## Changes

**Frontend** (`ProjectChangesets.tsx`)
- New **Dependencies** column, positioned as the last data column — immediately before the Revert action.
- Changes with no dependents render **nothing**; only breaking changes show a red `N dependencies` trigger (danger icon + red text). Cosmetic `update` changes are always empty.
- Hovering the trigger opens a downward `HoverCard` with a dense, scrollable list: a "Breaks if reverted" header + count badge, then one row per dependency — a type-colored icon, the name as a link (opens the chart/dashboard in a new tab), and a type badge. Height-capped with scroll for changes with many (~20) dependents.
- Reuses `ChangeWithDependencies` / `ChangeDependency` from PR 1. All Mantine v8 layout props only (no `style`/`styles`/`sx`).

## UI

```
 Change                  Created By   Dependencies          [ ⤺ Revert ]
 ─────────────────────────────────────────────────────────────────────
 net_revenue   (create)  Jane Doe     ⚠ 2 dependencies
 status        (update)  Jane Doe     —   (cosmetic → empty, renders nothing)
 orphan_metric (create)  Jane Doe     —   (no refs → empty, renders nothing)

 hover ▸ "⚠ 2 dependencies"  (opens below)
   ┌──────────────────────────────┐
   │ BREAKS IF REVERTED        [2] │
   ├──────────────────────────────┤
   │ ▦ Revenue by month     chart  │   ← name links to the chart
   │ ◆ Finance overview   dashboard│   ← name links to the dashboard
   └──────────────────────────────┘
```

## Test plan

- [x] `pnpm -F frontend typecheck` and `pnpm -F common typecheck` pass
- [x] `lint-staged` (frontend lint + format) clean on commit
- [x] Verified live (HMR) on the Changesets settings page against seeded data across charts + dashboards: breaking `create` changes show the red trigger and list the correct chart/dashboard; cosmetic and orphan changes render an empty cell; links open the right routes; overlay scrolls past ~12 rows
- View at: Settings → Project management → Changesets (`/generalSettings/projectManagement/{projectUuid}/changesets`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)