### PR TITLE
style(ai-agents): tweak suggestion chip dark colors

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
@@ -32,11 +32,11 @@
     @mixin dark {
         background-color: color-mix(
             in srgb,
-            var(--mantine-color-ldDark-5) 70%,
+            var(--mantine-color-ldDark-2) 70%,
             transparent
         );
         border-color: transparent;
-        color: var(--mantine-color-ldDark-7);
+        color: var(--mantine-color-ldDark-8);
     }
 
     &:hover {


### PR DESCRIPTION
## Summary

Tweak AI agent suggestion chip dark-theme colors to use a lighter background token and stronger text token.

## Validation

- Pre-commit frontend linter/formatter hook passed.
- `git diff --check`
