### PR TITLE
feat(pull-requests): redesign settings table with ContentTable, state filter and AI thread preview

### DIFF
--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
@@ -1,102 +1,3 @@
-/* White paper wrapper: clip the table corners to the card radius */
-.tablePaper {
-    overflow: hidden;
-    background-color: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-ldDark-7)
-    );
-}
-
-/* Vertical scroll container for infinite scroll; the sticky header stays
-   pinned while rows scroll under it. */
-.scrollArea {
-    max-height: calc(100dvh - 230px);
-    min-height: 200px;
-    overflow: auto;
-}
-
-.table {
-    /* Fixed layout + full width: columns honour their widths exactly, so the
-       Source/State tags never collapse and the Title absorbs the remainder. */
-    table-layout: fixed;
-    width: 100%;
-}
-
-/* Pull request medallion */
-.table th:nth-of-type(1),
-.table td:nth-of-type(1) {
-    width: 60px;
-}
-
-/* Created (relative time) */
-.table th:nth-of-type(2),
-.table td:nth-of-type(2) {
-    width: 150px;
-    white-space: nowrap;
-}
-
-/* Author */
-.table th:nth-of-type(3),
-.table td:nth-of-type(3) {
-    width: 160px;
-}
-
-/* Title (4th column) has no width → it takes all remaining space.
-   The source tag is appended inside this cell. */
-
-/* State */
-.table th:nth-of-type(5),
-.table td:nth-of-type(5) {
-    width: 90px;
-}
-
-/* Thread + PR icons share the same width */
-.table th:nth-of-type(6),
-.table td:nth-of-type(6),
-.table th:nth-of-type(7),
-.table td:nth-of-type(7) {
-    width: 72px;
-}
-
-/* Crisp sticky header */
-.thead {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-}
-
-.th {
-    background-color: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-7)
-    );
-    font-size: var(--mantine-font-size-xs);
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    color: light-dark(
-        var(--mantine-color-ldGray-7),
-        var(--mantine-color-ldDark-1)
-    );
-    white-space: nowrap;
-}
-
-/* Refined row hover */
-.row {
-    transition: background-color 120ms ease;
-}
-
-.row td {
-    border-top: 1px solid
-        light-dark(var(--mantine-color-ldGray-1), var(--mantine-color-ldDark-5));
-}
-
-.row:hover {
-    background-color: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-6)
-    );
-}
-
 /* Artsy pull-request medallion: a soft shadow gives it a little lift */
 .medallion {
     box-shadow: 0 1px 3px
@@ -107,10 +8,34 @@
    immediately after it rather than being pushed to the right edge */
 .title {
     min-width: 0;
-    cursor: default;
 }
 
-/* The small source tag keeps its size at the end of the title */
-.sourceBadge {
-    flex-shrink: 0;
+/* Row actions fade in on row hover (and stay visible while focused) */
+.rowActions {
+    opacity: 0;
+    transition: opacity 120ms ease;
+}
+
+.bodyRow:hover .rowActions,
+.bodyRow:focus-within .rowActions {
+    opacity: 1;
+}
+
+.clearFilter {
+    cursor: pointer;
+}
+
+.clearFilter:hover {
+    text-decoration: underline;
+}
+
+/* Right-side drawer sits below the navbar, matching the AI threads preview */
+.drawerInner {
+    top: var(--drawer-top-offset, 0);
+    height: calc(100% - var(--drawer-top-offset, 0));
+}
+
+.drawerOverlay {
+    top: var(--drawer-top-offset, 0);
+    height: calc(100% - var(--drawer-top-offset, 0));
 }

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -1,33 +1,48 @@
-import { formatTimestamp, TimeFrames } from '@lightdash/common';
+import {
+    formatTimestamp,
+    PullRequestState,
+    TimeFrames,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Alert,
-    Badge,
-    Box,
     Center,
+    Drawer,
     Group,
-    Loader,
-    Paper,
-    Skeleton,
+    SegmentedControl,
     Stack,
-    Table,
     Text,
     ThemeIcon,
     Title,
     Tooltip,
+    useMantineTheme,
 } from '@mantine-8/core';
 import {
     IconAlertCircle,
-    IconBrandGithub,
-    IconBrandGitlab,
+    IconExternalLink,
     IconGitPullRequest,
     IconMessageCircle,
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { useCallback, useEffect, useRef, type FC, type UIEvent } from 'react';
-import { Link } from 'react-router';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+    type UIEvent,
+} from 'react';
+import { CategoryBadge } from '../../../components/common/CategoryBadge/CategoryBadge';
+import {
+    ContentTable,
+    useContentTable,
+    type MRT_ColumnDef,
+} from '../../../components/common/ContentTable';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
+import { ThreadPreviewSidebar } from '../../../ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar';
 import { usePullRequestsTable } from '../hooks/usePullRequestsTable';
 import { type PullRequestRow } from '../types';
 import {
@@ -36,7 +51,6 @@ import {
     getSourceColor,
     getSourceLabel,
     getStateColor,
-    getStateLabel,
     getThreadPath,
 } from '../utils';
 import classes from './PullRequestsPage.module.css';
@@ -45,210 +59,37 @@ dayjs.extend(relativeTime);
 
 type Props = { projectUuid: string };
 
-const SKELETON_ROW_KEYS = [
-    'skeleton-0',
-    'skeleton-1',
-    'skeleton-2',
-    'skeleton-3',
-    'skeleton-4',
-] as const;
+/** State filter values, including a virtual "all" that applies no filter. */
+type StateFilter = 'open' | 'merged' | 'closed' | 'all';
 
-const PullRequestRowItem: FC<{ row: PullRequestRow }> = ({ row }) => {
-    const threadPath = getThreadPath(row);
-    const ProviderIcon =
-        row.provider === 'github' ? IconBrandGithub : IconBrandGitlab;
+const STATE_FILTER_OPTIONS: { label: string; value: StateFilter }[] = [
+    { label: 'Open', value: 'open' },
+    { label: 'Merged', value: 'merged' },
+    { label: 'Closed', value: 'closed' },
+    { label: 'All', value: 'all' },
+];
 
-    return (
-        <Table.Tr className={classes.row}>
-            <Table.Td>
-                <ThemeIcon
-                    variant="light"
-                    color={getStateColor(row.state)}
-                    radius="xl"
-                    size={34}
-                    className={classes.medallion}
-                >
-                    <MantineIcon icon={IconGitPullRequest} size="md" />
-                </ThemeIcon>
-            </Table.Td>
-            <Table.Td>
-                <Tooltip
-                    label={formatTimestamp(row.createdAt, TimeFrames.MINUTE)}
-                    openDelay={300}
-                    withinPortal
-                >
-                    <Text size="sm" c="ldGray.7" span>
-                        {dayjs(row.createdAt).fromNow()}
-                    </Text>
-                </Tooltip>
-            </Table.Td>
-            <Table.Td>
-                {row.author ? (
-                    <Text size="sm" truncate>
-                        {row.author.name}
-                    </Text>
-                ) : (
-                    <Text size="sm" c="dimmed">
-                        Unknown
-                    </Text>
-                )}
-            </Table.Td>
-            <Table.Td>
-                <Group gap="xs" wrap="nowrap">
-                    {row.title ? (
-                        <Tooltip
-                            label={row.title}
-                            openDelay={400}
-                            multiline
-                            maw={420}
-                            withinPortal
-                        >
-                            <Text size="sm" truncate className={classes.title}>
-                                {row.title}
-                            </Text>
-                        </Tooltip>
-                    ) : (
-                        <Text size="sm" c="dimmed" className={classes.title}>
-                            {EMPTY_VALUE}
-                        </Text>
-                    )}
-                    <Badge
-                        size="xs"
-                        variant="outline"
-                        color={getSourceColor(row.source)}
-                        radius="sm"
-                        className={classes.sourceBadge}
-                    >
-                        {getSourceLabel(row.source)}
-                    </Badge>
-                </Group>
-            </Table.Td>
-            <Table.Td>
-                {row.state ? (
-                    <Badge
-                        variant="light"
-                        color={getStateColor(row.state)}
-                        radius="sm"
-                    >
-                        {getStateLabel(row.state)}
-                    </Badge>
-                ) : (
-                    <Text size="sm" c="dimmed">
-                        {EMPTY_VALUE}
-                    </Text>
-                )}
-            </Table.Td>
-            <Table.Td>
-                {threadPath !== null ? (
-                    <Tooltip label="Open thread" openDelay={300} withinPortal>
-                        <ActionIcon
-                            component={Link}
-                            to={threadPath}
-                            variant="subtle"
-                            color="gray"
-                            aria-label="Open thread"
-                        >
-                            <MantineIcon icon={IconMessageCircle} />
-                        </ActionIcon>
-                    </Tooltip>
-                ) : null}
-            </Table.Td>
-            <Table.Td>
-                <Tooltip
-                    label={`View on ${getProviderLabel(row.provider)}`}
-                    openDelay={300}
-                    withinPortal
-                >
-                    <ActionIcon
-                        component="a"
-                        href={row.prUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        variant="subtle"
-                        color="dark"
-                        aria-label={`View pull request on ${getProviderLabel(
-                            row.provider,
-                        )}`}
-                    >
-                        <MantineIcon icon={ProviderIcon} />
-                    </ActionIcon>
-                </Tooltip>
-            </Table.Td>
-        </Table.Tr>
-    );
+/** A PR's live state can be null (resolution failed); those show only under "all". */
+const matchesStateFilter = (
+    row: PullRequestRow,
+    filter: StateFilter,
+): boolean => {
+    switch (filter) {
+        case 'all':
+            return true;
+        case 'open':
+            return row.state === PullRequestState.OPEN;
+        case 'merged':
+            return row.state === PullRequestState.MERGED;
+        case 'closed':
+            return row.state === PullRequestState.CLOSED;
+        default:
+            return true;
+    }
 };
 
-const PullRequestSkeletonRow: FC = () => (
-    <Table.Tr className={classes.row}>
-        <Table.Td>
-            <Skeleton height={34} width={34} circle />
-        </Table.Td>
-        <Table.Td>
-            <Skeleton height={12} width={90} radius="sm" />
-        </Table.Td>
-        <Table.Td>
-            <Skeleton height={12} width="70%" radius="sm" />
-        </Table.Td>
-        <Table.Td>
-            <Group gap="xs" wrap="nowrap">
-                <Skeleton height={12} width="80%" radius="sm" />
-                <Skeleton height={16} width={64} radius="sm" />
-            </Group>
-        </Table.Td>
-        <Table.Td>
-            <Skeleton height={18} width={56} radius="sm" />
-        </Table.Td>
-        <Table.Td>
-            <Skeleton height={24} width={24} circle />
-        </Table.Td>
-        <Table.Td>
-            <Skeleton height={24} width={24} circle />
-        </Table.Td>
-    </Table.Tr>
-);
-
-const PullRequestsTableShell: FC<{
-    children: React.ReactNode;
-    containerRef?: React.Ref<HTMLDivElement>;
-    onScroll?: (event: UIEvent<HTMLDivElement>) => void;
-}> = ({ children, containerRef, onScroll }) => (
-    <Paper
-        withBorder
-        shadow="subtle"
-        radius="md"
-        className={classes.tablePaper}
-    >
-        <Box
-            ref={containerRef}
-            onScroll={onScroll}
-            className={classes.scrollArea}
-        >
-            <Table
-                verticalSpacing="sm"
-                horizontalSpacing="sm"
-                className={classes.table}
-            >
-                <Table.Thead className={classes.thead}>
-                    <Table.Tr>
-                        <Table.Th
-                            className={classes.th}
-                            aria-label="Pull request"
-                        />
-                        <Table.Th className={classes.th}>Created</Table.Th>
-                        <Table.Th className={classes.th}>User</Table.Th>
-                        <Table.Th className={classes.th}>Title</Table.Th>
-                        <Table.Th className={classes.th}>State</Table.Th>
-                        <Table.Th className={classes.th}>Thread</Table.Th>
-                        <Table.Th className={classes.th}>PR</Table.Th>
-                    </Table.Tr>
-                </Table.Thead>
-                <Table.Tbody>{children}</Table.Tbody>
-            </Table>
-        </Box>
-    </Paper>
-);
-
 const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
+    const theme = useMantineTheme();
     const {
         rows,
         totalResults,
@@ -258,6 +99,14 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
         fetchNextPage,
         error,
     } = usePullRequestsTable(projectUuid);
+
+    const [stateFilter, setStateFilter] = useState<StateFilter>('open');
+    const [previewPr, setPreviewPr] = useState<PullRequestRow | null>(null);
+
+    const filteredRows = useMemo(
+        () => rows.filter((row) => matchesStateFilter(row, stateFilter)),
+        [rows, stateFilter],
+    );
 
     const tableContainerRef = useRef<HTMLDivElement>(null);
 
@@ -277,30 +126,209 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
         [fetchNextPage, isFetchingNextPage, hasNextPage],
     );
 
-    // The first page may not fill the viewport — fetch more on mount if so.
+    // The first page (or the filtered subset) may not fill the viewport — fetch
+    // more on mount and whenever the filter changes.
     useEffect(() => {
         fetchMoreOnBottomReached(tableContainerRef.current);
-    }, [fetchMoreOnBottomReached]);
+    }, [fetchMoreOnBottomReached, stateFilter]);
 
-    return (
-        <Stack gap="md">
-            <Title order={5}>Pull requests</Title>
+    const columns = useMemo<MRT_ColumnDef<PullRequestRow>[]>(
+        () => [
+            {
+                id: 'medallion',
+                header: '',
+                enableSorting: false,
+                size: 56,
+                Cell: ({ row }) => (
+                    <ThemeIcon
+                        variant="light"
+                        color={getStateColor(row.original.state)}
+                        radius="xl"
+                        size={34}
+                        className={classes.medallion}
+                    >
+                        <MantineIcon icon={IconGitPullRequest} size="md" />
+                    </ThemeIcon>
+                ),
+            },
+            {
+                id: 'source',
+                header: 'Source',
+                enableSorting: false,
+                size: 120,
+                Cell: ({ row }) => (
+                    <CategoryBadge
+                        label={getSourceLabel(row.original.source)}
+                        color={getSourceColor(row.original.source)}
+                        variant="dot"
+                    />
+                ),
+            },
+            {
+                accessorKey: 'title',
+                header: 'Pull request',
+                enableSorting: false,
+                size: 520,
+                Cell: ({ row }) => {
+                    const pr = row.original;
+                    return (
+                        <Stack gap={2} className={classes.title}>
+                            {pr.title ? (
+                                <Tooltip
+                                    label={pr.title}
+                                    openDelay={400}
+                                    multiline
+                                    maw={420}
+                                    withinPortal
+                                >
+                                    <Text size="sm" fw={500} truncate>
+                                        {pr.title}
+                                    </Text>
+                                </Tooltip>
+                            ) : (
+                                <Text size="sm" fw={500} c="dimmed">
+                                    {EMPTY_VALUE}
+                                </Text>
+                            )}
+                            <Tooltip
+                                label={formatTimestamp(
+                                    pr.createdAt,
+                                    TimeFrames.MINUTE,
+                                )}
+                                openDelay={300}
+                                withinPortal
+                            >
+                                <Text fz="xs" c="dimmed" truncate span>
+                                    opened {dayjs(pr.createdAt).fromNow()}
+                                    {pr.author ? ` by ${pr.author.name}` : ''}
+                                </Text>
+                            </Tooltip>
+                        </Stack>
+                    );
+                },
+            },
+        ],
+        [],
+    );
 
-            {error ? (
-                <Alert
-                    icon={<MantineIcon icon={IconAlertCircle} />}
-                    color="red"
-                    title="Failed to load pull requests"
-                >
-                    {error.error.message}
-                </Alert>
-            ) : isLoading ? (
-                <PullRequestsTableShell>
-                    {SKELETON_ROW_KEYS.map((key) => (
-                        <PullRequestSkeletonRow key={key} />
-                    ))}
-                </PullRequestsTableShell>
-            ) : rows.length === 0 ? (
+    const table = useContentTable({
+        columns,
+        data: filteredRows,
+        enableSorting: false,
+        enablePagination: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableColumnResizing: false,
+        enableDensityToggle: false,
+        enableFullScreenToggle: false,
+        enableFilters: false,
+        enableHiding: false,
+        enableRowVirtualization: true,
+        enableRowActions: true,
+        positionActionsColumn: 'last',
+        displayColumnDefOptions: {
+            'mrt-row-actions': {
+                header: '',
+                size: 96,
+            },
+        },
+        renderRowActions: ({ row }) => {
+            const pr = row.original;
+            const threadPath = getThreadPath(pr);
+            return (
+                <Group gap="two" wrap="nowrap" className={classes.rowActions}>
+                    {threadPath !== null ? (
+                        <Tooltip
+                            label="Preview thread"
+                            openDelay={300}
+                            withinPortal
+                        >
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                aria-label="Preview thread"
+                                onClick={() => setPreviewPr(pr)}
+                            >
+                                <MantineIcon icon={IconMessageCircle} />
+                            </ActionIcon>
+                        </Tooltip>
+                    ) : null}
+                    <Tooltip
+                        label={`View on ${getProviderLabel(pr.provider)}`}
+                        openDelay={300}
+                        withinPortal
+                    >
+                        <ActionIcon
+                            component="a"
+                            href={pr.prUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            variant="subtle"
+                            color="dark"
+                            aria-label={`View pull request on ${getProviderLabel(
+                                pr.provider,
+                            )}`}
+                        >
+                            <MantineIcon icon={IconExternalLink} />
+                        </ActionIcon>
+                    </Tooltip>
+                </Group>
+            );
+        },
+        mantinePaperProps: {
+            shadow: undefined,
+            sx: {
+                border: `1px solid ${theme.colors.ldGray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+                overflow: 'hidden',
+            },
+        },
+        mantineTableContainerProps: {
+            ref: tableContainerRef,
+            sx: { maxHeight: 'calc(100dvh - 260px)' },
+            onScroll: (event: UIEvent<HTMLDivElement>) =>
+                fetchMoreOnBottomReached(event.currentTarget),
+        },
+        mantineTableProps: {
+            highlightOnHover: true,
+            withColumnBorders: false,
+        },
+        mantineTableBodyRowProps: { className: classes.bodyRow },
+        renderTopToolbar: () => (
+            <Group justify="space-between" align="center" px="md" py="sm">
+                <Text fz="xs" c="dimmed">
+                    {filteredRows.length}
+                    {stateFilter === 'all' ? '' : ` ${stateFilter}`} shown
+                </Text>
+                <SegmentedControl
+                    size="xs"
+                    radius="md"
+                    value={stateFilter}
+                    onChange={(value) => setStateFilter(value as StateFilter)}
+                    data={STATE_FILTER_OPTIONS}
+                />
+            </Group>
+        ),
+        renderBottomToolbar: () => (
+            <Group justify="center" px="md" py="sm">
+                {isFetchingNextPage ? (
+                    <Text fz="xs" c="dimmed">
+                        Loading more...
+                    </Text>
+                ) : (
+                    <Text fz="xs" c="dimmed">
+                        {hasNextPage
+                            ? 'Scroll for more'
+                            : `All ${totalResults} loaded`}
+                    </Text>
+                )}
+            </Group>
+        ),
+        renderEmptyRowsFallback: () =>
+            rows.length === 0 ? (
                 <Center p="xl">
                     <Stack gap="xs" align="center">
                         <MantineIcon
@@ -318,39 +346,68 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                     </Stack>
                 </Center>
             ) : (
-                <Stack gap="sm">
-                    <PullRequestsTableShell
-                        containerRef={tableContainerRef}
-                        onScroll={(event) =>
-                            fetchMoreOnBottomReached(event.currentTarget)
-                        }
-                    >
-                        {rows.map((row) => (
-                            <PullRequestRowItem
-                                key={row.pullRequestUuid}
-                                row={row}
-                            />
-                        ))}
-                    </PullRequestsTableShell>
+                <Center p="xl">
+                    <Stack gap="xs" align="center">
+                        <Text size="sm" c="dimmed">
+                            No {stateFilter} pull requests in the loaded
+                            results.
+                        </Text>
+                        <Text
+                            size="xs"
+                            c="blue"
+                            className={classes.clearFilter}
+                            onClick={() => setStateFilter('all')}
+                        >
+                            Show all
+                        </Text>
+                    </Stack>
+                </Center>
+            ),
+        state: {
+            showSkeletons: isLoading,
+            density: 'md',
+        },
+    });
 
-                    <Group justify="center" gap="xs" h={20}>
-                        {isFetchingNextPage ? (
-                            <>
-                                <Loader size="xs" />
-                                <Text size="xs" c="dimmed">
-                                    Loading more...
-                                </Text>
-                            </>
-                        ) : (
-                            <Text size="xs" c="dimmed">
-                                {hasNextPage
-                                    ? 'Scroll for more'
-                                    : `All ${totalResults} loaded`}
-                            </Text>
-                        )}
-                    </Group>
-                </Stack>
+    return (
+        <Stack gap="md">
+            <Title order={5}>Pull requests</Title>
+
+            {error ? (
+                <Alert
+                    icon={<MantineIcon icon={IconAlertCircle} />}
+                    color="red"
+                    title="Failed to load pull requests"
+                >
+                    {error.error.message}
+                </Alert>
+            ) : (
+                <ContentTable table={table} />
             )}
+
+            <Drawer
+                opened={previewPr !== null}
+                onClose={() => setPreviewPr(null)}
+                position="right"
+                size="lg"
+                withCloseButton={false}
+                padding={0}
+                classNames={{
+                    inner: classes.drawerInner,
+                    overlay: classes.drawerOverlay,
+                }}
+                __vars={{ '--drawer-top-offset': `${NAVBAR_HEIGHT}px` }}
+            >
+                {previewPr?.aiAgentUuid && previewPr?.aiThreadUuid ? (
+                    <ThreadPreviewSidebar
+                        projectUuid={previewPr.projectUuid}
+                        agentUuid={previewPr.aiAgentUuid}
+                        threadUuid={previewPr.aiThreadUuid}
+                        isOpen={previewPr !== null}
+                        onClose={() => setPreviewPr(null)}
+                    />
+                ) : null}
+            </Drawer>
         </Stack>
     );
 };

--- a/packages/frontend/src/features/pullRequests/utils.ts
+++ b/packages/frontend/src/features/pullRequests/utils.ts
@@ -28,20 +28,6 @@ export const getSourceLabel = (source: PullRequestSource): string => {
     }
 };
 
-export const getStateLabel = (state: PullRequestState | null): string => {
-    if (state === null) return EMPTY_VALUE;
-    switch (state) {
-        case PullRequestState.OPEN:
-            return 'Open';
-        case PullRequestState.CLOSED:
-            return 'Closed';
-        case PullRequestState.MERGED:
-            return 'Merged';
-        default:
-            return assertUnreachable(state, `Unknown state ${state}`);
-    }
-};
-
 /** Mantine color for a PR state badge. */
 export const getStateColor = (state: PullRequestState | null): string => {
     if (state === null) return 'gray';


### PR DESCRIPTION
## What & why

Redesigns the **Pull requests** settings table (git-connected projects → Settings → Pull requests).

- Migrates from a hand-rolled Mantine `Table` to the shared **`ContentTable`** (virtualized, infinite scroll preserved).
- Adds a **state filter** — `SegmentedControl` (Open / Merged / Closed / All), default **Open**. Filtering is client-side over already-loaded rows (PR state is resolved live from GitHub/GitLab per page, not stored, so a server-side filter isn't cheap). Null-state PRs show only under **All**.
- Adds a **Source** column using the shared `CategoryBadge` dot-chip.
- Collapses State/User/Created into a **two-line title block**: title (medium weight) + muted `opened … by …` subline; the state-colored medallion is the single state indicator.
- **Thread** and **open-in-provider** actions are now hover-revealed row actions. The thread action opens a right-side **Drawer** with a read-only thread preview (reuses the existing `ThreadPreviewSidebar`) instead of navigating away; the external action uses an external-link icon.

## Scope / regression analysis

- **Frontend only**, confined to `packages/frontend/src/features/pullRequests/`. No API, backend, permission, or data-model changes.
- Only affects the Pull requests settings page, which renders solely for **git-connected projects** where the user has `SourceCode` **view** permission — unchanged. Users without that gate never see this page.
- Data hook (`usePullRequestsTable`) and common types are untouched; same endpoint, same pagination.
- The thread preview imports an `ee/` component; this matches existing practice (`Settings.tsx` imports `ee/` components directly) and the preview only renders for AI-agent PRs (which only exist when the EE AI write-back feature is present).

## Known tradeoff

Because filtering is client-side over loaded pages, the count chips ("N open shown" / "All N loaded") reflect fetched pages, not the whole repo. Accepted for a settings utility table.

## Test plan

- `pnpm -F frontend typecheck:fast` ✅
- `oxlint` ✅
- Manual: not run locally (page requires a git-connected project with SourceCode view).

---
_No Linear ticket linked — please add `Closes: PROD-XXXX` before merge._