### PR TITLE
fix(ai-review): make turn-signal supersede atomic and concurrency-safe

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -421,6 +421,8 @@ describe('AiAgentReviewClassifierModel', () => {
 
     describe('createTurnSignal', () => {
         it('persists a classified signal with inline finding fields', async () => {
+            tracker.on.any(/pg_advisory_xact_lock/).response([]);
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([]);
             tracker.on.delete(AiAgentTurnSignalTableName).responseOnce(0);
             tracker.on.insert(AiAgentTurnSignalTableName).responseOnce([
                 {
@@ -473,9 +475,19 @@ describe('AiAgentReviewClassifierModel', () => {
             expect(tracker.history.insert[1].sql).toContain(
                 AiAgentReviewItemTableName,
             );
+            // The supersede + item write are serialized behind a per-turn
+            // advisory lock so concurrent re-reviews cannot clobber each other.
+            expect(
+                [
+                    ...tracker.history.select,
+                    ...(tracker.history.any ?? []),
+                ].some((q) => q.sql.includes('pg_advisory_xact_lock')),
+            ).toBe(true);
         });
 
         it('does not upsert a review item when the turn is not promoted', async () => {
+            tracker.on.any(/pg_advisory_xact_lock/).response([]);
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([]);
             tracker.on.delete(AiAgentTurnSignalTableName).responseOnce(0);
             tracker.on.insert(AiAgentTurnSignalTableName).responseOnce([
                 {
@@ -493,6 +505,88 @@ describe('AiAgentReviewClassifierModel', () => {
             expect(tracker.history.insert[0].sql).toContain(
                 AiAgentTurnSignalTableName,
             );
+        });
+
+        it('removes a now-orphaned pristine review item when a re-review drops the finding', async () => {
+            const ORPHAN_FINGERPRINT = 'ai_agent_review_item:orphan';
+            tracker.on.any(/pg_advisory_xact_lock/).response([]);
+            const supersededSelect = tracker.on.select(
+                AiAgentTurnSignalTableName,
+            );
+            // 1st select: fingerprints being superseded. 2nd: which remain backed.
+            supersededSelect.responseOnce([
+                { fingerprint: ORPHAN_FINGERPRINT },
+            ]);
+            supersededSelect.responseOnce([]);
+            tracker.on.delete(AiAgentTurnSignalTableName).responseOnce(1);
+            tracker.on
+                .insert(AiAgentTurnSignalTableName)
+                .responseOnce([
+                    { ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID },
+                ]);
+            tracker.on.delete(AiAgentReviewItemTableName).responseOnce(1);
+
+            await model.createTurnSignal({
+                runUuid: RUN_UUID,
+                turnSignal: { ...turnSignal, promotedToFinding: false },
+                finding: null,
+            });
+
+            // No new item is written (the re-review is not a finding) ...
+            expect(tracker.history.insert).toHaveLength(1);
+            // ... and the orphaned item is deleted, guarded to pristine rows.
+            const itemDeletes = tracker.history.delete.filter((q) =>
+                q.sql.includes(AiAgentReviewItemTableName),
+            );
+            expect(itemDeletes).toHaveLength(1);
+            expect(itemDeletes[0].sql).toContain('status');
+            expect(itemDeletes[0].sql).toContain('assigned_to_user_uuid');
+            expect(itemDeletes[0].sql).toContain('linked_pr_url');
+            expect(itemDeletes[0].bindings).toContain(ORPHAN_FINGERPRINT);
+        });
+
+        it('keeps the review item when the finding is unchanged across a re-review', async () => {
+            tracker.on.any(/pg_advisory_xact_lock/).response([]);
+            // Superseded fingerprint equals the new one → not an orphan.
+            tracker.on
+                .select(AiAgentTurnSignalTableName)
+                .responseOnce([{ fingerprint: FINGERPRINT }]);
+            tracker.on.delete(AiAgentTurnSignalTableName).responseOnce(1);
+            tracker.on
+                .insert(AiAgentTurnSignalTableName)
+                .responseOnce([
+                    { ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID },
+                ]);
+            tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
+
+            await model.createTurnSignal({
+                runUuid: RUN_UUID,
+                turnSignal,
+                finding: {
+                    primaryRootCause: 'semantic_layer',
+                    secondaryRootCauses: [],
+                    subcategories: [],
+                    fixTargets: [],
+                    targetRefs: [],
+                    evidenceExcerpts: [],
+                    recommendation: null,
+                    projectContextEntry: null,
+                    reviewItem: {
+                        fingerprint: FINGERPRINT,
+                        title: 'Review airports.country',
+                        description: 'Country needs semantic clarification.',
+                        ownerType: 'semantic_layer_owner',
+                    },
+                },
+            });
+
+            // The item is re-touched (upsert), never deleted, since the
+            // fingerprint is stable across the re-review.
+            expect(
+                tracker.history.delete.filter((q) =>
+                    q.sql.includes(AiAgentReviewItemTableName),
+                ),
+            ).toHaveLength(0);
         });
     });
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1112,14 +1112,41 @@ export class AiAgentReviewClassifierModel {
 
     async createTurnSignal(args: CreateTurnSignalArgs): Promise<string> {
         const { finding, turnSignal } = args;
-        const [row] = await this.database.transaction(async (trx) => {
+        const promptUuid = turnSignal.subject.assistantPromptUuid;
+        const newFingerprint =
+            turnSignal.promotedToFinding && finding
+                ? finding.reviewItem.fingerprint
+                : null;
+
+        return this.database.transaction(async (trx) => {
+            // Serialize reviews of the same turn. A re-review (a feedback change,
+            // or the next turn supplying a correction) supersedes the prior
+            // signal with a delete+insert. Without this lock two concurrent
+            // reviews of the same turn can interleave so the loser's signal — and
+            // the review item it created — are clobbered and orphaned. The lock
+            // is transaction-scoped and released on commit/rollback.
+            await trx.raw(
+                'select pg_advisory_xact_lock(hashtextextended(?, 0))',
+                [promptUuid],
+            );
+
+            // Capture the fingerprints we're about to supersede so we can
+            // reconcile any review item left without a backing signal.
+            const supersededRows = await trx(AiAgentTurnSignalTableName)
+                .where('ai_prompt_uuid', promptUuid)
+                .whereNotNull('fingerprint')
+                .distinct('fingerprint');
+            const supersededFingerprints = supersededRows
+                .map((r) => r.fingerprint as string | null)
+                .filter((fp): fp is string => fp !== null);
+
             // Supersede: keep one current signal per turn. A re-review (once a
             // later turn supplies the correction) replaces the earlier judgment
             // instead of stacking a second signal — so the queue shows the
             // latest verdict and findingCount counts distinct turns, not
             // re-reviews of the same turn.
             await trx(AiAgentTurnSignalTableName)
-                .where('ai_prompt_uuid', turnSignal.subject.assistantPromptUuid)
+                .where('ai_prompt_uuid', promptUuid)
                 .delete();
             const inserted = await trx<AiAgentTurnSignalTable>(
                 AiAgentTurnSignalTableName,
@@ -1177,35 +1204,54 @@ export class AiAgentReviewClassifierModel {
                     ) as never,
                 })
                 .returning('ai_agent_review_turn_signal_uuid');
-            return inserted;
+
+            // Write the review item in the same transaction so a signal and the
+            // item it promotes are always created together.
+            if (newFingerprint) {
+                await trx<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+                    .insert({
+                        fingerprint: newFingerprint,
+                        organization_uuid: turnSignal.subject.organizationUuid,
+                        project_uuid: turnSignal.subject.projectUuid,
+                        agent_uuid: turnSignal.subject.agentUuid,
+                    })
+                    .onConflict('fingerprint')
+                    .merge({ updated_at: trx.fn.now() });
+            }
+
+            // Reconcile: a superseded finding can leave its review item with no
+            // backing signal. Drop such orphans, but only while still pristine —
+            // an item a human has triaged (assigned, linked, status changed) is
+            // kept so manual work is never discarded.
+            const orphanCandidates = supersededFingerprints.filter(
+                (fp) => fp !== newFingerprint,
+            );
+            if (orphanCandidates.length > 0) {
+                const stillReferencedRows = await trx(
+                    AiAgentTurnSignalTableName,
+                )
+                    .whereIn('fingerprint', orphanCandidates)
+                    .distinct('fingerprint');
+                const stillReferenced = new Set(
+                    stillReferencedRows.map((r) => r.fingerprint),
+                );
+                const orphaned = orphanCandidates.filter(
+                    (fp) => !stillReferenced.has(fp),
+                );
+                if (orphaned.length > 0) {
+                    await trx(AiAgentReviewItemTableName)
+                        .whereIn('fingerprint', orphaned)
+                        .where('status', 'open')
+                        .whereNull('assigned_to_user_uuid')
+                        .whereNull('linked_issue_url')
+                        .whereNull('linked_pr_url')
+                        .whereNull('pr_writeback_thread_uuid')
+                        .whereNull('status_updated_by_user_uuid')
+                        .delete();
+                }
+            }
+
+            return inserted[0].ai_agent_review_turn_signal_uuid;
         });
-
-        if (turnSignal.promotedToFinding && finding) {
-            await this.ensureReviewItem({
-                fingerprint: finding.reviewItem.fingerprint,
-                organizationUuid: turnSignal.subject.organizationUuid,
-                projectUuid: turnSignal.subject.projectUuid,
-                agentUuid: turnSignal.subject.agentUuid,
-            });
-        }
-
-        return row.ai_agent_review_turn_signal_uuid;
-    }
-
-    private async ensureReviewItem(args: {
-        fingerprint: string;
-        organizationUuid: string;
-        projectUuid: string;
-        agentUuid: string;
-    }): Promise<void> {
-        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
-            .insert({
-                fingerprint: args.fingerprint,
-                organization_uuid: args.organizationUuid,
-                project_uuid: args.projectUuid,
-                agent_uuid: args.agentUuid,
-            })
-            .onConflict('fingerprint')
-            .merge({ updated_at: this.database.fn.now() });
     }
 }


### PR DESCRIPTION
## Problem

The AI review classifier keeps **one signal per turn**: a re-review (a feedback change, or the next turn supplying a correction) *supersedes* the prior signal. `createTurnSignal` did this with a `DELETE … WHERE ai_prompt_uuid = ?` followed by an `INSERT`, and then wrote the promoted **review item** in a separate step *outside* the transaction.

There is no unique constraint on `ai_prompt_uuid` and no per-turn serialization, so two reviews of the same turn can run concurrently (e.g. a feedback event and a next-turn re-review, or two feedback events for the same message). When they interleave:

1. **Lost update** — both run `delete … then insert`; whichever commits last wins, so a *promoted* classification can be silently deleted by a concurrent *non-promoted* re-review.
2. **Orphaned review items** — because the review item was upserted outside the supersede transaction and never reconciled, the item survives even after its backing signal is deleted. The result is a review item with **no signal**, so its root cause and any context entry are unrecoverable, and the queue shows items that can't be traced back to a finding.

## Fix

`createTurnSignal` is now atomic and concurrency-safe:

- **Serialize per turn** with a transaction-scoped `pg_advisory_xact_lock` keyed on the prompt, so concurrent reviews of the same turn can't interleave their delete/insert. The lock releases on commit/rollback.
- **Write the review item in the same transaction** as the signal supersede, so a signal and the item it promotes are always created together (no out-of-band window).
- **Reconcile orphans**: when superseding, capture the prior fingerprints; after writing the new signal, delete any review item whose fingerprint no longer has *any* backing signal — but only while it is **pristine** (`open`, unassigned, no linked PR/issue, no writeback, no human status change). Items a human has triaged are never discarded.

## Behaviour change / regression analysis

- Only affects the EE AI-agent review classifier write path (`createTurnSignal`). No API, schema, or read-path changes.
- The advisory lock is keyed on a hash of the prompt id; hash collisions can only cause two unrelated turns to serialise briefly — correctness is unaffected.
- Orphan cleanup is intentionally conservative (pristine-only) so no human-actioned review item is ever deleted. A re-review that legitimately downgrades a finding to "not a failure" now correctly removes the stale auto-generated item instead of leaving it orphaned.
- Pre-existing orphaned rows are not touched by this change; they can be cleaned up separately if desired.

## Tests

`AiAgentReviewClassifierModel.test.ts` — extended `createTurnSignal` coverage:
- asserts the per-turn advisory lock is taken;
- a re-review that drops the finding deletes the now-orphaned item, guarded to pristine rows;
- a re-review with an unchanged fingerprint keeps (re-touches) the item rather than deleting it.

`pnpm -F backend typecheck:fast` ✅ · `jest AiAgentReviewClassifierModel` ✅ (17 passed)

---
_No Linear ticket linked — add `Closes: PROD-XXXX` before merge if there is one._