### PR TITLE
fix(pivot): warehouse-only column totals for all metric types

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.mock.ts
+++ b/packages/common/src/pivot/pivotQueryResults.mock.ts
@@ -1949,12 +1949,19 @@ export const EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS: PivotData = {
             null,
             null,
             {
+                fieldId: 'orders_average_order_size',
+            },
+        ],
+        [
+            null,
+            null,
+            {
                 fieldId: 'orders_total_order_amount',
             },
         ],
     ],
     rowTotals: [[52.5], [52.5], [52.5]],
-    columnTotals: [[52.5], [52.5]],
+    columnTotals: [[52.5], [52.5], [52.5]],
     cellsCount: 5,
     rowsCount: 3,
     pivotConfig: {

--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -54,6 +54,52 @@ const buildWarehouseRowTotalsFromExpected = (
     return map;
 };
 
+// Column totals are warehouse-only too. Reconstruct the warehouse map (keyed by
+// pivot SQL column name, `<metric>_any_<pivotValue...>`) from an expected
+// fixture's columnTotals + headerValues so fixtures stay the source of truth.
+const buildWarehouseColumnTotalsFromExpected = (
+    expected: PivotData,
+): Record<string, number> => {
+    const map: Record<string, number> = {};
+    const { columnTotals, columnTotalFields, headerValues, pivotConfig } =
+        expected;
+    if (!columnTotals || !columnTotalFields) return map;
+
+    const pivotValuesForColumn = (
+        dimRows: PivotData['headerValues'],
+        colIndex: number,
+    ): string[] | undefined => {
+        const values = dimRows.map((dimRow) => {
+            const cell = dimRow[colIndex];
+            return cell && cell.type === 'value'
+                ? String(cell.value?.raw)
+                : undefined;
+        });
+        return values.some((v) => v === undefined)
+            ? undefined
+            : (values as string[]);
+    };
+
+    const metricRow = headerValues[headerValues.length - 1] ?? [];
+    const pivotDimRows = pivotConfig.metricsAsRows
+        ? headerValues
+        : headerValues.slice(0, -1);
+
+    columnTotals.forEach((row, rowIndex) => {
+        row.forEach((value, colIndex) => {
+            if (typeof value !== 'number') return;
+            const metricFieldId = pivotConfig.metricsAsRows
+                ? columnTotalFields[rowIndex]?.find((f) => f?.fieldId)?.fieldId
+                : metricRow[colIndex]?.fieldId;
+            if (!metricFieldId) return;
+            const pivotValues = pivotValuesForColumn(pivotDimRows, colIndex);
+            if (!pivotValues) return;
+            map[[metricFieldId, 'any', ...pivotValues].join('_')] = value;
+        });
+    });
+    return map;
+};
+
 describe('convertSqlPivotedRowsToPivotData', () => {
     it('should convert SQL-pivoted rows to PivotData format', () => {
         // Convert SQL Pivoted rows to PivotData
@@ -96,6 +142,9 @@ describe('convertSqlPivotedRowsToPivotData', () => {
             getFieldLabel: (fieldId) => fieldId,
             groupedSubtotals: undefined,
             warehouseRowTotals: buildWarehouseRowTotalsFromExpected(
+                EXPECTED_PIVOT_DATA_WITH_TOTALS,
+            ),
+            warehouseColumnTotals: buildWarehouseColumnTotalsFromExpected(
                 EXPECTED_PIVOT_DATA_WITH_TOTALS,
             ),
         });
@@ -258,6 +307,9 @@ describe('convertSqlPivotedRowsToPivotData', () => {
             warehouseRowTotals: buildWarehouseRowTotalsFromExpected(
                 EXPECTED_PIVOT_DATA_METRICS_AS_ROWS,
             ),
+            warehouseColumnTotals: buildWarehouseColumnTotalsFromExpected(
+                EXPECTED_PIVOT_DATA_METRICS_AS_ROWS,
+            ),
         });
 
         expect(result).toStrictEqual(EXPECTED_PIVOT_DATA_METRICS_AS_ROWS);
@@ -297,6 +349,9 @@ describe('convertSqlPivotedRowsToPivotData', () => {
             },
             groupedSubtotals: undefined,
             warehouseRowTotals: buildWarehouseRowTotalsFromExpected(
+                EXPECTED_COMPLEX_PIVOT_DATA,
+            ),
+            warehouseColumnTotals: buildWarehouseColumnTotalsFromExpected(
                 EXPECTED_COMPLEX_PIVOT_DATA,
             ),
         });
@@ -340,11 +395,77 @@ describe('convertSqlPivotedRowsToPivotData', () => {
             warehouseRowTotals: buildWarehouseRowTotalsFromExpected(
                 EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS,
             ),
+            warehouseColumnTotals: buildWarehouseColumnTotalsFromExpected(
+                EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS,
+            ),
         });
 
         expect(result).toStrictEqual(
             EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS,
         );
+
+        // metricsAsRows column totals must include a footer row for every
+        // visible metric — including the non-summable avg — so warehouse
+        // totals can be overlaid for all metric types.
+        const totalMetricIds = result.columnTotalFields?.map(
+            (row) => row.find((cell) => cell?.fieldId)?.fieldId,
+        );
+        expect(totalMetricIds).toEqual([
+            'payments_total_revenue',
+            'orders_average_order_size',
+            'orders_total_order_amount',
+        ]);
+    });
+
+    it('leaves column totals null (no client-side fallback) without warehouse values', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: SQL_PIVOTED_ROWS,
+            pivotDetails: SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: true,
+                metricsAsRows: false,
+                columnOrder: [
+                    'payments_payment_method',
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        // The total row is allocated but every cell is blank until warehouse
+        // column totals are provided — there is no in-memory summation.
+        expect(result.columnTotals).toStrictEqual([[null, null, null, null]]);
+    });
+
+    it('fills only the column totals present in the warehouse map', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: SQL_PIVOTED_ROWS,
+            pivotDetails: SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: true,
+                metricsAsRows: false,
+                columnOrder: [
+                    'payments_payment_method',
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+            // Only two of the four pivot columns have a warehouse total.
+            warehouseColumnTotals: {
+                payments_total_revenue_any_bank_transfer: 111,
+                payments_total_revenue_any_credit_card: 333,
+            },
+        });
+
+        expect(result.columnTotals).toStrictEqual([[111, null, 333, null]]);
     });
 
     it('should limit pivot columns when columnLimit is provided', () => {

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1,15 +1,11 @@
-import isNumber from 'lodash/isNumber';
 import last from 'lodash/last';
-import { type Entries } from 'type-fest';
 import { LightdashParameters } from '../compiler/parameters';
 import type { ReadyQueryResultsPage } from '../index';
 import { UnexpectedIndexError } from '../types/errors';
 import {
     DimensionType,
     FieldType,
-    isDimension,
     isField,
-    isSummable,
     type ItemsMap,
 } from '../types/field';
 import { type ParametersValuesMap } from '../types/parameters';
@@ -28,6 +24,7 @@ import {
     shouldShiftItemTimezone,
     toIsoWithProjectOffset,
 } from '../utils/formatting';
+import { type PivotValuesColumn } from '../visualizations/types';
 
 type FieldFunction = (fieldId: string) => ItemsMap[string] | undefined;
 
@@ -97,13 +94,6 @@ const reformatCellWithParameters = (
     };
 };
 
-type RecursiveRecord<T = unknown> = {
-    [key: string]: RecursiveRecord<T> | T;
-};
-
-const isRecursiveRecord = (value: unknown): value is RecursiveRecord =>
-    typeof value === 'object' && value !== null;
-
 const create2DArray = <T>(
     rows: number,
     columns: number,
@@ -112,65 +102,6 @@ const create2DArray = <T>(
     Array.from({ length: rows }, () =>
         Array.from({ length: columns }, () => value),
     );
-
-const parseNumericValue = (value: ResultValue | null): number => {
-    if (value === null) return 0;
-
-    const parsedVal = Number(value.raw);
-    return Number.isNaN(parsedVal) ? 0 : parsedVal;
-};
-
-const setIndexByKey = (
-    obj: RecursiveRecord<number>,
-    keys: string[],
-    value: number,
-): boolean => {
-    if (keys.length === 0) {
-        return false;
-    }
-    const [key, ...rest] = keys;
-
-    if (key === undefined) {
-        throw new UnexpectedIndexError(
-            `setIndexByKey: Cannot get key from keys ${keys.length}`,
-        );
-    }
-    if (rest.length === 0) {
-        if (obj[key] === undefined) {
-            // eslint-disable-next-line no-param-reassign
-            obj[key] = value;
-            return true;
-        }
-        return false;
-    }
-    if (obj[key] === undefined) {
-        // eslint-disable-next-line no-param-reassign
-        obj[key] = {};
-    }
-
-    const nextObject = obj[key];
-    if (!isRecursiveRecord(nextObject)) {
-        throw new Error('Cannot set key on non-object');
-    }
-
-    return setIndexByKey(nextObject, rest, value);
-};
-
-const getAllIndicesForFieldId = (
-    obj: RecursiveRecord<number>,
-    fieldId: string,
-): number[] => {
-    const entries = Object.entries(obj) as Entries<typeof obj>;
-    return entries.reduce<number[]>((acc, [key, value]) => {
-        if (key === fieldId && isNumber(value)) {
-            return [...acc, value];
-        }
-        if (isRecursiveRecord(value)) {
-            return [...acc, ...getAllIndicesForFieldId(value, fieldId)];
-        }
-        return acc;
-    }, []);
-};
 
 /**
  * Rebuilds `data.retrofitData.{allCombinedData,pivotColumnInfo}` from
@@ -367,57 +298,75 @@ const getHeaderValueTypes = ({
 };
 
 const getColumnTotals = ({
-    summableMetricFieldIds,
-    rowIndices,
+    baseMetricFieldIds,
+    uniqueColumns,
+    filteredValuesColumns,
     totalColumns,
     dataColumns,
-    dataValues,
     hasIndex,
     pivotConfig,
     indexValues,
+    warehouseColumnTotals,
 }: {
-    summableMetricFieldIds: string[];
-    rowIndices: RecursiveRecord<number>;
+    baseMetricFieldIds: string[];
+    uniqueColumns: PivotValuesColumn[];
+    filteredValuesColumns: PivotValuesColumn[];
     totalColumns: number;
     dataColumns: number;
-    dataValues: (ResultValue | null)[][];
     hasIndex: boolean;
     indexValues: PivotData['indexValues'];
     pivotConfig: Pick<PivotConfig, 'metricsAsRows' | 'columnTotals'>;
+    warehouseColumnTotals: Record<string, number> | undefined;
 }) => {
     let columnTotalFields: PivotData['columnTotalFields'];
     let columnTotals: PivotData['columnTotals'];
     const N_DATA_COLUMNS = dataColumns;
+
+    // Column totals are exclusively warehouse-computed (like row totals): each
+    // data column's total is looked up by its pivot SQL column name. Returns
+    // null when no warehouse value is available (still loading, errored, or the
+    // source query can't be totalled) — there is no client-side fallback.
+    const lookupTotal = (
+        pivotColumnName: string | undefined,
+    ): number | null => {
+        if (!warehouseColumnTotals || !pivotColumnName) return null;
+        const value = warehouseColumnTotals[pivotColumnName];
+        return typeof value === 'number' ? value : null;
+    };
+
     if (pivotConfig.columnTotals && hasIndex) {
         if (pivotConfig.metricsAsRows) {
-            const N_TOTAL_ROWS = summableMetricFieldIds.length;
+            // One footer row per visible metric; each column is a unique pivot
+            // combination. Match the metric + pivot values back to its source
+            // value column to read the warehouse total by pivot column name.
+            const N_TOTAL_ROWS = baseMetricFieldIds.length;
             const N_TOTAL_COLS = totalColumns;
             columnTotalFields = create2DArray(N_TOTAL_ROWS, N_TOTAL_COLS);
             columnTotals = create2DArray(N_TOTAL_ROWS, N_DATA_COLUMNS);
 
-            summableMetricFieldIds.forEach((fieldId, metricIndex) => {
+            baseMetricFieldIds.forEach((fieldId, metricIndex) => {
                 columnTotalFields![metricIndex][N_TOTAL_COLS - 1] = {
                     fieldId,
                 };
             });
 
-            columnTotals = columnTotals.map((row, rowIndex) =>
-                row.map((_, totalColIndex) => {
-                    const totalColFieldId =
-                        columnTotalFields![rowIndex][N_TOTAL_COLS - 1]?.fieldId;
-
-                    const valueColIndices = totalColFieldId
-                        ? getAllIndicesForFieldId(rowIndices, totalColFieldId)
-                        : [];
-                    return dataValues
-                        .filter((__, dataValueColIndex) =>
-                            valueColIndices.includes(dataValueColIndex),
-                        )
-                        .reduce(
-                            (acc, value) =>
-                                acc + parseNumericValue(value[totalColIndex]),
-                            0,
-                        );
+            columnTotals = columnTotals.map((row, metricRowIndex) =>
+                row.map((_, dataColIndex) => {
+                    const metric = baseMetricFieldIds[metricRowIndex];
+                    const uniqueCol = uniqueColumns[dataColIndex];
+                    const matchingColumn = filteredValuesColumns.find(
+                        (col) =>
+                            col.referenceField === metric &&
+                            col.pivotValues.every((pv) =>
+                                uniqueCol.pivotValues.some(
+                                    (upv) =>
+                                        upv.referenceField ===
+                                            pv.referenceField &&
+                                        upv.value === pv.value,
+                                ),
+                            ),
+                    );
+                    return lookupTotal(matchingColumn?.pivotColumnName);
                 }),
             );
         } else {
@@ -432,14 +381,10 @@ const getColumnTotals = ({
                 fieldId: undefined,
             };
 
-            columnTotals = columnTotals.map((row, _totalRowIndex) =>
+            // Data columns map 1:1 to the value columns in this layout.
+            columnTotals = columnTotals.map((row) =>
                 row.map((_col, colIndex) =>
-                    dataValues
-                        .map((dataRow) => dataRow[colIndex])
-                        .reduce(
-                            (acc, value) => acc + parseNumericValue(value),
-                            0,
-                        ),
+                    lookupTotal(uniqueColumns[colIndex]?.pivotColumnName),
                 ),
             );
         }
@@ -498,6 +443,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     getFieldLabel,
     groupedSubtotals,
     warehouseRowTotals,
+    warehouseColumnTotals,
     columnLimit,
     parameters,
 }: {
@@ -524,6 +470,14 @@ export const convertSqlPivotedRowsToPivotData = ({
      * metrics-as-rows layouts.
      */
     warehouseRowTotals?: PivotRowTotalsByIndex;
+    /**
+     * Warehouse-computed column totals from `calculate-total`
+     * (`kind: 'columnTotal'`), keyed by pivot SQL column name. Column totals
+     * are exclusively warehouse-computed — there is no client-side fallback —
+     * so cells are blank until this resolves (or stay blank if the source
+     * query can't be totalled). Drives both layouts.
+     */
+    warehouseColumnTotals?: Record<string, number>;
     columnLimit?: number;
     parameters?: ParametersValuesMap;
 }): PivotData => {
@@ -770,8 +724,6 @@ export const convertSqlPivotedRowsToPivotData = ({
 
     // Build data values (the actual pivot data)
     let dataValues: PivotData['dataValues'];
-    const rowIndices: RecursiveRecord<number> = {};
-    let rowCount = 0;
 
     // Get unique columns
     const uniqueColumns = pivotConfig.metricsAsRows
@@ -794,13 +746,6 @@ export const convertSqlPivotedRowsToPivotData = ({
         // multiply rows per metric
         dataValues = rows.reduce<PivotData['dataValues']>((acc, row) => {
             baseMetricsArray.forEach((metric) => {
-                const indexRowValues = [
-                    ...indexColumns.map((fieldId) =>
-                        String(row[fieldId].value.raw),
-                    ),
-                    metric,
-                ];
-
                 // Build row data for this metric using unique columns
                 // For each unique column combination, find the corresponding value for this metric
                 const rowData = uniqueColumns.map((uniqueCol) => {
@@ -828,19 +773,12 @@ export const convertSqlPivotedRowsToPivotData = ({
                 });
 
                 acc.push(rowData);
-                setIndexByKey(rowIndices, indexRowValues, rowCount);
-                rowCount += 1;
             });
             return acc;
         }, []);
     } else {
-        dataValues = rows.map((row, rowIndex) => {
-            const indexRowValues = indexColumns.map((fieldId) =>
-                String(row[fieldId].value.raw),
-            );
-            setIndexByKey(rowIndices, indexRowValues, rowIndex);
-
-            return filteredValuesColumns.map((valueCol) =>
+        dataValues = rows.map((row) =>
+            filteredValuesColumns.map((valueCol) =>
                 row[valueCol.pivotColumnName]
                     ? (reformatCellWithParameters(
                           row[valueCol.pivotColumnName].value,
@@ -848,9 +786,8 @@ export const convertSqlPivotedRowsToPivotData = ({
                           parameters,
                       ) ?? null)
                     : null,
-            );
-        });
-        rowCount = rows.length;
+            ),
+        );
     }
 
     const fullPivotConfig: PivotConfig = {
@@ -873,16 +810,6 @@ export const convertSqlPivotedRowsToPivotData = ({
     const hasIndex = indexValueTypes.length > 0;
     const N_DATA_ROWS = hasIndex ? dataValues.length : 1;
     const N_DATA_COLUMNS = hasHeader ? uniqueColumns.length : 1;
-
-    const summableMetricFieldIds = baseMetricsArray.filter((metricId) => {
-        const field = getField(metricId);
-
-        // Skip if field is not found or is a dimension or is hidden
-        if (!field || isDimension(field)) return false;
-        if (!isMetricVisibleInPivot(metricId)) return false;
-
-        return isSummable(field);
-    });
 
     if (fullPivotConfig.rowTotals && hasHeader) {
         // Row totals are exclusively warehouse-computed: look up the value for a
@@ -968,14 +895,15 @@ export const convertSqlPivotedRowsToPivotData = ({
     }
 
     const { columnTotalFields, columnTotals } = getColumnTotals({
-        summableMetricFieldIds,
+        baseMetricFieldIds: baseMetricsArray,
+        uniqueColumns,
+        filteredValuesColumns,
         totalColumns: indexValueTypes.length,
         dataColumns: N_DATA_COLUMNS,
-        dataValues,
-        rowIndices,
         pivotConfig,
         indexValues,
         hasIndex,
+        warehouseColumnTotals,
     });
 
     // Passthrough dims — hidden non-sort pivot dims whose raw values are

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -316,10 +316,6 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 }
                                 onColumnWidthChange={onColumnWidthChange}
                                 parameters={parameters}
-                                columnTotalsAreWarehouseComputed={
-                                    visualizationConfig.chartConfig
-                                        .columnTotalsAreWarehouseComputed
-                                }
                                 {...rest}
                             />
                         ) : (
@@ -342,10 +338,6 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 }
                                 onColumnWidthChange={onColumnWidthChange}
                                 parameters={parameters}
-                                columnTotalsAreWarehouseComputed={
-                                    visualizationConfig.chartConfig
-                                        .columnTotalsAreWarehouseComputed
-                                }
                                 {...rest}
                             />
                         )}

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -10,7 +10,6 @@ import {
     isField,
     isHexCodeColor,
     isNumericItem,
-    isSummable,
     type ColumnProperties,
     type ConditionalFormattingConfig,
     type ConditionalFormattingMinMaxMap,
@@ -179,10 +178,6 @@ type PivotTableProps = BoxProps & // TODO: remove this
         sortBy?: SortField[];
         /** Renders inside a Mantine Menu opened by clicking sortable headers. */
         renderSortMenu?: (target: PivotSortMenuTarget) => React.ReactNode;
-        // When true the footer skips the `isSummable` gate that hides
-        // totals for count_distinct/avg/min/max — only safe to skip when
-        // `data.columnTotals` carries warehouse-recomputed values.
-        columnTotalsAreWarehouseComputed?: boolean;
     };
 
 export type PivotSortMenuTarget =
@@ -213,7 +208,6 @@ const PivotTable: FC<PivotTableProps> = ({
     parameters,
     sortBy,
     renderSortMenu,
-    columnTotalsAreWarehouseComputed = false,
     ...tableProps
 }) => {
     const { colorScheme } = useMantineColorScheme();
@@ -711,14 +705,8 @@ const PivotTable: FC<PivotTableProps> = ({
             if (!value || !value.fieldId) throw new Error('Invalid pivot data');
 
             const item = getField(value.fieldId);
-            // Skip the `isSummable` gate when totals were computed by the
-            // warehouse — the value is correct for any metric type
-            // (count_distinct, avg, min, max, ratios). Without this guard the
-            // legacy client-side path would (incorrectly) sum pre-aggregated
-            // cells, so the gate stays in place when totals are local.
-            if (!columnTotalsAreWarehouseComputed && !isSummable(item)) {
-                return null;
-            }
+            // Column totals are warehouse-computed for every metric type, so
+            // there is no `isSummable` gate; a null total just renders blank.
             if (total === null || total === undefined) {
                 return null;
             }
@@ -734,20 +722,18 @@ const PivotTable: FC<PivotTableProps> = ({
                 formatted: formattedValue,
             };
         },
-        [
-            data.headerValues,
-            columnTotalsAreWarehouseComputed,
-            getField,
-            parameters,
-        ],
+        [data.headerValues, getField, parameters],
     );
 
     const getMetricAsRowColumnTotalValueFromAxis = useCallback(
-        (total: unknown, rowIndex: number): ResultValue => {
+        (total: unknown, rowIndex: number): ResultValue | null => {
             const value = last(data.columnTotalFields?.[rowIndex]);
             if (!value || !value.fieldId) throw new Error('Invalid pivot data');
 
             const item = getField(value.fieldId);
+            if (total === null || total === undefined) {
+                return null;
+            }
 
             const formattedValue = formatItemValue(
                 item,

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -431,6 +431,7 @@ const useTableConfig = (
                 getFieldLabel,
                 groupedSubtotals,
                 warehouseRowTotals: asyncRowTotals,
+                warehouseColumnTotals: asyncTotals,
                 parameters,
             })
             .then((data) => {
@@ -462,6 +463,7 @@ const useTableConfig = (
         worker,
         groupedSubtotals,
         asyncRowTotals,
+        asyncTotals,
         parameters,
     ]);
 
@@ -649,86 +651,6 @@ const useTableConfig = (
 
     const exposedColumnProperties = columnProperties;
 
-    // Overlay warehouse-computed totals onto the worker's client-side ones.
-    // We match cells by (metric, pivotValue) since the warehouse keys
-    // (`<metric>_any_<value>`) differ from the worker's synthetic column ids.
-    const effectivePivotTableData = useMemo(() => {
-        if (!pivotTableData.data || !pivotTableData.data.columnTotals) {
-            return pivotTableData;
-        }
-        if (!asyncTotals) {
-            return pivotTableData;
-        }
-        const { headerValues } = pivotTableData.data;
-        const metricRow = headerValues[headerValues.length - 1] ?? [];
-        // metricsAsRows=true has a different headerValues shape — skip
-        // overlay there for now and let the worker's totals stand.
-        const pivotDimRows = headerValues.slice(0, -1);
-        if (pivotDimRows.length === 0) {
-            return pivotTableData;
-        }
-
-        const extractNumeric = (raw: unknown): number | undefined => {
-            const candidate =
-                typeof raw === 'object' && raw !== null && 'value' in raw
-                    ? (raw as { value?: { raw?: unknown } }).value?.raw
-                    : raw;
-            const n = Number(candidate);
-            return Number.isFinite(n) ? n : undefined;
-        };
-
-        const nextColumnTotals = pivotTableData.data.columnTotals.map((row) =>
-            row.map((existingValue, colIndex) => {
-                const metricCell = metricRow[colIndex];
-                if (!metricCell || !metricCell.fieldId) {
-                    return existingValue;
-                }
-                const pivotValues = pivotDimRows.map((dimRow) => {
-                    const cell = dimRow[colIndex];
-                    if (
-                        cell &&
-                        cell.type === 'value' &&
-                        cell.value?.raw !== undefined &&
-                        cell.value?.raw !== null
-                    ) {
-                        return String(cell.value.raw);
-                    }
-                    return undefined;
-                });
-                if (pivotValues.some((v) => v === undefined)) {
-                    return existingValue;
-                }
-                // Backend PivotQueryBuilder emits column names of the form
-                // `<metric>_<agg>_<pivotValue1>_<pivotValue2>...`. Metric
-                // aggregations default to 'any' when the source field is
-                // already aggregated (i.e. a Lightdash metric).
-                const key = [
-                    metricCell.fieldId,
-                    'any',
-                    ...(pivotValues as string[]),
-                ].join('_');
-                const rawTotal = asyncTotals[key];
-                if (rawTotal === undefined || rawTotal === null) {
-                    return existingValue;
-                }
-                const numeric = extractNumeric(rawTotal);
-                return numeric === undefined ? existingValue : numeric;
-            }),
-        );
-        return {
-            ...pivotTableData,
-            data: {
-                ...pivotTableData.data,
-                columnTotals: nextColumnTotals,
-            },
-        };
-    }, [pivotTableData, asyncTotals]);
-
-    // True when the overlay above replaced `columnTotals` — callers
-    // forward this so PivotTable skips the `isSummable` footer gate.
-    const columnTotalsAreWarehouseComputed =
-        effectivePivotTableData.data !== pivotTableData.data;
-
     const validConfig: TableChart = useMemo(
         () => ({
             showColumnCalculation,
@@ -798,8 +720,7 @@ const useTableConfig = (
             minMaxMap,
             conditionalFormattings,
             onSetConditionalFormattings: handleSetConditionalFormattings,
-            pivotTableData: effectivePivotTableData,
-            columnTotalsAreWarehouseComputed,
+            pivotTableData,
             metricsAsRows,
             setMetricsAsRows,
             isPivotTableEnabled,
@@ -843,8 +764,7 @@ const useTableConfig = (
             minMaxMap,
             conditionalFormattings,
             handleSetConditionalFormattings,
-            effectivePivotTableData,
-            columnTotalsAreWarehouseComputed,
+            pivotTableData,
             metricsAsRows,
             setMetricsAsRows,
             isPivotTableEnabled,


### PR DESCRIPTION
Closes: PROD-8085
Relates: #9981

### Description:

Pivot column totals are now computed exclusively from the warehouse `calculate-total` result (keyed by pivot column name) instead of client-side summation, so they work for every metric type — including the "metrics as rows" layout, where non-summable metrics (count distinct, average, min/max, ratios) previously showed no total at all. This removes the in-memory summation, the `isSummable` render gate, and the `columnTotalsAreWarehouseComputed` flag/overlay, bringing column totals in line with the warehouse-only row-totals model. As a consequence, column totals render blank while the warehouse query is loading or when the source query can't be totalled (e.g. it has metric/table-calculation filters), matching existing row-total behaviour. Verified in-app (metrics-as-rows now shows totals for an AVERAGE metric) and with updated `pivotQueryResults` unit tests.


### Demo

<img width="4348" height="2578" alt="CleanShot 2026-06-04 at 10 30 43@2x" src="https://github.com/user-attachments/assets/7d1d74db-380a-41eb-b73c-990797e1a586" />
