### PR TITLE
fix: scope `getByIdOrSlug` dashboard lookups to the requested project

### DIFF
--- a/packages/backend/src/ee/services/AiService/AiService.test.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.test.ts
@@ -1,0 +1,49 @@
+import { type SessionUser } from '@lightdash/common';
+import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
+import { AiService } from './AiService';
+
+describe('AiService', () => {
+    const projectUuid = 'project-uuid';
+    const dashboardUuid = 'dashboard-uuid';
+    const user = {
+        userUuid: 'user-uuid',
+        organizationUuid: 'organization-uuid',
+    } as SessionUser;
+
+    const createService = () => {
+        const dashboardModel = {
+            getByIdOrSlug: jest.fn().mockRejectedValue(new Error('stop')),
+        };
+
+        const service = new AiService({
+            analytics: {
+                track: jest.fn(),
+            },
+            dashboardModel,
+            dashboardSummaryModel: {
+                getByDashboardUuid: jest.fn(),
+            },
+            projectService: {},
+            openAi: {},
+            lightdashConfig: lightdashConfigMock,
+            featureFlagService: {
+                get: jest.fn().mockResolvedValue({ enabled: true }),
+            },
+        } as unknown as ConstructorParameters<typeof AiService>[0]);
+
+        return { service, dashboardModel };
+    };
+
+    test('scopes dashboard summary lookup to the requested project', async () => {
+        const { service, dashboardModel } = createService();
+
+        await expect(
+            service.getDashboardSummary(user, projectUuid, dashboardUuid),
+        ).rejects.toThrow('stop');
+
+        expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledWith(
+            dashboardUuid,
+            { projectUuid },
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -313,8 +313,10 @@ export class AiService {
     ) {
         await this.throwOnFeatureDisabled(user);
         const startTime = new Date().getTime();
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
         const dashboardCharts = await this.getDashboardChartsResults(
             user,
             dashboard,
@@ -422,8 +424,10 @@ export class AiService {
     ) {
         await this.throwOnFeatureDisabled(user);
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuidOrSlug,
+            { projectUuid },
+        );
         const dashboardSummary =
             await this.dashboardSummaryModel.getByDashboardUuid(dashboard.uuid);
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -1,10 +1,16 @@
-import { ForbiddenError, ParameterError } from '@lightdash/common';
+import {
+    ForbiddenError,
+    ParameterError,
+    type AnonymousAccount,
+} from '@lightdash/common';
 import { EmbedService } from './EmbedService';
 import {
     EmbedServiceArgumentsMock,
     mockAccountWithoutPermission,
     mockAccountWithPermission,
+    mockOrganizationUuid,
     mockProjectUuid,
+    mockUserUuid,
 } from './EmbedService.mock';
 
 describe('EmbedService', () => {
@@ -230,6 +236,69 @@ describe('EmbedService', () => {
                     updateWithUndefinedAllowAllCharts,
                 );
             });
+        });
+    });
+
+    describe('searchFilterValues', () => {
+        test('scopes dashboard lookup to the requested project', async () => {
+            const dashboardUuid = 'dashboard-1';
+            const dashboardModel = {
+                getByIdOrSlug: jest.fn().mockRejectedValue(new Error('stop')),
+            };
+            const embedModel = {
+                get: jest.fn().mockResolvedValue({
+                    dashboardUuids: [dashboardUuid],
+                    allowAllDashboards: false,
+                    user: {
+                        userUuid: mockUserUuid,
+                    },
+                }),
+            };
+            const scopedService = new EmbedService({
+                ...EmbedServiceArgumentsMock,
+                dashboardModel,
+                embedModel,
+            } as unknown as ConstructorParameters<typeof EmbedService>[0]);
+            const account = {
+                authentication: {
+                    type: 'jwt',
+                    source: 'embed-token',
+                    data: {
+                        content: {
+                            type: 'dashboard',
+                        },
+                    },
+                },
+                access: {
+                    content: {
+                        dashboardUuid,
+                    },
+                },
+                user: {
+                    id: mockUserUuid,
+                },
+                organization: {
+                    organizationUuid: mockOrganizationUuid,
+                },
+                isAnonymousUser: jest.fn().mockReturnValue(true),
+            } as unknown as AnonymousAccount;
+
+            await expect(
+                scopedService.searchFilterValues({
+                    account,
+                    projectUuid: mockProjectUuid,
+                    filterUuid: 'filter-uuid',
+                    search: 'search',
+                    limit: 10,
+                    filters: undefined,
+                    forceRefresh: false,
+                }),
+            ).rejects.toThrow('stop');
+
+            expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledWith(
+                dashboardUuid,
+                { projectUuid: mockProjectUuid },
+            );
         });
     });
 });

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -514,8 +514,10 @@ export class EmbedService extends BaseService {
                 dashboardUuid,
             );
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
 
         await this.isFeatureEnabled({
             userUuid: user?.userUuid ?? account.user.id,
@@ -1088,8 +1090,10 @@ export class EmbedService extends BaseService {
             );
         }
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
 
         const chart = await this._getChartFromDashboardTiles(
             dashboard,
@@ -1215,8 +1219,10 @@ export class EmbedService extends BaseService {
             );
         }
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
 
         const savedSqlUuid = EmbedService._getSqlChartUuidFromDashboardTiles(
             dashboard,
@@ -1283,8 +1289,10 @@ export class EmbedService extends BaseService {
             );
         }
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
 
         const savedSqlUuid = EmbedService._getSqlChartUuidFromDashboardTiles(
             dashboard,
@@ -1353,8 +1361,10 @@ export class EmbedService extends BaseService {
             );
         }
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
 
         const chart = await this._getChartFromDashboardTiles(
             dashboard,
@@ -1548,8 +1558,10 @@ export class EmbedService extends BaseService {
             );
         }
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
 
         const tile = dashboard.tiles
             .filter(isDashboardChartTileType)
@@ -1631,7 +1643,9 @@ export class EmbedService extends BaseService {
         // For chart embeds, dashboardUuid is undefined - use empty parameters
         const dashboardParameters = dashboardUuid
             ? getDashboardParametersValuesMap(
-                  await this.dashboardModel.getByIdOrSlug(dashboardUuid),
+                  await this.dashboardModel.getByIdOrSlug(dashboardUuid, {
+                      projectUuid,
+                  }),
               )
             : {};
 
@@ -1716,7 +1730,9 @@ export class EmbedService extends BaseService {
         // For chart embeds, dashboardUuid is undefined - use empty parameters
         const dashboardParameters = dashboardUuid
             ? getDashboardParametersValuesMap(
-                  await this.dashboardModel.getByIdOrSlug(dashboardUuid),
+                  await this.dashboardModel.getByIdOrSlug(dashboardUuid, {
+                      projectUuid,
+                  }),
               )
             : {};
 
@@ -1988,8 +2004,10 @@ export class EmbedService extends BaseService {
             },
             dashboardUuid,
         );
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
         const dashboardFilters = dashboard.filters.dimensions;
         const filter = dashboardFilters.find((f) => f.id === filterUuid);
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4745,8 +4745,10 @@ export class AsyncQueryService extends ProjectService {
             warehouseCredentials.startOfWeek,
         );
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
         // Combine default parameter values, dashboard parameters, and request parameters first
@@ -5723,8 +5725,10 @@ export class AsyncQueryService extends ProjectService {
             await this.assertSavedChartAccess(account, 'view', savedChart);
         }
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
         // Combine default parameter values, dashboard parameters, and request parameters first


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-8094/cross-tenant-data-exposure-and-arbitrary-sql-execution-via-unscoped](https://linear.app/lightdash/issue/PROD-8094/cross-tenant-data-exposure-and-arbitrary-sql-execution-via-unscoped)

![CleanShot 2026-06-04 at 10.29.50@2x.png](https://app.graphite.com/user-attachments/assets/2b9412ae-8b74-442c-aaf5-ad35946a9a78.png)



### Description:

All calls to `dashboardModel.getByIdOrSlug` now pass `{ projectUuid }` as a scoping option, ensuring that dashboard lookups are constrained to the requested project.

Tests have been added for `AiService.getDashboardSummary` and `EmbedService.searchFilterValues` to verify that the dashboard lookup is correctly scoped to the provided `projectUuid`.

test-frontend test-backend