### PR TITLE
fix: block dbt environment variable keys

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -48,6 +48,7 @@ import {
     DbtExposure,
     DbtExposureType,
     DbtManifestVersion,
+    DbtProjectConfig,
     DbtProjectEnvironmentVariable,
     DbtProjectType,
     DbtRawModelNode,
@@ -70,6 +71,7 @@ import {
     getAvailableParametersFromTables,
     getColumnTimezone,
     getDashboardFilterRulesForTables,
+    getDbtEnvironmentVariableKeyError,
     getDimensions,
     getErrorMessage,
     getFields,
@@ -2101,6 +2103,9 @@ export class ProjectService extends BaseService {
         await this.validateProjectCreationPermissions(user, data);
 
         const newProjectData = data;
+        ProjectService.validateDbtEnvironmentVariables(
+            newProjectData.dbtConnection,
+        );
 
         // If type preview and has upstream project, we first link the preview to the same organization warehouse credentials (if exists)
         if (
@@ -2324,6 +2329,7 @@ export class ProjectService extends BaseService {
         }
 
         await this.validateProjectCreationPermissions(user, data);
+        ProjectService.validateDbtEnvironmentVariables(data.dbtConnection);
 
         let encryptedData: string;
         try {
@@ -2650,6 +2656,31 @@ export class ProjectService extends BaseService {
     /* When editing a project, most fields are optional
     but if the user switches from one authentication type to another,
     we need to validate the secrets are present */
+    static validateDbtEnvironmentVariables(dbtConnection: DbtProjectConfig) {
+        if (!('environment' in dbtConnection) || !dbtConnection.environment) {
+            return;
+        }
+
+        const keys = new Set<string>();
+        dbtConnection.environment.forEach(({ key }) => {
+            const error = getDbtEnvironmentVariableKeyError(key);
+            if (error) {
+                throw new ParameterError(error);
+            }
+
+            if (key.length === 0) {
+                return;
+            }
+
+            if (keys.has(key)) {
+                throw new ParameterError(
+                    `Environment variable "${key}" is duplicated`,
+                );
+            }
+            keys.add(key);
+        });
+    }
+
     validateConfigSecrets(project: UpdateProject) {
         switch (project.warehouseConnection?.type) {
             case WarehouseTypes.BIGQUERY:
@@ -2759,6 +2790,9 @@ export class ProjectService extends BaseService {
         );
 
         this.validateConfigSecrets(updatedProject);
+        ProjectService.validateDbtEnvironmentVariables(
+            updatedProject.dbtConnection,
+        );
 
         await this.projectModel.update(projectUuid, updatedProject);
 

--- a/packages/common/src/types/projects.test.ts
+++ b/packages/common/src/types/projects.test.ts
@@ -1,0 +1,52 @@
+import {
+    getDbtEnvironmentVariableKeyError,
+    getInvalidDbtEnvironmentVariableKeys,
+    isSafeDbtEnvironmentVariableKey,
+    LIGHTDASH_DBT_PROFILE_ENV_VAR_PREFIX,
+} from './projects';
+
+describe('dbt environment variable validation', () => {
+    test('allows customer-defined environment variables', () => {
+        expect(isSafeDbtEnvironmentVariableKey('ENV')).toBe(true);
+        expect(isSafeDbtEnvironmentVariableKey('LD_CUSTOMER_ENV')).toBe(true);
+        expect(isSafeDbtEnvironmentVariableKey('SNOWFLAKE_ACCOUNT')).toBe(true);
+        expect(isSafeDbtEnvironmentVariableKey('DBT_ENV_SECRET_TOKEN')).toBe(
+            true,
+        );
+    });
+
+    test('blocks environment variables that can alter child process execution', () => {
+        expect(getDbtEnvironmentVariableKeyError('GIT_SSH_COMMAND')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('PYTHONPATH')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('LD_PRELOAD')).toContain(
+            'cannot be used',
+        );
+    });
+
+    test('reserves Lightdash profile variables for internal use', () => {
+        const key = `${LIGHTDASH_DBT_PROFILE_ENV_VAR_PREFIX}PASSWORD`;
+
+        expect(getDbtEnvironmentVariableKeyError(key)).toContain(
+            'reserved for Lightdash',
+        );
+        expect(
+            getDbtEnvironmentVariableKeyError(key, {
+                allowLightdashProfileEnvironmentVariables: true,
+            }),
+        ).toBeUndefined();
+    });
+
+    test('returns invalid project environment variable keys', () => {
+        expect(
+            getInvalidDbtEnvironmentVariableKeys([
+                { key: 'ENV', value: 'production' },
+                { key: 'GIT_SSH_COMMAND', value: 'echo unsafe' },
+                { key: 'PYTHONPATH', value: '/tmp' },
+            ]),
+        ).toEqual(['GIT_SSH_COMMAND', 'PYTHONPATH']);
+    });
+});

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -631,6 +631,78 @@ export type DbtProjectEnvironmentVariable = {
     value: string;
 };
 
+export const LIGHTDASH_DBT_PROFILE_ENV_VAR_PREFIX =
+    'LIGHTDASH_DBT_PROFILE_VAR_';
+
+const DBT_ENVIRONMENT_VARIABLE_KEY_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const BLOCKED_DBT_ENVIRONMENT_VARIABLE_KEYS = new Set([
+    'GIT_ASKPASS',
+    'GIT_SSH',
+    'GIT_SSH_COMMAND',
+    'LD_AUDIT',
+    'LD_LIBRARY_PATH',
+    'LD_PRELOAD',
+    'NODE_OPTIONS',
+    'NODE_PATH',
+    'PATH',
+    'PERL5OPT',
+    'PYTHONHOME',
+    'PYTHONPATH',
+    'RUBYOPT',
+    'SHELL',
+    'SSH_ASKPASS',
+]);
+
+const BLOCKED_DBT_ENVIRONMENT_VARIABLE_KEY_PREFIXES = ['DYLD_', 'GIT_CONFIG_'];
+
+export const getDbtEnvironmentVariableKeyError = (
+    key: string,
+    options: {
+        allowLightdashProfileEnvironmentVariables?: boolean;
+    } = {},
+): string | undefined => {
+    if (key.length === 0) {
+        return undefined;
+    }
+
+    if (!DBT_ENVIRONMENT_VARIABLE_KEY_REGEX.test(key)) {
+        return `Environment variable "${key}" must contain only letters, numbers, and underscores, and cannot start with a number`;
+    }
+
+    if (
+        !options.allowLightdashProfileEnvironmentVariables &&
+        key.startsWith(LIGHTDASH_DBT_PROFILE_ENV_VAR_PREFIX)
+    ) {
+        return `Environment variable "${key}" is reserved for Lightdash`;
+    }
+
+    if (
+        BLOCKED_DBT_ENVIRONMENT_VARIABLE_KEYS.has(key) ||
+        BLOCKED_DBT_ENVIRONMENT_VARIABLE_KEY_PREFIXES.some((prefix) =>
+            key.startsWith(prefix),
+        )
+    ) {
+        return `Environment variable "${key}" cannot be used because it can change how dbt or its child processes execute`;
+    }
+
+    return undefined;
+};
+
+export const isSafeDbtEnvironmentVariableKey = (
+    key: string,
+    options: {
+        allowLightdashProfileEnvironmentVariables?: boolean;
+    } = {},
+): boolean => getDbtEnvironmentVariableKeyError(key, options) === undefined;
+
+export const getInvalidDbtEnvironmentVariableKeys = (
+    environment: DbtProjectEnvironmentVariable[] | undefined,
+): string[] =>
+    (environment ?? [])
+        .map(({ key }) => key)
+        .filter((key) => getDbtEnvironmentVariableKeyError(key) !== undefined);
+
 export enum SupportedDbtVersions {
     V1_4 = 'v1.4',
     V1_5 = 'v1.5',

--- a/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
+++ b/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     DbtProjectType,
     DbtProjectTypeLabels,
+    getInvalidDbtEnvironmentVariableKeys,
     ProjectType,
     type ApiError,
     type DbtProjectEnvironmentVariable,
@@ -71,6 +72,7 @@ type EnvironmentVariablesInputProps = {
     disabled?: boolean;
     documentationUrl?: string;
     labelHelp?: string | React.ReactNode;
+    error?: string;
 };
 
 const EnvironmentVariablesInput: FC<EnvironmentVariablesInputProps> = ({
@@ -80,6 +82,7 @@ const EnvironmentVariablesInput: FC<EnvironmentVariablesInputProps> = ({
     disabled,
     documentationUrl,
     labelHelp,
+    error,
 }) => {
     const [isLabelInfoOpen, setIsLabelInfoOpen] = useState<boolean>(false);
 
@@ -136,6 +139,7 @@ const EnvironmentVariablesInput: FC<EnvironmentVariablesInputProps> = ({
                 </>
             }
             description={isLabelInfoOpen && labelHelp}
+            error={error}
         >
             <Stack>
                 {value.map((variable, index) => (
@@ -214,6 +218,7 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
     const [environment, setEnvironment] = useState<
         DbtProjectEnvironmentVariable[]
     >([]);
+    const [environmentError, setEnvironmentError] = useState<string>('');
     const [manifestJson, setManifestJson] = useState<string>('');
     const [manifestError, setManifestError] = useState<string>('');
 
@@ -361,6 +366,18 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
         if (manifestJson.trim() && !validateManifest(manifestJson)) {
             return;
         }
+
+        const invalidEnvironmentKeys =
+            getInvalidDbtEnvironmentVariableKeys(environment);
+        if (invalidEnvironmentKeys.length > 0) {
+            setEnvironmentError(
+                `Environment variable keys cannot change how dbt or its child processes execute. Invalid keys: ${invalidEnvironmentKeys.join(
+                    ', ',
+                )}`,
+            );
+            return;
+        }
+        setEnvironmentError('');
 
         // Reduce manifest size by removing unnecessary keys
         const finalManifest = manifestJson.trim()
@@ -539,10 +556,12 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
                                 <EnvironmentVariablesInput
                                     label="Environment Variables"
                                     value={environment}
-                                    onChange={(newVariables) =>
-                                        setEnvironment(newVariables)
-                                    }
+                                    onChange={(newVariables) => {
+                                        setEnvironment(newVariables);
+                                        setEnvironmentError('');
+                                    }}
                                     disabled={isPreviewCreating}
+                                    error={environmentError}
                                 />
 
                                 <Textarea

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/validators.ts
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/validators.ts
@@ -1,4 +1,8 @@
-import { validateDbtSelector } from '@lightdash/common';
+import {
+    getInvalidDbtEnvironmentVariableKeys,
+    validateDbtSelector,
+    type DbtProjectEnvironmentVariable,
+} from '@lightdash/common';
 import {
     everyValidator,
     hasNoWhiteSpaces,
@@ -13,9 +17,21 @@ const selectorValidator = (value?: string) => {
     return 'dbt selector is invalid';
 };
 
+const environmentValidator = (
+    value?: DbtProjectEnvironmentVariable[],
+): string | undefined => {
+    const invalidKeys = getInvalidDbtEnvironmentVariableKeys(value);
+    if (invalidKeys.length === 0) return undefined;
+
+    return `Environment variable keys cannot change how dbt or its child processes execute. Invalid keys: ${invalidKeys.join(
+        ', ',
+    )}`;
+};
+
 export const dbtFormValidators = {
     api_key: hasNoWhiteSpaces('API Key'),
     environment_id: hasNoWhiteSpaces('Environment ID'),
+    environment: environmentValidator,
     selector: selectorValidator,
     // TODO :: improve this for github to detect the prefix
     // @mantine/form@7.5.2 doesn't support replacing validators after initialization

--- a/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
@@ -32,6 +32,7 @@ export const MultiKeyValuePairsInput = ({
 
     const values: { id: string; key: string; value: string }[] =
         get(form.values, name) ?? [];
+    const error = form.errors[name];
 
     const addValue = () => {
         form.insertListItem(name, {
@@ -79,6 +80,7 @@ export const MultiKeyValuePairsInput = ({
                 </>
             }
             description={isLabelInfoOpen && labelHelp}
+            error={error}
         >
             <Stack>
                 {values.map((value, index) => (


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-8109/command-injection-via-unsanitized-dbt-environment-variables](https://linear.app/lightdash/issue/PROD-8109/command-injection-via-unsanitized-dbt-environment-variables)

![CleanShot 2026-06-04 at 15.29.14.png](https://app.graphite.com/user-attachments/assets/182c7ffa-6ee1-4043-b30a-32327012e103.png)

![CleanShot 2026-06-04 at 15.29.49.png](https://app.graphite.com/user-attachments/assets/0de03c96-2974-4ce0-92c1-96ebb3494d31.png)

Even if some varialbes are already used in projects, it will not block compile, only project create/update![CleanShot 2026-06-04 at 16.07.42.png](https://app.graphite.com/user-attachments/assets/8a509159-a0d9-4b76-9087-a03c0d9dc0ce.png)



### Description

- Blocks dangerous dbt environment variable keys when project configuration is created or updated.
- Keeps customer-defined env vars such as `ENV` and custom `LD_*` names supported.
- Shows matching validation in project settings and preview project creation.