### PR TITLE
fix: restrict per-resource scheduled deliveries visibility to the owner

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -731,8 +731,9 @@ export class SchedulerModel {
 
     async getSqlChartSchedulers(
         savedSqlUuid: string,
+        createdByUserUuid?: string,
     ): Promise<SchedulerAndTargets[]> {
-        const schedulers = SchedulerModel.getBaseSchedulerQuery(this.database)
+        let schedulers = SchedulerModel.getBaseSchedulerQuery(this.database)
             .where(`${SchedulerTableName}.saved_sql_uuid`, savedSqlUuid)
             .orderBy([
                 {
@@ -744,6 +745,12 @@ export class SchedulerModel {
                     order: 'asc',
                 },
             ]);
+        if (createdByUserUuid) {
+            schedulers = schedulers.where(
+                `${SchedulerTableName}.created_by`,
+                createdByUserUuid,
+            );
+        }
         return this.getSchedulersWithTargets(await schedulers);
     }
 

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -88,6 +88,7 @@ const projectModel = {
 const schedulerModel = {
     getScheduler: jest.fn(),
     getProjectSchedulerRuns: jest.fn(),
+    getSchedulers: jest.fn(),
 };
 
 const contentVerificationModel = {
@@ -812,6 +813,77 @@ describe('DashboardService', () => {
             expect(
                 schedulerModel.getProjectSchedulerRuns,
             ).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getSchedulers', () => {
+        const adminUser: SessionUser = {
+            ...user,
+            ability: defineUserAbility(
+                {
+                    ...user,
+                    role: OrganizationMemberRole.MEMBER,
+                },
+                [
+                    {
+                        projectUuid: dashboard.projectUuid,
+                        role: ProjectMemberRole.ADMIN,
+                        userUuid: user.userUuid,
+                        roleUuid: undefined,
+                    },
+                ],
+            ),
+        };
+        const editorUser: SessionUser = {
+            ...user,
+            ability: defineUserAbility(
+                {
+                    ...user,
+                    role: OrganizationMemberRole.MEMBER,
+                },
+                [
+                    {
+                        projectUuid: dashboard.projectUuid,
+                        role: ProjectMemberRole.EDITOR,
+                        userUuid: user.userUuid,
+                        roleUuid: undefined,
+                    },
+                ],
+            ),
+        };
+
+        beforeEach(() => {
+            schedulerModel.getSchedulers.mockResolvedValue({
+                data: [],
+                pagination: undefined,
+            });
+        });
+
+        test('admin lists all schedulers for the dashboard', async () => {
+            await service.getSchedulers(adminUser, dashboard.uuid);
+
+            expect(schedulerModel.getSchedulers).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    filters: {
+                        resourceType: 'dashboard',
+                        resourceUuids: [dashboard.uuid],
+                    },
+                }),
+            );
+        });
+
+        test('editor lists only their own schedulers for the dashboard', async () => {
+            await service.getSchedulers(editorUser, dashboard.uuid);
+
+            expect(schedulerModel.getSchedulers).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    filters: {
+                        resourceType: 'dashboard',
+                        resourceUuids: [dashboard.uuid],
+                        createdByUserUuids: [user.userUuid],
+                    },
+                }),
+            );
         });
     });
 });

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -1604,6 +1604,14 @@ export class DashboardService
             user,
             dashboardUuid,
         );
+        const auditedAbility = this.createAuditedAbility(user);
+        const canManageAll = auditedAbility.can(
+            'manage',
+            subject('ScheduledDeliveries', {
+                organizationUuid: dashboard.organizationUuid,
+                projectUuid: dashboard.projectUuid,
+            }),
+        );
         const schedulers = await this.schedulerModel.getSchedulers({
             projectUuid: dashboard.projectUuid,
             organizationUuid: dashboard.organizationUuid,
@@ -1612,6 +1620,9 @@ export class DashboardService
             filters: {
                 resourceType: 'dashboard',
                 resourceUuids: [dashboardUuid],
+                ...(canManageAll
+                    ? {}
+                    : { createdByUserUuids: [user.userUuid] }),
             },
         });
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -1665,6 +1665,14 @@ export class SavedChartService
             user,
             chartUuid,
         );
