### PR TITLE
feat(pull-requests): read preview link from GitLab merge requests [PROD-8113]

### DIFF
--- a/packages/backend/src/clients/gitlab/Gitlab.test.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.test.ts
@@ -1,0 +1,67 @@
+import fetchMock from 'jest-fetch-mock';
+import { getMergeRequestComments } from './Gitlab';
+
+describe('GitlabClient.getMergeRequestComments', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // GitLab returns notes newest-first (sort=desc). The reader drops system
+    // notes and empty bodies, then reverses to oldest-first so it matches the
+    // GitHub comments contract (extractPreviewUrlFromComments scans newest-last).
+    it('drops system/empty notes and returns bodies oldest-first', async () => {
+        fetchMock.mockResponseOnce(
+            JSON.stringify([
+                { body: 'newest human note', system: false },
+                { body: '', system: false },
+                { body: 'changed the description', system: true },
+                { body: 'oldest human note', system: false },
+            ]),
+        );
+
+        const comments = await getMergeRequestComments({
+            owner: 'my-group',
+            repo: 'my-repo',
+            iid: 42,
+            token: 'glpat-xxx',
+        });
+
+        expect(comments).toEqual(['oldest human note', 'newest human note']);
+    });
+
+    it('requests the notes endpoint on the default host with a bearer token', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        await getMergeRequestComments({
+            owner: 'my-group',
+            repo: 'my-repo',
+            iid: 7,
+            token: 'glpat-xxx',
+        });
+
+        const [url, options] = fetchMock.mock.calls[0];
+        expect(url).toBe(
+            'https://gitlab.com/api/v4/projects/my-group%2Fmy-repo/merge_requests/7/notes?order_by=created_at&sort=desc&per_page=100',
+        );
+        expect((options?.headers as Record<string, string>).Authorization).toBe(
+            'Bearer glpat-xxx',
+        );
+    });
+
+    it('targets a self-hosted host when hostDomain is provided', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        await getMergeRequestComments({
+            owner: 'my-group',
+            repo: 'my-repo',
+            iid: 7,
+            token: 'glpat-xxx',
+            hostDomain: 'gitlab.internal.acme.com',
+        });
+
+        const [url] = fetchMock.mock.calls[0];
+        expect(url).toBe(
+            'https://gitlab.internal.acme.com/api/v4/projects/my-group%2Fmy-repo/merge_requests/7/notes?order_by=created_at&sort=desc&per_page=100',
+        );
+    });
+});

--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -399,6 +399,37 @@ export const getMergeRequest = async ({
     };
 };
 
