### PR TITLE
feat(changesets): write back all changeset changes to dbt

### DIFF
--- a/packages/backend/src/ee/controllers/ChangesetWritebackController.ts
+++ b/packages/backend/src/ee/controllers/ChangesetWritebackController.ts
@@ -1,0 +1,59 @@
+import {
+    assertRegisteredAccount,
+    type ApiAiWritebackResponse,
+    type ApiErrorPayload,
+} from '@lightdash/common';
+import {
+    Hidden,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { ChangesetWritebackService } from '../services/ChangesetWritebackService/ChangesetWritebackService';
+
+@Route('/api/v1/ee/projects/{projectUuid}/changesets')
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class ChangesetWritebackController extends BaseController {
+    /**
+     * Write back every change in the project's active changeset to the dbt
+     * project in a single pull request. Synchronous — the request is held open
+     * until the writeback run completes.
+     * @summary Write back all changeset changes
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/writeback')
+    @OperationId('writebackChangeset')
+    async writebackChangeset(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiAiWritebackResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results = await this.services
+            .getChangesetWritebackService<ChangesetWritebackService>()
+            .writebackActiveChangeset(toSessionUser(req.account), projectUuid);
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -53,6 +53,7 @@ import { AiWritebackService } from './services/AiWritebackService/AiWritebackSer
 import { AppGenerateService } from './services/AppGenerateService/AppGenerateService';
 import { PreAggregateStrategy } from './services/AsyncQueryService/PreAggregateStrategy';
 import { PreAggregationDuckDbClient } from './services/AsyncQueryService/PreAggregationDuckDbClient';
+import { ChangesetWritebackService } from './services/ChangesetWritebackService/ChangesetWritebackService';
 import { CommercialCacheService } from './services/CommercialCacheService';
 import { CommercialSlackIntegrationService } from './services/CommercialSlackIntegrationService';
 import { EmbedService } from './services/EmbedService/EmbedService';
@@ -137,6 +138,13 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         getRepoDefaultBranch,
                         getRepoWorkflowFiles,
                     },
+                }),
+            changesetWritebackService: ({ models, repository }) =>
+                new ChangesetWritebackService({
+                    changesetModel: models.getChangesetModel(),
+                    projectModel: models.getProjectModel(),
+                    aiWritebackService:
+                        repository.getAiWritebackService<AiWritebackService>(),
                 }),
             appGenerateService: ({ context, models, clients, repository }) =>
                 new AppGenerateService({

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -120,7 +120,8 @@ export type AiWritebackSource =
     | 'web'
     | 'mcp'
     | 'api'
-    | 'admin_review';
+    | 'admin_review'
+    | 'changeset';
 
 /** Coarse phase of the agent's work, inferred from the tools it calls. */
 export type AgentPhase = 'discovering' | 'editing' | 'compiling';

--- a/packages/backend/src/ee/services/ChangesetWritebackService/ChangesetWritebackService.ts
+++ b/packages/backend/src/ee/services/ChangesetWritebackService/ChangesetWritebackService.ts
@@ -1,0 +1,115 @@
+import { subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    ParameterError,
+    type AiWritebackRunResult,
+    type Change,
+    type ChangesetWithChanges,
+    type SessionUser,
+} from '@lightdash/common';
+import type { ChangesetModel } from '../../../models/ChangesetModel';
+import type { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { BaseService } from '../../../services/BaseService';
+import type { AiWritebackService } from '../AiWritebackService/AiWritebackService';
+
+type ChangesetWritebackServiceArguments = {
+    changesetModel: ChangesetModel;
+    projectModel: ProjectModel;
+    aiWritebackService: AiWritebackService;
+};
+
+const describeChange = (change: Change): string => {
+    const target = `${change.entityType} \`${change.entityName}\` on model \`${change.entityTableName}\``;
+    switch (change.type) {
+        case 'create': {
+            const { value } = change.payload;
+            return `Add a new ${value.type} metric \`${value.name}\` (label: "${value.label}") to model \`${value.table}\` with SQL: ${value.sql}`;
+        }
+        case 'update': {
+            const patches = change.payload.patches
+                .map(
+                    (patch) =>
+                        `set \`${patch.path}\` to ${JSON.stringify(patch.value)}`,
+                )
+                .join(', ');
+            return `Update ${target}: ${patches}`;
+        }
+        case 'delete':
+            return `Delete ${target}`;
+        default:
+            return `Apply change to ${target}`;
+    }
+};
+
+/** Turn a changeset's structured changes into a prompt for the writeback agent. */
+const buildPrompt = (changeset: ChangesetWithChanges): string => {
+    const instructions = changeset.changes
+        .map((change, index) => `${index + 1}. ${describeChange(change)}`)
+        .join('\n');
+    return [
+        `Apply the following ${changeset.changes.length} semantic-layer change(s) from the Lightdash changeset "${changeset.name}" to the dbt project, then open a single pull request with all of them.`,
+        '',
+        instructions,
+        '',
+        'Make only the changes listed above. Preserve existing formatting and unrelated content.',
+    ].join('\n');
+};
+
+export class ChangesetWritebackService extends BaseService {
+    private readonly changesetModel: ChangesetModel;
+
+    private readonly projectModel: ProjectModel;
+
+    private readonly aiWritebackService: AiWritebackService;
+
+    constructor(args: ChangesetWritebackServiceArguments) {
+        super({ serviceName: 'ChangesetWritebackService' });
+        this.changesetModel = args.changesetModel;
+        this.projectModel = args.projectModel;
+        this.aiWritebackService = args.aiWritebackService;
+    }
+
+    /**
+     * Read the project's active changeset and write every change back to the dbt
+     * project in a single pull request. Synchronous — the request is held open
+     * until the writeback run completes. Requires `manage:SourceCode`; the
+     * feature flag is enforced by AiWritebackService.run.
+     */
+    async writebackActiveChangeset(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<AiWritebackRunResult> {
+        const project = await this.projectModel.get(projectUuid);
+        // Writeback opens a PR from a fresh feature branch, so mirror run()'s
+        // gate: `manage:SourceCode` with `isProtectedBranch: false`.
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('SourceCode', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                    isProtectedBranch: false,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const changeset =
+            await this.changesetModel.findActiveChangesetWithChangesByProjectUuid(
+                projectUuid,
+            );
+        if (!changeset || changeset.changes.length === 0) {
+            throw new ParameterError(
+                'There are no changes to write back for this project',
+            );
+        }
+
+        return this.aiWritebackService.run({
+            user,
+            projectUuid,
+            prompt: buildPrompt(changeset),
+            source: 'changeset',
+        });
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -137,6 +137,8 @@ import { AppGenerateController } from './../ee/controllers/appGenerateController
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserAppsController } from './../ee/controllers/appGenerateController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ChangesetWritebackController } from './../ee/controllers/ChangesetWritebackController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { CustomRolesController } from './../ee/controllers/CustomRolesController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { DatabricksSSOController } from './../ee/controllers/databricksSSOController';
@@ -49008,6 +49010,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'removeScopeFromRole',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsChangesetWritebackController_writebackChangeset: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/changesets/writeback',
+        ...fetchMiddlewares<RequestHandler>(ChangesetWritebackController),
+        ...fetchMiddlewares<RequestHandler>(
+            ChangesetWritebackController.prototype.writebackChangeset,
+        ),
+
+        async function ChangesetWritebackController_writebackChangeset(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsChangesetWritebackController_writebackChangeset,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ChangesetWritebackController>(
+                        ChangesetWritebackController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'writebackChangeset',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -135,6 +135,7 @@ interface ServiceManifest {
     /** An implementation signature for these services are not available at this stage */
     aiWritebackService: unknown;
     previewDeploySetupService: unknown;
+    changesetWritebackService: unknown;
     appGenerateService: unknown;
     embedService: unknown;
     aiService: unknown;
@@ -1269,6 +1270,12 @@ export class ServiceRepository
         PreviewDeploySetupServiceImplT,
     >(): PreviewDeploySetupServiceImplT {
         return this.getService('previewDeploySetupService');
+    }
+
+    public getChangesetWritebackService<
+        ChangesetWritebackServiceImplT,
+    >(): ChangesetWritebackServiceImplT {
+        return this.getService('changesetWritebackService');
     }
 
     public getAppGenerateService<


### PR DESCRIPTION
## Description

Adds a synchronous EE endpoint that writes a project's **active changeset** back to its dbt project: it reads the changeset, serializes every change into a prompt, and runs the existing AI writeback agent to open one pull request with all of them.

`ChangesetWritebackService` (EE) reads the active changeset via `ChangesetModel` and calls the unchanged `AiWritebackService.run({ source: 'changeset' })`. `ChangesetWritebackController` (EE) exposes `POST /api/v1/ee/projects/{projectUuid}/changesets/writeback`. The orchestration lives entirely in EE, so nothing in the OSS/base layer depends on EE. Permissions (`manage:SourceCode`) and the `ai-writeback` feature flag are enforced inside `run`.

```
POST /ee/projects/{uuid}/changesets/writeback
        │
        ▼
ChangesetWritebackController  (EE, @Hidden)
        │
        ▼
ChangesetWritebackService     (EE)
   ├─ ChangesetModel.findActiveChangeset()   → N changes
   ├─ buildPrompt(changeset)
   └─ AiWritebackService.run({ source: 'changeset' })   (unchanged)
            └─ sandbox → clone → edit dbt → lightdash compile → open PR
        │
        ▼
   { prUrl, exitCode, output }
```

## Test plan

- [x] `pnpm generate-api`, `pnpm -F backend typecheck`, `pnpm -F backend lint` pass
- [x] Happy path: `POST .../changesets/writeback` against a project with a 6-change active changeset and a GitHub-connected dbt repo → `200` in ~94s, `exitCode: 0`, output `"All 6 changes applied successfully and compile passed"`, response carries `prUrl`
- [x] The agent applied all 6 changes, ran `lightdash compile` (ok), and opened a single PR
- [x] No active changeset → `400 ParameterError("There are no changes to write back for this project")`
- [ ] Authorization + flag: enforced by `AiWritebackService.run` (`manage:SourceCode` + `ai-writeback`)

## Notes (out of scope)

- Synchronous: the request blocks for the full agent run (can be a minute-plus). Async/worker + polling is a later slice.
- The changeset is not auto-cleared after a successful PR.
- Changeset is read as "active = latest" per existing `ChangesetModel` behaviour.

Closes: PROD-8105