### PR TITLE
fix(ai-agents): enforce project access on open agents & searchSemanticLayer [PROD-8115]

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -733,7 +733,13 @@ export class AiAgentService extends BaseService {
         const hasUserAccess = agent.userAccess && agent.userAccess.length > 0;
 
         if (!hasGroupAccess && !hasUserAccess) {
-            return true;
+            return auditedAbility.can(
+                'view',
+                subject('Project', {
+                    organizationUuid: agent.organizationUuid,
+                    projectUuid: agent.projectUuid,
+                }),
+            );
         }
 
         // Check user access first (direct access)
@@ -4991,6 +4997,21 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 'AiAgent.searchSemanticLayer',
                 args,
                 async () => {
+                    const auditedAbility = this.createAuditedAbility(user);
+                    if (
+                        auditedAbility.cannot(
+                            'view',
+                            subject('Project', {
+                                organizationUuid,
+                                projectUuid,
+                            }),
+                        )
+                    ) {
+                        throw new ForbiddenError(
+                            'You do not have permission to view this project',
+                        );
+                    }
+
                     const agentSettings = await this.getAgentSettings(
                         user,
                         prompt,


### PR DESCRIPTION
## What & why

Closes [PROD-8115](https://linear.app/lightdash/issue/PROD-8115).

An AI agent with no user/group access list ("open access") was reachable by **any organization member**, and the `searchSemanticLayer` tool returned the project's entire field inventory with no `view:Project` authorization check. A user with no access to a project could therefore open a thread on its unrestricted agent and enumerate the whole semantic layer — even though the equivalent catalog HTTP endpoint (and the sibling agent tools `getProjectInfo` / `listProjects`) enforce that check.

Root cause:
- `checkAgentAccess` treated an open-access agent as available to anyone in the org (returned `true` unconditionally), with no project-visibility floor.
- `searchSemanticLayer` calls `CatalogService.searchCatalog` directly, which applies user-attribute filtering only — no `view:Project` gate.

## Changes

- **`checkAgentAccess`** — an open-access agent (no user/group allow-list) is now available only to users who can `view:Project` for the agent's project, instead of anyone in the org. Explicit user/group grants are unchanged. All agent entry points (`createAgentThread`, `createAgentThreadMessage`, `generate`, `stream`) funnel through this method, so the boundary is covered uniformly.
- **`searchSemanticLayer`** — re-checks `view:Project` on every call (defense in depth, matching `getProjectInfo` / `listProjects`), so an explicit agent grant without project access still cannot read the semantic layer.

## Verification

Reproduced and confirmed the fix against a running instance:

| Scenario | Before | After |
|---|---|---|
| Org member, no project access → create thread on unrestricted agent | 200 | 403 ForbiddenError |
| Org member with explicit agent grant → `searchSemanticLayer` | full field inventory returned | ForbiddenError (tool refuses) |
| Catalog HTTP endpoint (control) | 403 | 403 |

Typecheck and lint pass.

## Follow-ups
- Add an integration regression test (member-role `SessionUser` → `createAgentThread` expects `ForbiddenError`).
- Audit other agent tools that read the catalog/explores directly (`discoverFields`, `searchFieldValues`) for the same omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)