### PR TITLE
feat(ai-agents): add chat content mentions

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -437,3 +437,98 @@
         border: 1px solid var(--mantine-color-indigo-7);
     }
 }
+
+.contentMention {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    max-width: min(100%, 340px);
+    padding: 2px 7px 2px 4px;
+    border-radius: var(--mantine-radius-md);
+    font-weight: 500;
+    font-size: 0.95em;
+    line-height: 1.35;
+    vertical-align: baseline;
+    white-space: nowrap;
+    box-decoration-break: clone;
+
+    @mixin light {
+        color: var(--mantine-color-ldDark-7);
+        background-color: var(--mantine-color-white);
+        border: 1px solid var(--mantine-color-ldGray-3);
+    }
+
+    @mixin dark {
+        color: var(--mantine-color-ldGray-1);
+        background-color: var(--mantine-color-ldDark-6);
+        border: 1px solid var(--mantine-color-ldDark-4);
+    }
+}
+
+.contentMentionIcon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    flex: 0 0 18px;
+    border-radius: var(--mantine-radius-sm);
+
+    @mixin light {
+        color: var(--mantine-color-blue-7);
+        background-color: var(--mantine-color-ldGray-1);
+        box-shadow: inset 0 0 0 1px var(--mantine-color-ldGray-3);
+    }
+
+    @mixin dark {
+        color: var(--mantine-color-blue-3);
+        background-color: var(--mantine-color-ldDark-5);
+        box-shadow: inset 0 0 0 1px var(--mantine-color-ldDark-3);
+    }
+}
+
+.contentMention[data-content-type='dashboard'] .contentMentionIcon {
+    @mixin light {
+        color: var(--mantine-color-green-7);
+    }
+
+    @mixin dark {
+        color: var(--mantine-color-green-3);
+    }
+}
+
+.contentMentionIcon::before {
+    content: '';
+    display: block;
+    width: 12px;
+    height: 12px;
+    background:
+        linear-gradient(currentColor 0 0) 1px 8px / 2px 3px no-repeat,
+        linear-gradient(currentColor 0 0) 5px 5px / 2px 6px no-repeat,
+        linear-gradient(currentColor 0 0) 9px 2px / 2px 9px no-repeat,
+        linear-gradient(currentColor 0 0) 0 11px / 12px 1px no-repeat;
+    border-radius: 1px;
+}
+
+.contentMentionIcon[data-icon-type='dashboard']::before {
+    background:
+        linear-gradient(currentColor 0 0) 1px 1px / 4px 4px no-repeat,
+        linear-gradient(currentColor 0 0) 7px 1px / 4px 3px no-repeat,
+        linear-gradient(currentColor 0 0) 1px 7px / 4px 4px no-repeat,
+        linear-gradient(currentColor 0 0) 7px 6px / 4px 5px no-repeat;
+}
+
+.contentMentionLabel {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.contentMentionSuggestionItem {
+    padding: 6px var(--mantine-spacing-xs);
+}
+
+.contentMentionSuggestionText {
+    min-width: 0;
+    flex: 1;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -1,6 +1,8 @@
 import {
     FeatureFlags,
     type AgentSuggestion,
+    type AiPromptContextInput,
+    type AiPromptContextItem,
     type AiModelOption,
 } from '@lightdash/common';
 import {
@@ -36,6 +38,12 @@ import { AgentSelector } from '../AgentSelector';
 import { type Agent } from '../AgentSelector/AgentSelectorUtils';
 import styles from './AgentChatInput.module.css';
 import { AgentSuggestionChips } from './AgentSuggestionChips';
+import {
+    createContentMentionExtension,
+    extractContentMentionContext,
+    isContentMentionSuggestionActive,
+    type ContentMentionSuggestionItem,
+} from './contentMentions';
 import { getAgentSuggestionModes } from './suggestionModes';
 
 const SUGGESTION_CHIP_MENTION_NAME = 'suggestionChip';
@@ -63,6 +71,8 @@ const SuggestionChipMention = Mention.extend({
 type SubmitArgs = {
     message: string;
     toolHints: string[];
+    context?: AiPromptContextInput;
+    optimisticContext?: AiPromptContextItem[];
 };
 
 interface AgentChatInputProps {
@@ -90,6 +100,7 @@ interface AgentChatInputProps {
     fullWidth?: boolean;
     clearOnSubmit?: boolean;
     showSuggestions?: boolean;
+    contentMentionPriorityItems?: ContentMentionSuggestionItem[];
 }
 
 const extractToolHints = (editor: Editor | null): string[] => {
@@ -131,6 +142,7 @@ export const AgentChatInput = ({
     fullWidth = false,
     clearOnSubmit = true,
     showSuggestions = true,
+    contentMentionPriorityItems = [],
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
@@ -147,6 +159,10 @@ export const AgentChatInput = ({
     disabledRef.current = disabled;
     const clearOnSubmitRef = useRef(clearOnSubmit);
     clearOnSubmitRef.current = clearOnSubmit;
+    const projectUuidRef = useRef(projectUuid);
+    projectUuidRef.current = projectUuid;
+    const contentMentionPriorityItemsRef = useRef(contentMentionPriorityItems);
+    contentMentionPriorityItemsRef.current = contentMentionPriorityItems;
 
     // Hide the chip strip while the user is scrolled away from the input.
     // Reappears as they scroll back toward the bottom of the thread — chips
@@ -256,6 +272,10 @@ export const AgentChatInput = ({
                         : '',
                 ],
             }),
+            createContentMentionExtension({
+                getProjectUuid: () => projectUuidRef.current,
+                getPriorityItems: () => contentMentionPriorityItemsRef.current,
+            }),
         ],
         editable: !disabled,
         autofocus: true,
@@ -272,17 +292,23 @@ export const AgentChatInput = ({
                     !event.shiftKey &&
                     !event.isComposing
                 ) {
+                    const ed = editorRef.current;
+                    if (isContentMentionSuggestionActive(ed)) {
+                        return false;
+                    }
                     if (loadingRef.current || disabledRef.current) {
                         return true;
                     }
-                    const ed = editorRef.current;
                     if (!ed) return false;
                     const text = ed.getText().trim();
                     if (!text) return true;
                     event.preventDefault();
+                    const mentionedContext = extractContentMentionContext(ed);
                     onSubmitRef.current({
                         message: text,
                         toolHints: extractToolHints(ed),
+                        context: mentionedContext.context,
+                        optimisticContext: mentionedContext.optimisticContext,
                     });
                     if (clearOnSubmitRef.current) {
                         ed.commands.clearContent();
@@ -399,6 +425,7 @@ export const AgentChatInput = ({
         onSubmitRef.current({
             message: text,
             toolHints: extractToolHints(ed),
+            ...extractContentMentionContext(ed),
         });
         if (clearOnSubmitRef.current) {
             ed.commands.clearContent();

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
@@ -1,0 +1,111 @@
+import { ChartKind, ContentType } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    buildContentMentionSuggestionItems,
+    contextItemsToContentMentionSuggestions,
+    mergeAiPromptContextInput,
+} from './contentMentions';
+
+describe('contentMentions', () => {
+    it('dedupes prompt context preserving first occurrence', () => {
+        expect(
+            mergeAiPromptContextInput(
+                [
+                    {
+                        type: 'dashboard',
+                        dashboardUuid: 'dashboard-1',
+                        dashboardSlug: 'exec-dashboard',
+                    },
+                    {
+                        type: 'chart',
+                        chartUuid: 'chart-1',
+                        chartSlug: 'revenue-chart',
+                    },
+                ],
+                [
+                    {
+                        type: 'chart',
+                        chartUuid: 'chart-1',
+                        chartSlug: 'duplicate-chart',
+                    },
+                ],
+            ),
+        ).toEqual([
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                dashboardSlug: 'exec-dashboard',
+            },
+            {
+                type: 'chart',
+                chartUuid: 'chart-1',
+                chartSlug: 'revenue-chart',
+            },
+        ]);
+    });
+
+    it('maps existing context into mention suggestions', () => {
+        expect(
+            contextItemsToContentMentionSuggestions(
+                [
+                    {
+                        type: 'chart',
+                        chartUuid: 'chart-1',
+                        chartSlug: 'revenue-chart',
+                        displayName: 'Revenue',
+                        pinnedVersionUuid: null,
+                        runtimeOverrides: null,
+                        chartKind: ChartKind.VERTICAL_BAR,
+                    },
+                ],
+                'thread',
+            ),
+        ).toEqual([
+            {
+                id: 'thread:chart:chart-1',
+                label: 'Revenue',
+                contentType: ContentType.CHART,
+                uuid: 'chart-1',
+                slug: 'revenue-chart',
+                chartKind: ChartKind.VERTICAL_BAR,
+                group: 'thread',
+            },
+        ]);
+    });
+
+    it('filters priority suggestions by query when no project search is available', async () => {
+        await expect(
+            buildContentMentionSuggestionItems({
+                projectUuid: undefined,
+                query: 'rev',
+                priorityItems: [
+                    {
+                        id: 'current:dashboard:dashboard-1',
+                        label: 'Executive dashboard',
+                        contentType: ContentType.DASHBOARD,
+                        uuid: 'dashboard-1',
+                        slug: 'exec-dashboard',
+                        group: 'current',
+                    },
+                    {
+                        id: 'dashboardTile:chart:chart-1',
+                        label: 'Revenue by month',
+                        contentType: ContentType.CHART,
+                        uuid: 'chart-1',
+                        slug: 'revenue-by-month',
+                        group: 'dashboardTile',
+                    },
+                ],
+            }),
+        ).resolves.toEqual([
+            {
+                id: 'dashboardTile:chart:chart-1',
+                label: 'Revenue by month',
+                contentType: ContentType.CHART,
+                uuid: 'chart-1',
+                slug: 'revenue-by-month',
+                group: 'dashboardTile',
+            },
+        ]);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -1,0 +1,533 @@
+import {
+    ChartSourceType,
+    ContentType,
+    type AiPromptContextInput,
+    type AiPromptContextItem,
+    type ApiContentResponse,
+    type ChartKind,
+    type SummaryContent,
+} from '@lightdash/common';
+import { Group, Text } from '@mantine-8/core';
+import { IconCircleCheck, IconLayoutDashboard } from '@tabler/icons-react';
+import Mention, { type MentionOptions } from '@tiptap/extension-mention';
+import { type DOMOutputSpec } from '@tiptap/pm/model';
+import { PluginKey } from '@tiptap/pm/state';
+import { ReactRenderer, type Editor } from '@tiptap/react';
+import tippy, { type Instance as TippyInstance } from 'tippy.js';
+import { lightdashApi } from '../../../../../api';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { PolymorphicGroupButton } from '../../../../../components/common/PolymorphicGroupButton';
+import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
+import {
+    SuggestionList,
+    type SuggestionItem,
+    type SuggestionListRef,
+} from '../../../../../components/common/SuggestionList/SuggestionList';
+import suggestionStyles from '../../../../../components/common/SuggestionList/SuggestionList.module.css';
+import styles from './AgentChatInput.module.css';
+
+const CONTENT_MENTION_NAME = 'contentMention';
+
+const contentMentionPluginKey = new PluginKey('contentMention');
+
+const DOM_RECT_FALLBACK: DOMRect = {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+    toJSON() {
+        return {};
+    },
+};
+
+type ContentMentionGroup = 'thread' | 'current' | 'dashboardTile' | 'search';
+
+export type ContentMentionSuggestionItem = SuggestionItem & {
+    contentType: ContentType.CHART | ContentType.DASHBOARD;
+    uuid: string;
+    slug: string | null;
+    chartKind?: ChartKind | null;
+    spaceName?: string | null;
+    group: ContentMentionGroup;
+    dashboardUuid?: string | null;
+    dashboardSlug?: string | null;
+    dashboardName?: string | null;
+    verified?: boolean;
+};
+
+const groupLabels: Record<ContentMentionGroup, string> = {
+    thread: 'Already mentioned',
+    current: 'Current page',
+    dashboardTile: 'Dashboard tiles',
+    search: 'Search results',
+};
+
+export const isContentMentionSuggestionActive = (editor: Editor | null) => {
+    if (!editor) return false;
+    const state = contentMentionPluginKey.getState(editor.state) as
+        | { active?: boolean }
+        | undefined;
+    return state?.active === true;
+};
+
+const getContentMentionContentType = (value: unknown) =>
+    value === ContentType.DASHBOARD ? ContentType.DASHBOARD : ContentType.CHART;
+
+const getContentMentionIconSpec = (
+    contentType: ContentType.CHART | ContentType.DASHBOARD,
+): DOMOutputSpec => [
+    'span',
+    {
+        class: styles.contentMentionIcon,
+        'aria-hidden': 'true',
+        'data-icon-type': contentType,
+    },
+];
+
+const getContextKey = (item: AiPromptContextInput[number]) =>
+    item.type === 'chart'
+        ? `chart:${item.chartUuid}`
+        : `dashboard:${item.dashboardUuid}`;
+
+export const mergeAiPromptContextInput = (
+    ...contextGroups: Array<AiPromptContextInput | undefined>
+): AiPromptContextInput | undefined => {
+    const seen = new Set<string>();
+    const merged = contextGroups
+        .flatMap((context) => context ?? [])
+        .filter((item) => {
+            const key = getContextKey(item);
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
+    return merged.length > 0 ? merged : undefined;
+};
+
+export const mergeAiPromptContextItems = (
+    ...contextGroups: Array<AiPromptContextItem[] | undefined>
+): AiPromptContextItem[] | undefined => {
+    const seen = new Set<string>();
+    const merged = contextGroups
+        .flatMap((context) => context ?? [])
+        .filter((item) => {
+            const key =
+                item.type === 'chart'
+                    ? `chart:${item.chartUuid}`
+                    : `dashboard:${item.dashboardUuid}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
+    return merged.length > 0 ? merged : undefined;
+};
+
+export const contextItemsToContentMentionSuggestions = (
+    context: AiPromptContextItem[],
+    group: ContentMentionGroup,
+): ContentMentionSuggestionItem[] =>
+    context.map((item) =>
+        item.type === 'chart'
+            ? {
+                  id: `${group}:chart:${item.chartUuid}`,
+                  label: item.displayName ?? item.chartSlug ?? 'Chart',
+                  contentType: ContentType.CHART,
+                  uuid: item.chartUuid,
+                  slug: item.chartSlug,
+                  chartKind: item.chartKind,
+                  group,
+              }
+            : {
+                  id: `${group}:dashboard:${item.dashboardUuid}`,
+                  label: item.displayName ?? item.dashboardSlug ?? 'Dashboard',
+                  contentType: ContentType.DASHBOARD,
+                  uuid: item.dashboardUuid,
+                  slug: item.dashboardSlug,
+                  group,
+              },
+    );
+
+const summaryContentToSuggestion = (
+    item: SummaryContent,
+): ContentMentionSuggestionItem | null => {
+    if (item.contentType === ContentType.CHART) {
+        if (item.source !== ChartSourceType.DBT_EXPLORE) return null;
+        return {
+            id: `search:chart:${item.uuid}`,
+            label: item.name,
+            contentType: ContentType.CHART,
+            uuid: item.uuid,
+            slug: item.slug,
+            chartKind: item.chartKind,
+            spaceName: item.space.name,
+            group: 'search',
+            verified: item.verification !== null,
+        };
+    }
+
+    if (item.contentType === ContentType.DASHBOARD) {
+        return {
+            id: `search:dashboard:${item.uuid}`,
+            label: item.name,
+            contentType: ContentType.DASHBOARD,
+            uuid: item.uuid,
+            slug: item.slug,
+            spaceName: item.space.name,
+            group: 'search',
+            verified: item.verification !== null,
+        };
+    }
+
+    return null;
+};
+
+const getSearchSuggestions = async (
+    projectUuid: string,
+    query: string,
+): Promise<ContentMentionSuggestionItem[]> => {
+    const params = new URLSearchParams();
+    params.append('projectUuids', projectUuid);
+    params.append('contentTypes', ContentType.CHART);
+    params.append('contentTypes', ContentType.DASHBOARD);
+    params.set('pageSize', '20');
+    params.set('page', '1');
+    if (query.trim()) params.set('search', query.trim());
+
+    const results = await lightdashApi<ApiContentResponse['results']>({
+        version: 'v2',
+        url: `/content?${params.toString()}`,
+        method: 'GET',
+        body: undefined,
+    }).catch(() => ({ data: [] }));
+
+    return results.data
+        .map(summaryContentToSuggestion)
+        .filter((item): item is ContentMentionSuggestionItem => item !== null);
+};
+
+export const buildContentMentionSuggestionItems = async ({
+    projectUuid,
+    query,
+    priorityItems,
+}: {
+    projectUuid: string | undefined;
+    query: string;
+    priorityItems: ContentMentionSuggestionItem[];
+}) => {
+    const normalizedQuery = query.trim().toLowerCase();
+    const matchingPriorityItems = priorityItems.filter((item) =>
+        item.label.toLowerCase().includes(normalizedQuery),
+    );
+    const searchItems = projectUuid
+        ? await getSearchSuggestions(projectUuid, query)
+        : [];
+
+    const seen = new Set<string>();
+    return [...matchingPriorityItems, ...searchItems].filter((item) => {
+        const key = `${item.contentType}:${item.uuid}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
+};
+
+const renderContentMentionItem = (
+    item: ContentMentionSuggestionItem,
+    isSelected: boolean,
+    onClick: () => void,
+) => {
+    const Icon =
+        item.contentType === ContentType.DASHBOARD
+            ? IconLayoutDashboard
+            : getChartIcon(item.chartKind ?? undefined);
+    const iconColor =
+        item.contentType === ContentType.DASHBOARD ? 'green.7' : 'blue.7';
+    const detail = item.spaceName ?? groupLabels[item.group];
+
+    return (
+        <PolymorphicGroupButton
+            onClick={onClick}
+            className={`${suggestionStyles.suggestionItem} ${styles.contentMentionSuggestionItem}`}
+            data-selected={isSelected}
+        >
+            <Group wrap="nowrap" gap="xs" w="100%">
+                <MantineIcon icon={Icon} size="sm" color={iconColor} />
+                <div className={styles.contentMentionSuggestionText}>
+                    <Group gap={4} wrap="nowrap">
+                        <Text size="xs" truncate fw={500}>
+                            {item.label}
+                        </Text>
+                        {item.verified && (
+                            <MantineIcon
+                                icon={IconCircleCheck}
+                                size="xs"
+                                color="green.6"
+                            />
+                        )}
+                    </Group>
+                    <Text size="xs" c="dimmed" truncate>
+                        {detail}
+                    </Text>
+                </div>
+            </Group>
+        </PolymorphicGroupButton>
+    );
+};
+
+const generateContentMentionSuggestion = ({
+    getProjectUuid,
+    getPriorityItems,
+}: {
+    getProjectUuid: () => string | undefined;
+    getPriorityItems: () => ContentMentionSuggestionItem[];
+}): MentionOptions['suggestion'] => ({
+    char: '@',
+    allowSpaces: true,
+    pluginKey: contentMentionPluginKey,
+    items: ({ query }) =>
+        buildContentMentionSuggestionItems({
+            projectUuid: getProjectUuid(),
+            query,
+            priorityItems: getPriorityItems(),
+        }),
+    command: ({ editor, range, props }) => {
+        const item = props as ContentMentionSuggestionItem;
+        editor
+            .chain()
+            .focus()
+            .insertContentAt(range, [
+                {
+                    type: CONTENT_MENTION_NAME,
+                    attrs: {
+                        contentType: item.contentType,
+                        uuid: item.uuid,
+                        slug: item.slug,
+                        label: item.label,
+                        chartKind: item.chartKind ?? null,
+                        dashboardUuid: item.dashboardUuid ?? null,
+                        dashboardSlug: item.dashboardSlug ?? null,
+                        dashboardName: item.dashboardName ?? null,
+                    },
+                },
+                { type: 'text', text: ' ' },
+            ])
+            .run();
+    },
+    render: () => {
+        let component: ReactRenderer<SuggestionListRef> | undefined;
+        let popup: TippyInstance | undefined;
+
+        return {
+            onStart: (props) => {
+                component = new ReactRenderer(SuggestionList, {
+                    props: {
+                        ...props,
+                        renderItem: renderContentMentionItem,
+                        getGroupKey: (item: ContentMentionSuggestionItem) =>
+                            item.group,
+                        groupLabels,
+                        emptyMessage: 'No content found',
+                    },
+                    editor: props.editor,
+                });
+
+                popup = tippy('body', {
+                    getReferenceClientRect: () =>
+                        props.clientRect?.() ?? DOM_RECT_FALLBACK,
+                    appendTo: () => document.body,
+                    content: component.element,
+                    showOnCreate: true,
+                    interactive: true,
+                    trigger: 'manual',
+                    placement: 'bottom-start',
+                    maxWidth: 'none',
+                })[0];
+            },
+            onUpdate: (props) => {
+                component?.updateProps({
+                    ...props,
+                    renderItem: renderContentMentionItem,
+                    getGroupKey: (item: ContentMentionSuggestionItem) =>
+                        item.group,
+                    groupLabels,
+                    emptyMessage: 'No content found',
+                });
+                popup?.setProps({
+                    getReferenceClientRect: () =>
+                        props.clientRect?.() ?? DOM_RECT_FALLBACK,
+                });
+            },
+            onKeyDown: (props) => {
+                if (props.event.key === 'Escape') {
+                    popup?.hide();
+                    return true;
+                }
+                return component?.ref?.onKeyDown(props) ?? false;
+            },
+            onExit: () => {
+                popup?.destroy();
+                component?.destroy();
+                popup = undefined;
+                component = undefined;
+            },
+        };
+    },
+});
+
+export const createContentMentionExtension = ({
+    getProjectUuid,
+    getPriorityItems,
+}: {
+    getProjectUuid: () => string | undefined;
+    getPriorityItems: () => ContentMentionSuggestionItem[];
+}) =>
+    Mention.extend({
+        name: CONTENT_MENTION_NAME,
+        atom: true,
+        addAttributes() {
+            return {
+                contentType: { default: null },
+                uuid: { default: null },
+                slug: { default: null },
+                label: { default: null },
+                chartKind: { default: null },
+                dashboardUuid: { default: null },
+                dashboardSlug: { default: null },
+                dashboardName: { default: null },
+            };
+        },
+        addKeyboardShortcuts() {
+            return {
+                Backspace: () =>
+                    this.editor.commands.command(({ tr, state }) => {
+                        const { selection } = state;
+                        const { empty, anchor } = selection;
+                        if (!empty || anchor <= 0) return false;
+                        let deleted = false;
+                        state.doc.nodesBetween(
+                            Math.max(0, anchor - 1),
+                            anchor,
+                            (node, pos) => {
+                                if (node.type.name === this.name) {
+                                    tr.delete(pos, pos + node.nodeSize);
+                                    deleted = true;
+                                    return false;
+                                }
+                            },
+                        );
+                        return deleted;
+                    }),
+            };
+        },
+    }).configure({
+        suggestion: generateContentMentionSuggestion({
+            getProjectUuid,
+            getPriorityItems,
+        }),
+        renderText: ({ node }) =>
+            typeof node.attrs.label === 'string' ? node.attrs.label : '',
+        renderHTML: ({ node }) => {
+            const contentType = getContentMentionContentType(
+                node.attrs.contentType,
+            );
+            return [
+                'span',
+                {
+                    class: styles.contentMention,
+                    'data-content-type': contentType,
+                },
+                getContentMentionIconSpec(contentType),
+                [
+                    'span',
+                    { class: styles.contentMentionLabel },
+                    typeof node.attrs.label === 'string'
+                        ? node.attrs.label
+                        : '',
+                ],
+            ];
+        },
+    });
+
+export const extractContentMentionContext = (
+    editor: Editor | null,
+): {
+    context: AiPromptContextInput | undefined;
+    optimisticContext: AiPromptContextItem[] | undefined;
+} => {
+    if (!editor) return { context: undefined, optimisticContext: undefined };
+
+    const context: AiPromptContextInput = [];
+    const optimisticContext: AiPromptContextItem[] = [];
+
+    editor.state.doc.descendants((node) => {
+        if (node.type.name !== CONTENT_MENTION_NAME) return;
+
+        const attrs = node.attrs as {
+            contentType?: ContentType;
+            uuid?: string;
+            slug?: string | null;
+            label?: string | null;
+            chartKind?: ChartKind | null;
+            dashboardUuid?: string | null;
+            dashboardSlug?: string | null;
+            dashboardName?: string | null;
+        };
+
+        if (attrs.dashboardUuid && attrs.contentType === ContentType.CHART) {
+            context.push({
+                type: 'dashboard',
+                dashboardUuid: attrs.dashboardUuid,
+                dashboardSlug: attrs.dashboardSlug ?? null,
+            });
+            optimisticContext.push({
+                type: 'dashboard',
+                dashboardUuid: attrs.dashboardUuid,
+                dashboardSlug: attrs.dashboardSlug ?? null,
+                displayName: attrs.dashboardName ?? null,
+                pinnedVersionUuid: null,
+            });
+        }
+
+        if (attrs.contentType === ContentType.CHART && attrs.uuid) {
+            context.push({
+                type: 'chart',
+                chartUuid: attrs.uuid,
+                chartSlug: attrs.slug ?? null,
+            });
+            optimisticContext.push({
+                type: 'chart',
+                chartUuid: attrs.uuid,
+                chartSlug: attrs.slug ?? null,
+                displayName: attrs.label ?? null,
+                pinnedVersionUuid: null,
+                runtimeOverrides: null,
+                chartKind: attrs.chartKind ?? null,
+            });
+            return;
+        }
+
+        if (attrs.contentType === ContentType.DASHBOARD && attrs.uuid) {
+            context.push({
+                type: 'dashboard',
+                dashboardUuid: attrs.uuid,
+                dashboardSlug: attrs.slug ?? null,
+            });
+            optimisticContext.push({
+                type: 'dashboard',
+                dashboardUuid: attrs.uuid,
+                dashboardSlug: attrs.slug ?? null,
+                displayName: attrs.label ?? null,
+                pinnedVersionUuid: null,
+            });
+        }
+    });
+
+    return {
+        context: mergeAiPromptContextInput(context),
+        optimisticContext: mergeAiPromptContextItems(optimisticContext),
+    };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -1,6 +1,12 @@
 import { type AiAgentSummary } from '@lightdash/common';
 import { Center, Group, Loader, Stack, Text } from '@mantine-8/core';
-import { useCallback, useState, type CSSProperties, type FC } from 'react';
+import {
+    useCallback,
+    useMemo,
+    useState,
+    type CSSProperties,
+    type FC,
+} from 'react';
 import { createPath, useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import useApp from '../../../../../providers/App/useApp';
@@ -26,6 +32,11 @@ import { getDashboardNavigationUrlFromContentToolResult } from '../../utils/cont
 import { AiAgentNewThreadMcpConnections } from '../AiAgentNewThreadMcpConnections';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../ChatElements/AgentChatInput';
+import {
+    contextItemsToContentMentionSuggestions,
+    mergeAiPromptContextInput,
+    mergeAiPromptContextItems,
+} from '../ChatElements/contentMentions';
 import { PinnedContextCard } from '../PinnedContextCard/PinnedContextCard';
 import styles from './AiAgentsLauncher.module.css';
 import { PanelHeader } from './PanelHeader';
@@ -101,6 +112,7 @@ const NewThreadPanel: FC<{
     const {
         contextInput,
         previewItems,
+        contentMentionItems,
         isReady: isPinnedContextReady,
     } = usePinnedContext({
         projectUuid,
@@ -158,17 +170,25 @@ const NewThreadPanel: FC<{
     const handleSubmit = ({
         message,
         toolHints,
+        context,
+        optimisticContext,
     }: {
         message: string;
         toolHints: string[];
+        context?: typeof contextInput;
+        optimisticContext?: typeof previewItems;
     }) => {
         if (!isPinnedContextReady) return;
+        const mergedContext = mergeAiPromptContextInput(contextInput, context);
+        const mergedOptimisticContext = mergeAiPromptContextItems(
+            previewItems,
+            optimisticContext,
+        );
         void createAgentThread({
             agentUuid: agent.uuid,
             prompt: message,
-            context: contextInput.length > 0 ? contextInput : undefined,
-            optimisticContext:
-                previewItems.length > 0 ? previewItems : undefined,
+            context: mergedContext,
+            optimisticContext: mergedOptimisticContext,
             enableSqlMode: sqlModeAvailable && sqlMode,
             toolHints,
         });
@@ -241,6 +261,7 @@ const NewThreadPanel: FC<{
                     fullWidth
                     sqlMode={sqlModeAvailable ? sqlMode : undefined}
                     onSqlModeChange={sqlModeAvailable ? setSqlMode : undefined}
+                    contentMentionPriorityItems={contentMentionItems}
                 />
             </div>
         </div>
@@ -294,13 +315,29 @@ const ExistingThreadPanel: FC<{
     const dispatchToStore = useAiAgentStoreDispatch();
 
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
+    const contentMentionItems = useMemo(
+        () =>
+            contextItemsToContentMentionSuggestions(
+                thread?.messages.flatMap((message) =>
+                    message.role === 'user' ? message.context : [],
+                ) ?? [],
+                'thread',
+            ),
+        [thread?.messages],
+    );
 
     const handleSubmit = ({
         message,
         toolHints,
+        context,
+        optimisticContext,
     }: {
         message: string;
         toolHints: string[];
+        context?: Parameters<typeof createAgentThreadMessage>[0]['context'];
+        optimisticContext?: Parameters<
+            typeof createAgentThreadMessage
+        >[0]['optimisticContext'];
     }) => {
         const firstAssistantMessage = thread?.messages?.find(
             (m) => m.role === 'assistant',
@@ -309,6 +346,8 @@ const ExistingThreadPanel: FC<{
         void createAgentThreadMessage({
             prompt: message,
             modelConfig,
+            context,
+            optimisticContext,
             enableSqlMode: sqlModeAvailable && sqlMode,
             toolHints,
         });
@@ -380,6 +419,7 @@ const ExistingThreadPanel: FC<{
                         agentUuid={agent.uuid}
                         fullWidth
                         threadUuid={threadId}
+                        contentMentionPriorityItems={contentMentionItems}
                         latestAssistantMessageUuid={
                             [...(thread.messages ?? [])]
                                 .reverse()

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
@@ -1,11 +1,17 @@
 import {
+    ContentType,
     getChartKind,
+    isDashboardChartTileType,
     type AiPromptContextInput,
     type AiPromptContextItem,
 } from '@lightdash/common';
 import { useMemo } from 'react';
 import { useDashboardQuery } from '../../../../hooks/dashboard/useDashboard';
 import { useSavedQuery } from '../../../../hooks/useSavedQuery';
+import {
+    contextItemsToContentMentionSuggestions,
+    type ContentMentionSuggestionItem,
+} from '../components/ChatElements/contentMentions';
 
 type Args = {
     projectUuid: string | undefined;
@@ -110,5 +116,34 @@ export const usePinnedContext = ({
         dashboard?.slug,
     ]);
 
-    return { contextInput, previewItems, isReady };
+    const contentMentionItems = useMemo<ContentMentionSuggestionItem[]>(() => {
+        const dashboardTileItems: ContentMentionSuggestionItem[] =
+            dashboard?.tiles
+                .filter(isDashboardChartTileType)
+                .filter((tile) => !!tile.properties.savedChartUuid)
+                .map((tile) => ({
+                    id: `dashboardTile:chart:${tile.properties.savedChartUuid}`,
+                    label:
+                        (!tile.properties.hideTitle && tile.properties.title) ||
+                        tile.properties.chartName ||
+                        'Chart',
+                    contentType: ContentType.CHART,
+                    uuid: tile.properties.savedChartUuid!,
+                    slug: tile.properties.chartSlug ?? null,
+                    chartKind: tile.properties.lastVersionChartKind ?? null,
+                    group: 'dashboardTile',
+                    dashboardUuid: dashboard.uuid,
+                    dashboardSlug: dashboard.slug,
+                    dashboardName: dashboard.name,
+                    spaceName: dashboard.spaceName,
+                    verified: false,
+                })) ?? [];
+
+        return [
+            ...dashboardTileItems,
+            ...contextItemsToContentMentionSuggestions(previewItems, 'current'),
+        ];
+    }, [dashboard, previewItems]);
+
+    return { contextInput, previewItems, contentMentionItems, isReady };
 };

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,9 +1,10 @@
 import { Center, Loader } from '@mantine-8/core';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useOutletContext, useParams } from 'react-router';
 import useApp from '../../../providers/App/useApp';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
+import { contextItemsToContentMentionSuggestions } from '../../features/aiCopilot/components/ChatElements/contentMentions';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { useAiAgentThreadArtifact } from '../../features/aiCopilot/hooks/useAiAgentThreadArtifact';
@@ -155,17 +156,35 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const activeDisabledReason = disabledReasons.find((r) => r.when);
     const inputDisabled = !!activeDisabledReason;
     const inputDisabledReason = activeDisabledReason?.message;
+    const contentMentionItems = useMemo(
+        () =>
+            contextItemsToContentMentionSuggestions(
+                thread?.messages.flatMap((message) =>
+                    message.role === 'user' ? message.context : [],
+                ) ?? [],
+                'thread',
+            ),
+        [thread?.messages],
+    );
 
     const handleSubmit = ({
         message,
         toolHints,
+        context,
+        optimisticContext,
     }: {
         message: string;
         toolHints: string[];
+        context?: Parameters<typeof createAgentThreadMessage>[0]['context'];
+        optimisticContext?: Parameters<
+            typeof createAgentThreadMessage
+        >[0]['optimisticContext'];
     }) => {
         void createAgentThreadMessage({
             prompt: message,
             modelConfig: threadModelConfig ?? undefined,
+            context,
+            optimisticContext,
             enableSqlMode: sqlModeAvailable && sqlMode,
             toolHints,
         });
@@ -201,6 +220,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                 projectUuid={projectUuid}
                 agentUuid={agentUuid}
                 threadUuid={threadUuid}
+                contentMentionPriorityItems={contentMentionItems}
                 latestAssistantMessageUuid={
                     [...(thread.messages ?? [])]
                         .reverse()

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -1,5 +1,7 @@
 import {
     type AiAgentSummary,
+    type AiPromptContext,
+    type AiPromptContextInput,
     type AiRouterRouteResponseResult,
 } from '@lightdash/common';
 import {
@@ -49,7 +51,9 @@ type Phase =
     | { kind: 'routing' }
     | {
           kind: 'picker';
+          context?: AiPromptContextInput;
           decision: AiRouterRouteResponseResult;
+          optimisticContext?: AiPromptContext;
           prompt: string;
           toolHints: string[];
       }
@@ -130,12 +134,16 @@ const AgentsRouterPage = () => {
     const startThreadForDecision = useCallback(
         async (args: {
             agentUuid: string;
+            context?: AiPromptContextInput;
             decisionUuid: string;
+            optimisticContext?: AiPromptContext;
             prompt: string;
             toolHints: string[];
         }) => {
             const thread = await createThread({
                 agentUuid: args.agentUuid,
+                context: args.context,
+                optimisticContext: args.optimisticContext,
                 prompt: args.prompt,
                 toolHints: args.toolHints,
             });
@@ -151,10 +159,14 @@ const AgentsRouterPage = () => {
 
     const handleSubmit = useCallback(
         async ({
+            context,
             message,
+            optimisticContext,
             toolHints,
         }: {
+            context?: AiPromptContextInput;
             message: string;
+            optimisticContext?: AiPromptContext;
             toolHints: string[];
         }) => {
             if (!projectUuid) return;
@@ -171,14 +183,18 @@ const AgentsRouterPage = () => {
                     setPhase({ kind: 'creating' });
                     await startThreadForDecision({
                         agentUuid: result.decision.suggestedAgentUuid,
+                        context,
                         decisionUuid: result.decision.decisionUuid,
+                        optimisticContext,
                         prompt: message,
                         toolHints,
                     });
                 } else {
                     setPhase({
                         kind: 'picker',
+                        context,
                         decision: result,
+                        optimisticContext,
                         prompt: message,
                         toolHints,
                     });
@@ -210,11 +226,14 @@ const AgentsRouterPage = () => {
     const confirmPick = useCallback(
         async (agentUuid: string) => {
             if (phase.kind !== 'picker') return;
-            const { decision, prompt, toolHints } = phase;
+            const { context, decision, optimisticContext, prompt, toolHints } =
+                phase;
             setPhase({ kind: 'creating' });
             await startThreadForDecision({
                 agentUuid,
+                context,
                 decisionUuid: decision.decision.decisionUuid,
+                optimisticContext,
                 prompt,
                 toolHints,
             });

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -24,6 +24,10 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { getModelKey } from '../../../components/common/ModelSelector/utils';
 import { AiAgentNewThreadMcpConnections } from '../../features/aiCopilot/components/AiAgentNewThreadMcpConnections';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
+import {
+    mergeAiPromptContextInput,
+    mergeAiPromptContextItems,
+} from '../../features/aiCopilot/components/ChatElements/contentMentions';
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
 import { DefaultAgentButton } from '../../features/aiCopilot/components/DefaultAgentButton/DefaultAgentButton';
 import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
@@ -51,6 +55,7 @@ const AiAgentNewThreadPage: FC = () => {
     const {
         contextInput,
         previewItems,
+        contentMentionItems,
         isReady: isPinnedContextReady,
     } = usePinnedContext({
         projectUuid,
@@ -149,16 +154,33 @@ const AiAgentNewThreadPage: FC = () => {
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
 
     const onSubmit = useCallback(
-        ({ message, toolHints }: { message: string; toolHints: string[] }) => {
+        ({
+            message,
+            toolHints,
+            context,
+            optimisticContext,
+        }: {
+            message: string;
+            toolHints: string[];
+            context?: typeof contextInput;
+            optimisticContext?: typeof previewItems;
+        }) => {
             if (!agentUuid) return;
             if (!isPinnedContextReady) return;
             setPendingPrompt('');
+            const mergedContext = mergeAiPromptContextInput(
+                contextInput,
+                context,
+            );
+            const mergedOptimisticContext = mergeAiPromptContextItems(
+                previewItems,
+                optimisticContext,
+            );
             void createAgentThread({
                 agentUuid,
                 prompt: message,
-                context: contextInput.length > 0 ? contextInput : undefined,
-                optimisticContext:
-                    previewItems.length > 0 ? previewItems : undefined,
+                context: mergedContext,
+                optimisticContext: mergedOptimisticContext,
                 enableSqlMode: sqlModeAvailable && sqlMode,
                 toolHints,
                 modelConfig: selectedModel
@@ -329,6 +351,7 @@ const AiAgentNewThreadPage: FC = () => {
                         }
                         defaultValue={pendingPrompt}
                         onValueChange={setPendingPrompt}
+                        contentMentionPriorityItems={contentMentionItems}
                     />
                 </Stack>
             </Stack>


### PR DESCRIPTION
## Summary

Closes: ZAP-462

Adds Tiptap `@` mentions for accessible charts and dashboards in AI chat, then passes selected content through prompt context for thread creation and message submission.

## Details

- Adds dense chart/dashboard mention suggestions backed by content search.
- Prioritizes existing thread context, current page context, dashboard tiles, then search results.
- Extracts selected mentions into backend prompt context plus optimistic UI metadata.
- Prevents Enter from submitting while the mention menu is active.
- Carries mentioned context through agent-specific threads, auto-router threads, launcher threads, and follow-up messages.

## Stack

1. #23893: backend access validation.
2. This PR: Tiptap content mentions and context routing.
3. `joaoviana/ai-chat-content-reference-pills`: submitted-message reference pills.

## Validation

- `pnpm -F frontend test src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts`
- `pnpm -F frontend exec oxlint ...`
- `pnpm -F frontend typecheck`
- `git diff --check`
- Browser smoke on `/projects/3675b69e-8324-4110-bdca-059031aa8da3/ai-agents`: `@fanout`, Enter selects mention without submitting, send through router, context reaches thread.
