### PR TITLE
feat(ai-review): prefer an Anthropic judge model when configured

### DIFF
--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -6,7 +6,10 @@ import {
 } from '@lightdash/common';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
-import { AiAgentReviewClassifierService } from './AiAgentReviewClassifierService';
+import {
+    AiAgentReviewClassifierService,
+    resolveReviewJudgeProvider,
+} from './AiAgentReviewClassifierService';
 
 const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
 const PROJECT_UUID = '00000000-0000-0000-0000-000000000002';
@@ -593,6 +596,27 @@ describe('AiAgentReviewClassifierService', () => {
                     primaryRootCause: 'product_capability',
                 }),
             }),
+        );
+    });
+});
+
+describe('resolveReviewJudgeProvider', () => {
+    const copilotWith = (
+        providers: Record<string, unknown>,
+    ): Parameters<typeof resolveReviewJudgeProvider>[0] =>
+        ({ defaultProvider: 'openai', providers }) as never;
+
+    it('prefers anthropic for the judge when it is configured', () => {
+        expect(
+            resolveReviewJudgeProvider(
+                copilotWith({ openai: {}, anthropic: { apiKey: 'x' } }),
+            ),
+        ).toBe('anthropic');
+    });
+
+    it('falls back to the default provider when anthropic is absent', () => {
+        expect(resolveReviewJudgeProvider(copilotWith({ openai: {} }))).toBe(
+            undefined,
         );
     });
 });

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -37,6 +37,18 @@ import { getModel } from './ai/models';
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
 const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v2';
 
+/**
+ * Provider for the review judge. Prefer Anthropic (Claude) when it is configured
+ * — it follows the project_context vs semantic_layer routing far more reliably
+ * than other providers. Returns undefined to fall back to the org's default
+ * provider, so EE orgs that have an EE license but no Anthropic key (OpenAI /
+ * Azure only) keep working.
+ */
+export const resolveReviewJudgeProvider = (
+    copilot: LightdashConfig['ai']['copilot'],
+): LightdashConfig['ai']['copilot']['defaultProvider'] | undefined =>
+    copilot.providers.anthropic ? 'anthropic' : undefined;
+
 type AiAgentReviewClassifierJudge = (
     candidate: AiAgentReviewClassifierTurnCandidate,
     evidencePacket: AiAgentReviewJudgeEvidencePacket,
@@ -876,6 +888,9 @@ export class AiAgentReviewClassifierService extends BaseService {
         evidencePacket: AiAgentReviewJudgeEvidencePacket,
     ): Promise<AiAgentReviewClassifierJudgeOutput> {
         const model = getModel(this.lightdashConfig.ai.copilot, {
+            provider: resolveReviewJudgeProvider(
+                this.lightdashConfig.ai.copilot,
+            ),
             useFastModel: true,
         });
 


### PR DESCRIPTION
## Why

The review judge resolved its model from `getModel(ai.copilot, { useFastModel: true })`, which falls back to the org's **`defaultProvider`**. In practice this means the judge runs on whatever chat provider the instance defaults to — and the choice matters a lot for classification quality:

- On instances defaulting to **Anthropic**, the judge (Claude) reliably distinguishes `project_context` (wrong explore / missing knowledge of what a term means) from `semantic_layer` (a field/metric/join definition), and emits the durable project-context entry.
- On instances defaulting to **OpenAI**, the judge tends to collapse those same `project_context` cases into `semantic_layer`, so the project-context queue and its write-back entries stay empty.

Judge quality is a meta-task; it shouldn't depend on which chat provider an org happens to default to.

## Change

Prefer **Anthropic (Claude)** for the review judge whenever an Anthropic provider is configured, regardless of the org's `defaultProvider`. When Anthropic isn't configured, fall back to the default provider exactly as before.

The decision is a tiny pure helper, `resolveReviewJudgeProvider(copilot)` → `'anthropic'` when configured, else `undefined` (so `getModel` uses the default), wired into `judgeTurnWithLlm`.

## OSS / EE consideration

Lightdash is open source, and an org can hold an EE license without an Anthropic key (OpenAI- or Azure-only). The fallback keeps those orgs working unchanged — this only *upgrades* the judge for orgs that already have Anthropic configured. No new required config, no behaviour change for Anthropic-default orgs.

## Behaviour change / regression analysis

- EE AI-agent review classifier judge-model selection only. No schema, API, prompt, or read-path changes.
- Anthropic-default orgs: unchanged (already used Anthropic).
- OpenAI/Azure-only orgs: unchanged (no Anthropic → fall back to default).
- Orgs with Anthropic configured but a different default: the **review judge** now uses Claude (their interactive agents are unaffected). This is the intended improvement.

## Tests

`AiAgentReviewClassifierService.test.ts` — `resolveReviewJudgeProvider` prefers `anthropic` when configured and returns `undefined` (default-provider fallback) when absent.

`pnpm -F backend typecheck:fast` ✅ · `jest AiAgentReviewClassifierService` ✅ (10 passed)

---
_No Linear ticket linked — add `Closes: PROD-XXXX` before merge if there is one._