### PR TITLE
fix: make agent rows clickable

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -436,7 +436,11 @@ const AiAgentAdminAgentsTable = () => {
                         >
                             {' '}
                             <Menu.Target>
-                                <ActionIcon variant="subtle" color="gray">
+                                <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
+                                    onClick={(event) => event.stopPropagation()}
+                                >
                                     <MantineIcon icon={IconDots} />
                                 </ActionIcon>
                             </Menu.Target>
@@ -445,7 +449,8 @@ const AiAgentAdminAgentsTable = () => {
                                     leftSection={
                                         <MantineIcon icon={IconSettings} />
                                     }
-                                    onClick={() => {
+                                    onClick={(event) => {
+                                        event.stopPropagation();
                                         void navigate(
                                             `/projects/${agent.projectUuid}/ai-agents/${agent.uuid}/edit`,
                                         );
@@ -457,7 +462,8 @@ const AiAgentAdminAgentsTable = () => {
                                     leftSection={
                                         <MantineIcon icon={IconMessageCircle} />
                                     }
-                                    onClick={() => {
+                                    onClick={(event) => {
+                                        event.stopPropagation();
                                         void navigate(
                                             `/projects/${agent.projectUuid}/ai-agents/${agent.uuid}`,
                                         );
@@ -505,11 +511,29 @@ const AiAgentAdminAgentsTable = () => {
                 maxHeight: 'calc(100dvh - 350px)',
             },
         },
+        mantineTableProps: {
+            highlightOnHover: true,
+        },
 
         mantineTableHeadRowProps: {
             style: {
                 boxShadow: 'none',
             },
+        },
+        mantineTableBodyRowProps: ({ row, table: mantineTable }) => {
+            if (mantineTable.getState().showSkeletons) {
+                return {};
+            }
+
+            const agent = row.original;
+
+            return {
+                onClick: () => {
+                    void navigate(
+                        `/projects/${agent.projectUuid}/ai-agents/${agent.uuid}`,
+                    );
+                },
+            };
         },
         mantineTableBodyCellProps: {
             h: 72,


### PR DESCRIPTION
### Description
- Make agent rows in settings open the agent page.
- Keep menu actions isolated from row click handling.
- Enable hover background for clickable rows.

### Testing
- pnpm -F frontend exec oxlint -c .oxlintrc.json --ignore-path ./../../.gitignore src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
- pnpm -F frontend exec oxfmt src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx --check
- Browser verified row click, hover class, and Edit menu navigation.

Closes: PROD-8125