### PR TITLE
fix(mcp): remove agent scope cache

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -503,29 +503,6 @@ describe('MCP async query polling', () => {
         });
     });
 
-    it('memoizes active agent scope within a tool request', async () => {
-        const { aiAgentService } = makeMcpService({
-            context: {
-                projectUuid,
-                projectName: 'Project',
-                agentUuid: 'agent-uuid',
-                agentName: 'Agent',
-                tags: null,
-            },
-            agent: {
-                uuid: 'agent-uuid',
-                name: 'Agent',
-                tags: ['ai'],
-                spaceAccess: [],
-            },
-            explores: { orders: makeExplore({ tags: ['ai'] }) },
-        });
-
-        await getToolCallback(McpToolName.LIST_EXPLORES)({}, extra);
-
-        expect(aiAgentService.getAgent).toHaveBeenCalledTimes(1);
-    });
-
     it('filters content by active agent space access', async () => {
         const allowedChart = makeChartSearchResult({
             name: 'Allowed Chart',

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -282,11 +282,6 @@ export class McpService extends BaseService {
 
     private mcpCompatLayer: McpSchemaCompatLayer;
 
-    private effectiveScopeCache = new WeakMap<
-        McpProtocolContext,
-        Map<string, Promise<McpEffectiveScope>>
-    >();
-
     constructor({
         lightdashConfig,
         analytics,
@@ -2413,34 +2408,6 @@ export class McpService extends BaseService {
     }
 
     private async getEffectiveScopeFromContext(
-        context: McpProtocolContext,
-        projectUuid?: string,
-    ): Promise<McpEffectiveScope> {
-        const cacheKey = projectUuid ?? '';
-        let contextCache = this.effectiveScopeCache.get(context);
-        if (!contextCache) {
-            contextCache = new Map<string, Promise<McpEffectiveScope>>();
-            this.effectiveScopeCache.set(context, contextCache);
-        }
-
-        const cachedScope = contextCache.get(cacheKey);
-        if (cachedScope) {
-            return cachedScope;
-        }
-
-        const scopePromise = this.resolveEffectiveScopeFromContext(
-            context,
-            projectUuid,
-        ).catch((error) => {
-            contextCache.delete(cacheKey);
-            throw error;
-        });
-        contextCache.set(cacheKey, scopePromise);
-
-        return scopePromise;
-    }
-
-    private async resolveEffectiveScopeFromContext(
         context: McpProtocolContext,
         projectUuid?: string,
     ): Promise<McpEffectiveScope> {


### PR DESCRIPTION
## Summary
- remove service-level effective agent scope cache
- restore direct MCP scope resolution on each check
- remove memoization test

## Testing
- pnpm -F backend test src/ee/services/McpService/McpService.queryPolling.test.ts --runInBand
- eslint changed MCP files

Note: pnpm -F backend typecheck currently fails on unrelated main/common export issues after latest main pull.