### PR TITLE
feat(ai-agent): use Slack feedback buttons

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -272,6 +272,10 @@ import {
     getTextBlocks,
     getThinkingBlocks,
     getWritebackPreviewReplyBlocks,
+    PROMPT_HUMAN_SCORE_ACTION_ID,
+    PROMPT_HUMAN_SCORE_BLOCK_ID,
+    PROMPT_HUMAN_SCORE_DOWNVOTE_ACTION_ID,
+    PROMPT_HUMAN_SCORE_UPVOTE_ACTION_ID,
 } from '../ai/utils/getSlackBlocks';
 import { llmAsAJudge } from '../ai/utils/llmAsAJudge';
 import {
@@ -7375,6 +7379,110 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         });
     }
 
+    private static parsePromptFeedbackActionValue(
+        value: string | undefined,
+    ): { promptUuid: string; humanScore: 1 | -1 } | undefined {
+        if (!value) return undefined;
+
+        try {
+            const parsed = JSON.parse(value) as {
+                promptUuid?: unknown;
+                humanScore?: unknown;
+            };
+            if (
+                typeof parsed.promptUuid !== 'string' ||
+                (parsed.humanScore !== 1 && parsed.humanScore !== -1)
+            ) {
+                return undefined;
+            }
+
+            return {
+                promptUuid: parsed.promptUuid,
+                humanScore: parsed.humanScore,
+            };
+        } catch {
+            return undefined;
+        }
+    }
+
+    private static getPromptFeedbackSubmittedBlock(
+        userId: string,
+        humanScore: 1 | -1,
+    ): Block | KnownBlock {
+        return {
+            type: 'context',
+            elements: [
+                {
+                    type: 'mrkdwn',
+                    text:
+                        humanScore === 1
+                            ? `<@${userId}> upvoted this answer :thumbsup:`
+                            : `<@${userId}> downvoted this answer :thumbsdown:`,
+                },
+            ],
+        };
+    }
+
+    private static async openDownvoteFeedbackModal({
+        client,
+        triggerId,
+        promptUuid,
+    }: {
+        client: WebClient;
+        triggerId: string;
+        promptUuid: string;
+    }) {
+        await client.views.open({
+            trigger_id: triggerId,
+            view: {
+                type: 'modal',
+                callback_id: 'downvote_feedback_modal',
+                private_metadata: JSON.stringify({
+                    promptUuid,
+                }),
+                title: {
+                    type: 'plain_text',
+                    text: 'Feedback',
+                },
+                submit: {
+                    type: 'plain_text',
+                    text: 'Submit',
+                },
+                close: {
+                    type: 'plain_text',
+                    text: 'Skip',
+                },
+                blocks: [
+                    {
+                        type: 'section',
+                        text: {
+                            type: 'mrkdwn',
+                            text: 'Help us improve! What went wrong with this answer?',
+                        },
+                    },
+                    {
+                        type: 'input',
+                        block_id: 'feedback_input',
+                        optional: false,
+                        element: {
+                            type: 'plain_text_input',
+                            action_id: 'feedback_text',
+                            multiline: true,
+                            placeholder: {
+                                type: 'plain_text',
+                                text: 'Your feedback will help improve the AI agent (optional)',
+                            },
+                        },
+                        label: {
+                            type: 'plain_text',
+                            text: 'Feedback',
+                        },
+                    },
+                ],
+            },
+        });
+    }
+
     // TODO: remove this once we have analytics tracking
     // eslint-disable-next-line class-methods-use-this
     public handleClickExploreButton(app: App) {
@@ -7579,9 +7687,78 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         );
     }
 
