### PR TITLE
feat(settings): refine settings sidebar appearance and interactions

### DIFF
--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -46,6 +46,7 @@ type Props = {
     isSidebarCollapsed?: boolean;
     isSidebarCollapsible?: boolean;
     collapsedSidebarContent?: React.ReactNode;
+    sidebarWidthProps?: SidebarWidthProps;
     rightSidebar?: React.ReactNode;
     isRightSidebarOpen?: boolean;
     rightSidebarWidthProps?: SidebarWidthProps;
@@ -60,6 +61,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
     isSidebarCollapsed = false,
     isSidebarCollapsible = false,
     collapsedSidebarContent,
+    sidebarWidthProps,
     rightSidebar,
     isRightSidebarOpen = false,
     rightSidebarWidthProps,
@@ -126,6 +128,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
                         isCollapsed={isSidebarCollapsed}
                         collapsible={isSidebarCollapsible}
                         collapsedContent={collapsedSidebarContent}
+                        widthProps={sidebarWidthProps}
                         onResizeStart={startSidebarResizing}
                         onResizeEnd={stopSidebarResizing}
                     >

--- a/packages/frontend/src/components/common/Page/Sidebar.module.css
+++ b/packages/frontend/src/components/common/Page/Sidebar.module.css
@@ -36,18 +36,29 @@
         var(--sidebar-ease-conceal);
 }
 
+/* Pinned: flush against content — a single clean hairline, no shadow. */
 .floatingPanel[data-collapsed='false'] {
     transform: translateX(0);
     border-radius: 0;
+    border-right: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-dark-4));
+    box-shadow: none;
     transition: transform var(--sidebar-reveal-duration)
         var(--sidebar-ease-reveal);
 }
 
 /* Off-screen at rest; the extra 24px clears the shadow and floating margin. */
+/* Floating: lifts off the page — soft border + a gentle, diffuse shadow. */
 .floatingPanel[data-collapsed='true'] {
     transform: translateX(calc(-100% - 24px));
     margin: 8px;
     border-radius: var(--mantine-radius-md);
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-dark-4));
+    box-shadow: light-dark(
+        0 8px 24px -6px rgba(15, 18, 22, 0.12),
+        0 8px 24px -6px rgba(0, 0, 0, 0.5)
+    );
     will-change: transform;
 }
 
@@ -61,14 +72,14 @@
 }
 
 /* Invisible full-height hover zone along the page's left edge — approaching it
-   reveals the sidebar. Its width matches the collapsed panel's 8px inset so the
-   zone meets the panel with no dead gap that would drop the hover mid-transit. */
+   reveals the sidebar. Kept generous so the panel reveals as the cursor nears
+   the edge, well before reaching the collapsed panel itself. */
 .edgeTrigger {
     position: absolute;
     top: 0;
     bottom: 0;
     left: 0;
-    width: 8px;
+    width: 30px;
     z-index: 1;
 }
 
@@ -84,7 +95,7 @@
 .trigger {
     position: absolute;
     top: 10px;
-    left: 10px;
+    left: 20px;
     z-index: 1;
 }
 

--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -88,7 +88,7 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                     {...containerProps}
                 >
                     <Paper
-                        shadow="lg"
+                        withBorder={false}
                         radius={0}
                         className={classes.floatingPanel}
                         data-collapsed={isCollapsed}

--- a/packages/frontend/src/pages/Settings.module.css
+++ b/packages/frontend/src/pages/Settings.module.css
@@ -14,3 +14,128 @@
     flex: 1 1 auto;
     min-height: 0;
 }
