### PR TITLE
fix: preserve ask ai project settings filter

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -25,8 +25,14 @@ import {
     IconUser,
     IconUsers,
 } from '@tabler/icons-react';
-import { useDeferredValue, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import {
+    useCallback,
+    useDeferredValue,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
+import { useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import {
     ContentTable,
@@ -40,6 +46,7 @@ import {
 } from '../../../../../hooks/slack/useSlack';
 import { useIsTruncated } from '../../../../../hooks/useIsTruncated';
 import { useProjects } from '../../../../../hooks/useProjects';
+import useSearchParams from '../../../../../hooks/useSearchParams';
 import SlackSvg from '../../../../../svgs/slack.svg?react';
 import { useAiAgentAdminAgents } from '../../hooks/useAiAgentAdmin';
 import ProjectsFilter from './ProjectsFilter';
@@ -48,12 +55,45 @@ import { SearchFilter } from './SearchFilter';
 const AiAgentAdminAgentsTable = () => {
     const theme = useMantineTheme();
     const navigate = useNavigate();
+    const { pathname, search: locationSearch } = useLocation();
     const { data: agents, isLoading } = useAiAgentAdminAgents();
     const { data: projects } = useProjects();
+    const projectsParam = useSearchParams<string>('projects');
 
     const [search, setSearch] = useState<string | undefined>(undefined);
     const [selectedProjectUuids, setSelectedProjectUuids] = useState<string[]>(
-        [],
+        () => projectsParam?.split(',').filter(Boolean) ?? [],
+    );
+
+    useEffect(() => {
+        setSelectedProjectUuids(
+            projectsParam?.split(',').filter(Boolean) ?? [],
+        );
+    }, [projectsParam]);
+
+    const handleSelectedProjectUuidsChange = useCallback(
+        (projectUuids: string[]) => {
+            setSelectedProjectUuids(projectUuids);
+
+            const searchParams = new URLSearchParams(locationSearch);
+            if (projectUuids.length > 0) {
+                searchParams.set('projects', projectUuids.join(','));
+            } else {
+                searchParams.delete('projects');
+            }
+
+            const nextSearch = searchParams.toString();
+            if (nextSearch !== new URLSearchParams(locationSearch).toString()) {
+                void navigate(
+                    {
+                        pathname,
+                        search: nextSearch,
+                    },
+                    { replace: true },
+                );
+            }
+        },
+        [locationSearch, navigate, pathname],
     );
 
     const {
@@ -137,7 +177,7 @@ const AiAgentAdminAgentsTable = () => {
 
     const handleClearFilters = () => {
         setSearch(undefined);
-        setSelectedProjectUuids([]);
+        handleSelectedProjectUuidsChange([]);
     };
 
     const columns: MRT_ColumnDef<AiAgentSummary>[] = useMemo(
@@ -568,7 +608,9 @@ const AiAgentAdminAgentsTable = () => {
                         />
                         <ProjectsFilter
                             selectedProjectUuids={selectedProjectUuids}
-                            setSelectedProjectUuids={setSelectedProjectUuids}
+                            setSelectedProjectUuids={
+                                handleSelectedProjectUuidsChange
+                            }
                             tooltipLabel="Filter agents by project"
                         />
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -242,6 +242,9 @@ const AgentsRouterPage = () => {
               : null;
 
     const placeholder = 'Ask anything about your data...';
+    const settingsHref = projectUuid
+        ? `/generalSettings/ai/agents?projects=${projectUuid}`
+        : '/generalSettings/ai/agents';
 
     return (
         <AiAgentPageLayout
@@ -255,11 +258,7 @@ const AgentsRouterPage = () => {
             }
             Header={
                 <AgentPageHeader
-                    settingsHref={
-                        canManageAgents
-                            ? '/generalSettings/ai/agents'
-                            : undefined
-                    }
+                    settingsHref={canManageAgents ? settingsHref : undefined}
                 />
             }
         >


### PR DESCRIPTION
### Description
- Preserve the originating project when opening Ask AI settings from a project.
- Preselect the project filter on the AI agents settings table from the `projects` query param.
- Keep project filter changes in sync with the URL.

### Testing
- pnpm -F frontend exec oxlint -c .oxlintrc.json --ignore-path ./../../.gitignore src/ee/pages/AiAgents/AgentsRouterPage.tsx src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
- pnpm -F frontend exec oxfmt src/ee/pages/AiAgents/AgentsRouterPage.tsx src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx --check
- Browser verified project Ask AI Settings link opens agents settings with the project filter selected.

Closes: PROD-8123