+    public handlePromptFeedback(app: App) {
+        app.action(
+            PROMPT_HUMAN_SCORE_ACTION_ID,
+            async ({ ack, body, respond, context, client }) => {
+                await ack();
+
+                if (body.type !== 'block_actions') {
+                    return;
+                }
+
+                const action = body.actions[0] as
+                    | { value?: string }
+                    | undefined;
+                const feedback = AiAgentService.parsePromptFeedbackActionValue(
+                    action?.value,
+                );
+                if (!feedback) {
+                    return;
+                }
+
+                const { user } = body;
+                const { teamId } = context;
+                const triggeringMessage = body.message;
+                const organizationUuid =
+                    await this.getSlackVoteOrganizationUuid({
+                        teamId,
+                        userId: user.id,
+                        channelId: body.channel?.id,
+                        messageId: triggeringMessage?.ts,
+                        threadTs: triggeringMessage?.thread_ts,
+                        client,
+                    });
+
+                if (organizationUuid === null) {
+                    return;
+                }
+
+                await this.updateHumanScoreForSlackPrompt(
+                    user.id,
+                    organizationUuid,
+                    feedback.promptUuid,
+                    feedback.humanScore,
+                );
+
+                if (triggeringMessage?.blocks) {
+                    await respond({
+                        replace_original: true,
+                        blocks: AiAgentService.replaceSlackBlockByBlockId(
+                            triggeringMessage.blocks,
+                            PROMPT_HUMAN_SCORE_BLOCK_ID,
+                            AiAgentService.getPromptFeedbackSubmittedBlock(
+                                user.id,
+                                feedback.humanScore,
+                            ),
+                        ),
+                    });
+                }
+
+                if (feedback.humanScore === -1) {
+                    await AiAgentService.openDownvoteFeedbackModal({
+                        client,
+                        triggerId: body.trigger_id,
+                        promptUuid: feedback.promptUuid,
+                    });
+                }
+            },
+        );
+    }
+
     public handlePromptUpvote(app: App) {
         app.action(
-            'prompt_human_score.upvote',
+            PROMPT_HUMAN_SCORE_UPVOTE_ACTION_ID,
             async ({ ack, body, respond, context, client }) => {
                 await ack();
                 const { user } = body;
@@ -7605,15 +7782,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     return;
                 }
 
-                const newBlock = {
-                    type: 'context',
-                    elements: [
-                        {
-                            type: 'mrkdwn',
-                            text: `<@${user.id}> upvoted this answer :thumbsup:`,
-                        },
-                    ],
-                };
                 if (body.type === 'block_actions') {
                     const action = body.actions[0];
                     if (action && action.type === 'button') {
@@ -7636,8 +7804,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             replace_original: true,
                             blocks: AiAgentService.replaceSlackBlockByBlockId(
                                 blocks,
-                                'prompt_human_score',
-                                newBlock,
+                                PROMPT_HUMAN_SCORE_BLOCK_ID,
+                                AiAgentService.getPromptFeedbackSubmittedBlock(
+                                    user.id,
+                                    1,
+                                ),
                             ),
                         });
                     }
@@ -7648,7 +7819,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
     public handlePromptDownvote(app: App) {
         app.action(
-            'prompt_human_score.downvote',
+            PROMPT_HUMAN_SCORE_DOWNVOTE_ACTION_ID,
             async ({ ack, body, respond, client, context }) => {
                 await ack();
                 const { user } = body;
@@ -7672,15 +7843,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     return;
                 }
 
-                const newBlock = {
-                    type: 'context',
-                    elements: [
-                        {
-                            type: 'mrkdwn',
-                            text: `<@${user.id}> downvoted this answer :thumbsdown:`,
-                        },
-                    ],
-                };
                 if (body.type === 'block_actions') {
                     const action = body.actions[0];
                     if (action && action.type === 'button') {
@@ -7703,60 +7865,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                                 replace_original: true,
                                 blocks: AiAgentService.replaceSlackBlockByBlockId(
                                     blocks,
-                                    'prompt_human_score',
-                                    newBlock,
+                                    PROMPT_HUMAN_SCORE_BLOCK_ID,
+                                    AiAgentService.getPromptFeedbackSubmittedBlock(
+                                        user.id,
+                                        -1,
+                                    ),
                                 ),
                             });
                         }
 
-                        await client.views.open({
-                            trigger_id: body.trigger_id,
-                            view: {
-                                type: 'modal',
-                                callback_id: 'downvote_feedback_modal',
-                                private_metadata: JSON.stringify({
-                                    promptUuid,
-                                }),
-                                title: {
-                                    type: 'plain_text',
-                                    text: 'Feedback',
-                                },
-                                submit: {
-                                    type: 'plain_text',
-                                    text: 'Submit',
-                                },
-                                close: {
-                                    type: 'plain_text',
-                                    text: 'Skip',
-                                },
-                                blocks: [
-                                    {
-                                        type: 'section',
-                                        text: {
-                                            type: 'mrkdwn',
-                                            text: 'Help us improve! What went wrong with this answer?',
-                                        },
-                                    },
-                                    {
-                                        type: 'input',
-                                        block_id: 'feedback_input',
-                                        optional: false,
-                                        element: {
-                                            type: 'plain_text_input',
-                                            action_id: 'feedback_text',
-                                            multiline: true,
-                                            placeholder: {
-                                                type: 'plain_text',
-                                                text: 'Your feedback will help improve the AI agent (optional)',
-                                            },
-                                        },
-                                        label: {
-                                            type: 'plain_text',
-                                            text: 'Feedback',
-                                        },
-                                    },
-                                ],
-                            },
+                        await AiAgentService.openDownvoteFeedbackModal({
+                            client,
+                            triggerId: body.trigger_id,
+                            promptUuid,
                         });
                     }
                 }

--- a/packages/backend/src/ee/services/SlackService/SlackService.ts
+++ b/packages/backend/src/ee/services/SlackService/SlackService.ts
@@ -33,6 +33,7 @@ export class CommercialSlackService extends SlackService {
         );
         this.aiAgentService.handleAgentSelection(slackApp);
         this.aiAgentService.handleProjectSelection(slackApp);
+        this.aiAgentService.handlePromptFeedback(slackApp);
         this.aiAgentService.handlePromptUpvote(slackApp);
         this.aiAgentService.handlePromptDownvote(slackApp);
         this.aiAgentService.handleClickExploreButton(slackApp);

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -1,0 +1,114 @@
+import { type AiAgentToolResult, type SlackPrompt } from '@lightdash/common';
+import {
+    getFeedbackBlocks,
+    PROMPT_HUMAN_SCORE_ACTION_ID,
+    PROMPT_HUMAN_SCORE_BLOCK_ID,
+} from './getSlackBlocks';
+
+type FeedbackButtonsBlock = {
+    type: string;
+    block_id: string;
+    elements: Array<{
+        type: string;
+        action_id: string;
+        positive_button: { value: string };
+        negative_button: { value: string };
+    }>;
+};
+
+type ActionsBlock = {
+    type: string;
+    elements: Array<{
+        action_id: string;
+        url: string;
+    }>;
+};
+
+const slackPrompt: SlackPrompt = {
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    agentUuid: 'agent-uuid',
+    promptUuid: 'prompt-uuid',
+    threadUuid: 'thread-uuid',
+    createdByUserUuid: 'user-uuid',
+    prompt: 'Show revenue',
+    createdAt: new Date('2026-06-03T00:00:00Z'),
+    response: 'Done',
+    errorMessage: null,
+    humanScore: null,
+    modelConfig: null,
+    response_slack_ts: '1.2',
+    slackUserId: 'U123',
+    slackChannelId: 'C123',
+    promptSlackTs: '1.1',
+    slackThreadTs: '1.1',
+};
+
+const toolResult = (toolName: string, status: string): AiAgentToolResult =>
+    ({
+        uuid: 'tool-result-uuid',
+        promptUuid: slackPrompt.promptUuid,
+        result: '{}',
+        createdAt: new Date('2026-06-03T00:00:00Z'),
+        toolCallId: 'tool-call-uuid',
+        toolType: 'built-in',
+        toolName,
+        metadata: { status },
+    }) as unknown as AiAgentToolResult;
+
+describe('getFeedbackBlocks', () => {
+    it('uses native Slack feedback buttons with score values', () => {
+        const blocks = getFeedbackBlocks(
+            slackPrompt,
+            [toolResult('runQuery', 'success')],
+            'agent-uuid',
+            'https://lightdash.example.com',
+        );
+
+        const feedbackBlock = blocks[0] as unknown as FeedbackButtonsBlock;
+        const feedbackElement = feedbackBlock.elements[0];
+
+        expect(feedbackBlock.type).toBe('context_actions');
+        expect(feedbackBlock.block_id).toBe(PROMPT_HUMAN_SCORE_BLOCK_ID);
+        expect(feedbackElement.type).toBe('feedback_buttons');
+        expect(feedbackElement.action_id).toBe(PROMPT_HUMAN_SCORE_ACTION_ID);
+
+        expect(JSON.parse(feedbackElement.positive_button.value)).toEqual({
+            promptUuid: slackPrompt.promptUuid,
+            humanScore: 1,
+        });
+        expect(JSON.parse(feedbackElement.negative_button.value)).toEqual({
+            promptUuid: slackPrompt.promptUuid,
+            humanScore: -1,
+        });
+    });
+
+    it('keeps the Lightdash chat link in a separate action row', () => {
+        const blocks = getFeedbackBlocks(
+            slackPrompt,
+            [toolResult('runQuery', 'success')],
+            'agent-uuid',
+            'https://lightdash.example.com',
+        );
+
+        const viewChatBlock = blocks[1] as unknown as ActionsBlock;
+        const [viewChatButton] = viewChatBlock.elements;
+
+        expect(viewChatBlock.type).toBe('actions');
+        expect(viewChatButton.action_id).toBe('view_chat_in_lightdash');
+        expect(viewChatButton.url).toBe(
+            'https://lightdash.example.com/projects/project-uuid/ai-agents/agent-uuid/threads/thread-uuid',
+        );
+    });
+
+    it('does not render when there is no successful answer-producing tool', () => {
+        expect(
+            getFeedbackBlocks(
+                slackPrompt,
+                [toolResult('findExplores', 'success')],
+                'agent-uuid',
+                'https://lightdash.example.com',
+            ),
+        ).toEqual([]);
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -17,6 +17,18 @@ import { populateCustomMetricsSQL } from './populateCustomMetricsSQL';
 
 const SLACK_SECTION_TEXT_LIMIT = 3000;
 
+export const PROMPT_HUMAN_SCORE_BLOCK_ID = 'prompt_human_score';
+export const PROMPT_HUMAN_SCORE_ACTION_ID = 'prompt_human_score.feedback';
+export const PROMPT_HUMAN_SCORE_UPVOTE_ACTION_ID = 'prompt_human_score.upvote';
+export const PROMPT_HUMAN_SCORE_DOWNVOTE_ACTION_ID =
+    'prompt_human_score.downvote';
+
+const getPromptHumanScoreValue = (promptUuid: string, humanScore: 1 | -1) =>
+    JSON.stringify({
+        promptUuid,
+        humanScore,
+    });
+
 /**
  * Splits text into chunks that fit within Slack's section block text limit (3000 chars).
  * Splits at markdown-safe boundaries to avoid breaking links, code blocks, or formatting.
@@ -244,9 +256,8 @@ const ANSWER_PRODUCING_TOOLS = new Set([
     'proposeWriteback',
 ]);
 
-// One compact footer: small "How did I do?" header + a single row with
-// thumbs and the chat permalink. Only rendered when at least one
-// answer-producing tool succeeded for this prompt.
+// Native feedback buttons plus the chat permalink. Only rendered when at least
+// one answer-producing tool succeeded for this prompt.
 export function getFeedbackBlocks(
     slackPrompt: SlackPrompt,
     toolResults: AiAgentToolResult[],
@@ -263,21 +274,35 @@ export function getFeedbackBlocks(
     const threadUrl = `${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}`;
     return [
         {
-            block_id: 'prompt_human_score',
-            type: 'actions',
+            block_id: PROMPT_HUMAN_SCORE_BLOCK_ID,
+            type: 'context_actions',
             elements: [
                 {
-                    type: 'button',
-                    text: { type: 'plain_text', text: '👍', emoji: true },
-                    value: slackPrompt.promptUuid,
-                    action_id: 'prompt_human_score.upvote',
+                    type: 'feedback_buttons',
+                    action_id: PROMPT_HUMAN_SCORE_ACTION_ID,
+                    positive_button: {
+                        text: { type: 'plain_text', text: '' },
+                        value: getPromptHumanScoreValue(
+                            slackPrompt.promptUuid,
+                            1,
+                        ),
+                        accessibility_label: 'Upvote this answer',
+                    },
+                    negative_button: {
+                        text: { type: 'plain_text', text: '' },
+                        value: getPromptHumanScoreValue(
+                            slackPrompt.promptUuid,
+                            -1,
+                        ),
+                        accessibility_label: 'Downvote this answer',
+                    },
                 },
-                {
-                    type: 'button',
-                    text: { type: 'plain_text', text: '👎', emoji: true },
-                    value: slackPrompt.promptUuid,
-                    action_id: 'prompt_human_score.downvote',
-                },
+            ],
+        } as unknown as Block,
+        {
+            block_id: 'prompt_human_score_view_chat',
+            type: 'actions',
+            elements: [
                 {
                     type: 'button',
                     text: {


### PR DESCRIPTION
## Summary
- Replace AI agent Slack emoji vote buttons with native Slack feedback buttons
- Store selected +1/-1 values through the existing human score flow
- Keep legacy Slack vote handlers compatible with already-posted messages

## Testing
- pnpm -F backend test src/ee/services/ai/utils/getSlackBlocks.test.ts
- pnpm -F backend typecheck
- pnpm -F backend linter src/ee/services/ai/utils/getSlackBlocks.test.ts src/ee/services/ai/utils/getSlackBlocks.ts src/ee/services/AiAgentService/AiAgentService.ts src/ee/services/SlackService/SlackService.ts