### PR TITLE
feat(totals): table calculation totals in v2 calculate-total endpoint

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.test.ts
@@ -43,13 +43,14 @@ const pivotConfiguration: PivotConfiguration = {
 };
 
 describe('getGrandTotalMetricQuery', () => {
-    it('strips dimensions, sorts, table calculations and clamps the limit to 1', () => {
+    it('strips dimensions and sorts, clamps the limit to 1, and drops calcs referencing non-metric fields', () => {
         const result = getGrandTotalMetricQuery({
             ...baseMetricQuery,
             tableCalculations: [
                 {
                     name: 'profit_margin',
                     displayName: 'Profit margin',
+                    // references orders_total_cost which is not a metric
                     sql: '${orders.total_revenue} - ${orders.total_cost}',
                 } as never,
             ],
@@ -59,6 +60,169 @@ describe('getGrandTotalMetricQuery', () => {
         expect(result.sorts).toEqual([]);
         expect(result.tableCalculations).toEqual([]);
         expect(result.limit).toBe(1);
+    });
+
+    it('keeps SQL and formula table calcs that reference only metrics', () => {
+        const result = getGrandTotalMetricQuery({
+            ...baseMetricQuery,
+            tableCalculations: [
+                {
+                    name: 'rev_per_customer_sql',
+                    displayName: 'Rev per customer (sql)',
+                    sql: '${orders.total_revenue} / ${orders.unique_customer_count}',
+                } as never,
+                {
+                    name: 'rev_per_customer_formula',
+                    displayName: 'Rev per customer (formula)',
+                    formula:
+                        '=orders_total_revenue / orders_unique_customer_count',
+                } as never,
+            ],
+        });
+
+        expect(result.tableCalculations.map((tc) => tc.name)).toEqual([
+            'rev_per_customer_sql',
+            'rev_per_customer_formula',
+        ]);
+    });
+
+    it('drops calcs that reference a dimension, use window functions, or are template-based', () => {
+        const result = getGrandTotalMetricQuery({
+            ...baseMetricQuery,
+            tableCalculations: [
+                {
+                    name: 'sql_with_dimension',
+                    displayName: 'Sql with dimension',
+                    sql: '${orders.total_revenue} / ${orders.status}',
+                } as never,
+                {
+                    name: 'sql_with_window',
+                    displayName: 'Sql with window',
+                    sql: 'SUM(${orders.total_revenue}) OVER ()',
+                } as never,
+                {
+                    name: 'formula_with_dimension',
+                    displayName: 'Formula with dimension',
+                    formula: '=orders_total_revenue / orders_status',
+                } as never,
+                {
+                    name: 'template_rank',
+                    displayName: 'Template rank',
+                    template: { type: 'rank_in_column' },
+                } as never,
+            ],
+        });
+
+        expect(result.tableCalculations).toEqual([]);
+    });
+
+    it('drops SQL calcs using row/pivot/total helper functions', () => {
+        const result = getGrandTotalMetricQuery({
+            ...baseMetricQuery,
+            tableCalculations: [
+                {
+                    name: 'with_offset',
+                    displayName: 'With offset',
+                    sql: 'offset(${orders.total_revenue}, 1)',
+                } as never,
+                {
+                    name: 'with_row',
+                    displayName: 'With row',
+                    sql: 'row()',
+                } as never,
+                {
+                    name: 'percent_of_total',
+                    displayName: 'Percent of total',
+                    sql: '${orders.total_revenue} / total(${orders.total_revenue})',
+                } as never,
+                {
+                    name: 'with_pivot_offset',
+                    displayName: 'With pivot offset',
+                    sql: 'pivot_offset(${orders.total_revenue}, -1)',
+                } as never,
+            ],
+        });
+
+        expect(result.tableCalculations).toEqual([]);
+    });
+
+    it('drops calcs with unresolvable references instead of throwing', () => {
+        expect(() =>
+            getGrandTotalMetricQuery({
+                ...baseMetricQuery,
+                tableCalculations: [
+                    {
+                        name: 'bad_ref',
+                        displayName: 'Bad ref',
+                        sql: '${orders.total.revenue} + 1',
+                    } as never,
+                ],
+            }),
+        ).not.toThrow();
+
+        const result = getGrandTotalMetricQuery({
+            ...baseMetricQuery,
+            tableCalculations: [
+                {
+                    name: 'bad_ref',
+                    displayName: 'Bad ref',
+                    sql: '${orders.total.revenue} + 1',
+                } as never,
+            ],
+        });
+
+        expect(result.tableCalculations).toEqual([]);
+    });
+
+    it('drops formula calcs that use aggregates or window functions', () => {
+        const result = getGrandTotalMetricQuery({
+            ...baseMetricQuery,
+            tableCalculations: [
+                {
+                    name: 'formula_aggregate',
+                    displayName: 'Formula aggregate',
+                    formula:
+                        '=SUM(orders_total_revenue) / SUM(orders_unique_customer_count)',
+                } as never,
+                {
+                    name: 'formula_window',
+                    displayName: 'Formula window',
+                    formula:
+                        '=SUM(orders_total_revenue) OVER (ORDER BY orders_total_revenue)',
+                } as never,
+            ],
+        });
+
+        expect(result.tableCalculations).toEqual([]);
+    });
+
+    it('drops calcs that reference a stripped period-over-period metric', () => {
+        const result = getGrandTotalMetricQuery({
+            ...baseMetricQuery,
+            metrics: ['orders_total_revenue', 'orders_total_revenue_pop_12m'],
+            additionalMetrics: [
+                {
+                    name: 'total_revenue_pop_12m',
+                    table: 'orders',
+                    sql: '${TABLE}.revenue',
+                    type: 'sum' as never,
+                    generationType: 'periodOverPeriod',
+                    baseMetricId: 'orders_total_revenue',
+                    timeDimensionId: 'orders_created_at',
+                    granularity: 'MONTH' as never,
+                    periodOffset: 12,
+                } as never,
+            ],
+            tableCalculations: [
+                {
+                    name: 'pop_delta',
+                    displayName: 'PoP delta',
+                    sql: '${orders.total_revenue} - ${orders_total_revenue_pop_12m}',
+                } as never,
+            ],
+        });
+
+        expect(result.tableCalculations).toEqual([]);
     });
 
     it('preserves the metrics list when no PoP metrics are present', () => {
@@ -173,6 +337,31 @@ describe('getColumnTotalQueryFromSource', () => {
             expect(result.pivotConfiguration?.groupByColumns).toEqual(
                 pivotConfiguration.groupByColumns,
             );
+        });
+
+        it('keeps metric-only table calcs and drops dimension-referencing ones', () => {
+            const result = getColumnTotalQueryFromSource({
+                metricQuery: {
+                    ...baseMetricQuery,
+                    tableCalculations: [
+                        {
+                            name: 'rev_per_customer',
+                            displayName: 'Rev per customer',
+                            sql: '${orders.total_revenue} / ${orders.unique_customer_count}',
+                        } as never,
+                        {
+                            name: 'rev_by_status',
+                            displayName: 'Rev by status',
+                            sql: '${orders.total_revenue} / ${orders.status}',
+                        } as never,
+                    ],
+                },
+                pivotConfiguration,
+            });
+
+            expect(
+                result.metricQuery.tableCalculations.map((tc) => tc.name),
+            ).toEqual(['rev_per_customer']);
         });
 
         it('throws when groupByColumns reference dimensions not in the source query', () => {
@@ -295,6 +484,31 @@ describe('getRowTotalQueryFromSource', () => {
             expect(result.pivotConfiguration?.indexColumn).toEqual(
                 pivotConfiguration.indexColumn,
             );
+        });
+
+        it('keeps metric-only table calcs and drops dimension-referencing ones', () => {
+            const result = getRowTotalQueryFromSource({
+                metricQuery: {
+                    ...baseMetricQuery,
+                    tableCalculations: [
+                        {
+                            name: 'rev_per_customer',
+                            displayName: 'Rev per customer',
+                            sql: '${orders.total_revenue} / ${orders.unique_customer_count}',
+                        } as never,
+                        {
+                            name: 'rev_by_status',
+                            displayName: 'Rev by status',
+                            sql: '${orders.total_revenue} / ${orders.status}',
+                        } as never,
+                    ],
+                },
+                pivotConfiguration,
+            });
+
+            expect(
+                result.metricQuery.tableCalculations.map((tc) => tc.name),
+            ).toEqual(['rev_per_customer']);
         });
 
         it('handles an indexColumn array by expanding all references into dimensions', () => {
@@ -504,6 +718,32 @@ describe('getColumnSubtotalQueryFromSource', () => {
             expect(result.metricQuery.sorts).toEqual([]);
             expect(result.metricQuery.tableCalculations).toEqual([]);
             expect(result.pivotConfiguration).toBeUndefined();
+        });
+
+        it('keeps metric-only table calcs and drops dimension-referencing ones', () => {
+            const result = getColumnSubtotalQueryFromSource({
+                metricQuery: {
+                    ...baseMetricQuery,
+                    tableCalculations: [
+                        {
+                            name: 'rev_per_customer',
+                            displayName: 'Rev per customer',
+                            sql: '${orders.total_revenue} / ${orders.unique_customer_count}',
+                        } as never,
+                        {
+                            name: 'rev_by_status',
+                            displayName: 'Rev by status',
+                            sql: '${orders.total_revenue} / ${orders.status}',
+                        } as never,
+                    ],
+                },
+                pivotConfiguration: singleGroupByPivotConfiguration,
+                subtotalDimensions: ['orders_status'],
+            });
+
+            expect(
+                result.metricQuery.tableCalculations.map((tc) => tc.name),
+            ).toEqual(['rev_per_customer']);
         });
 
         it('dedupes when a subtotal dimension is also a pivot groupBy column', () => {

--- a/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.ts
+++ b/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.ts
@@ -1,11 +1,23 @@
 import {
+    convertFieldRefToFieldId,
     flattenFilterGroup,
     getItemId,
+    isFormulaTableCalculation,
     isPeriodOverPeriodAdditionalMetric,
+    isSqlTableCalculation,
+    isTemplateTableCalculation,
+    lightdashVariablePattern,
     NotSupportedError,
+    parseTableCalculationFunctions,
     type MetricQuery,
     type PivotConfiguration,
+    type TableCalculation,
 } from '@lightdash/common';
+import {
+    containsAggregateOrWindow,
+    extractColumnRefs,
+    parse as parseFormula,
+} from '@lightdash/formula';
 
 const getPopMetricIds = (metricQuery: MetricQuery): Set<string> =>
     new Set(
@@ -13,6 +25,72 @@ const getPopMetricIds = (metricQuery: MetricQuery): Set<string> =>
             .filter(isPeriodOverPeriodAdditionalMetric)
             .map(getItemId),
     );
+
+const WINDOW_CLAUSE_PATTERN = /\bover\s*\(/i;
+
+// Extract the field ids a table calc references, or null if the calc can't be
+// safely totaled. Only pure per-row scalar arithmetic over metrics survives:
+// template calcs, row/pivot/total helper functions, raw window SQL, and formula
+// aggregates/window functions all compile to cross-row/cross-column SQL that is
+// meaningless once the query collapses to a totals row.
+const getTotalableReferences = (calc: TableCalculation): string[] | null => {
+    if (isTemplateTableCalculation(calc)) {
+        return null;
+    }
+
+    if (isSqlTableCalculation(calc)) {
+        if (
+            WINDOW_CLAUSE_PATTERN.test(calc.sql) ||
+            parseTableCalculationFunctions(calc.sql).length > 0
+        ) {
+            return null;
+        }
+        try {
+            // convertFieldRefToFieldId throws on refs that aren't `table.field`;
+            // treat an unresolvable ref as non-totalable rather than failing the
+            // whole totals query.
+            return [...calc.sql.matchAll(lightdashVariablePattern)].map(
+                (match) =>
+                    match[1].includes('.')
+                        ? convertFieldRefToFieldId(match[1])
+                        : match[1],
+            );
+        } catch {
+            return null;
+        }
+    }
+
+    if (isFormulaTableCalculation(calc)) {
+        try {
+            const ast = parseFormula(calc.formula);
+            if (containsAggregateOrWindow(ast)) {
+                return null;
+            }
+            return extractColumnRefs(ast);
+        } catch {
+            return null;
+        }
+    }
+
+    return null;
+};
+
+// A table calc can be totaled when it depends only on aggregated metrics:
+// applying its formula to the collapsed totals row reproduces the correct
+// total. Calcs that reference dimensions, dropped PoP metrics, sibling table
+// calcs, or use window functions are excluded (their total stays blank).
+const getTotalableTableCalculations = (
+    metricQuery: MetricQuery,
+    keptMetricIds: Set<string>,
+): TableCalculation[] =>
+    metricQuery.tableCalculations.filter((calc) => {
+        const references = getTotalableReferences(calc);
+        return (
+            references !== null &&
+            references.length > 0 &&
+            references.every((ref) => keptMetricIds.has(ref))
+        );
+    });
 
 const assertNoBlockingFilters = (
     metricQuery: MetricQuery,
@@ -36,15 +114,21 @@ export const getGrandTotalMetricQuery = (
     metricQuery: MetricQuery,
 ): MetricQuery => {
     const popMetricIds = getPopMetricIds(metricQuery);
+    const keptMetrics = metricQuery.metrics.filter(
+        (id) => !popMetricIds.has(id),
+    );
 
     const totalQuery: MetricQuery = {
         ...metricQuery,
         limit: 1,
-        tableCalculations: [],
+        tableCalculations: getTotalableTableCalculations(
+            metricQuery,
+            new Set(keptMetrics),
+        ),
         sorts: [],
         dimensions: [],
         customDimensions: metricQuery.customDimensions,
-        metrics: metricQuery.metrics.filter((id) => !popMetricIds.has(id)),
+        metrics: keptMetrics,
         additionalMetrics: (metricQuery.additionalMetrics ?? []).filter(
             (am) => !isPeriodOverPeriodAdditionalMetric(am),
         ),
@@ -94,15 +178,19 @@ export const getColumnTotalQueryFromSource = (
 
     // PoP entries would fail validation once the index dim is dropped.
     const popMetricIds = getPopMetricIds(source.metricQuery);
+    const keptMetrics = source.metricQuery.metrics.filter(
+        (id) => !popMetricIds.has(id),
+    );
 
     const totalsMetricQuery: MetricQuery = {
         ...source.metricQuery,
         dimensions: groupByFieldIds,
         sorts: [],
-        tableCalculations: [],
-        metrics: source.metricQuery.metrics.filter(
-            (id) => !popMetricIds.has(id),
+        tableCalculations: getTotalableTableCalculations(
+            source.metricQuery,
+            new Set(keptMetrics),
         ),
+        metrics: keptMetrics,
         additionalMetrics: (source.metricQuery.additionalMetrics ?? []).filter(
             (am) => !isPeriodOverPeriodAdditionalMetric(am),
         ),
@@ -161,15 +249,19 @@ export const getColumnSubtotalQueryFromSource = (
     }
 
     const popMetricIds = getPopMetricIds(source.metricQuery);
+    const keptMetrics = source.metricQuery.metrics.filter(
+        (id) => !popMetricIds.has(id),
+    );
 
     const subtotalMetricQuery: MetricQuery = {
         ...source.metricQuery,
         dimensions: [...new Set([...subtotalDimensions, ...groupByFieldIds])],
         sorts: [],
-        tableCalculations: [],
-        metrics: source.metricQuery.metrics.filter(
-            (id) => !popMetricIds.has(id),
+        tableCalculations: getTotalableTableCalculations(
+            source.metricQuery,
+            new Set(keptMetrics),
         ),
+        metrics: keptMetrics,
         additionalMetrics: (source.metricQuery.additionalMetrics ?? []).filter(
             (am) => !isPeriodOverPeriodAdditionalMetric(am),
         ),
@@ -234,15 +326,19 @@ export const getRowTotalQueryFromSource = (
     // collapsed pivot, and keeping the two transforms symmetric makes the
     // contract easier to reason about.
     const popMetricIds = getPopMetricIds(source.metricQuery);
+    const keptMetrics = source.metricQuery.metrics.filter(
+        (id) => !popMetricIds.has(id),
+    );
 
     const totalsMetricQuery: MetricQuery = {
         ...source.metricQuery,
         dimensions: indexFieldIds,
         sorts: [],
-        tableCalculations: [],
-        metrics: source.metricQuery.metrics.filter(
-            (id) => !popMetricIds.has(id),
+        tableCalculations: getTotalableTableCalculations(
+            source.metricQuery,
+            new Set(keptMetrics),
         ),
+        metrics: keptMetrics,
         additionalMetrics: (source.metricQuery.additionalMetrics ?? []).filter(
             (am) => !isPeriodOverPeriodAdditionalMetric(am),
         ),

--- a/packages/formula/src/ast.ts
+++ b/packages/formula/src/ast.ts
@@ -54,6 +54,62 @@ export const isAggregateCall = (node: ASTNode): boolean => {
     }
 };
 
+// True if the formula contains any aggregate (SUM, COUNT, ...) or window
+// function (WindowedAggregate, WindowFn, MovingWindowFn). Such formulas can't
+// be safely re-totaled by re-applying them to an aggregated totals row, so
+// callers use this to exclude them.
+export const containsAggregateOrWindow = (node: ASTNode): boolean => {
+    switch (node.type) {
+        case 'WindowedAggregate':
+        case 'WindowFn':
+        case 'MovingWindowFn':
+        case 'ConditionalAggregate':
+        case 'CountIf':
+        case 'CountDistinct':
+            return true;
+        case 'ColumnRef':
+        case 'NumberLiteral':
+        case 'StringLiteral':
+        case 'BooleanLiteral':
+        case 'ZeroArgFn':
+            return false;
+        case 'BinaryOp':
+        case 'Comparison':
+        case 'Logical':
+            return (
+                containsAggregateOrWindow(node.left) ||
+                containsAggregateOrWindow(node.right)
+            );
+        case 'UnaryOp':
+            return containsAggregateOrWindow(node.operand);
+        case 'If':
+            return (
+                containsAggregateOrWindow(node.condition) ||
+                containsAggregateOrWindow(node.then) ||
+                (node.else ? containsAggregateOrWindow(node.else) : false)
+            );
+        case 'SingleArgFn':
+            return isAggregateCall(node) || containsAggregateOrWindow(node.arg);
+        case 'ZeroOrOneArgFn':
+            return (
+                isAggregateCall(node) ||
+                (node.arg ? containsAggregateOrWindow(node.arg) : false)
+            );
+        case 'OneOrTwoArgFn':
+            return (
+                isAggregateCall(node) ||
+                node.args.some((arg) => containsAggregateOrWindow(arg))
+            );
+        case 'TwoArgFn':
+        case 'ThreeArgFn':
+        case 'VariadicFn':
+        case 'DateFn':
+            return node.args.some((arg) => containsAggregateOrWindow(arg));
+        default:
+            return assertUnreachable(node, `Unknown AST node type`);
+    }
+};
+
 export const extractColumnRefs = (node: ASTNode): string[] => {
     switch (node.type) {
         case 'ColumnRef':

--- a/packages/formula/src/index.ts
+++ b/packages/formula/src/index.ts
@@ -23,7 +23,7 @@ export type {
     FunctionDefinitionFor,
 } from './functions';
 export { parse } from './compiler';
-export { extractColumnRefs } from './ast';
+export { extractColumnRefs, containsAggregateOrWindow } from './ast';
 export { FUNCTION_CATALOG, FUNCTION_DEFINITIONS } from './functions';
 
 // Dialects the formula package can compile to. Consumers (backend mapper,

--- a/packages/formula/tests/containsAggregateOrWindow.test.ts
+++ b/packages/formula/tests/containsAggregateOrWindow.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { containsAggregateOrWindow } from '../src/ast';
+import { parse } from '../src/compiler';
+
+describe('containsAggregateOrWindow', () => {
+    it.each([
+        ['=A', false],
+        ['=100 * A / B', false],
+        ['=A + B - C', false],
+        ['=IF(A > 0, B, C)', false],
+        ['=ABS(A - B)', false],
+        ['=SUM(A)', true],
+        ['=SUM(A) / SUM(B)', true],
+        ['=COUNT(A)', true],
+        ['=COUNTIF(A > 0)', true],
+        ['=COUNT(DISTINCT A)', true],
+        ['=SUMIF(A, B = "EU")', true],
+        ['=SUM(A) OVER (PARTITION BY B)', true],
+        ['=AVG(A) OVER (ORDER BY B DESC)', true],
+        ['=SUM(A) OVER ()', true],
+    ])('%s -> %s', (formula, expected) => {
+        expect(containsAggregateOrWindow(parse(formula))).toBe(expected);
+    });
+});


### PR DESCRIPTION
Closes: PROD-638
Closes: #4067

### Description:

Table calculation column/row/subtotal totals were always blank because the v2 calculate-total path stripped all table calcs from the re-run query. This keeps the subset that depends only on aggregated metrics, so their totals are computed by re-applying the formula to the aggregated metric row (e.g. `100 * sum(profit) / sum(revenue)`) across grand, column, row, and subtotal queries. Everything else is left blank since it is meaningless once the query collapses to a totals row. A new `containsAggregateOrWindow` helper in `@lightdash/formula` detects unsafe formulas, and unresolvable references are treated as non-totalable rather than failing the whole totals query.

### Supported (total is computed)

- **SQL table calcs** (`${table.field}`) that reference **only metrics** — pure per-row scalar arithmetic, e.g. `100 * ${orders.profit} / ${orders.revenue}`.
- **Formula table calcs** that reference **only metrics** and contain no aggregates/window functions, e.g. `=100 * orders_profit / orders_revenue`.

These are correct for grand totals, pivot column totals, pivot row totals, and subtotals, because the formula is applied to the already-aggregated metric values.

### Unsupported (total is left blank)

- **Template table calcs** (all are window-function based): Percent change from previous, Percent of previous value, Percent of column total, Rank in column, Running total, Window function.
- Calcs that reference a **dimension** (only metric references can be totaled).
- SQL **row functions**: `row()`, `offset()`, `index()`, `offset_list()`, `lookup()`, `list()`.
- SQL **pivot functions**: `pivot_column()`, `pivot_index()`, `pivot_offset()`, `pivot_offset_list()`, `pivot_row()`, `pivot_where()`.
- SQL **aggregate-reference functions**: `total()`, `row_total()`.
- SQL containing a raw window clause (`... OVER (...)`).
- **Formula** calcs containing aggregates (`SUM`, `COUNT`, `AVG`, ...) or window functions.
- Calcs referencing a dropped period-over-period metric, or with unresolvable references.

### Demo
https://lightdash-pr-23891.lightdash.okteto.dev/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/1020ecfd-73b5-4daa-9620-a1866426abf1/edit

<img width="3702" height="2578" alt="CleanShot 2026-06-04 at 14 47 24@2x" src="https://github.com/user-attachments/assets/fc8a73f8-193d-4c30-bb41-105426087c75" />

