### PR TITLE
fix(ai): mint GitHub MCP installation token per run + recover on reconnect [PROD-8112]

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1833,7 +1833,7 @@ export type AiAgentGithubMcpConnectedEvent = BaseTrack & {
         mcpServerId: string;
         // Distinguishes the one-click flow (auto-config from the org's GitHub
         // integration) from manually creating a GitHub MCP server.
-        method: 'one_click';
+        method: 'one_click' | 'one_click_reconnect';
     };
 };
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -189,6 +189,7 @@ import {
     type AiAgentMcpServerToolPermissionSetting,
     type AiAgentMcpServerToolPermissionSettingUpdate,
     type AiMcpCredential,
+    type AiMcpServerWithSensitiveData,
 } from '../../models/AiAgentModel';
 import { CommercialSlackAuthenticationModel } from '../../models/CommercialSlackAuthenticationModel';
 import { ProjectContextModel } from '../../models/ProjectContextModel';
@@ -2667,18 +2668,6 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        // Idempotency: if a GitHub MCP server already exists, return it.
-        const existing = await this.aiAgentModel.listMcpServers(
-            projectUuid,
-            user.userUuid,
-        );
-        const alreadyConnected = existing.find(
-            (server) => server.url === GITHUB_MCP_SERVER_URL,
-        );
-        if (alreadyConnected) {
-            return alreadyConnected;
-        }
-
         const installationId =
             await this.githubAppInstallationsModel.findInstallationId(
                 organizationUuid,
@@ -2690,6 +2679,73 @@ export class AiAgentService extends BaseService {
         }
 
         const bearerToken = await getInstallationToken(installationId);
+
+        // Reconnect path: if a GitHub MCP server already exists, re-mint and
+        // upsert a fresh token rather than early-returning. The previous
+        // early-return left stuck (expired-token) servers unrecoverable.
+        const existing = await this.aiAgentModel.listMcpServers(
+            projectUuid,
+            user.userUuid,
+        );
+        const alreadyConnected = existing.find(
+            (server) => server.url === GITHUB_MCP_SERVER_URL,
+        );
+        if (alreadyConnected) {
+            try {
+                await this.aiAgentMcpRuntimeClient.testConnection({
+                    name: GITHUB_MCP_SERVER_NAME,
+                    url: GITHUB_MCP_SERVER_URL,
+                    authType: 'bearer',
+                    bearerToken,
+                    onUncaughtError: (error) => {
+                        Logger.error(
+                            `[AiAgent][MCP][${GITHUB_MCP_SERVER_NAME}] Uncaught MCP client error while reconnecting`,
+                            error,
+                        );
+                    },
+                });
+            } catch (error) {
+                throw new ParameterError(
+                    `We couldn't reconnect to the GitHub MCP server. Details: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+
+            await this.aiAgentModel.upsertCredential({
+                serverUuid: alreadyConnected.uuid,
+                scope: 'shared',
+                credentials: { type: 'bearer', bearerToken },
+                actorUserUuid: user.userUuid,
+            });
+            await this.aiAgentModel.updateMcpServerRuntimeState({
+                serverUuid: alreadyConnected.uuid,
+                connectionStatus: 'connected',
+                error: null,
+                actorUserUuid: user.userUuid,
+            });
+
+            this.analytics.track({
+                event: 'ai_agent.github_mcp_connected',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    mcpServerId: alreadyConnected.uuid,
+                    method: 'one_click_reconnect',
+                },
+            });
+
+            const refreshed = await this.aiAgentModel.listMcpServers(
+                projectUuid,
+                user.userUuid,
+            );
+            return (
+                refreshed.find(
+                    (server) => server.url === GITHUB_MCP_SERVER_URL,
+                ) ?? alreadyConnected
+            );
+        }
 
         // Delegates to createMcpServer, which additionally asserts the caller
         // can manage MCP servers, validates the URL, tests the connection and
@@ -2714,6 +2770,45 @@ export class AiAgentService extends BaseService {
         });
 
         return server;
+    }
+
+    /**
+     * The GitHub MCP server is authed with a GitHub App installation token,
+     * which expires after ~1h. Rather than rely on the (stale) stored token,
+     * mint a fresh one per run — mirroring how writeback mints per run — so the
+     * connection can never expire mid-session.
+     */
+    private async refreshGithubMcpCredentials(
+        organizationUuid: string | undefined,
+        servers: AiMcpServerWithSensitiveData[],
+    ): Promise<AiMcpServerWithSensitiveData[]> {
+        const hasGithubMcp = servers.some(
+            (server) =>
+                server.url === GITHUB_MCP_SERVER_URL &&
+                server.authType === 'bearer',
+        );
+        if (!hasGithubMcp || !organizationUuid) {
+            return servers;
+        }
+
+        const installationId =
+            await this.githubAppInstallationsModel.findInstallationId(
+                organizationUuid,
+            );
+        if (!installationId) {
+            return servers;
+        }
+
+        const bearerToken = await getInstallationToken(installationId);
+
+        return servers.map((server) =>
+            server.url === GITHUB_MCP_SERVER_URL && server.authType === 'bearer'
+                ? {
+                      ...server,
+                      resolvedCredential: { type: 'bearer', bearerToken },
+                  }
+                : server,
+        );
     }
 
     public async startMcpOAuthConnection(
@@ -6346,9 +6441,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 projectUuid: prompt.projectUuid,
             });
         const agentMcpServersWithSensitiveData =
-            await this.aiAgentModel.getAgentMcpServersWithSensitiveData(
-                agentSettings.uuid,
-                user.userUuid,
+            await this.refreshGithubMcpCredentials(
+                user.organizationUuid,
+                await this.aiAgentModel.getAgentMcpServersWithSensitiveData(
+                    agentSettings.uuid,
+                    user.userUuid,
+                ),
             );
         const mcpServers = this.aiAgentMcpRuntimeClient.attachRuntimeProviders({
             projectUuid: prompt.projectUuid,


### PR DESCRIPTION
## What & why

Linear: [PROD-8112](https://linear.app/lightdash/issue/PROD-8112)

> Stacked on `preview-deploy-prod-8108`.

The GitHub MCP "one-click connect" stored a GitHub App **installation token** as the MCP bearer credential. Installation tokens expire after ~1h and there's no refresh, so the connection reliably broke within the hour. Two compounding bugs:

1. **Short-lived token persisted, never refreshed** — the stored token expired and nothing re-minted it.
2. **Idempotent connect early-returned** — once a GitHub MCP server existed, the connect endpoint returned the existing server without re-minting, so "Reconnect" could never recover a stuck (expired-token) server. The only escape was deleting and recreating the server.

## Changes

- **Mint per run (eliminates the expiry class).** `refreshGithubMcpCredentials()` mints a fresh installation token before each agent run and overrides the resolved bearer credential for the GitHub MCP server — mirroring how writeback mints a token per run. The persisted token is no longer used at runtime, so the connection can never expire mid-session.
- **Reconnect recovers a stuck server.** `connectGithubMcpServer()` no longer early-returns for an existing server. It re-mints, re-tests the connection, upserts the fresh token, and resets the runtime status to `connected`.

## Testing

Verified end-to-end against a local instance with the real GitHub App installed:

- **Reconnect path:** forced a server into the stuck state (`connection_status=error`, frozen credential timestamp). Calling connect again flipped status back to `connected`, cleared the error, and advanced the credential's `updated_at` (proving re-mint). Previously it stayed frozen.
- **Per-run mint:** deleted the stored credential entirely and set status to `error`, then ran an agent prompt. The agent connected to GitHub MCP and listed real tools, status flipped back to `connected`, and **no credential was persisted** — confirming the token is minted ephemerally per run.
- `pnpm -F backend typecheck` + lint: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)