### PR TITLE
fix(ai-review): disambiguate project_context vs semantic_layer in judge prompt

### DIFF
--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -35,7 +35,7 @@ import { defaultAgentOptions } from './ai/agents/agentV2';
 import { getModel } from './ai/models';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
-const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v2';
+const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v3';
 
 type AiAgentReviewClassifierJudge = (
     candidate: AiAgentReviewClassifierTurnCandidate,
@@ -948,15 +948,17 @@ When promoting, pick primaryRootCause by mapping the dominant signal:
    - assistant_no_answer due to disabled SQL or data access, missing instructions, or missing knowledge docs → agent_configuration.
    - assistant_no_answer because the warehouse genuinely lacks the data → data_gap.
    - assistant_no_answer because Lightdash cannot express the question (missing chart type, unsupported pivot, etc.) → product_capability.
-   - next_user_correction or next_user_dispute about field choice, scoping, or definition → semantic_layer or project_context.
+   - next_user_correction or next_user_dispute about which explore/source/table to use, or about what an entity, acronym, or business term refers to → project_context.
+   - next_user_correction or next_user_dispute about a field, metric, dimension, join, or filter definition within the right explore → semantic_layer.
    - next_user_retry after a failed or empty answer → runtime_reliability or agent_configuration depending on cause.
    - tool_error → runtime_reliability.
    - product_capability_request → product_capability.
    - human_intervention → agent_configuration unless evidence clearly points elsewhere.
+   - Tiebreaker for semantic_layer vs project_context: if the durable fix is a fact the agent should KNOW — what a term/acronym/entity refers to, or which explore answers a kind of question → project_context. If the durable fix is a CHANGE to the semantic YAML — a model, dimension, metric, join, or filter definition → semantic_layer. Do not default to semantic_layer when the real gap is missing routing or knowledge about which explore to use.
 
 3. Only set promotedToFinding=false when there is no promotable implicit signal AND the assistant answered the user's actual question. In that case use signal=acceptance_or_continuation, new_question, output_shape_correction, or normal_refinement and primaryRootCause=not_a_failure.
 
-4. Successful queries can still be findings even without implicit signals when the user asked broad business language and the semantic / catalog context does not clearly support the selected field, explore, or metric. Promote those as semantic_layer or project_context when a model definition, AI hint, or project context rule would prevent future ambiguity.
+4. Successful queries can still be findings even without implicit signals when the user asked broad business language and the semantic / catalog context does not clearly support the selected field, explore, or metric. Promote those as semantic_layer or project_context when a model definition, AI hint, or project context rule would prevent future ambiguity, choosing between them with the explore-vs-definition tiebreaker above.
 
 5. Use agentConfig to catch Lightdash-layer fixes: missing instructions, disabled data access, missing knowledge docs, access restrictions, or capability settings. Promote those as agent_configuration when the answer quality depends on agent setup.
 


### PR DESCRIPTION
## Problem

The review judge has a clean explore-vs-field discriminator, but **only on the `assistant_no_answer` path**:
- "names a missing join/column/field → `semantic_layer`"
- "picked a wrong/unrelated explore or field → `project_context`"

Promotions driven by a user **correction or dispute** (the common case) routed instead through a rule that read:

> "next_user_correction or next_user_dispute about field choice, scoping, or definition → **semantic_layer or project_context**."

That rule has **no discriminator** and lists `semantic_layer` first. Combined with `semantic_layer` being the broader bucket (it covers model/dimension/metric/join/filter/AI-hint), the judge consistently labelled wrong-explore / missing-knowledge failures as `semantic_layer`. The successful-but-wrong-field rule had the same "semantic_layer or project_context" ambiguity.

This also **starves the project-context entry path**: a durable `projectContextEntry` is only emitted when `primaryRootCause = project_context`, so once a turn is mis-routed to `semantic_layer` it can never carry the routing/acronym fact that would prevent the failure recurring.

## Change

Prompt-only change to the judge system prompt:

- Split the correction/dispute mapping into two discriminated rules: **which explore/source to use, or what an entity/acronym/business term refers to → `project_context`**; **a field/metric/dimension/join/filter definition within the right explore → `semantic_layer`**.
- Add an explicit tiebreaker: *durable fix is a fact the agent should **know** (what a term means, which explore answers a question) → `project_context`; durable fix is a **change to the semantic YAML** → `semantic_layer`; don't default to `semantic_layer` when the real gap is missing routing/knowledge.*
- Point the "successful query, weak catalog support" rule at the same tiebreaker.
- Bump `JUDGE_PROMPT_HASH` to `…-v3` so runs are versioned across the prompt change.

## Behaviour change / regression analysis

- EE AI-agent review classifier only; prompt text + version constant. No schema, API, or read-path changes.
- Expected effect: correction-driven failures whose real cause is "wrong explore / missing knowledge of what a term or entity means" now route to `project_context` (and can emit a context entry) instead of `semantic_layer`. Field/metric/definition corrections still route to `semantic_layer`.
- The `JUDGE_PROMPT_HASH` bump means new runs are tagged `v3`; historical runs keep their prior tag, so before/after can be compared.

## Validation

The judge is an LLM call; the service unit tests mock the model output, so they don't (and can't) assert routing — they pass unchanged. Real validation should go through the review eval harness against representative correction turns (e.g. "which explore should I use" / acronym-meaning corrections vs field-definition corrections) before/after the prompt change. Recommend coordinating with whoever is actively iterating on the classifier so this doesn't collide.

---
_No Linear ticket linked — add `Closes: PROD-XXXX` before merge if there is one._