### PR TITLE
fix: scope changeset, chart, dashboard, and space operations to the authorized project

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4346,7 +4346,10 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        const change = await this.changesetModel.getChange(changeUuid);
+        const change = await this.changesetModel.getChange(
+            changeUuid,
+            agent.projectUuid,
+        );
 
         const originalExplores = await this.projectModel.findExploresFromCache(
             agent.projectUuid,
@@ -4355,7 +4358,7 @@ export class AiAgentService extends BaseService {
             { applyChangeset: false },
         );
 
-        await this.changesetModel.revertChange(changeUuid);
+        await this.changesetModel.revertChange(changeUuid, agent.projectUuid);
 
         await this.catalogModel.indexCatalogReverts({
             projectUuid: agent.projectUuid,

--- a/packages/backend/src/models/ChangesetModel.ts
+++ b/packages/backend/src/models/ChangesetModel.ts
@@ -169,9 +169,23 @@ export class ChangesetModel {
         });
     }
 
-    async getChange(changeUuid: string): Promise<Change> {
+    async getChange(changeUuid: string, projectUuid?: string): Promise<Change> {
         const change = await this.database(ChangesTableName)
+            .innerJoin(
+                ChangesetsTableName,
+                `${ChangesetsTableName}.changeset_uuid`,
+                `${ChangesTableName}.changeset_uuid`,
+            )
+            .select(`${ChangesTableName}.*`)
             .where('change_uuid', changeUuid)
+            .modify((queryBuilder) => {
+                if (projectUuid) {
+                    void queryBuilder.where(
+                        `${ChangesetsTableName}.project_uuid`,
+                        projectUuid,
+                    );
+                }
+            })
             .first();
 
         if (!change) {
@@ -206,9 +220,24 @@ export class ChangesetModel {
             .delete();
     }
 
-    async revertChange(changeUuid: string): Promise<void> {
-        await this.getChange(changeUuid);
+    async revertChange(
+        changeUuid: string,
+        projectUuid?: string,
+    ): Promise<void> {
+        await this.getChange(changeUuid, projectUuid);
 
-        await this.revertChanges({ changeUuids: [changeUuid] });
+        await this.database(ChangesTableName)
+            .where('change_uuid', changeUuid)
+            .modify((queryBuilder) => {
+                if (projectUuid) {
+                    void queryBuilder.whereIn(
+                        'changeset_uuid',
+                        this.database(ChangesetsTableName)
+                            .select('changeset_uuid')
+                            .where('project_uuid', projectUuid),
+                    );
+                }
+            })
+            .delete();
     }
 }

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -2358,6 +2358,17 @@ export class DashboardModel {
         const updateCount = await tx(DashboardsTableName)
             .update({ space_id: space.space_id })
             .where('dashboard_uuid', dashboardUuid)
+            .whereIn(
+                `${DashboardsTableName}.space_id`,
+                tx(SpaceTableName)
+                    .select(`${SpaceTableName}.space_id`)
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
+                    )
+                    .where(`${ProjectTableName}.project_uuid`, projectUuid),
+            )
             .whereNull('deleted_at');
 
         if (updateCount !== 1) {

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -2034,6 +2034,36 @@ export class SavedChartModel {
             // if we move a chart from a dashboard to a space, we need to set the dashboard_uuid to null
             .update({ space_id: space.space_id, dashboard_uuid: null })
             .where('saved_query_uuid', savedChartUuid)
+            .whereIn(
+                `${SavedChartsTableName}.saved_query_id`,
+                tx(`${SavedChartsTableName} as source_saved_queries`)
+                    .select('source_saved_queries.saved_query_id')
+                    .leftJoin(
+                        `${DashboardsTableName} as source_dashboards`,
+                        'source_dashboards.dashboard_uuid',
+                        'source_saved_queries.dashboard_uuid',
+                    )
+                    .innerJoin(
+                        `${SpaceTableName} as source_spaces`,
+                        function sourceSpaceJoin() {
+                            this.on(
+                                'source_spaces.space_id',
+                                '=',
+                                'source_dashboards.space_id',
+                            ).orOn(
+                                'source_spaces.space_id',
+                                '=',
+                                'source_saved_queries.space_id',
+                            );
+                        },
+                    )
+                    .innerJoin(
+                        `${ProjectTableName} as source_projects`,
+                        'source_projects.project_id',
+                        'source_spaces.project_id',
+                    )
+                    .where('source_projects.project_uuid', projectUuid),
+            )
             .whereNull('deleted_at');
 
         if (updateCount !== 1) {

--- a/packages/backend/src/models/SearchModel/SearchModel.test.ts
+++ b/packages/backend/src/models/SearchModel/SearchModel.test.ts
@@ -1,0 +1,50 @@
+import { NotFoundError } from '@lightdash/common';
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { SearchModel } from '.';
+import { DashboardsTableName } from '../../database/entities/dashboards';
+import { ProjectTableName } from '../../database/entities/projects';
+import { SpaceTableName } from '../../database/entities/spaces';
+
+describe('SearchModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const contentVerificationModel = {
+        getByContentUuids: jest.fn(),
+    };
+    const model = new SearchModel({
+        database,
+        contentVerificationModel,
+    } as unknown as ConstructorParameters<typeof SearchModel>[0]);
+
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+        jest.clearAllMocks();
+    });
+
+    test('scopes dashboard chart lookup to the requested project', async () => {
+        const dashboardUuid = 'dashboard-uuid';
+        const projectUuid = 'project-uuid';
+
+        tracker.on.select(DashboardsTableName).response([]);
+
+        await expect(
+            model.getDashboardCharts(dashboardUuid, projectUuid, 1, 20),
+        ).rejects.toThrow(NotFoundError);
+
+        const [dashboardLookup] = tracker.history.select;
+
+        expect(dashboardLookup.sql).toContain(SpaceTableName);
+        expect(dashboardLookup.sql).toContain(ProjectTableName);
+        expect(dashboardLookup.bindings).toContain(dashboardUuid);
+        expect(dashboardLookup.bindings).toContain(projectUuid);
+        expect(
+            contentVerificationModel.getByContentUuids,
+        ).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -506,6 +506,7 @@ export class SearchModel {
 
     async getDashboardCharts(
         dashboardUuid: string,
+        projectUuid: string,
         page: number,
         pageSize: number,
     ): Promise<{
@@ -519,9 +520,23 @@ export class SearchModel {
         };
     }> {
         const dashboard = await this.database(DashboardsTableName)
-            .select('dashboard_uuid', 'name')
-            .where('dashboard_uuid', dashboardUuid)
-            .whereNull('deleted_at')
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${DashboardsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .select(
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${DashboardsTableName}.name`,
+            )
+            .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid)
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
             .first();
 
         if (!dashboard) {

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -840,7 +840,7 @@ export class SpaceModel {
 
     async getSpaceSummary(
         spaceUuid: string,
-        options?: { deleted?: boolean },
+        options?: { deleted?: boolean; projectUuid?: string },
     ): Promise<SpaceSummaryBase> {
         return wrapSentryTransaction(
             'SpaceModel.getSpaceSummary',
@@ -849,6 +849,7 @@ export class SpaceModel {
                 const [space] = await this.find({
                     spaceUuid,
                     deleted: options?.deleted,
+                    projectUuid: options?.projectUuid,
                 });
                 if (space === undefined)
                     throw new NotFoundError(

--- a/packages/backend/src/services/ChangesetService.test.ts
+++ b/packages/backend/src/services/ChangesetService.test.ts
@@ -1,0 +1,77 @@
+import { buildAccount } from '../auth/account/account.mock';
+import { ChangesetService } from './ChangesetService';
+
+const projectUuid = '11111111-1111-4111-8111-111111111111';
+const changeUuid = '22222222-2222-4222-8222-222222222222';
+const account = buildAccount();
+
+const changesetModel = {
+    getChange: jest.fn(),
+    revertChange: jest.fn(),
+    findActiveChangesetWithChangesByProjectUuid: jest.fn(),
+};
+
+const projectModel = {
+    findExploresFromCache: jest.fn(),
+};
+
+const catalogModel = {
+    indexCatalogReverts: jest.fn(),
+};
+
+const service = new ChangesetService({
+    changesetModel: changesetModel as never,
+    catalogModel: catalogModel as never,
+    projectModel: projectModel as never,
+    savedChartModel: {} as never,
+    dashboardModel: {} as never,
+});
+
+describe('ChangesetService tenant scoping', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('gets a change scoped to the authorized project', async () => {
+        changesetModel.getChange.mockResolvedValue({
+            changeUuid,
+            dependencies: [],
+        });
+
+        await service.getChange(account, projectUuid, changeUuid);
+
+        expect(changesetModel.getChange).toHaveBeenCalledWith(
+            changeUuid,
+            projectUuid,
+        );
+    });
+
+    test('reverts a change scoped to the authorized project', async () => {
+        changesetModel.findActiveChangesetWithChangesByProjectUuid.mockResolvedValue(
+            {
+                changes: [
+                    {
+                        changeUuid,
+                        entityTableName: 'orders',
+                    },
+                ],
+            },
+        );
+        changesetModel.getChange.mockResolvedValue({
+            changeUuid,
+            entityTableName: 'orders',
+        });
+        projectModel.findExploresFromCache.mockResolvedValue([]);
+
+        await service.revertChange(account, projectUuid, changeUuid);
+
+        expect(changesetModel.getChange).toHaveBeenCalledWith(
+            changeUuid,
+            projectUuid,
+        );
+        expect(changesetModel.revertChange).toHaveBeenCalledWith(
+            changeUuid,
+            projectUuid,
+        );
+    });
+});

--- a/packages/backend/src/services/ChangesetService.ts
+++ b/packages/backend/src/services/ChangesetService.ts
@@ -176,7 +176,7 @@ export class ChangesetService extends BaseService {
             );
         }
 
-        return this.changesetModel.getChange(changeUuid);
+        return this.changesetModel.getChange(changeUuid, projectUuid);
     }
 
     async revertChange(
@@ -210,7 +210,10 @@ export class ChangesetService extends BaseService {
             return;
         }
 
-        const change = await this.changesetModel.getChange(changeUuid);
+        const change = await this.changesetModel.getChange(
+            changeUuid,
+            projectUuid,
+        );
 
         // Get original explores WITHOUT any changes for revert reconstruction
         const originalExplores = await this.projectModel.findExploresFromCache(
@@ -221,7 +224,7 @@ export class ChangesetService extends BaseService {
         );
 
         // Delete the change
-        await this.changesetModel.revertChange(changeUuid);
+        await this.changesetModel.revertChange(changeUuid, projectUuid);
 
         // Update catalog using revert logic
         await this.catalogModel.indexCatalogReverts({

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -502,9 +502,13 @@ export class ContentService extends BaseService {
             case ContentType.CHART:
                 switch (item.source) {
                     case ChartSourceType.DBT_EXPLORE:
-                        return this.savedChartService.restore(user, item.uuid);
+                        return this.savedChartService.restore(user, item.uuid, {
+                            projectUuid,
+                        });
                     case ChartSourceType.SQL:
-                        return this.savedSqlService.restore(user, item.uuid);
+                        return this.savedSqlService.restore(user, item.uuid, {
+                            projectUuid,
+                        });
                     default:
                         return assertUnreachable(
                             item.source,
@@ -512,9 +516,13 @@ export class ContentService extends BaseService {
                         );
                 }
             case ContentType.DASHBOARD:
-                return this.dashboardService.restore(user, item.uuid);
+                return this.dashboardService.restore(user, item.uuid, {
+                    projectUuid,
+                });
             case ContentType.SPACE:
-                return this.spaceService.restore(user, item.uuid);
+                return this.spaceService.restore(user, item.uuid, {
+                    projectUuid,
+                });
             case ContentType.DATA_APP:
                 return this.getAppGenerateService().restoreApp(
                     user,
@@ -561,11 +569,13 @@ export class ContentService extends BaseService {
                         return this.savedChartService.permanentDelete(
                             user,
                             item.uuid,
+                            { projectUuid },
                         );
                     case ChartSourceType.SQL:
                         return this.savedSqlService.permanentDelete(
                             user,
                             item.uuid,
+                            { projectUuid },
                         );
                     default:
                         return assertUnreachable(
@@ -574,9 +584,13 @@ export class ContentService extends BaseService {
                         );
                 }
             case ContentType.DASHBOARD:
-                return this.dashboardService.permanentDelete(user, item.uuid);
+                return this.dashboardService.permanentDelete(user, item.uuid, {
+                    projectUuid,
+                });
             case ContentType.SPACE:
-                return this.spaceService.permanentDelete(user, item.uuid);
+                return this.spaceService.permanentDelete(user, item.uuid, {
+                    projectUuid,
+                });
             case ContentType.DATA_APP:
                 return this.getAppGenerateService().permanentDeleteApp(
                     user,

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -210,6 +210,7 @@ describe('DashboardService', () => {
         );
         expect(searchModel.getDashboardCharts).toHaveBeenCalledWith(
             dashboard.uuid,
+            projectUuid,
             1,
             20,
         );

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -578,6 +578,7 @@ export class DashboardService
 
         return this.searchModel.getDashboardCharts(
             dashboard.uuid,
+            projectUuid,
             page,
             pageSize,
         );
@@ -1552,11 +1553,11 @@ export class DashboardService
     async restore(
         user: SessionUser,
         dashboardUuidOrSlug: string,
-        options?: SoftDeleteOptions,
+        options?: SoftDeleteOptions & { projectUuid?: string },
     ): Promise<void> {
         const dashboard = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
-            { deleted: true },
+            { deleted: true, projectUuid: options?.projectUuid },
         );
 
         if (options?.bypassPermissions) {
@@ -1607,14 +1608,14 @@ export class DashboardService
     async permanentDelete(
         user: SessionUser,
         dashboardUuidOrSlug: string,
-        options?: SoftDeleteOptions,
+        options?: SoftDeleteOptions & { projectUuid?: string },
     ): Promise<void> {
         // 'any' so this works whether called directly on a soft-deleted
         // dashboard (restore-then-purge flow) or via `delete()` on a
         // not-yet-deleted dashboard (when softDelete config is off).
         const dashboard = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
-            { deleted: 'any' },
+            { deleted: 'any', projectUuid: options?.projectUuid },
         );
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -93,6 +93,9 @@ export class RenameService extends BaseService {
         chartUuid: string;
     }) {
         const chart = await this.savedChartModel.get(chartUuid);
+        if (chart.projectUuid !== projectUuid) {
+            throw new NotFoundError(`Chart ${chartUuid} not found`);
+        }
 
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -358,8 +361,10 @@ export class RenameService extends BaseService {
         dashboardUuid: string;
         tableName?: string;
     }) {
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
 
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -483,8 +488,10 @@ export class RenameService extends BaseService {
             throw new ForbiddenError();
         }
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
 
         // Derive the table name from the dashboard's filters
         let tableName: string;

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -2247,12 +2247,12 @@ export class SavedChartService
     async restore(
         user: SessionUser,
         chartUuid: string,
-        options?: SoftDeleteOptions,
+        options?: SoftDeleteOptions & { projectUuid?: string },
     ): Promise<void> {
         const deletedChart = await this.savedChartModel.get(
             chartUuid,
             undefined,
-            { deleted: true },
+            { deleted: true, projectUuid: options?.projectUuid },
         );
         const { organizationUuid, projectUuid } = deletedChart;
 
@@ -2326,7 +2326,7 @@ export class SavedChartService
     async permanentDelete(
         user: SessionUser,
         chartUuid: string,
-        options?: SoftDeleteOptions,
+        options?: SoftDeleteOptions & { projectUuid?: string },
     ): Promise<void> {
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
@@ -2338,7 +2338,7 @@ export class SavedChartService
             const deletedChart = await this.savedChartModel.get(
                 chartUuid,
                 undefined,
-                { deleted: true },
+                { deleted: true, projectUuid: options?.projectUuid },
             );
             const { organizationUuid, projectUuid } = deletedChart;
 

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -477,10 +477,11 @@ export class SavedSqlService
     async restore(
         user: SessionUser,
         savedSqlUuid: string,
-        options?: SoftDeleteOptions,
+        options?: SoftDeleteOptions & { projectUuid?: string },
     ): Promise<void> {
         const savedChart = await this.savedSqlModel.getByUuid(savedSqlUuid, {
             deleted: true,
+            projectUuid: options?.projectUuid,
         });
         const { projectUuid } = savedChart.project;
         const { organizationUuid } = savedChart.organization;
@@ -539,7 +540,7 @@ export class SavedSqlService
     async permanentDelete(
         user: SessionUser,
         savedSqlUuid: string,
-        options?: SoftDeleteOptions,
+        options?: SoftDeleteOptions & { projectUuid?: string },
     ): Promise<void> {
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
@@ -550,7 +551,7 @@ export class SavedSqlService
         } else {
             const savedChart = await this.savedSqlModel.getByUuid(
                 savedSqlUuid,
-                { deleted: true },
+                { deleted: true, projectUuid: options?.projectUuid },
             );
             const { projectUuid } = savedChart.project;
             const { organizationUuid } = savedChart.organization;

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -48,6 +48,64 @@ describe('SpaceService', () => {
         jest.clearAllMocks();
     });
 
+    describe('moveToSpace', () => {
+        it('scopes the source space lookup and move to the requested project', async () => {
+            const requestedProjectUuid = 'authorized-project-uuid';
+            const spaceUuid = 'space-uuid';
+            const targetSpaceUuid = 'target-space-uuid';
+            const spaceModel = {
+                getSpaceSummary: jest.fn().mockResolvedValue({
+                    uuid: spaceUuid,
+                    name: 'Space',
+                    parentSpaceUuid: 'old-parent-space-uuid',
+                    projectUuid: 'source-project-uuid',
+                }),
+                moveToSpace: jest.fn().mockResolvedValue(undefined),
+            };
+            const spacePermissionService = {
+                can: jest.fn().mockResolvedValue(true),
+            };
+            const scopedService = new SpaceService({
+                analytics: analyticsMock,
+                lightdashConfig: lightdashConfigMock,
+                projectModel: {} as ProjectModel,
+                spaceModel: spaceModel as unknown as SpaceModel,
+                organizationModel: {} as OrganizationModel,
+                pinnedListModel: {} as PinnedListModel,
+                spacePermissionService:
+                    spacePermissionService as unknown as SpacePermissionService,
+                savedChartService: {} as SavedChartService,
+                dashboardService: {} as DashboardService,
+                appGenerateService: undefined,
+            });
+
+            await scopedService.moveToSpace(
+                createTestUser({
+                    projectUuid: requestedProjectUuid,
+                    projectRole: ProjectMemberRole.ADMIN,
+                }) as unknown as SessionUser,
+                {
+                    projectUuid: requestedProjectUuid,
+                    itemUuid: spaceUuid,
+                    targetSpaceUuid,
+                },
+                { trackEvent: false },
+            );
+
+            expect(spaceModel.getSpaceSummary).toHaveBeenCalledWith(spaceUuid, {
+                projectUuid: requestedProjectUuid,
+            });
+            expect(spaceModel.moveToSpace).toHaveBeenCalledWith(
+                {
+                    projectUuid: requestedProjectUuid,
+                    itemUuid: spaceUuid,
+                    targetSpaceUuid,
+                },
+                { tx: undefined },
+            );
+        });
+    });
+
     describe('_userCanActionSpace', () => {
         describe('organization admins', () => {
             it.each([

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -469,7 +469,9 @@ export class SpaceService
             trackEvent?: boolean;
         } = {},
     ) {
-        const space = await this.spaceModel.getSpaceSummary(spaceUuid);
+        const space = await this.spaceModel.getSpaceSummary(spaceUuid, {
+            projectUuid,
+        });
 
         if (!space) {
             throw new NotFoundError('Space not found');
@@ -494,7 +496,7 @@ export class SpaceService
 
         await this.spaceModel.moveToSpace(
             {
-                projectUuid: space.projectUuid,
+                projectUuid,
                 itemUuid: spaceUuid,
                 targetSpaceUuid,
             },
@@ -686,10 +688,11 @@ export class SpaceService
     async restore(
         user: SessionUser,
         spaceUuid: string,
-        options?: SoftDeleteOptions,
+        options?: SoftDeleteOptions & { projectUuid?: string },
     ): Promise<void> {
         const space = await this.spaceModel.getSpaceSummary(spaceUuid, {
             deleted: true,
+            projectUuid: options?.projectUuid,
         });
 
         if (options?.bypassPermissions) {
@@ -800,7 +803,7 @@ export class SpaceService
     async permanentDelete(
         user: SessionUser,
         spaceUuid: string,
-        options?: SoftDeleteOptions,
+        options?: SoftDeleteOptions & { projectUuid?: string },
     ): Promise<void> {
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
@@ -811,6 +814,7 @@ export class SpaceService
         } else {
             const space = await this.spaceModel.getSpaceSummary(spaceUuid, {
                 deleted: true,
+                projectUuid: options?.projectUuid,
             });
             const auditedAbility = this.createAuditedAbility(user);
             if (

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -1484,6 +1484,9 @@ export class ValidationService extends BaseService {
 
         // Get the chart to find which explore it uses
         const chart = await this.savedChartModel.get(chartUuid);
+        if (chart.projectUuid !== projectUuid) {
+            throw new NotFoundError(`Chart ${chartUuid} not found`);
+        }
 
         // Check user permissions
         const { inheritsFromOrgOrProject, access } =
@@ -1569,8 +1572,10 @@ export class ValidationService extends BaseService {
         }
 
         // Get the dashboard to check permissions
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
 
         // Check user permissions
         const { inheritsFromOrgOrProject, access } =


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8095/insecure-direct-object-reference-idor-in-multi-tenant-content

<img width="878" height="194" alt="CleanShot 2026-06-04 at 12 40 29@2x" src="https://github.com/user-attachments/assets/ff6deb2e-0811-4578-8663-9fcdbf8f1e4b" />

### Description:

Adds project-scoped tenant isolation to several database queries and service methods to prevent cross-project data access vulnerabilities.

- `ChangesetModel.getChange` and `revertChange` now accept an optional `projectUuid` and filter changes by joining through the changesets table to verify the change belongs to the specified project before returning or deleting it.
- `DashboardModel` and `SavedChartModel` move-to-space operations now verify the target resource belongs to the specified project via subquery joins before applying updates.
- `SearchModel.getDashboardCharts` now requires a `projectUuid` and joins through spaces and projects to ensure the dashboard lookup is scoped to the correct project.
- `SpaceModel.getSpaceSummary`, `DashboardService`, `SavedChartService`, `SavedSqlService`, and `SpaceService` restore and permanent delete operations now accept and propagate a `projectUuid` option to scope their underlying model lookups.
- `RenameService` and `ValidationService` now explicitly verify that charts and dashboards belong to the requested project before proceeding, throwing a `NotFoundError` if there is a mismatch.
- `AiAgentService` passes `projectUuid` through to changeset operations and dashboard chart lookups.
- Tests added for `SearchModel.getDashboardCharts` and `ChangesetService` to verify that queries are correctly scoped to the authorized project.