+/**
+ * Read a merge request's notes (comments). Used to surface the preview-project
+ * URL that the dbt repo's CI posts on the MR. Returns note bodies oldest-first
+ * — the same contract as the GitHub comments reader — so
+ * `extractPreviewUrlFromComments` (which scans newest-last) picks the most
+ * recent preview. System notes (auto-generated activity) and empty bodies are
+ * dropped. Fetches the 100 most recent notes; preview comments are recent, so a
+ * single page is enough.
+ */
+export const getMergeRequestComments = async ({
+    owner,
+    repo,
+    iid,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabApiParams & { iid: number }): Promise<string[]> => {
+    const projectId = getProjectId(owner, repo);
+    const url = getApiUrl(
+        hostDomain,
+        `/projects/${projectId}/merge_requests/${iid}/notes?order_by=created_at&sort=desc&per_page=100`,
+    );
+    const notes: Array<{ body?: string; system?: boolean }> =
+        await makeGitlabRequest(url, token);
+
+    return notes
+        .filter((note) => !note.system)
+        .map((note) => note.body ?? '')
+        .filter((body) => body.length > 0)
+        .reverse();
+};
+
 /** Patch a merge request's title/description (writeback resume turns). */
 export const updateMergeRequest = async ({
     owner,

--- a/packages/backend/src/services/PullRequestsService/PullRequestsService.test.ts
+++ b/packages/backend/src/services/PullRequestsService/PullRequestsService.test.ts
@@ -1,0 +1,204 @@
+import { Ability } from '@casl/ability';
+import {
+    DbtProjectType,
+    OrganizationMemberRole,
+    PullRequest,
+    PullRequestProvider,
+    PullRequestSource,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import * as GithubClient from '../../clients/github/Github';
+import * as GitlabClient from '../../clients/gitlab/Gitlab';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import type { PullRequestsModel } from '../../models/PullRequestsModel';
+import type { GitIntegrationService } from '../GitIntegrationService/GitIntegrationService';
+import { PullRequestsService } from './PullRequestsService';
+
+jest.mock('../../clients/github/Github');
+jest.mock('../../clients/gitlab/Gitlab');
+
+const githubClientMock = jest.mocked(GithubClient);
+const gitlabClientMock = jest.mocked(GitlabClient);
+
+// siteUrl from lightdashConfigMock is https://test.lightdash.cloud
+const PREVIEW_URL =
+    'https://test.lightdash.cloud/projects/123e4567-e89b-12d3-a456-426614174000/dashboards';
+
+const baseUser = {
+    email: 'test@test.com',
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid: 'org-uuid',
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    timezone: null,
+    isSetupComplete: true,
+    userId: 1,
+    role: OrganizationMemberRole.EDITOR,
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const user: SessionUser = {
+    ...baseUser,
+    userUuid: 'user-uuid',
+    ability: new Ability<PossibleAbilities>([
+        { subject: 'SourceCode', action: ['view', 'manage'] },
+    ]),
+};
+
+const makePullRequest = (provider: PullRequestProvider): PullRequest => ({
+    pullRequestUuid: 'pr-uuid',
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    createdByUserUuid: 'user-uuid',
+    provider,
+    source: PullRequestSource.AI_AGENT,
+    owner: 'my-group',
+    repo: 'my-repo',
+    prNumber: 42,
+    prUrl: 'https://gitlab.com/my-group/my-repo/-/merge_requests/42',
+    aiThreadUuid: null,
+    aiAgentUuid: null,
+    createdAt: new Date(),
+});
+
+const pullRequestsModel = {
+    findByProjectAndUrl: jest.fn(),
+};
+
+const gitIntegrationService = {
+    getInstallationId: jest.fn(),
+    getGitCredentials: jest.fn(),
+};
+
+const projectModel = {
+    getSummary: jest.fn(),
+};
+
+describe('PullRequestsService.getPullRequestPreview', () => {
+    let service: PullRequestsService;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        service = new PullRequestsService({
+            lightdashConfig: lightdashConfigMock,
+            pullRequestsModel:
+                pullRequestsModel as unknown as PullRequestsModel,
+            gitIntegrationService:
+                gitIntegrationService as unknown as GitIntegrationService,
+            projectModel: projectModel as unknown as ProjectModel,
+        });
+    });
+
+    it('reads the preview URL from a GitLab MR notes', async () => {
+        pullRequestsModel.findByProjectAndUrl.mockResolvedValue(
+            makePullRequest(PullRequestProvider.GITLAB),
+        );
+        gitIntegrationService.getGitCredentials.mockResolvedValue({
+            owner: 'my-group',
+            repo: 'my-repo',
+            token: 'glpat-xxx',
+            hostDomain: 'gitlab.internal.acme.com',
+            type: DbtProjectType.GITLAB,
+        });
+        gitlabClientMock.getMergeRequestComments.mockResolvedValue([
+            'no preview here',
+            `deploy ready: ${PREVIEW_URL}`,
+        ]);
+
+        const result = await service.getPullRequestPreview(
+            user,
+            'project-uuid',
+            'https://gitlab.com/my-group/my-repo/-/merge_requests/42',
+        );
+
+        expect(result).toEqual({ previewUrl: PREVIEW_URL });
+        expect(gitlabClientMock.getMergeRequestComments).toHaveBeenCalledWith({
+            owner: 'my-group',
+            repo: 'my-repo',
+            iid: 42,
+            token: 'glpat-xxx',
+            hostDomain: 'gitlab.internal.acme.com',
+        });
+        expect(githubClientMock.getPullRequestComments).not.toHaveBeenCalled();
+    });
+
+    it('returns null for a GitLab MR with no preview comment', async () => {
+        pullRequestsModel.findByProjectAndUrl.mockResolvedValue(
+            makePullRequest(PullRequestProvider.GITLAB),
+        );
+        gitIntegrationService.getGitCredentials.mockResolvedValue({
+            owner: 'my-group',
+            repo: 'my-repo',
+            token: 'glpat-xxx',
+            type: DbtProjectType.GITLAB,
+        });
+        gitlabClientMock.getMergeRequestComments.mockResolvedValue([
+            'just a regular discussion',
+        ]);
+
+        const result = await service.getPullRequestPreview(
+            user,
+            'project-uuid',
+            'https://gitlab.com/my-group/my-repo/-/merge_requests/42',
+        );
+
+        expect(result).toEqual({ previewUrl: null });
+    });
+
+    it('returns null (not throwing) when GitLab credentials cannot be resolved', async () => {
+        pullRequestsModel.findByProjectAndUrl.mockResolvedValue(
+            makePullRequest(PullRequestProvider.GITLAB),
+        );
+        gitIntegrationService.getGitCredentials.mockRejectedValue(
+            new Error('Invalid personal access token for GitLab project'),
+        );
+
+        const result = await service.getPullRequestPreview(
+            user,
+            'project-uuid',
+            'https://gitlab.com/my-group/my-repo/-/merge_requests/42',
+        );
+
+        expect(result).toEqual({ previewUrl: null });
+        expect(gitlabClientMock.getMergeRequestComments).not.toHaveBeenCalled();
+    });
+
+    it('still reads the preview URL from a GitHub PR (unchanged path)', async () => {
+        pullRequestsModel.findByProjectAndUrl.mockResolvedValue(
+            makePullRequest(PullRequestProvider.GITHUB),
+        );
+        gitIntegrationService.getInstallationId.mockResolvedValue('install-1');
+        githubClientMock.getPullRequestComments.mockResolvedValue([
+            `preview: ${PREVIEW_URL}`,
+        ]);
+
+        const result = await service.getPullRequestPreview(
+            user,
+            'project-uuid',
+            'https://github.com/my-group/my-repo/pull/42',
+        );
+
+        expect(result).toEqual({ previewUrl: PREVIEW_URL });
+        expect(gitlabClientMock.getMergeRequestComments).not.toHaveBeenCalled();
+    });
+
+    it('returns null for an unknown pull request', async () => {
+        pullRequestsModel.findByProjectAndUrl.mockResolvedValue(undefined);
+
+        const result = await service.getPullRequestPreview(
+            user,
+            'project-uuid',
+            'https://gitlab.com/my-group/my-repo/-/merge_requests/99',
+        );
+
+        expect(result).toEqual({ previewUrl: null });
+    });
+});

--- a/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
+++ b/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
@@ -206,7 +206,7 @@ export class PullRequestsService extends BaseService {
      * this reads the PR's comments and extracts the link.
      *
      * Returns `{ previewUrl: null }` (rather than throwing) whenever a preview
-     * isn't available yet — an unknown PR, a non-GitHub provider, missing git
+     * isn't available yet — an unknown PR, an unsupported provider, missing git
      * credentials, or a transient provider error — so the caller can poll until
      * the preview appears without surfacing errors.
      */
@@ -240,47 +240,77 @@ export class PullRequestsService extends BaseService {
             throw new ForbiddenError();
         }
 
-        // Only GitHub is supported for reading preview comments today.
-        if (pullRequest.provider !== PullRequestProvider.GITHUB) {
-            return { previewUrl: null };
-        }
-
         try {
-            // Read the PR's comments using the GitHub App installation — the
-            // same identity the write-back used to open the PR — so a stale
-            // OAuth user token can't block the lookup. Fall back to the
-            // project's stored credentials (e.g. a personal access token) only
-            // when there is no installation.
-            let installationId: string | undefined;
-            let token: string | undefined;
-            try {
-                installationId =
-                    await this.gitIntegrationService.getInstallationId(user);
-            } catch {
+            if (pullRequest.provider === PullRequestProvider.GITHUB) {
+                // Read the PR's comments using the GitHub App installation —
+                // the same identity the write-back used to open the PR — so a
+                // stale OAuth user token can't block the lookup. Fall back to
+                // the project's stored credentials (e.g. a personal access
+                // token) only when there is no installation.
+                let installationId: string | undefined;
+                let token: string | undefined;
+                try {
+                    installationId =
+                        await this.gitIntegrationService.getInstallationId(
+                            user,
+                        );
+                } catch {
+                    const credentials =
+                        await this.gitIntegrationService.getGitCredentials(
+                            user,
+                            projectUuid,
+                        );
+                    if (credentials.type !== DbtProjectType.GITHUB) {
+                        return { previewUrl: null };
+                    }
+                    installationId = credentials.installationId;
+                    token = credentials.token;
+                }
+                const comments = await GithubClient.getPullRequestComments({
+                    owner: pullRequest.owner,
+                    repo: pullRequest.repo,
+                    pullNumber: pullRequest.prNumber,
+                    installationId,
+                    token,
+                });
+                return {
+                    previewUrl: extractPreviewUrlFromComments(
+                        comments,
+                        this.lightdashConfig.siteUrl,
+                    ),
+                };
+            }
+
+            if (pullRequest.provider === PullRequestProvider.GITLAB) {
+                // GitLab has no installation-token equivalent here, so read the
+                // MR's notes with the project's stored GitLab credentials (PAT
+                // + host domain for self-hosted), the same creds used to
+                // resolve live MR metadata.
                 const credentials =
                     await this.gitIntegrationService.getGitCredentials(
                         user,
                         projectUuid,
                     );
-                if (credentials.type !== DbtProjectType.GITHUB) {
+                if (credentials.type !== DbtProjectType.GITLAB) {
                     return { previewUrl: null };
                 }
-                installationId = credentials.installationId;
-                token = credentials.token;
+                const comments = await GitlabClient.getMergeRequestComments({
+                    owner: pullRequest.owner,
+                    repo: pullRequest.repo,
+                    iid: pullRequest.prNumber,
+                    token: credentials.token,
+                    hostDomain: credentials.hostDomain,
+                });
+                return {
+                    previewUrl: extractPreviewUrlFromComments(
+                        comments,
+                        this.lightdashConfig.siteUrl,
+                    ),
+                };
             }
-            const comments = await GithubClient.getPullRequestComments({
-                owner: pullRequest.owner,
-                repo: pullRequest.repo,
-                pullNumber: pullRequest.prNumber,
-                installationId,
-                token,
-            });
-            return {
-                previewUrl: extractPreviewUrlFromComments(
-                    comments,
-                    this.lightdashConfig.siteUrl,
-                ),
-            };
+
+            // Unsupported provider — nothing to read.
+            return { previewUrl: null };
         } catch (error) {
             this.logger.warn('Failed to resolve pull request preview URL', {
                 projectUuid,


### PR DESCRIPTION
## What & why

Linear: [PROD-8113](https://linear.app/lightdash/issue/PROD-8113)

The "View preview" affordance resolves a Lightdash preview-project URL by reading the comments the dbt repo's CI posts on the pull request. This worked for GitHub PRs but was hard-gated to GitHub only — GitLab merge requests always returned `{ previewUrl: null }`, so GitLab users never saw a preview link even when their CI posted one.

Most of the infrastructure was already provider-agnostic (GitLab is a first-class writeback provider, the `pull_requests` table is provider-neutral, and `extractPreviewUrlFromComments()` just takes comment-body strings). The only missing pieces were a GitLab "read MR notes" call and a provider branch in the reader.

## Changes

- **`GitlabClient.getMergeRequestComments()`** — reads an MR's notes (`GET /projects/{id}/merge_requests/{iid}/notes`). Drops system/auto-generated notes and empty bodies, and returns bodies **oldest-first** to match the GitHub comments reader's contract (`extractPreviewUrlFromComments` scans newest-last). Supports self-hosted GitLab via `hostDomain`.
- **`PullRequestsService.getPullRequestPreview()`** — now branches on `pullRequest.provider`:
  - GitHub: unchanged (installation-token path).
  - GitLab: resolves the project's stored GitLab credentials (PAT + host domain) and reuses the provider-agnostic extractor.
  - Unsupported providers and transient errors still return `{ previewUrl: null }` without throwing, so the caller can keep polling.

## Testing

No GitLab project/MR is available locally for a live end-to-end test, so this is covered by deterministic unit tests:

- **`Gitlab.test.ts`** (3 tests): note filtering (system/empty), oldest-first reverse ordering, request shape, and self-hosted host.
- **`PullRequestsService.test.ts`** (5 tests): GitLab preview extraction, no-preview → null, credentials-failure → null (no throw), the unchanged GitHub path, and unknown PR → null.
- `pnpm -F backend typecheck` + lint: clean.

## Acceptance criteria

- [x] GitLab-backed project surfaces the preview link from its MR, same as GitHub.
- [x] Self-hosted GitLab (custom `hostDomain`) supported.
- [x] Non-GitLab/GitHub providers and missing previews return `{ previewUrl: null }` without throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)