### PR TITLE
fix(ai-project-context): serialize entries before jsonb insert

### DIFF
--- a/packages/backend/src/ee/models/ProjectContextModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectContextModel.test.ts
@@ -24,7 +24,7 @@ describe('ProjectContextModel', () => {
         tracker.reset();
     });
 
-    test('stores entries as JSONB data instead of a JSON string', async () => {
+    test('serializes entries to a JSON string so pg writes valid jsonb', async () => {
         const entries: ProjectContextEntry[] = [
             {
                 id: 'hr',
@@ -44,11 +44,11 @@ describe('ProjectContextModel', () => {
             expect.arrayContaining([
                 PROJECT_UUID,
                 PROJECT_CONTEXT_FILE_VERSION,
-                entries,
+                JSON.stringify(entries),
             ]),
         );
-        expect(tracker.history.insert[0].bindings).not.toContain(
-            JSON.stringify(entries),
-        );
+        // A raw JS array binding is what pg turns into an array literal and
+        // rejects for jsonb, so it must NOT be passed through unstringified.
+        expect(tracker.history.insert[0].bindings).not.toContainEqual(entries);
     });
 });

--- a/packages/backend/src/ee/models/ProjectContextModel.ts
+++ b/packages/backend/src/ee/models/ProjectContextModel.ts
@@ -30,7 +30,9 @@ export class ProjectContextModel {
             .insert({
                 project_uuid: projectUuid,
                 version: PROJECT_CONTEXT_FILE_VERSION,
-                entries,
+                // Stringify: pg serializes a top-level JS array as a Postgres
+                // array literal, not JSON, which a jsonb column rejects.
+                entries: JSON.stringify(entries),
                 updated_at: this.database.fn.now(),
             })
             .onConflict('project_uuid')


### PR DESCRIPTION
## Summary

Project compile failed with `invalid input syntax for type json` when caching the project_context document.

`ProjectContextModel.replaceEntriesForProject` passed the `entries` **array** straight to Knex for the `jsonb` column. The `pg` driver serializes a top-level JS array as a Postgres **array literal** (`{...}`), not JSON, so the `jsonb` column rejected it. (A plain object would have been auto-stringified by `pg` — arrays are the exception, which is why this slipped through.)

Fix: `JSON.stringify(entries)` so the column receives valid JSON.

```
insert into "project_context_document" ("entries", "project_uuid", "updated_at", "version")
  values ($1, $2, CURRENT_TIMESTAMP, $3)
  on conflict ("project_uuid") do update set ...
-- ERROR: invalid input syntax for type json
```

## Why the test didn't catch it

The existing unit test used `knex-mock-client`, which doesn't replicate real `pg` array-vs-JSON binding behavior — it actually **asserted the buggy unstringified array**. The test is flipped to assert the stringified binding, so it now matches what real Postgres requires.

## Regression analysis

- **Scope:** EE-only, behind the `ai-project-context` feature flag. The write path runs on project compile/refresh (and PR-merge reconcile) for GitHub-connected projects that have a `lightdash.project_context.yml`.
- **Affected:** any project whose ingest produced a non-empty `entries` array — the compile step that calls `replaceEntriesForProject` threw. Empty arrays happened to serialize to a valid-JSON literal, so unset projects were unaffected.
- **Not affected:** OSS installs, projects without the flag, projects with no project_context file, and the read path (`getDocument`) — `jsonb` is returned already-parsed by `pg`, so reads were never broken.
- No migration or data backfill needed; the column type is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)