+        const auditedAbility = this.createAuditedAbility(user);
+        const canManageAll = auditedAbility.can(
+            'manage',
+            subject('ScheduledDeliveries', {
+                organizationUuid: chart.organizationUuid,
+                projectUuid: chart.projectUuid,
+            }),
+        );
         const schedulers = await this.schedulerModel.getSchedulers({
             projectUuid: chart.projectUuid,
             organizationUuid: chart.organizationUuid,
@@ -1674,6 +1682,9 @@ export class SavedChartService
                 resourceType: 'chart',
                 resourceUuids: [chartUuid],
                 formats: filters?.formats,
+                ...(canManageAll
+                    ? {}
+                    : { createdByUserUuids: [user.userUuid] }),
             },
         });
 

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -142,16 +142,24 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
     afterEach(() => jest.clearAllMocks());
 
     describe('getSchedulers', () => {
-        it('admin can list SQL chart schedulers', async () => {
+        it('admin lists all SQL chart schedulers', async () => {
             await expect(
                 service.getSchedulers(adminUser, projectUuid, savedSqlUuid),
             ).resolves.toEqual([]);
+            expect(schedulerModel.getSqlChartSchedulers).toHaveBeenCalledWith(
+                savedSqlUuid,
+                undefined,
+            );
         });
 
-        it('editor can list SQL chart schedulers (PROD-7098 regression)', async () => {
+        it('editor lists only their own SQL chart schedulers', async () => {
             await expect(
                 service.getSchedulers(editorUser, projectUuid, savedSqlUuid),
             ).resolves.toEqual([]);
+            expect(schedulerModel.getSqlChartSchedulers).toHaveBeenCalledWith(
+                savedSqlUuid,
+                'editor-uuid',
+            );
         });
 
         it('viewer is blocked from listing SQL chart schedulers', async () => {

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -855,12 +855,24 @@ export class SavedSqlService
         projectUuid: string,
         savedSqlUuid: string,
     ): Promise<SchedulerAndTargets[]> {
-        await this.checkCreateScheduledDeliveryAccess(
-            user,
-            projectUuid,
-            savedSqlUuid,
+        const { organizationUuid } =
+            await this.checkCreateScheduledDeliveryAccess(
+                user,
+                projectUuid,
+                savedSqlUuid,
+            );
+        const auditedAbility = this.createAuditedAbility(user);
+        const canManageAll = auditedAbility.can(
+            'manage',
+            subject('ScheduledDeliveries', {
+                organizationUuid,
+                projectUuid,
+            }),
         );
-        return this.schedulerModel.getSqlChartSchedulers(savedSqlUuid);
+        return this.schedulerModel.getSqlChartSchedulers(
+            savedSqlUuid,
+            canManageAll ? undefined : user.userUuid,
+        );
     }
 
     async createScheduler(


### PR DESCRIPTION
Closes: PROD-8129

### Description:

The dashboard, chart, and SQL-chart "Scheduled deliveries" modals (three-dots menu) listed every scheduler on the resource regardless of owner, unlike the Settings list which already filters to the current user — so any user with create access could see other users' deliveries, breaking data isolation for row-level-security setups. This restricts each per-resource scheduler list to the caller's own deliveries unless they can manage all scheduled deliveries (i.e. hold the unrestricted `manage:ScheduledDeliveries` scope), mirroring the existing CASL ownership model used elsewhere in the scheduler service. The fix adds an owner filter in `DashboardService`, `SavedChartService`, and `SavedSqlService` (with a new optional `createdByUserUuid` filter on `SchedulerModel.getSqlChartSchedulers`). Admins and custom roles with the manage scope still see all deliveries on the modal. Unit tests cover both the admin (sees all) and non-admin (own only) paths.