### PR TITLE
fix(ai): improve content mention search

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
@@ -19,6 +19,7 @@ import {
     ContentTypePriority,
     SummaryContentRow,
 } from '../ContentModelTypes';
+import { applyContentNameSearch } from '../ContentSearchUtils';
 
 export const dashboardContentConfiguration: ContentConfiguration<SummaryContentRow> =
     {
@@ -210,9 +211,10 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                                             limit 1)`),
                     );
                     if (filters.search) {
-                        void builder.whereRaw(
-                            `LOWER(${DashboardsTableName}.name) LIKE ?`,
-                            [`%${filters.search.toLowerCase()}%`],
+                        applyContentNameSearch(
+                            builder,
+                            `${DashboardsTableName}.name`,
+                            filters.search,
                         );
                     }
 

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -15,6 +15,7 @@ import {
     ContentTypePriority,
     SummaryContentRow,
 } from '../ContentModelTypes';
+import { applyContentNameSearch } from '../ContentSearchUtils';
 
 export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow> =
     {
@@ -176,9 +177,10 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                     );
 
                     if (filters.search) {
-                        void builder.whereRaw(
-                            `LOWER(${AppsTableName}.name) LIKE ?`,
-                            [`%${filters.search.toLowerCase()}%`],
+                        applyContentNameSearch(
+                            builder,
+                            `${AppsTableName}.name`,
+                            filters.search,
                         );
                     }
 

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
@@ -23,6 +23,7 @@ import {
     ContentTypePriority,
     SummaryContentRow,
 } from '../ContentModelTypes';
+import { applyContentNameSearch } from '../ContentSearchUtils';
 
 type SelectSavedChart = SummaryContentRow<{
     source: ChartSourceType.DBT_EXPLORE;
@@ -202,9 +203,10 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                         );
                     }
                     if (filters.search) {
-                        void builder.whereRaw(
-                            `LOWER(${SavedChartsTableName}.name) LIKE ?`,
-                            [`%${filters.search.toLowerCase()}%`],
+                        applyContentNameSearch(
+                            builder,
+                            `${SavedChartsTableName}.name`,
+                            filters.search,
                         );
                     }
 

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -16,6 +16,7 @@ import {
     ContentTypePriority,
     SummaryContentRow,
 } from '../ContentModelTypes';
+import { applyContentNameSearch } from '../ContentSearchUtils';
 
 type SpaceContentRow = SummaryContentRow<{
     dashboardCount: number;
@@ -197,9 +198,10 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                     }
 
                     if (filters.search) {
-                        void builder.whereRaw(
-                            `LOWER(${SpaceTableName}.name) LIKE ?`,
-                            [`%${filters.search.toLowerCase()}%`],
+                        applyContentNameSearch(
+                            builder,
+                            `${SpaceTableName}.name`,
+                            filters.search,
                         );
                     }
 

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
@@ -18,6 +18,7 @@ import {
     ContentTypePriority,
     SummaryContentRow,
 } from '../ContentModelTypes';
+import { applyContentNameSearch } from '../ContentSearchUtils';
 
 type SelectSavedSql = SummaryContentRow<{
     source: ChartSourceType.SQL;
@@ -192,9 +193,10 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                         );
                     }
                     if (filters.search) {
-                        void builder.whereRaw(
-                            `LOWER(${SavedSqlTableName}.name) LIKE ?`,
-                            [`%${filters.search.toLowerCase()}%`],
+                        applyContentNameSearch(
+                            builder,
+                            `${SavedSqlTableName}.name`,
+                            filters.search,
                         );
                     }
 

--- a/packages/backend/src/models/ContentModel/ContentSearchUtils.test.ts
+++ b/packages/backend/src/models/ContentModel/ContentSearchUtils.test.ts
@@ -1,0 +1,14 @@
+import {
+    compactContentSearchText,
+    getContentSearchPatterns,
+} from './ContentSearchUtils';
+
+describe('ContentSearchUtils', () => {
+    it('compacts punctuation for fuzzy content name search', () => {
+        expect(compactContentSearchText("What's new?")).toBe('whatsnew');
+        expect(getContentSearchPatterns("What's")).toEqual({
+            lower: "%what's%",
+            compact: 'whats',
+        });
+    });
+});

--- a/packages/backend/src/models/ContentModel/ContentSearchUtils.ts
+++ b/packages/backend/src/models/ContentModel/ContentSearchUtils.ts
@@ -1,0 +1,32 @@
+import { type Knex } from 'knex';
+
+export const compactContentSearchText = (value: string) =>
+    value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+
+export const getContentSearchPatterns = (search: string) => ({
+    lower: `%${search.toLowerCase()}%`,
+    compact: compactContentSearchText(search),
+});
+
+// Remote mention suggestions use v2/content, so the fuzzy part has to be
+// expressed in SQL instead of the frontend-only label matcher.
+export const applyContentNameSearch = (
+    builder: Knex.QueryBuilder,
+    column: string,
+    search: string,
+) => {
+    const patterns = getContentSearchPatterns(search);
+
+    void builder.where((searchBuilder) => {
+        void searchBuilder.whereRaw(`LOWER(${column}) LIKE ?`, [
+            patterns.lower,
+        ]);
+
+        if (patterns.compact) {
+            void searchBuilder.orWhereRaw(
+                `regexp_replace(LOWER(${column}), '[^a-z0-9]+', '', 'g') LIKE ?`,
+                [`%${patterns.compact}%`],
+            );
+        }
+    });
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -459,9 +459,9 @@
     }
 
     @mixin dark {
-        color: var(--mantine-color-ldGray-1);
-        background-color: var(--mantine-color-ldDark-6);
-        border: 1px solid var(--mantine-color-ldDark-4);
+        color: var(--mantine-color-ldGray-8);
+        background-color: var(--mantine-color-ldDark-2);
+        border: 1px solid var(--mantine-color-ldDark-5);
     }
 }
 
@@ -482,8 +482,8 @@
 
     @mixin dark {
         color: var(--mantine-color-blue-3);
-        background-color: var(--mantine-color-ldDark-5);
-        box-shadow: inset 0 0 0 1px var(--mantine-color-ldDark-3);
+        background-color: var(--mantine-color-ldDark-3);
+        box-shadow: inset 0 0 0 1px var(--mantine-color-ldDark-5);
     }
 }
 
@@ -518,6 +518,10 @@
         linear-gradient(currentColor 0 0) 7px 6px / 4px 5px no-repeat;
 }
 
+.contentMentionIcon[data-rendered-icon='true']::before {
+    content: none;
+}
+
 .contentMentionLabel {
     min-width: 0;
     overflow: hidden;
@@ -531,4 +535,9 @@
 .contentMentionSuggestionText {
     min-width: 0;
     flex: 1;
+}
+
+.contentMentionSuggestionLabel {
+    min-width: 0;
+    max-width: 100%;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentMentionNodeView.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentMentionNodeView.tsx
@@ -1,0 +1,53 @@
+import { ContentType, type ChartKind } from '@lightdash/common';
+import { IconLayoutDashboard } from '@tabler/icons-react';
+import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
+import TruncatedText from '../../../../../components/common/TruncatedText';
+import styles from './AgentChatInput.module.css';
+
+const getContentMentionContentType = (value: unknown) =>
+    value === ContentType.DASHBOARD ? ContentType.DASHBOARD : ContentType.CHART;
+
+export const ContentMentionNodeView = ({ node }: NodeViewProps) => {
+    const contentType = getContentMentionContentType(node.attrs.contentType);
+    const Icon =
+        contentType === ContentType.DASHBOARD
+            ? IconLayoutDashboard
+            : getChartIcon(
+                  (node.attrs.chartKind as ChartKind | null) ?? undefined,
+              );
+    const iconColor =
+        contentType === ContentType.DASHBOARD ? 'green.7' : 'blue.7';
+    const label = typeof node.attrs.label === 'string' ? node.attrs.label : '';
+
+    return (
+        <NodeViewWrapper
+            as="span"
+            className={styles.contentMention}
+            data-content-type={contentType}
+        >
+            <span
+                className={styles.contentMentionIcon}
+                data-rendered-icon="true"
+            >
+                <MantineIcon
+                    icon={Icon}
+                    size={12}
+                    color={iconColor}
+                    stroke={1.8}
+                />
+            </span>
+            <TruncatedText
+                className={styles.contentMentionLabel}
+                fz="inherit"
+                fw="inherit"
+                inline
+                maxWidth={260}
+                style={{ flex: 1, minWidth: 0 }}
+            >
+                {label}
+            </TruncatedText>
+        </NodeViewWrapper>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
@@ -1,12 +1,25 @@
 import { ChartKind, ContentType } from '@lightdash/common';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../../../api';
 import {
     buildContentMentionSuggestionItems,
     contextItemsToContentMentionSuggestions,
+    fuzzyContentMentionLabelMatch,
+    getContentMentionEmptyMessage,
     mergeAiPromptContextInput,
 } from './contentMentions';
 
+vi.mock('../../../../../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+const mockedLightdashApi = vi.mocked(lightdashApi);
+
 describe('contentMentions', () => {
+    beforeEach(() => {
+        mockedLightdashApi.mockReset();
+    });
+
     it('dedupes prompt context preserving first occurrence', () => {
         expect(
             mergeAiPromptContextInput(
@@ -107,5 +120,36 @@ describe('contentMentions', () => {
                 group: 'dashboardTile',
             },
         ]);
+    });
+
+    it('matches priority suggestions ignoring punctuation', () => {
+        expect(fuzzyContentMentionLabelMatch("What's revenue", 'Whats')).toBe(
+            true,
+        );
+        expect(
+            fuzzyContentMentionLabelMatch('Revenue by month', 'rev mon'),
+        ).toBe(true);
+    });
+
+    it('does not search content API until the query has at least two characters', async () => {
+        await expect(
+            buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'r',
+                priorityItems: [],
+            }),
+        ).resolves.toEqual([]);
+
+        expect(mockedLightdashApi).not.toHaveBeenCalled();
+    });
+
+    it('prompts for more characters before content API search starts', () => {
+        expect(getContentMentionEmptyMessage('')).toBe(
+            'Type 2 more characters to search content',
+        );
+        expect(getContentMentionEmptyMessage('r')).toBe(
+            'Type 1 more character to search content',
+        );
+        expect(getContentMentionEmptyMessage('re')).toBe('No content found');
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -12,7 +12,11 @@ import { IconCircleCheck, IconLayoutDashboard } from '@tabler/icons-react';
 import Mention, { type MentionOptions } from '@tiptap/extension-mention';
 import { type DOMOutputSpec } from '@tiptap/pm/model';
 import { PluginKey } from '@tiptap/pm/state';
-import { ReactRenderer, type Editor } from '@tiptap/react';
+import {
+    ReactNodeViewRenderer,
+    ReactRenderer,
+    type Editor,
+} from '@tiptap/react';
 import tippy, { type Instance as TippyInstance } from 'tippy.js';
 import { lightdashApi } from '../../../../../api';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -24,9 +28,12 @@ import {
     type SuggestionListRef,
 } from '../../../../../components/common/SuggestionList/SuggestionList';
 import suggestionStyles from '../../../../../components/common/SuggestionList/SuggestionList.module.css';
+import TruncatedText from '../../../../../components/common/TruncatedText';
 import styles from './AgentChatInput.module.css';
+import { ContentMentionNodeView } from './ContentMentionNodeView';
 
 const CONTENT_MENTION_NAME = 'contentMention';
+const MIN_CONTENT_SEARCH_QUERY_LENGTH = 2;
 
 const contentMentionPluginKey = new PluginKey('contentMention');
 
@@ -92,6 +99,36 @@ const getContextKey = (item: AiPromptContextInput[number]) =>
     item.type === 'chart'
         ? `chart:${item.chartUuid}`
         : `dashboard:${item.dashboardUuid}`;
+
+const normalizeSearchText = (value: string) =>
+    value
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase();
+
+const compactSearchText = (value: string) =>
+    normalizeSearchText(value).replace(/[^a-z0-9]+/g, '');
+
+// Priority suggestions come from local chat/page context, so they need the
+// same punctuation-insensitive matching that remote content search applies.
+export const fuzzyContentMentionLabelMatch = (label: string, query: string) => {
+    const normalizedQuery = normalizeSearchText(query).trim();
+    if (!normalizedQuery) return true;
+
+    const normalizedLabel = normalizeSearchText(label);
+    const compactLabel = compactSearchText(label);
+    const queryTokens = normalizedQuery
+        .split(/[^a-z0-9]+/)
+        .map((token) => token.trim())
+        .filter(Boolean);
+
+    if (queryTokens.length === 0) return true;
+
+    return queryTokens.every(
+        (token) =>
+            normalizedLabel.includes(token) || compactLabel.includes(token),
+    );
+};
 
 export const mergeAiPromptContextInput = (
     ...contextGroups: Array<AiPromptContextInput | undefined>
@@ -189,13 +226,16 @@ const getSearchSuggestions = async (
     projectUuid: string,
     query: string,
 ): Promise<ContentMentionSuggestionItem[]> => {
+    const trimmedQuery = query.trim();
+    if (trimmedQuery.length < MIN_CONTENT_SEARCH_QUERY_LENGTH) return [];
+
     const params = new URLSearchParams();
     params.append('projectUuids', projectUuid);
     params.append('contentTypes', ContentType.CHART);
     params.append('contentTypes', ContentType.DASHBOARD);
     params.set('pageSize', '20');
     params.set('page', '1');
-    if (query.trim()) params.set('search', query.trim());
+    params.set('search', trimmedQuery);
 
     const results = await lightdashApi<ApiContentResponse['results']>({
         version: 'v2',
@@ -218,9 +258,8 @@ export const buildContentMentionSuggestionItems = async ({
     query: string;
     priorityItems: ContentMentionSuggestionItem[];
 }) => {
-    const normalizedQuery = query.trim().toLowerCase();
     const matchingPriorityItems = priorityItems.filter((item) =>
-        item.label.toLowerCase().includes(normalizedQuery),
+        fuzzyContentMentionLabelMatch(item.label, query),
     );
     const searchItems = projectUuid
         ? await getSearchSuggestions(projectUuid, query)
@@ -233,6 +272,15 @@ export const buildContentMentionSuggestionItems = async ({
         seen.add(key);
         return true;
     });
+};
+
+export const getContentMentionEmptyMessage = (query: string) => {
+    const remainingChars =
+        MIN_CONTENT_SEARCH_QUERY_LENGTH - query.trim().length;
+
+    if (remainingChars <= 0) return 'No content found';
+    if (remainingChars === 1) return 'Type 1 more character to search content';
+    return `Type ${remainingChars} more characters to search content`;
 };
 
 const renderContentMentionItem = (
@@ -257,10 +305,20 @@ const renderContentMentionItem = (
             <Group wrap="nowrap" gap="xs" w="100%">
                 <MantineIcon icon={Icon} size="sm" color={iconColor} />
                 <div className={styles.contentMentionSuggestionText}>
-                    <Group gap={4} wrap="nowrap">
-                        <Text size="xs" truncate fw={500}>
+                    <Group
+                        gap={4}
+                        wrap="nowrap"
+                        className={styles.contentMentionSuggestionLabel}
+                    >
+                        <TruncatedText
+                            maxWidth="100%"
+                            fz="xs"
+                            fw={500}
+                            inline
+                            style={{ flex: 1, minWidth: 0 }}
+                        >
                             {item.label}
-                        </Text>
+                        </TruncatedText>
                         {item.verified && (
                             <MantineIcon
                                 icon={IconCircleCheck}
@@ -330,7 +388,9 @@ const generateContentMentionSuggestion = ({
                         getGroupKey: (item: ContentMentionSuggestionItem) =>
                             item.group,
                         groupLabels,
-                        emptyMessage: 'No content found',
+                        emptyMessage: getContentMentionEmptyMessage(
+                            props.query,
+                        ),
                     },
                     editor: props.editor,
                 });
@@ -354,7 +414,7 @@ const generateContentMentionSuggestion = ({
                     getGroupKey: (item: ContentMentionSuggestionItem) =>
                         item.group,
                     groupLabels,
-                    emptyMessage: 'No content found',
+                    emptyMessage: getContentMentionEmptyMessage(props.query),
                 });
                 popup?.setProps({
                     getReferenceClientRect: () =>
@@ -422,6 +482,9 @@ export const createContentMentionExtension = ({
                         return deleted;
                     }),
             };
+        },
+        addNodeView() {
+            return ReactNodeViewRenderer(ContentMentionNodeView);
         },
     }).configure({
         suggestion: generateContentMentionSuggestion({


### PR DESCRIPTION
## Summary

- Gate AI chat content mention API search until the query has enough characters.
- Make content name search punctuation-insensitive so queries like `Whats` can match `What's`.
- Use `TruncatedText` for long content mention suggestion labels.

## Validation

- `source .env.development.local && pnpm -F frontend test contentMentions.test.ts`
- `source .env.development.local && pnpm -F backend test ContentSearchUtils.test.ts`
- `pnpm -F frontend linter src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts`
- `pnpm -F backend linter src/models/ContentModel/ContentSearchUtils.ts src/models/ContentModel/ContentSearchUtils.test.ts src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts`
- `pnpm -F frontend typecheck:fast`
- `pnpm -F backend typecheck:fast`