### PR TITLE
fix(pivot): drop dangling sort refs from row totals query

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.test.ts
@@ -1,5 +1,6 @@
 import {
     NotSupportedError,
+    SortByDirection,
     VizAggregationOptions,
     VizIndexType,
     type MetricQuery,
@@ -420,6 +421,66 @@ describe('getRowTotalQueryFromSource', () => {
                     pivotConfiguration,
                 }),
             ).toThrow(NotSupportedError);
+        });
+
+        it('drops sortBy on the pivot column dimension that the collapse removes', () => {
+            const result = getRowTotalQueryFromSource({
+                metricQuery: baseMetricQuery,
+                pivotConfiguration: {
+                    ...pivotConfiguration,
+                    sortBy: [
+                        {
+                            reference: 'orders_payment_method',
+                            direction: SortByDirection.ASC,
+                        },
+                    ],
+                },
+            });
+
+            expect(result.pivotConfiguration?.sortBy).toEqual([]);
+        });
+
+        it('drops sortBy on a metric (exposed under an `_any` alias in the collapsed query)', () => {
+            const result = getRowTotalQueryFromSource({
+                metricQuery: baseMetricQuery,
+                pivotConfiguration: {
+                    ...pivotConfiguration,
+                    sortBy: [
+                        {
+                            reference: 'orders_total_revenue',
+                            direction: SortByDirection.DESC,
+                        },
+                    ],
+                },
+            });
+
+            expect(result.pivotConfiguration?.sortBy).toEqual([]);
+        });
+
+        it('keeps sortBy on index columns and drops sorts on non-index dimensions', () => {
+            const result = getRowTotalQueryFromSource({
+                metricQuery: baseMetricQuery,
+                pivotConfiguration: {
+                    ...pivotConfiguration,
+                    sortBy: [
+                        {
+                            reference: 'orders_created_at',
+                            direction: SortByDirection.ASC,
+                        },
+                        {
+                            reference: 'orders_payment_method',
+                            direction: SortByDirection.ASC,
+                        },
+                    ],
+                },
+            });
+
+            expect(result.pivotConfiguration?.sortBy).toEqual([
+                {
+                    reference: 'orders_created_at',
+                    direction: SortByDirection.ASC,
+                },
+            ]);
         });
 
         it('clears sortOnlyDimensions and passthroughDimensions on the totals pivot config', () => {

--- a/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.ts
+++ b/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.ts
@@ -256,9 +256,17 @@ export const getRowTotalQueryFromSource = (
     // `groupByColumns: []` opts out of the pivot SQL path in
     // PivotQueryBuilder, so the totals query returns a flat shape:
     // one row per index-dim value combination with plain metric columns.
+    // Keep only sorts on index columns: the collapsed query no longer selects
+    // pivot/groupBy dimensions and exposes metrics under an `_any` alias, so any
+    // other sort reference would produce an ORDER BY on a non-existent column.
+    // Row totals are matched by index key, not order, so this is safe.
+    const indexFieldIdSet = new Set(indexFieldIds);
     const totalsPivotConfiguration: PivotConfiguration = {
         ...source.pivotConfiguration!,
         groupByColumns: [],
+        sortBy: source.pivotConfiguration!.sortBy?.filter((sort) =>
+            indexFieldIdSet.has(sort.reference),
+        ),
         sortOnlyDimensions: undefined,
         passthroughDimensions: undefined,
     };


### PR DESCRIPTION
Closes: PROD-8132
Relates: #9981

### Description:

Pivot table row totals rendered as `-` for every cell. The warehouse row-totals query collapses the pivot (`groupByColumns: []`) but kept the source `sortBy`, so `PivotQueryBuilder` emitted an `ORDER BY` on a column no longer selected in the collapsed query (the pivot dimension, a metric's pre-alias name, or a non-index dimension), and the warehouse rejected the whole query. This regression came in with warehouse-computed row totals (since there's no client-side fallback, the failed query left every cell blank). The fix keeps only sorts that reference an index column — row totals are matched by index key, not order, so dropping the others is safe — and adds tests for the three sort variants.