### PR TITLE
chore: add AI tool artifacts (`.agents`, `.codex`, `.claude/*.lock`, `AGENTS.md`) to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,9 @@ http-client.private.env.json
 scripts/har-replay-server.ts
 *.har
 agent-harness/cloud/credentials.env
+
+# AI
+.agents
+.codex
+.claude/*.lock
+AGENTS.md


### PR DESCRIPTION
Closes:

### Description:
Adds AI-related paths to `.gitignore` to prevent accidental commits of AI tool artifacts and configuration files. This includes `.agents`, `.codex`, `.claude/*.lock`, and `AGENTS.md`.