+
+/* Keep the thumb visible while scrolling — the theme sets it via inline styles
+   (very faint ldGray-3), so override needs !important to win. */
+.sidebarScroll :global([class*='-ScrollArea-thumb']) {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-5),
+        var(--mantine-color-dark-2)
+    ) !important;
+}
+
+/* ------------------------------------------------------------------ *
+ * Sidebar nav polish — scoped to .sidebarScroll so other RouterNavLink
+ * usages elsewhere in the app are untouched. Substring class matches
+ * (`-NavLink-root`) so it survives the Mantine class prefix.
+ * ------------------------------------------------------------------ */
+
+/* Section labels ("Your settings", "Organization settings", …) */
+.sidebarScroll :global([class*='-Title-root']) {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-dark-2)
+    );
+}
+
+/* Nav item */
+.sidebarScroll :global([class*='-NavLink-root']) {
+    position: relative;
+    border-radius: var(--mantine-radius-md);
+    padding-block: 7px;
+    margin-bottom: 2px;
+    font-weight: 500;
+    color: light-dark(
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-dark-1)
+    );
+    transition:
+        background-color 150ms ease,
+        color 150ms ease,
+        transform 150ms ease;
+}
+
+/* Icon */
+.sidebarScroll :global([class*='-NavLink-section']) {
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-dark-2)
+    );
+    transition:
+        color 150ms ease,
+        transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Icon micro-pop on hover (settles with a touch of spring) */
+.sidebarScroll
+    :global([class*='-NavLink-root']:hover [class*='-NavLink-section']) {
+    transform: scale(1.12);
+}
+
+/* Hover (non-active): soft neutral fill */
+.sidebarScroll :global([class*='-NavLink-root']:not([data-active]):hover) {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-dark-6)
+    );
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-dark-0)
+    );
+}
+
+.sidebarScroll
+    :global(
+        [class*='-NavLink-root']:not([data-active]):hover
+            [class*='-NavLink-section']
+    ) {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-dark-0)
+    );
+}
+
+/* Active: neutral grey fill + stronger text */
+.sidebarScroll :global([class*='-NavLink-root'][data-active]) {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-2),
+        var(--mantine-color-dark-5)
+    );
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-dark-0)
+    );
+    font-weight: 600;
+}
+
+.sidebarScroll :global([class*='-NavLink-root'][data-active]:hover) {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-3),
+        var(--mantine-color-dark-4)
+    );
+}
+
+.sidebarScroll
+    :global([class*='-NavLink-root'][data-active] [class*='-NavLink-section']) {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-dark-0)
+    );
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .sidebarScroll :global([class*='-NavLink-root']),
+    .sidebarScroll :global([class*='-NavLink-section']) {
+        transition: none;
+    }
+    .sidebarScroll :global([class*='-NavLink-root']:hover) {
+        transform: none;
+    }
+    .sidebarScroll
+        :global([class*='-NavLink-root']:hover [class*='-NavLink-section']) {
+        transform: none;
+    }
+}

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -856,6 +856,7 @@ const Settings: FC = () => {
             withFixedContent={isFixedContent}
             withPaddedContent
             title="Settings"
+            sidebarWidthProps={{ defaultWidth: 300, minWidth: 260 }}
             isSidebarCollapsed={isSidebarCollapsed}
             isSidebarCollapsible
             collapsedSidebarContent={
@@ -915,9 +916,9 @@ const Settings: FC = () => {
                         </Tooltip>
                     </Group>
                     <ScrollArea
-                        variant="primary"
-                        offsetScrollbars
+                        type="scroll"
                         scrollbarSize={8}
+                        scrollHideDelay={800}
                         className={classes.sidebarScroll}
                     >
                         <Stack gap="lg">
@@ -1316,9 +1317,14 @@ const Settings: FC = () => {
                                 }),
                             ) ? (
                                 <Box>
-                                    <Title order={6} fw={600} mb="xs">
-                                        Current project ({project?.name})
-                                    </Title>
+                                    <Box mb="xs">
+                                        <Title order={6} fw={600}>
+                                            Current project
+                                        </Title>
+                                        <Text fz="sm" fw={700} mt={2}>
+                                            {project?.name}
+                                        </Text>
+                                    </Box>
 
                                     <RouterNavLink
                                         label="Connection settings"


### PR DESCRIPTION
## What & why

Polishes the Settings sidebar so it reads lighter and more refined, from a round of iterative design feedback.

### Changes
- Narrower default width for the Settings sidebar (400 → 300px), via a new optional `sidebarWidthProps` on `Page`.
- Active item uses a neutral grey fill (was the blue/primary tint) and no longer has a left accent bar.
- Cleaner hover: soft neutral fill, dropped the horizontal nudge.
- Section labels in sentence case (was ALL-CAPS) for a more understated look.
- "Current project" now shows the project name prominently on its own line instead of in muted parentheses.
- Scrollbar appears only while scrolling (`type="scroll"`), with a clearly visible thumb and a short hide delay.
- Floating (collapsed) panel: removed the heavy shadow in favour of a soft diffuse shadow and a refined hairline border. The pinned panel uses a single clean right border with no shadow.
- Wider edge hover zone (8 → 30px) so the collapsed panel reveals as the cursor nears the edge; collapsed toggle nudged right and kept clickable.

### Scope / regression analysis
- `sidebarWidthProps` is a new optional prop on `Page` and defaults to existing behaviour, so all other pages are unaffected.
- The shadow/border, edge-zone, and trigger changes live in the collapsible floating-sidebar code path, which only the Settings page uses (no other page passes `isSidebarCollapsible`).
- CSS/markup only. No data, API, or behavioural changes outside the sidebar.

### Testing
- Checked light and dark, in both pinned and floating (collapsed) states.
- `pnpm -F frontend lint` and `pnpm -F frontend typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)