### PR TITLE
fix(mcp): show agent space scope

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -239,7 +239,16 @@ const makeMcpService = ({
     const aiAgentService = {
         getAgent: jest.fn().mockImplementation(async () => {
             if (!agent) throw new Error('Agent not mocked');
-            return agent;
+            return {
+                description: null,
+                projectUuid,
+                context: {
+                    explores: [],
+                    verifiedQuestions: [],
+                    instruction: null,
+                },
+                ...agent,
+            };
         }),
     };
 
@@ -249,7 +258,9 @@ const makeMcpService = ({
 
     const service = new McpService({
         aiAgentService,
-        aiOrganizationSettingsService: {},
+        aiOrganizationSettingsService: {
+            getSettings: jest.fn().mockResolvedValue({ aiAgentsVisible: true }),
+        },
         aiWritebackService: {},
         analytics: { track: jest.fn() },
         asyncQueryService,
@@ -295,6 +306,14 @@ const getToolCallback = (toolName: McpToolName) => {
         throw new Error(`Tool ${toolName} was not registered`);
     }
     return callback;
+};
+
+const parseTextResult = (result: unknown) => {
+    const response = result as { content?: Array<{ text?: string }> };
+    return JSON.parse(response.content?.[0]?.text ?? '{}') as Record<
+        string,
+        unknown
+    >;
 };
 
 describe('MCP async query polling', () => {
@@ -405,6 +424,35 @@ describe('MCP async query polling', () => {
             headerProjectUuid,
             account,
         );
+    });
+
+    it('returns active agent space access in get_current_agent', async () => {
+        makeMcpService({
+            context: {
+                projectUuid,
+                projectName: 'Project',
+                agentUuid: 'agent-uuid',
+                agentName: 'Agent',
+                tags: null,
+            },
+            agent: {
+                uuid: 'agent-uuid',
+                name: 'Agent',
+                tags: ['ai'],
+                spaceAccess: ['space-uuid'],
+            },
+        });
+
+        const result = await getToolCallback(McpToolName.GET_CURRENT_AGENT)(
+            {},
+            extra,
+        );
+
+        expect(parseTextResult(result)).toMatchObject({
+            agentUuid: 'agent-uuid',
+            agentTags: ['ai'],
+            agentSpaceAccess: ['space-uuid'],
+        });
     });
 
     it('uses active agent tags for run_metric_query', async () => {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1601,6 +1601,7 @@ export class McpService extends BaseService {
                                     agentName: agent.name,
                                     agentDescription: agent.description,
                                     agentTags: agent.tags,
+                                    agentSpaceAccess: agent.spaceAccess,
                                     agentProjectUuid: agent.projectUuid,
                                     explores: agent.context.explores,
                                     verifiedQuestions:
@@ -1726,6 +1727,7 @@ export class McpService extends BaseService {
                                     agentName: agent.name,
                                     agentDescription: agent.description,
                                     agentTags: agent.tags,
+                                    agentSpaceAccess: agent.spaceAccess,
                                     agentProjectUuid: agent.projectUuid,
                                     explores: agent.context.explores,
                                     verifiedQuestions:

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -312,7 +312,7 @@ Usage tips:
     },
     {
       "agentName": null,
-      "description": "Set the active AI agent for the active project. Returns the agent's full context including: explores it has access to, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+      "description": "Set the active AI agent for the active project. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -343,7 +343,7 @@ Usage tips:
     },
     {
       "agentName": null,
-      "description": "Get the currently active AI agent with its full context: explores it has access to, verified questions (curated example queries), and custom instructions. Use this to retrieve the agent's domain knowledge before making data queries.",
+      "description": "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. Use this to retrieve the agent's domain knowledge before making data queries.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -702,7 +702,7 @@ export const setAgentToolDefinition = defineTool({
     name: 'setAgent',
     title: 'Set agent',
     description:
-        "Set the active AI agent for the active project. Returns the agent's full context including: explores it has access to, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+        "Set the active AI agent for the active project. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
     availability: ['mcp'],
     inputSchema: z.object({
         agentUuid: z.string(),
@@ -724,7 +724,7 @@ export const getCurrentAgentToolDefinition = defineTool({
     name: 'getCurrentAgent',
     title: 'Get current agent',
     description:
-        "Get the currently active AI agent with its full context: explores it has access to, verified questions (curated example queries), and custom instructions. Use this to retrieve the agent's domain knowledge before making data queries.",
+        "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. Use this to retrieve the agent's domain knowledge before making data queries.",
     availability: ['mcp'],
     inputSchema: emptyInputSchema,
     mcp: { annotations: readOnlyAnnotations },


### PR DESCRIPTION
## Summary
- show active agent space access in MCP agent responses
- mention space restrictions in agent tool descriptions
- add coverage for get_current_agent

## Testing
- pnpm -F backend typecheck
- pnpm -F backend test src/ee/services/McpService/McpService.queryPolling.test.ts --runInBand
- pnpm -F backend test src/ee/services/McpService/mcpToolContracts.snapshot.test.ts --runInBand
- pnpm -F common lint