### PR TITLE
feat(mcp): add list content tool

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
@@ -1,0 +1,391 @@
+import { McpService, McpToolName } from './McpService';
+
+type RegisteredToolCallback = (
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>,
+) => Promise<unknown>;
+
+const mockRegisteredMcpTools = new Map<string, RegisteredToolCallback>();
+
+jest.mock('@sentry/node', () => ({
+    captureException: jest.fn(),
+    getActiveSpan: () => undefined,
+    isEnabled: () => false,
+    startSpanManual: (_options: unknown, callback: CallableFunction) =>
+        callback({ spanContext: () => ({ spanId: 'span-id' }) }, jest.fn()),
+    wrapMcpServerWithSentry: (server: unknown) => server,
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+    McpServer: jest.fn().mockImplementation(() => ({
+        registerResource: jest.fn(),
+        registerPrompt: jest.fn(),
+        registerTool: jest.fn(
+            (
+                name: string,
+                _config: Record<string, unknown>,
+                callback: RegisteredToolCallback,
+            ) => {
+                mockRegisteredMcpTools.set(name, callback);
+                return {};
+            },
+        ),
+    })),
+}));
+
+const projectUuid = 'project-uuid';
+const organizationUuid = 'organization-uuid';
+const userUuid = 'user-uuid';
+const allowedSpaceUuid = 'allowed-space-uuid';
+const blockedSpaceUuid = 'blocked-space-uuid';
+
+const account = {
+    isRegisteredUser: () => true,
+    isServiceAccount: () => false,
+    user: { id: userUuid },
+};
+
+const user = {
+    userUuid,
+    organizationUuid,
+    ability: {
+        can: jest.fn(() => true),
+        cannot: jest.fn(() => false),
+        relevantRuleFor: jest.fn(() => undefined),
+        rules: [],
+    },
+};
+
+const extra = {
+    signal: new AbortController().signal,
+    requestId: 'request-id',
+    sendNotification: jest.fn(),
+    sendRequest: jest.fn(),
+    authInfo: {
+        extra: {
+            user,
+            account,
+        },
+    },
+};
+
+type TestSpace = {
+    uuid: string;
+    name: string;
+    path: string;
+    parentSpaceUuid: string | null;
+    chartCount: number;
+    dashboardCount: number;
+    childSpaceCount: number;
+    appCount: number;
+    userAccess?: { hasDirectAccess: boolean };
+    access?: string[];
+};
+
+type TestContentItem =
+    | {
+          contentType: 'chart' | 'dashboard' | 'data_app';
+          name: string;
+          slug: string;
+      }
+    | {
+          contentType: 'space';
+          uuid: string;
+          name: string;
+          path: string;
+          chartCount: number;
+          dashboardCount: number;
+          childSpaceCount: number;
+          appCount: number;
+          access: string[];
+      };
+
+type TestRuntimeContext = {
+    spaceAccess: string[] | null;
+};
+
+const makeMcpService = ({
+    context = {
+        projectUuid,
+        projectName: 'Project',
+        agentUuid: null,
+        agentName: null,
+        tags: null,
+    },
+    agent = null,
+    spaces = [],
+    contentResults = { data: [], pagination: undefined },
+}: {
+    context?: {
+        projectUuid: string;
+        projectName: string;
+        agentUuid: string | null;
+        agentName: string | null;
+        tags: string[] | null;
+    };
+    agent?: {
+        uuid: string;
+        name: string;
+        tags: string[] | null;
+        spaceAccess: string[];
+    } | null;
+    spaces?: TestSpace[];
+    contentResults?: {
+        data: TestContentItem[];
+        pagination:
+            | {
+                  page: number;
+                  pageSize: number;
+                  totalResults: number;
+                  totalPageCount: number;
+              }
+            | undefined;
+    };
+} = {}) => {
+    const aiAgentService = {
+        getAgent: jest.fn().mockImplementation(async () => {
+            if (!agent) throw new Error('Agent not mocked');
+            return {
+                description: null,
+                projectUuid,
+                context: {
+                    explores: [],
+                    verifiedQuestions: [],
+                    instruction: null,
+                },
+                ...agent,
+            };
+        }),
+    };
+
+    const toSpaceSlug = (path: string) =>
+        path.replace(/\./g, '/').replace(/_/g, '-');
+    const aiAgentToolsService = {
+        createRuntime: jest.fn((runtimeContext: TestRuntimeContext) => ({
+            listContent: jest.fn(async ({ spaceSlug, page }) => {
+                if (spaceSlug === null) {
+                    const visibleSpaces = spaces.filter(
+                        (space) =>
+                            !runtimeContext.spaceAccess?.length ||
+                            runtimeContext.spaceAccess.includes(space.uuid),
+                    );
+                    return {
+                        spaceSlug,
+                        items: visibleSpaces.map((space) => ({
+                            contentType: 'space',
+                            name: space.name,
+                            slug: toSpaceSlug(space.path),
+                            chartCount: space.chartCount,
+                            dashboardCount: space.dashboardCount,
+                            childSpaceCount: space.childSpaceCount,
+                            appCount: space.appCount,
+                            directAccess:
+                                space.userAccess?.hasDirectAccess === true,
+                        })),
+                        pagination: {
+                            page,
+                            pageSize: 25,
+                            totalResults: visibleSpaces.length,
+                            totalPageCount: 1,
+                        },
+                    };
+                }
+
+                return {
+                    spaceSlug,
+                    items: contentResults.data.map((item) =>
+                        item.contentType === 'space'
+                            ? {
+                                  contentType: 'space',
+                                  name: item.name,
+                                  slug: toSpaceSlug(item.path),
+                                  chartCount: item.chartCount,
+                                  dashboardCount: item.dashboardCount,
+                                  childSpaceCount: item.childSpaceCount,
+                                  appCount: item.appCount,
+                                  directAccess:
+                                      item.access?.includes(userUuid) === true,
+                              }
+                            : item,
+                    ),
+                    pagination: contentResults.pagination,
+                };
+            }),
+        })),
+    };
+
+    const projectService = {
+        getProject: jest.fn().mockResolvedValue({ organizationUuid }),
+        getSpaces: jest.fn().mockResolvedValue(spaces),
+    };
+
+    const service = new McpService({
+        aiAgentService,
+        aiAgentToolsService,
+        aiOrganizationSettingsService: {
+            getSettings: jest.fn().mockResolvedValue({ aiAgentsVisible: true }),
+        },
+        aiWritebackService: {},
+        analytics: { track: jest.fn() },
+        asyncQueryService: {},
+        catalogService: {},
+        contentVerificationService: {},
+        featureFlagService: {},
+        lightdashConfig: {
+            ai: {
+                copilot: {
+                    maxQueryLimit: 500,
+                },
+            },
+            mcp: {
+                enabled: true,
+                runSqlMaxLimit: 500,
+            },
+            siteUrl: 'https://lightdash.example',
+        },
+        mcpContextModel: {
+            getContext: jest.fn().mockResolvedValue({ context }),
+        },
+        projectModel: {},
+        projectService,
+        searchModel: {},
+        shareService: {},
+        spaceService: {},
+        userAttributesModel: {},
+    } as unknown as ConstructorParameters<typeof McpService>[0]);
+
+    return {
+        aiAgentToolsService,
+        projectService,
+        service,
+    };
+};
+
+const getToolCallback = (toolName: McpToolName) => {
+    const callback = mockRegisteredMcpTools.get(toolName);
+    if (!callback) {
+        throw new Error(`Tool ${toolName} was not registered`);
+    }
+    return callback;
+};
+
+const getTextResult = (result: unknown) => {
+    const response = result as { content?: Array<{ text?: string }> };
+    return response.content?.[0]?.text ?? '';
+};
+
+describe('MCP list_content', () => {
+    beforeEach(() => {
+        mockRegisteredMcpTools.clear();
+    });
+
+    it('lists root content spaces with active agent space access', async () => {
+        makeMcpService({
+            context: {
+                projectUuid,
+                projectName: 'Project',
+                agentUuid: 'agent-uuid',
+                agentName: 'Agent',
+                tags: null,
+            },
+            agent: {
+                uuid: 'agent-uuid',
+                name: 'Agent',
+                tags: [],
+                spaceAccess: [allowedSpaceUuid],
+            },
+            spaces: [
+                {
+                    uuid: allowedSpaceUuid,
+                    name: 'Allowed Space',
+                    path: 'allowed_space',
+                    parentSpaceUuid: null,
+                    chartCount: 2,
+                    dashboardCount: 1,
+                    childSpaceCount: 0,
+                    appCount: 0,
+                    userAccess: { hasDirectAccess: true },
+                },
+                {
+                    uuid: blockedSpaceUuid,
+                    name: 'Blocked Space',
+                    path: 'blocked_space',
+                    parentSpaceUuid: null,
+                    chartCount: 1,
+                    dashboardCount: 0,
+                    childSpaceCount: 0,
+                    appCount: 0,
+                    userAccess: { hasDirectAccess: true },
+                },
+            ],
+        });
+
+        const result = await getToolCallback(McpToolName.LIST_CONTENT)(
+            { spaceSlug: null, page: 1 },
+            extra,
+        );
+        const text = getTextResult(result);
+
+        expect(text).toContain('contentType="space"');
+        expect(text).toContain('name="Allowed Space"');
+        expect(text).toContain('slug="allowed-space"');
+        expect(text).toContain('chartCount="2"');
+        expect(text).not.toContain('Blocked Space');
+    });
+
+    it('lists direct content inside a space slug', async () => {
+        makeMcpService({
+            spaces: [
+                {
+                    uuid: allowedSpaceUuid,
+                    name: 'Allowed Space',
+                    path: 'allowed_space',
+                    parentSpaceUuid: null,
+                    chartCount: 2,
+                    dashboardCount: 1,
+                    childSpaceCount: 1,
+                    appCount: 0,
+                    userAccess: { hasDirectAccess: true },
+                },
+            ],
+            contentResults: {
+                data: [
+                    {
+                        contentType: 'chart',
+                        name: 'Revenue Chart',
+                        slug: 'revenue-chart',
+                    },
+                    {
+                        contentType: 'space',
+                        uuid: 'child-space-uuid',
+                        name: 'Child Space',
+                        path: 'allowed_space.child_space',
+                        chartCount: 0,
+                        dashboardCount: 0,
+                        childSpaceCount: 0,
+                        appCount: 0,
+                        access: [userUuid],
+                    },
+                ],
+                pagination: {
+                    page: 1,
+                    pageSize: 25,
+                    totalResults: 2,
+                    totalPageCount: 1,
+                },
+            },
+        });
+
+        const result = await getToolCallback(McpToolName.LIST_CONTENT)(
+            { spaceSlug: 'allowed-space', page: 1 },
+            extra,
+        );
+        const text = getTextResult(result);
+
+        expect(text).toContain('spaceSlug="allowed-space"');
+        expect(text).toContain('name="Revenue Chart"');
+        expect(text).toContain('slug="revenue-chart"');
+        expect(text).toContain('name="Child Space"');
+        expect(text).toContain('slug="allowed-space/child-space"');
+    });
+});

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -397,6 +397,7 @@ const makeMcpService = ({
         analytics: { track: jest.fn() },
         asyncQueryService,
         catalogService,
+        contentService: {},
         contentVerificationService,
         featureFlagService: {},
         lightdashConfig: {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -28,6 +28,7 @@ import {
     getValidAiQueryLimit,
     ItemsMap,
     listAgentsToolDefinition,
+    listContentToolDefinition,
     listExploresToolDefinition,
     listSkillsToolDefinition,
     listVerifiedContentToolDefinition,
@@ -107,6 +108,7 @@ import {
 import { getFindContent } from '../ai/tools/findContent';
 import { getFindExplores } from '../ai/tools/findExplores';
 import { getFindFields } from '../ai/tools/findFields';
+import { getListContent } from '../ai/tools/listContent';
 import { getMcpListExplores } from '../ai/tools/mcpListExplores';
 import { validateRunQueryTool } from '../ai/tools/runQuery';
 import { getSearchFieldValues } from '../ai/tools/searchFieldValues';
@@ -136,6 +138,7 @@ export enum McpToolName {
     FIND_EXPLORES = 'find_explores',
     FIND_FIELDS = 'find_fields',
     FIND_CONTENT = 'find_content',
+    LIST_CONTENT = 'list_content',
     LIST_PROJECTS = 'list_projects',
     SET_PROJECT = 'set_project',
     GET_CURRENT_PROJECT = 'get_current_project',
@@ -164,6 +167,7 @@ const mcpListExploresTool = listExploresToolDefinition.for('mcp');
 const mcpFindExploresTool = findExploresToolDefinition.for('mcp');
 const mcpFindFieldsTool = findFieldsToolDefinition.for('mcp');
 const mcpFindContentTool = findContentToolDefinition.for('mcp');
+const mcpListContentTool = listContentToolDefinition.for('mcp');
 const mcpListProjectsTool = mcpListProjectsToolDefinition.for('mcp');
 const mcpSetProjectTool = setProjectToolDefinition.for('mcp');
 const mcpGetCurrentProjectTool = getCurrentProjectToolDefinition.for('mcp');
@@ -1276,6 +1280,46 @@ export class McpService extends BaseService {
                     trackCoverage: () => {},
                 });
                 const result = await findContentTool.execute!(argsWithProject, {
+                    toolCallId: '',
+                    messages: [],
+                });
+
+                return this.buildScopedResponse(
+                    ctx,
+                    await McpService.streamToolResult(result),
+                    undefined,
+                    projectUuid,
+                );
+            },
+        );
+
+        this.mcpServer.registerTool(
+            mcpListContentTool.name,
+            {
+                title: mcpListContentTool.title,
+                description: mcpListContentTool.description,
+                inputSchema: this.getMcpCompatibleSchema(
+                    mcpListContentTool.inputSchema,
+                ),
+                annotations: mcpListContentTool.annotations,
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+
+                const projectUuid = await this.resolveProjectUuid(ctx);
+                const argsWithProject = { ...args, projectUuid };
+
+                this.trackToolCall(ctx, McpToolName.LIST_CONTENT, projectUuid);
+
+                const toolsRuntime = await this.getToolsRuntime(
+                    ctx,
+                    projectUuid,
+                );
+
+                const listContentTool = getListContent({
+                    listContent: toolsRuntime.listContent,
+                });
+                const result = await listContentTool.execute!(argsWithProject, {
                     toolCallId: '',
                     messages: [],
                 });

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -29,7 +29,8 @@ exports[`MCP tool contracts matches the current MCP tool and prompt contract sna
 4. **Run queries**: Use \`run_metric_query\` for semantic-layer metric queries, or \`run_sql\` for custom SQL
 5. **Poll long-running queries**: If a query returns \`status: "running"\`, call \`get_query_result\` with the \`queryUuid\` until it returns done/error/cancelled/expired
 6. **Render charts**: If the user wants a chart, call \`render_chart\` after \`run_metric_query\` or \`get_query_result\` returns done with a \`queryUuid\`
-7. **Find content**: Use \`find_content\` to search for existing dashboards and charts
+7. **Browse content**: Use \`list_content\` to browse accessible spaces and direct content inside a space
+8. **Find content**: Use \`find_content\` to search for existing dashboards and charts
 
 ## Critical Rules
 
@@ -243,6 +244,36 @@ Usage tips:
       },
       "name": "find_content",
       "title": "Find content",
+    },
+    {
+      "agentName": null,
+      "description": "Tool: "listContent"
+Purpose:
+Lists accessible Lightdash content in a project as a browsable hierarchy.
+
+Usage tips:
+- By default, lists root-level spaces.
+- Pass a spaceSlug to list direct children and content inside that space.
+- Use page for pagination. Page starts at 1.
+- Results include names, slugs, content types, and space content counts.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "page": {
+            "description": "Use this to paginate through the results. Starts at 1., ",
+            "exclusiveMinimum": 0,
+            "type": "number",
+          },
+          "spaceSlug": {
+            "description": "Optional space slug/path to list. Use null to list root-level content., ",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "list_content",
+      "title": "List content",
     },
     {
       "agentName": null,
@@ -7798,6 +7829,7 @@ exports[`MCP tool contracts matches the shared MCP tool definition names snapsho
   "run_sql",
   "get_query_result",
   "render_chart",
+  "list_content",
   "get_lightdash_version",
   "list_explores",
   "list_skills",

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -87,6 +87,7 @@ const makeMcpService = (): McpService =>
         analytics: {},
         asyncQueryService: {},
         catalogService: {},
+        contentService: {},
         contentVerificationService: {},
         featureFlagService: {},
         lightdashConfig: {

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -15,7 +15,8 @@ export const MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelines
 4. **Run queries**: Use \`run_metric_query\` for semantic-layer metric queries, or \`run_sql\` for custom SQL
 5. **Poll long-running queries**: If a query returns \`status: "running"\`, call \`get_query_result\` with the \`queryUuid\` until it returns done/error/cancelled/expired
 6. **Render charts**: If the user wants a chart, call \`render_chart\` after \`run_metric_query\` or \`get_query_result\` returns done with a \`queryUuid\`
-7. **Find content**: Use \`find_content\` to search for existing dashboards and charts
+7. **Browse content**: Use \`list_content\` to browse accessible spaces and direct content inside a space
+8. **Find content**: Use \`find_content\` to search for existing dashboards and charts
 
 ## Critical Rules
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -476,9 +476,13 @@ export const listContentToolDefinition = defineTool({
     name: 'listContent',
     title: 'List content',
     description: TOOL_LIST_CONTENT_DESCRIPTION,
-    availability: ['agent'],
+    availability: ['agent', 'mcp'],
     inputSchema: toolListContentArgsSchema,
     agent: { outputSchema: toolListContentOutputSchema },
+    mcp: {
+        name: 'list_content',
+        annotations: readOnlyAnnotations,
+    },
 });
 
 export const improveContextToolDefinition = defineTool({


### PR DESCRIPTION
Related ZAP-391

## Summary
- Add MCP `list_content` for browsing accessible root spaces and direct contents inside a space.
- Reuse `AiAgentToolsService` runtime so MCP follows the same identity, space-scope, and permission behavior as AI agents.
- Keep `find_content` focused on search while giving agents a way to walk space → content.

## Testing
- `pnpm -F common build`
- `pnpm -F backend typecheck:fast`
- `pnpm -F common typecheck:fast`
- `pnpm -F backend exec jest --config jest.config.js --runTestsByPath src/ee/services/McpService/mcpToolContracts.snapshot.test.ts`
