### PR TITLE
fix(spaces): search nested spaces in Spaces list (#23887)

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.test.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.test.ts
@@ -1,0 +1,26 @@
+import knex from 'knex';
+import { MockClient } from 'knex-mock-client';
+import { ContentFilters } from '../ContentModelTypes';
+import { spaceContentConfiguration } from './SpaceContentConfiguration';
+
+const db = knex({ client: MockClient, dialect: 'pg' });
+
+const buildSql = (filters: ContentFilters): string =>
+    spaceContentConfiguration.getSummaryQuery(db, filters).toSQL().sql;
+
+const baseFilters: ContentFilters = {
+    spaceUuids: ['00000000-0000-0000-0000-000000000001'],
+    space: { rootSpaces: true },
+};
+
+describe('spaceContentConfiguration.getSummaryQuery rootSpaces search', () => {
+    it('restricts to root spaces when no search term is provided', () => {
+        const sql = buildSql(baseFilters);
+        expect(sql).toContain('nlevel(path) = 1');
+    });
+
+    it('matches spaces at any nesting level when searching (issue #23887)', () => {
+        const sql = buildSql({ ...baseFilters, search: 'nested space' });
+        expect(sql).not.toContain('nlevel(path) = 1');
+    });
+});

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -235,12 +235,16 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                         // scoped to allowed spaceUuids from access control
                         void builder.whereNull(`${SpaceTableName}.deleted_at`);
                         if (filters.space?.rootSpaces) {
-                            void builder
-                                .whereIn(
-                                    `${SpaceTableName}.space_uuid`,
-                                    filters.spaceUuids ?? [],
-                                )
-                                .andWhereRaw('nlevel(path) = 1');
+                            void builder.whereIn(
+                                `${SpaceTableName}.space_uuid`,
+                                filters.spaceUuids ?? [],
+                            );
+                            // When searching, match spaces at any nesting level
+                            // to stay consistent with global search. The
+                            // space_uuid filter above already enforces access.
+                            if (!filters.search) {
+                                void builder.andWhereRaw('nlevel(path) = 1');
+                            }
                         } else {
                             void builder.whereIn(
                                 `${SpaceTableName}.parent_space_uuid`,


### PR DESCRIPTION
## Closes #23887

### Problem
The search box on the Spaces list page (`/spaces`) only returned root-level spaces. Nested/child spaces never appeared when searched by name, even though the global search bar finds those exact same spaces — a confusing UX inconsistency.

### Root cause
In `SpaceContentConfiguration.getSummaryQuery()`, the `rootSpaces` query path (the default for `/spaces`) always applies `AND nlevel(path) = 1`. The search term is applied on top of this, so nested spaces are filtered out before the name match can ever succeed.

### Fix
Only apply the `nlevel(path) = 1` root-level restriction when there is **no** search term. When the user is searching, results are matched at any nesting level — consistent with global search. Access control is unaffected: the existing `space_uuid IN (...)` filter already scopes results to spaces the user can view (it contains accessible spaces at every level).

### Testing
Added a unit regression test (`SpaceContentConfiguration.test.ts`) asserting the generated SQL:
- contains `nlevel(path) = 1` with no search term
- omits it when a search term is present

```
✓ restricts to root spaces when no search term is provided
✓ matches spaces at any nesting level when searching (issue #23887)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)