### PR TITLE
fix(ai): re-land GitHub MCP per-run token mint to main [PROD-8112]

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1833,7 +1833,7 @@ export type AiAgentGithubMcpConnectedEvent = BaseTrack & {
         mcpServerId: string;
         // Distinguishes the one-click flow (auto-config from the org's GitHub
         // integration) from manually creating a GitHub MCP server.
-        method: 'one_click';
+        method: 'one_click' | 'one_click_reconnect';
     };
 };
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -189,6 +189,7 @@ import {
     type AiAgentMcpServerToolPermissionSetting,
     type AiAgentMcpServerToolPermissionSettingUpdate,
     type AiMcpCredential,
+    type AiMcpServerWithSensitiveData,
 } from '../../models/AiAgentModel';
 import { CommercialSlackAuthenticationModel } from '../../models/CommercialSlackAuthenticationModel';
 import { ProjectContextModel } from '../../models/ProjectContextModel';
@@ -2673,18 +2674,6 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        // Idempotency: if a GitHub MCP server already exists, return it.
-        const existing = await this.aiAgentModel.listMcpServers(
-            projectUuid,
-            user.userUuid,
-        );
-        const alreadyConnected = existing.find(
-            (server) => server.url === GITHUB_MCP_SERVER_URL,
-        );
-        if (alreadyConnected) {
-            return alreadyConnected;
-        }
-
         const installationId =
             await this.githubAppInstallationsModel.findInstallationId(
                 organizationUuid,
@@ -2696,6 +2685,73 @@ export class AiAgentService extends BaseService {
         }
 
         const bearerToken = await getInstallationToken(installationId);
+
+        // Reconnect path: if a GitHub MCP server already exists, re-mint and
+        // upsert a fresh token rather than early-returning. The previous
+        // early-return left stuck (expired-token) servers unrecoverable.
+        const existing = await this.aiAgentModel.listMcpServers(
+            projectUuid,
+            user.userUuid,
+        );
+        const alreadyConnected = existing.find(
+            (server) => server.url === GITHUB_MCP_SERVER_URL,
+        );
+        if (alreadyConnected) {
+            try {
+                await this.aiAgentMcpRuntimeClient.testConnection({
+                    name: GITHUB_MCP_SERVER_NAME,
+                    url: GITHUB_MCP_SERVER_URL,
+                    authType: 'bearer',
+                    bearerToken,
+                    onUncaughtError: (error) => {
+                        Logger.error(
+                            `[AiAgent][MCP][${GITHUB_MCP_SERVER_NAME}] Uncaught MCP client error while reconnecting`,
+                            error,
+                        );
+                    },
+                });
+            } catch (error) {
+                throw new ParameterError(
+                    `We couldn't reconnect to the GitHub MCP server. Details: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+
+            await this.aiAgentModel.upsertCredential({
+                serverUuid: alreadyConnected.uuid,
+                scope: 'shared',
+                credentials: { type: 'bearer', bearerToken },
+                actorUserUuid: user.userUuid,
+            });
+            await this.aiAgentModel.updateMcpServerRuntimeState({
+                serverUuid: alreadyConnected.uuid,
+                connectionStatus: 'connected',
+                error: null,
+                actorUserUuid: user.userUuid,
+            });
+
+            this.analytics.track({
+                event: 'ai_agent.github_mcp_connected',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    mcpServerId: alreadyConnected.uuid,
+                    method: 'one_click_reconnect',
+                },
+            });
+
+            const refreshed = await this.aiAgentModel.listMcpServers(
+                projectUuid,
+                user.userUuid,
+            );
+            return (
+                refreshed.find(
+                    (server) => server.url === GITHUB_MCP_SERVER_URL,
+                ) ?? alreadyConnected
+            );
+        }
 
         // Delegates to createMcpServer, which additionally asserts the caller
         // can manage MCP servers, validates the URL, tests the connection and
@@ -2720,6 +2776,45 @@ export class AiAgentService extends BaseService {
         });
 
         return server;
+    }
+
+    /**
+     * The GitHub MCP server is authed with a GitHub App installation token,
+     * which expires after ~1h. Rather than rely on the (stale) stored token,
+     * mint a fresh one per run — mirroring how writeback mints per run — so the
+     * connection can never expire mid-session.
+     */
+    private async refreshGithubMcpCredentials(
+        organizationUuid: string | undefined,
+        servers: AiMcpServerWithSensitiveData[],
+    ): Promise<AiMcpServerWithSensitiveData[]> {
+        const hasGithubMcp = servers.some(
+            (server) =>
+                server.url === GITHUB_MCP_SERVER_URL &&
+                server.authType === 'bearer',
+        );
+        if (!hasGithubMcp || !organizationUuid) {
+            return servers;
+        }
+
+        const installationId =
+            await this.githubAppInstallationsModel.findInstallationId(
+                organizationUuid,
+            );
+        if (!installationId) {
+            return servers;
+        }
+
+        const bearerToken = await getInstallationToken(installationId);
+
+        return servers.map((server) =>
+            server.url === GITHUB_MCP_SERVER_URL && server.authType === 'bearer'
+                ? {
+                      ...server,
+                      resolvedCredential: { type: 'bearer', bearerToken },
+                  }
+                : server,
+        );
     }
 
     public async startMcpOAuthConnection(
@@ -6367,9 +6462,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 projectUuid: prompt.projectUuid,
             });
         const agentMcpServersWithSensitiveData =
-            await this.aiAgentModel.getAgentMcpServersWithSensitiveData(
-                agentSettings.uuid,
-                user.userUuid,
+            await this.refreshGithubMcpCredentials(
+                user.organizationUuid,
+                await this.aiAgentModel.getAgentMcpServersWithSensitiveData(
+                    agentSettings.uuid,
+                    user.userUuid,
+                ),
             );
         const mcpServers = this.aiAgentMcpRuntimeClient.attachRuntimeProviders({
             projectUuid: prompt.projectUuid,


### PR DESCRIPTION
## What & why

Re-lands [PROD-8112](https://linear.app/lightdash/issue/PROD-8112) onto `main`.

The fix (originally **#23858**) was merged into the stacked branch `preview-deploy-prod-8108` *after* that branch had already squash-merged to `main` (#23853), so the fix commit was orphaned and **never reached `main`** — it is not in 0.3087.x. The running release therefore still stores a static ~1h GitHub App installation token for the one-click GitHub MCP connection and never re-mints it, so it expires and reconnect can't recover it ("The MCP server rejected the saved credentials" / "Reconnect required").

This PR cherry-picks the orphaned fix commit (`2b46f65`) onto `main` unchanged (clean cherry-pick, no conflicts).

## What it does
- Mints the GitHub MCP installation token **per run** (installation tokens expire ~1h) instead of persisting a static one.
- Lets reconnect re-mint / recover instead of early-returning when a server already exists.

Original PR: #23858 (merged to the wrong base). Backend typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)