### PR TITLE
fix: gate agent content access by data access

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2121,7 +2121,8 @@ export class AiAgentService extends BaseService {
             mcpServerUuids: body.mcpServerUuids,
             enableDataAccess: body.enableDataAccess,
             enableSelfImprovement: body.enableSelfImprovement,
-            enableContentTools: body.enableContentTools,
+            enableContentTools:
+                body.enableDataAccess && (body.enableContentTools ?? false),
             version: body.version,
         });
 
@@ -3015,6 +3016,9 @@ export class AiAgentService extends BaseService {
             throw new ForbiddenError();
         }
 
+        const nextEnableDataAccess =
+            body.enableDataAccess ?? agent.enableDataAccess;
+
         const updatedAgent = await this.aiAgentModel.updateAgent({
             agentUuid,
             name: body.name,
@@ -3031,7 +3035,9 @@ export class AiAgentService extends BaseService {
             mcpServerUuids: body.mcpServerUuids,
             enableDataAccess: body.enableDataAccess,
             enableSelfImprovement: body.enableSelfImprovement,
-            enableContentTools: body.enableContentTools,
+            enableContentTools: nextEnableDataAccess
+                ? body.enableContentTools
+                : false,
             version: body.version,
         });
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -322,6 +322,11 @@ const getAgentTools = (
           })
         : null;
 
+    const enableContentTools =
+        args.enableAgentRevamp &&
+        args.enableDataAccess &&
+        args.enableContentTools;
+
     const tools: ToolSet = {
         findContent,
         discoverFields,
@@ -330,7 +335,7 @@ const getAgentTools = (
         getProjectInfo,
         listKnowledgeDocuments,
         getKnowledgeDocumentContent,
-        ...(args.enableAgentRevamp && args.enableContentTools
+        ...(enableContentTools
             ? {
                   readContent,
                   editContent,
@@ -389,7 +394,9 @@ const getAgentMessages = (args: AiAgentArgs, availableExplores: Explore[]) => {
             enableSearchSemanticLayer: args.enableSearchSemanticLayer,
             enableAiWriteback: args.enableAiWriteback,
             enableContentTools:
-                args.enableAgentRevamp && args.enableContentTools,
+                args.enableAgentRevamp &&
+                args.enableDataAccess &&
+                args.enableContentTools,
             canRunSql: args.canRunSql,
             warehouseType: args.warehouseType,
             warehouseSchema: args.warehouseSchema,

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -377,6 +377,21 @@ export const AiAgentFormSetup = ({
                                 {...form.getInputProps('enableDataAccess', {
                                     type: 'checkbox',
                                 })}
+                                onChange={(event) => {
+                                    const enabled = event.currentTarget.checked;
+
+                                    form.setFieldValue(
+                                        'enableDataAccess',
+                                        enabled,
+                                    );
+
+                                    if (!enabled) {
+                                        form.setFieldValue(
+                                            'enableContentTools',
+                                            false,
+                                        );
+                                    }
+                                }}
                             />
                             {isAgentRevampEnabled && (
                                 <Switch
@@ -388,7 +403,7 @@ export const AiAgentFormSetup = ({
                                                 content
                                             </Text>
                                             <Tooltip
-                                                label="Only works for users with content-as-code access (admins and developers)."
+                                                label="Requires data access to be enabled. Only works for users with content-as-code access (admins and developers)."
                                                 withArrow
                                                 withinPortal
                                                 multiline
@@ -422,6 +437,7 @@ export const AiAgentFormSetup = ({
                                             type: 'checkbox',
                                         },
                                     )}
+                                    disabled={!form.values.enableDataAccess}
                                 />
                             )}
                         </Stack>

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -121,7 +121,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             mcpServerUuids: [],
             enableDataAccess: true,
             enableSelfImprovement: false,
-            enableContentTools: false,
+            enableContentTools: true,
             version: 2, // INFO: Default to v2 for now
         },
         validate: zodResolver(formSchema),
@@ -146,7 +146,9 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 mcpServerUuids: agentMcpServers?.map((mcp) => mcp.uuid) ?? [],
                 enableDataAccess: agent.enableDataAccess ?? false,
                 enableSelfImprovement: agent.enableSelfImprovement ?? false,
-                enableContentTools: agent.enableContentTools ?? false,
+                enableContentTools:
+                    (agent.enableDataAccess ?? false) &&
+                    (agent.enableContentTools ?? false),
                 version: agent.version ?? 2, // INFO: Default to v2 for now
             };
             form.setValues(values);


### PR DESCRIPTION
### Summary
- enable content access by default for new AI agents
- turn off and disable content access when data access is disabled
- enforce the same invariant in AI agent API writes and runtime tool selection

### Testing
- pnpm -F frontend exec oxfmt src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx --check
- pnpm -F frontend exec oxlint -c .oxlintrc.json src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
- pnpm -F backend exec oxfmt src/ee/services/AiAgentService/AiAgentService.ts src/ee/services/ai/agents/agentV2.ts --check
- pnpm -F backend run linter src/ee/services/AiAgentService/AiAgentService.ts src/ee/services/ai/agents/agentV2.ts

No Linear ticket.