### PR TITLE
fix(ai-review): debounce feedback_changed review so it sees full feedback

### DIFF
--- a/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
@@ -1,0 +1,17 @@
+import { aiAgentReviewRunAt } from './SchedulerClient';
+
+describe('aiAgentReviewRunAt', () => {
+    const now = new Date('2026-06-04T11:33:48.000Z');
+
+    it('defers feedback_changed reviews so a rate-then-comment pair coalesces', () => {
+        const runAt = aiAgentReviewRunAt('feedback_changed', now);
+        // Delayed by the debounce window so the shared jobKey can replace the
+        // still-pending job when the comment arrives shortly after the rating.
+        expect(runAt.getTime() - now.getTime()).toBe(60_000);
+    });
+
+    it('runs response_saved reviews immediately', () => {
+        const runAt = aiAgentReviewRunAt('response_saved', now);
+        expect(runAt.getTime()).toBe(now.getTime());
+    });
+});

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -11,6 +11,26 @@ import {
 } from '@lightdash/common';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 
+/**
+ * How long to defer a feedback-driven review so a rate-then-comment pair (two
+ * separate feedback requests) coalesces into one review via the shared jobKey.
+ */
+const FEEDBACK_REVIEW_DEBOUNCE_MS = 60_000;
+
+/**
+ * When a review for `eventType` should run. Feedback-driven reviews are deferred
+ * so a rate-then-comment pair (two separate feedback requests) coalesces into a
+ * single review via the shared jobKey — otherwise a review on the bare score
+ * races a second review on the full feedback. Everything else runs immediately.
+ */
+export const aiAgentReviewRunAt = (
+    eventType: AiAgentReviewClassifierJobPayload['eventType'],
+    now: Date,
+): Date =>
+    eventType === 'feedback_changed'
+        ? new Date(now.getTime() + FEEDBACK_REVIEW_DEBOUNCE_MS)
+        : now;
+
 export class CommercialSchedulerClient extends SchedulerClient {
     /**
      * Enqueue (or re-enqueue) a poll for a write-back PR's preview URL. Keyed by
@@ -64,12 +84,12 @@ export class CommercialSchedulerClient extends SchedulerClient {
 
     async aiAgentReviewClassifier(payload: AiAgentReviewClassifierJobPayload) {
         const graphileClient = await this.graphileUtils;
-        const now = new Date();
+        const runAt = aiAgentReviewRunAt(payload.eventType, new Date());
         const { id: jobId } = await graphileClient.addJob(
             EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER,
             payload,
             {
-                runAt: now,
+                runAt,
                 maxAttempts: 1,
                 jobKey: `ai-agent-review:${payload.eventType}:${payload.promptUuid}`,
             },


### PR DESCRIPTION
## Problem

Rating a message (👎) and writing a comment are **two separate `…/feedback` requests**, and each one enqueues a `feedback_changed` review (`updateHumanScoreForMessage`). The enqueue already shares a `jobKey` (`ai-agent-review:feedback_changed:<promptUuid>`), but graphile only coalesces **pending** jobs — once the first review starts running, a second enqueue creates a **new** job.

In practice the user rates, then types a comment a few seconds later, so:

- Review 1 starts on the bare **score** — the comment isn't saved yet — and produces a weaker judgment.
- Review 2 runs on **score + comment** and produces the correct one.
- The two race, and the weaker/earlier review can supersede the better one.

(The supersede race that lets the worse review win is fixed separately; this PR removes the duplicate review at the source and, more importantly, ensures the single review sees the *complete* feedback.)

## Change

Defer `feedback_changed` reviews by a short debounce window (`FEEDBACK_REVIEW_DEBOUNCE_MS`, 60s) via `runAt`. Because the job carries the shared `jobKey` and graphile's default `jobKeyMode` is `replace`, the second feedback request **replaces the still-pending job** instead of spawning a new one — so a single review runs once both the score and comment are persisted. `response_saved` reviews are unchanged and run immediately.

The scheduling decision is extracted into a pure `aiAgentReviewRunAt(eventType, now)` helper so it's directly testable without standing up graphile.

## Behaviour change / regression analysis

- EE AI-agent review classifier scheduling only. No schema, API, or read-path changes.
- Feedback-driven reviews now run up to ~60s later (a background quality signal — not latency-sensitive). Reviews triggered by a message response are unaffected.
- A single review now sees score + comment together, which is strictly more context than the previous "review on bare score" first pass.
- The debounce relies on the existing `jobKey` + graphile's default `replace` mode; no queue/config changes.

## Tests

`SchedulerClient.test.ts` — `aiAgentReviewRunAt` defers `feedback_changed` by the debounce window and runs `response_saved` immediately.

`pnpm -F backend typecheck:fast` ✅ · `jest ee/scheduler/SchedulerClient` ✅

---
_No Linear ticket linked — add `Closes: PROD-XXXX` before merge if there is one._