### PR TITLE
fix(data-apps): hash filters in data app tile URL to avoid oversized request

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -1,5 +1,9 @@
 import { subject } from '@casl/ability';
-import { ProjectType, type DashboardDataAppTile } from '@lightdash/common';
+import {
+    hashStringToBase36,
+    ProjectType,
+    type DashboardDataAppTile,
+} from '@lightdash/common';
 import { Box, Loader, Stack, Text } from '@mantine-8/core';
 import { IconAppsOff, IconPencil } from '@tabler/icons-react';
 import React, { useMemo, useState, type FC } from 'react';
@@ -133,16 +137,18 @@ const DataAppTile: FC<Props> = (props) => {
     // reloads and its mount-time metric queries re-fire — by then the bridge
     // is stamping the new filters onto every outgoing call. Without this the
     // bridge sees no new traffic until the user manually refreshes.
+    //
+    // Hash rather than serialize the filters: the app reads them from the
+    // bridge, not this URL, and embedding the full object made the URL grow
+    // with filters × tiles and 502 on large dashboards.
     const filtersKey = useMemo(
-        () => JSON.stringify(dashboardFiltersForApp),
+        () => hashStringToBase36(JSON.stringify(dashboardFiltersForApp)),
         [dashboardFiltersForApp],
     );
 
     const previewUrl =
         token && latestReadyVersion
-            ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/?f=${encodeURIComponent(
-                  filtersKey,
-              )}&r=${refreshCounter}#transport=postMessage&projectUuid=${projectUuid}`
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/?f=${filtersKey}&r=${refreshCounter}#transport=postMessage&projectUuid=${projectUuid}`
             : undefined;
 
     const isForbidden =

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
@@ -1,4 +1,7 @@
-import { type DashboardDataAppTile } from '@lightdash/common';
+import {
+    hashStringToBase36,
+    type DashboardDataAppTile,
+} from '@lightdash/common';
 import { Box, Loader, Stack } from '@mantine-8/core';
 import { IconAppsOff } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
@@ -48,15 +51,14 @@ const EmbedDataAppTile: FC<Props> = ({ tile, projectUuid }) => {
 
     // Bumping the URL whenever filters change forces the iframe to remount so
     // its mount-time metric queries re-fire — matching DashboardDataAppTile.
+    // Hash instead of serialize so the URL doesn't 502 on large dashboards.
     const filtersKey = useMemo(
-        () => JSON.stringify(dashboardFiltersForApp),
+        () => hashStringToBase36(JSON.stringify(dashboardFiltersForApp)),
         [dashboardFiltersForApp],
     );
 
     const previewUrl = tokenQuery.data
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/t/${tokenQuery.data.token}/?f=${encodeURIComponent(
-              filtersKey,
-          )}#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/t/${tokenQuery.data.token}/?f=${filtersKey}#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
 
     const statusCode = tokenQuery.error?.error?.statusCode;


### PR DESCRIPTION
Closes: #23870

### Description:
The dashboard data app tile serialized the full dashboard filter object (including the per-tile tileTargets map) into the iframe URL's `f=` query param. That param is only a cache-buster — the app receives the actual filters via the postMessage bridge, not the URL. On large dashboards the serialized filters grew O(filters × tiles), pushing the URL past the reverse proxy's limit and returning a 502 ("Server Error").

Replace the serialized filters with a short hashStringToBase36 fingerprint so the iframe still reloads whenever filters change, but the URL stays a constant small size regardless of dashboard size. Applies to both the in-app and embed data app tiles.

