### PR TITLE
feat(ai-agents): render content mention references

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.module.css
@@ -24,3 +24,17 @@
     font-size: 0.8125rem;
     font-weight: 500;
 }
+
+.messageText {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.inlineMarkdown {
+    display: inline;
+}
+
+.inlineMarkdown :global(p) {
+    display: inline;
+    margin: 0;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -8,6 +8,11 @@ import { useTimeAgo } from '../../../../../hooks/useTimeAgo';
 import useApp from '../../../../../providers/App/useApp';
 import { PinnedContextCard } from '../PinnedContextCard/PinnedContextCard';
 import styles from './AgentChatUserBubble.module.css';
+import { ContentReferenceLink } from './ContentReferenceLink';
+import {
+    buildContentReferenceSegments,
+    getPromptContextItemHref,
+} from './contentReferenceUtils';
 
 type Props = {
     message: AiAgentMessageUser<AiAgentUser>;
@@ -20,6 +25,21 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
     const name = message.user.name;
     const app = useApp();
     const showUserName = app.user?.data?.userUuid !== message.user.uuid;
+    const { matchedKeys, segments } = buildContentReferenceSegments(
+        message.message,
+        message.context,
+    );
+    const hasInlineReferences = segments.some(
+        (segment) => segment.type === 'reference',
+    );
+    const remainingContext = message.context.filter((item) => {
+        if (!hasInlineReferences) return true;
+        const key =
+            item.type === 'chart'
+                ? `chart:${item.chartUuid}`
+                : `dashboard:${item.dashboardUuid}`;
+        return !matchedKeys.has(key);
+    });
 
     return (
         <Stack
@@ -48,14 +68,14 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                 </Tooltip>
             </Stack>
 
-            {message.context.length > 0 && projectUuid && (
+            {remainingContext.length > 0 && projectUuid && (
                 <Group
                     gap="xs"
                     wrap="wrap"
                     justify="flex-end"
                     className={styles.contextGroup}
                 >
-                    {message.context.map((item, idx) => (
+                    {remainingContext.map((item, idx) => (
                         <PinnedContextCard
                             key={`${item.type}-${
                                 item.type === 'chart'
@@ -78,10 +98,43 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                 color="white"
                 className={styles.messageCard}
             >
-                <MDEditor.Markdown
-                    source={message.message}
-                    className={styles.markdown}
-                />
+                {hasInlineReferences && projectUuid ? (
+                    <div className={`${styles.markdown} ${styles.messageText}`}>
+                        {segments.map((segment, idx) =>
+                            segment.type === 'text' ? (
+                                <MDEditor.Markdown
+                                    key={`text-${idx}`}
+                                    source={segment.text}
+                                    className={`${styles.markdown} ${styles.inlineMarkdown}`}
+                                />
+                            ) : (
+                                <ContentReferenceLink
+                                    key={`${segment.key}-${idx}`}
+                                    chartKind={
+                                        segment.item.type === 'chart'
+                                            ? (segment.item.chartKind ??
+                                              undefined)
+                                            : undefined
+                                    }
+                                    kind={segment.item.type}
+                                    rel="noreferrer"
+                                    target="_blank"
+                                    to={getPromptContextItemHref(
+                                        segment.item,
+                                        projectUuid,
+                                    )}
+                                >
+                                    {segment.label}
+                                </ContentReferenceLink>
+                            ),
+                        )}
+                    </div>
+                ) : (
+                    <MDEditor.Markdown
+                        source={message.message}
+                        className={styles.markdown}
+                    />
+                )}
             </Card>
         </Stack>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -1,7 +1,6 @@
 import { ChartKind, type AiAgentMessageAssistant } from '@lightdash/common';
 import { Anchor, Button, Text } from '@mantine-8/core';
 import {
-    IconArrowRight,
     IconChartBar,
     IconLayoutDashboard,
     IconTerminal2,
@@ -9,13 +8,13 @@ import {
 import { type FC, type MouseEvent, type ReactNode } from 'react';
 import { Link, createPath, useLocation, useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
 import { setArtifact } from '../../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
 import styles from './ContentLink.module.css';
+import { ContentReferenceLink } from './ContentReferenceLink';
 
 export type SqlRunnerLinkState = {
     sql: string;
@@ -46,6 +45,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
     const navigate = useNavigate();
     const location = useLocation();
     const dashboardHref = typeof props.href === 'string' ? props.href : '';
+    const title = typeof props.title === 'string' ? props.title : undefined;
     const dispatch = useAiAgentStoreDispatch();
     const currentArtifact = useAiAgentStoreSelector(
         (state) => state.aiArtifact.artifact,
@@ -86,39 +86,14 @@ export const ContentLink: FC<ContentLinkProps> = ({
     switch (contentType) {
         case 'dashboard-link':
             return (
-                <Anchor
-                    {...props}
-                    data-content-link="true"
+                <ContentReferenceLink
+                    href={dashboardHref}
+                    kind="dashboard"
                     onClick={handleDashboardClick}
-                    fz="xs"
-                    fw={500}
-                    c="ldGray.8"
-                    td="none"
-                    classNames={{
-                        root: styles.contentLink,
-                    }}
+                    title={title}
                 >
-                    <MantineIcon
-                        icon={IconLayoutDashboard}
-                        size={13}
-                        color="green.7"
-                        fill="green.6"
-                        fillOpacity={0.2}
-                        stroke={1.5}
-                    />
-
-                    {/* margin is added by md package */}
-                    <Text fz="xs" fw={500} m={0}>
-                        {children}
-                    </Text>
-
-                    <MantineIcon
-                        icon={IconArrowRight}
-                        color="ldGray.6"
-                        size={11}
-                        stroke={1.5}
-                    />
-                </Anchor>
+                    {children}
+                </ContentReferenceLink>
             );
 
         case 'chart-link': {
@@ -135,41 +110,18 @@ export const ContentLink: FC<ContentLinkProps> = ({
                     : ChartKind.VERTICAL_BAR;
 
             return (
-                <Anchor
-                    {...props}
-                    data-content-link="true"
+                <ContentReferenceLink
+                    chartKind={chartTypeKind}
+                    href={
+                        typeof props.href === 'string' ? props.href : undefined
+                    }
+                    kind="chart"
+                    rel="noreferrer"
                     target="_blank"
-                    fz="xs"
-                    fw={500}
-                    c="ldGray.8"
-                    td="none"
-                    classNames={{
-                        root: styles.contentLink,
-                    }}
+                    title={title}
                 >
-                    {chartTypeKind && (
-                        <MantineIcon
-                            icon={getChartIcon(chartTypeKind)}
-                            size={13}
-                            color="blue.7"
-                            fill="blue.4"
-                            fillOpacity={0.2}
-                            stroke={1.5}
-                        />
-                    )}
-
-                    {/* margin is added by md package */}
-                    <Text fz="xs" fw={500} m={0}>
-                        {children}
-                    </Text>
-
-                    <MantineIcon
-                        icon={IconArrowRight}
-                        color="ldGray.6"
-                        size={11}
-                        stroke={1.5}
-                    />
-                </Anchor>
+                    {children}
+                </ContentReferenceLink>
             );
         }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
@@ -1,0 +1,121 @@
+import { ChartKind } from '@lightdash/common';
+import { Anchor, Text, type AnchorProps } from '@mantine-8/core';
+import {
+    IconArrowRight,
+    IconChartBar,
+    IconLayoutDashboard,
+    type Icon,
+} from '@tabler/icons-react';
+import { type AnchorHTMLAttributes, type ReactNode } from 'react';
+import { Link, type LinkProps } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
+import styles from './ContentLink.module.css';
+
+type ContentReferenceKind = 'artifact' | 'chart' | 'dashboard';
+
+type Props = {
+    chartKind?: ChartKind;
+    children: ReactNode;
+    kind: ContentReferenceKind;
+    showArrow?: boolean;
+    to?: LinkProps['to'];
+} & Omit<
+    AnchorProps,
+    'children' | 'classNames' | 'c' | 'component' | 'fw' | 'fz' | 'td'
+> &
+    Pick<
+        AnchorHTMLAttributes<HTMLAnchorElement>,
+        'href' | 'onClick' | 'rel' | 'target' | 'title'
+    >;
+
+const getIconMeta = ({
+    chartKind,
+    kind,
+}: {
+    chartKind?: ChartKind;
+    kind: ContentReferenceKind;
+}): { color: string; fill: string; icon: Icon } => {
+    switch (kind) {
+        case 'dashboard':
+            return {
+                color: 'green.7',
+                fill: 'green.6',
+                icon: IconLayoutDashboard,
+            };
+        case 'artifact':
+            return {
+                color: 'indigo.6',
+                fill: 'indigo.1',
+                icon: IconChartBar,
+            };
+        case 'chart':
+        default:
+            return {
+                color: 'blue.7',
+                fill: 'blue.4',
+                icon: getChartIcon(chartKind ?? ChartKind.VERTICAL_BAR),
+            };
+    }
+};
+
+export const ContentReferenceLink = ({
+    chartKind,
+    children,
+    kind,
+    showArrow = true,
+    to,
+    ...props
+}: Props) => {
+    const { color, fill, icon } = getIconMeta({ chartKind, kind });
+
+    const content = (
+        <>
+            <MantineIcon
+                icon={icon}
+                size={13}
+                color={color}
+                fill={fill}
+                fillOpacity={0.2}
+                stroke={1.5}
+            />
+
+            <Text fz="xs" fw={500} m={0} truncate>
+                {children}
+            </Text>
+
+            {showArrow && (
+                <MantineIcon
+                    icon={IconArrowRight}
+                    color="ldGray.6"
+                    size={11}
+                    stroke={1.5}
+                />
+            )}
+        </>
+    );
+
+    const anchorProps = {
+        ...props,
+        fz: 'xs',
+        fw: 500,
+        c: 'ldGray.8',
+        td: 'none',
+        classNames: { root: styles.contentLink },
+    };
+
+    return to ? (
+        <Anchor
+            {...anchorProps}
+            component={Link}
+            data-content-link="true"
+            to={to}
+        >
+            {content}
+        </Anchor>
+    ) : (
+        <Anchor {...anchorProps} data-content-link="true">
+            {content}
+        </Anchor>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
@@ -1,0 +1,64 @@
+import { ChartKind } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { buildContentReferenceSegments } from './contentReferenceUtils';
+
+describe('contentReferenceUtils', () => {
+    it('turns mentioned content labels into ordered reference segments', () => {
+        const result = buildContentReferenceSegments(
+            'Table Calculations Tests Dashboard & [Fanout] Inflated vs Safe [Fanout] One-to-One Addresses use these as inspo',
+            [
+                {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-1',
+                    dashboardSlug: 'table-calculations-tests-dashboard',
+                    displayName: 'Table Calculations Tests Dashboard',
+                    pinnedVersionUuid: null,
+                },
+                {
+                    type: 'chart',
+                    chartUuid: 'chart-1',
+                    chartSlug: 'fanout-inflated-vs-safe',
+                    displayName: '[Fanout] Inflated vs Safe',
+                    pinnedVersionUuid: null,
+                    runtimeOverrides: null,
+                    chartKind: ChartKind.VERTICAL_BAR,
+                },
+                {
+                    type: 'chart',
+                    chartUuid: 'chart-2',
+                    chartSlug: 'fanout-one-to-one-addresses',
+                    displayName: '[Fanout] One-to-One Addresses',
+                    pinnedVersionUuid: null,
+                    runtimeOverrides: null,
+                    chartKind: ChartKind.VERTICAL_BAR,
+                },
+            ],
+        );
+
+        expect(result.segments).toEqual([
+            expect.objectContaining({
+                type: 'reference',
+                key: 'dashboard:dashboard-1',
+                label: 'Table Calculations Tests Dashboard',
+            }),
+            { type: 'text', text: ' & ' },
+            expect.objectContaining({
+                type: 'reference',
+                key: 'chart:chart-1',
+                label: '[Fanout] Inflated vs Safe',
+            }),
+            { type: 'text', text: ' ' },
+            expect.objectContaining({
+                type: 'reference',
+                key: 'chart:chart-2',
+                label: '[Fanout] One-to-One Addresses',
+            }),
+            { type: 'text', text: ' use these as inspo' },
+        ]);
+        expect([...result.matchedKeys]).toEqual([
+            'dashboard:dashboard-1',
+            'chart:chart-1',
+            'chart:chart-2',
+        ]);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -1,0 +1,90 @@
+import { type AiPromptContextItem } from '@lightdash/common';
+
+export type ContentReferenceSegment =
+    | {
+          type: 'text';
+          text: string;
+      }
+    | {
+          type: 'reference';
+          item: AiPromptContextItem;
+          key: string;
+          label: string;
+      };
+
+const getPromptContextItemKey = (item: AiPromptContextItem) =>
+    item.type === 'chart'
+        ? `chart:${item.chartUuid}`
+        : `dashboard:${item.dashboardUuid}`;
+
+const getPromptContextItemLabel = (item: AiPromptContextItem) => {
+    if (item.displayName) return item.displayName;
+    if (item.type === 'chart') return item.chartSlug ?? 'Chart';
+    return item.dashboardSlug ?? 'Dashboard';
+};
+
+export const getPromptContextItemHref = (
+    item: AiPromptContextItem,
+    projectUuid: string,
+) =>
+    item.type === 'chart'
+        ? `/projects/${projectUuid}/saved/${item.chartUuid}`
+        : `/projects/${projectUuid}/dashboards/${item.dashboardUuid}`;
+
+export const buildContentReferenceSegments = (
+    message: string,
+    context: AiPromptContextItem[],
+): { matchedKeys: Set<string>; segments: ContentReferenceSegment[] } => {
+    const candidates = context
+        .map((item, index) => ({
+            item,
+            index,
+            key: getPromptContextItemKey(item),
+            label: getPromptContextItemLabel(item),
+        }))
+        .filter(({ label }) => label.length > 0);
+
+    const matchedKeys = new Set<string>();
+    const segments: ContentReferenceSegment[] = [];
+    let cursor = 0;
+
+    while (cursor < message.length) {
+        const nextMatch = candidates
+            .filter(({ key }) => !matchedKeys.has(key))
+            .map((candidate) => ({
+                ...candidate,
+                start: message.indexOf(candidate.label, cursor),
+            }))
+            .filter(({ start }) => start >= 0)
+            .sort((a, b) => {
+                if (a.start !== b.start) return a.start - b.start;
+                if (a.label.length !== b.label.length) {
+                    return b.label.length - a.label.length;
+                }
+                return a.index - b.index;
+            })[0];
+
+        if (!nextMatch) {
+            segments.push({ type: 'text', text: message.slice(cursor) });
+            break;
+        }
+
+        if (nextMatch.start > cursor) {
+            segments.push({
+                type: 'text',
+                text: message.slice(cursor, nextMatch.start),
+            });
+        }
+
+        matchedKeys.add(nextMatch.key);
+        segments.push({
+            type: 'reference',
+            item: nextMatch.item,
+            key: nextMatch.key,
+            label: nextMatch.label,
+        });
+        cursor = nextMatch.start + nextMatch.label.length;
+    }
+
+    return { matchedKeys, segments };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -1,16 +1,6 @@
 import { assertUnreachable, type AiPromptContextItem } from '@lightdash/common';
-import { Anchor, Text } from '@mantine-8/core';
-import {
-    IconArrowRight,
-    IconLayoutDashboard,
-    type Icon,
-} from '@tabler/icons-react';
 import { type FC } from 'react';
-import { Link } from 'react-router';
-import MantineIcon from '../../../../../components/common/MantineIcon';
-import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
-import contentLinkStyles from '../ChatElements/ContentLink.module.css';
-import styles from './PinnedContextCard.module.css';
+import { ContentReferenceLink } from '../ChatElements/ContentReferenceLink';
 
 type Props = {
     item: AiPromptContextItem;
@@ -18,9 +8,7 @@ type Props = {
 };
 
 type ItemMeta = {
-    icon: Icon;
-    iconColor: string;
-    iconFill: string;
+    kind: 'chart' | 'dashboard';
     label: string;
     href: string;
 };
@@ -32,17 +20,13 @@ const getItemMeta = (
     switch (item.type) {
         case 'chart':
             return {
-                icon: getChartIcon(item.chartKind ?? undefined),
-                iconColor: 'blue.7',
-                iconFill: 'blue.4',
+                kind: 'chart',
                 label: item.displayName ?? 'Chart',
                 href: `/projects/${projectUuid}/saved/${item.chartUuid}`,
             };
         case 'dashboard':
             return {
-                icon: IconLayoutDashboard,
-                iconColor: 'green.7',
-                iconFill: 'green.6',
+                kind: 'dashboard',
                 label: item.displayName ?? 'Dashboard',
                 href: `/projects/${projectUuid}/dashboards/${item.dashboardUuid}`,
             };
@@ -54,34 +38,13 @@ const getItemMeta = (
 export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
     const meta = getItemMeta(item, projectUuid);
     return (
-        <Anchor
-            component={Link}
+        <ContentReferenceLink
+            kind={meta.kind}
+            rel="noreferrer"
             to={meta.href}
             target="_blank"
-            fz="sm"
-            fw={500}
-            bg="ldGray.0"
-            c="ldGray.7"
-            td="none"
-            classNames={{ root: contentLinkStyles.contentLink }}
         >
-            <MantineIcon
-                icon={meta.icon}
-                size="md"
-                color={meta.iconColor}
-                fill={meta.iconFill}
-                fillOpacity={0.2}
-                strokeWidth={1.9}
-            />
-            <Text fz="sm" fw={500} m={0} truncate className={styles.label}>
-                {meta.label}
-            </Text>
-            <MantineIcon
-                icon={IconArrowRight}
-                color="ldGray.7"
-                size="sm"
-                strokeWidth={2.0}
-            />
-        </Anchor>
+            {meta.label}
+        </ContentReferenceLink>
     );
 };


### PR DESCRIPTION
## Summary

Reuses the Streamdown content-link pill UI for AI content references, including submitted user messages that contain selected `@` mentions.

## Details

- Adds a shared `ContentReferenceLink` component used by assistant markdown links and pinned context cards.
- Converts submitted user message text back into inline content reference pills when the message context matches the labels.
- Leaves unmatched context as separate pinned context pills.
- Opens submitted-message references in a new tab with `target="_blank"` and `rel="noreferrer"`.
- Adds unit coverage for turning existing message context into ordered reference segments.

## Stack

1. #23893: backend access validation.
2. #23894: Tiptap content mentions and context routing.
3. This PR: submitted-message reference pills.

## Validation

- `pnpm -F frontend test src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts`
- `pnpm -F frontend exec oxlint ...`
- `pnpm -F frontend typecheck`
- `git diff --check`
- Browser smoke on `/projects/3675b69e-8324-4110-bdca-059031aa8da3/ai-agents`: submitted user bubble renders `Fanout Tests Dashboard` as a `data-content-link` pill with `target="_blank"` and `rel="noreferrer"`.
