### PR TITLE
fix: speed up SavedChartModel.get with lateral version join

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -966,17 +966,9 @@ export class SavedChartModel {
                         `${DashboardsTableName}.dashboard_uuid`,
                         `${SavedChartsTableName}.dashboard_uuid`,
                     )
-                    .innerJoin(SpaceTableName, function spaceJoin() {
-                        this.on(
-                            `${SpaceTableName}.space_id`,
-                            '=',
-                            `${DashboardsTableName}.space_id`,
-                        ).orOn(
-                            `${SpaceTableName}.space_id`,
-                            '=',
-                            `${SavedChartsTableName}.space_id`,
-                        );
-                    })
+                    .joinRaw(
+                        `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
+                    )
                     .innerJoin(
                         ProjectTableName,
                         `${SpaceTableName}.project_id`,
@@ -987,10 +979,23 @@ export class SavedChartModel {
                         `${OrganizationTableName}.organization_id`,
                         `${ProjectTableName}.organization_id`,
                     )
-                    .innerJoin(
-                        'saved_queries_versions',
-                        `${SavedChartsTableName}.saved_query_id`,
-                        'saved_queries_versions.saved_query_id',
+                    // Lateral join fetches only the target version instead of
+                    // joining every historical version and sorting afterwards
+                    .joinRaw(
+                        versionUuid
+                            ? `CROSS JOIN LATERAL (
+                                SELECT * FROM ${SavedChartVersionsTableName}
+                                WHERE ${SavedChartVersionsTableName}.saved_query_id = ${SavedChartsTableName}.saved_query_id
+                                AND ${SavedChartVersionsTableName}.saved_queries_version_uuid = ?
+                                LIMIT 1
+                            ) AS ${SavedChartVersionsTableName}`
+                            : `CROSS JOIN LATERAL (
+                                SELECT * FROM ${SavedChartVersionsTableName}
+                                WHERE ${SavedChartVersionsTableName}.saved_query_id = ${SavedChartsTableName}.saved_query_id
+                                ORDER BY ${SavedChartVersionsTableName}.created_at DESC, ${SavedChartVersionsTableName}.saved_queries_version_id DESC
+                                LIMIT 1
+                            ) AS ${SavedChartVersionsTableName}`,
+                        versionUuid ? [versionUuid] : [],
                     )
                     .leftJoin(
                         UserTableName,
@@ -1097,13 +1102,6 @@ export class SavedChartModel {
                     void chartQuery.where(
                         `${ProjectTableName}.project_uuid`,
                         options.projectUuid,
-                    );
-                }
-
-                if (versionUuid) {
-                    void chartQuery.where(
-                        `${SavedChartVersionsTableName}.saved_queries_version_uuid`,
-                        versionUuid,
                     );
                 }
 

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -946,25 +946,19 @@ export class SavedChartModel {
     }
 
     /**
-     * Resolves the saved_query_id for a uuid-or-slug lookup using two
-     * single-column index probes combined in a CTE. A combined
-     * `saved_query_uuid = ? OR slug = ?` filter lets the planner mis-estimate
-     * the slug match under degraded statistics and fall back to scanning the
-     * whole table; single-predicate probes always stay on their indexes.
-     * A uuid match takes priority over a slug that happens to be uuid-shaped.
+     * Finds candidate chart ids via two single-column index probes instead of
+     * a `uuid = ? OR slug = ?` filter, which can degrade to a seq scan under
+     * stale statistics. Returns all matches; the outer ORDER BY picks the winner.
      */
     private buildChartLookupCte(
         queryBuilder: Knex.QueryBuilder,
         savedChartUuidOrSlug: string,
         options?: { deleted?: boolean | 'any'; projectUuid?: string },
     ): void {
-        const buildProbe = (matchPriority: number) => {
-            const lookupQuery = this.database(SavedChartsTableName)
-                .select(
-                    `${SavedChartsTableName}.saved_query_id`,
-                    this.database.raw(`${matchPriority} as match_priority`),
-                )
-                .limit(1);
+        const buildProbe = () => {
+            const lookupQuery = this.database(SavedChartsTableName).select(
+                `${SavedChartsTableName}.saved_query_id`,
+            );
 
             if (options?.deleted === 'any') {
                 // No filter — match regardless of deleted status
@@ -1005,14 +999,13 @@ export class SavedChartModel {
             return lookupQuery;
         };
 
-        const lookupByUuid = buildProbe(1).where(
+        const lookupByUuid = buildProbe().where(
             `${SavedChartsTableName}.saved_query_uuid`,
             savedChartUuidOrSlug,
         );
 
-        // The slug probe always runs as a uuid-shaped-slug fallback, even
-        // without a projectUuid
-        const lookupBySlug = buildProbe(2).where(
+        // Fallback for uuid-shaped slugs
+        const lookupBySlug = buildProbe().where(
             `${SavedChartsTableName}.slug`,
             savedChartUuidOrSlug,
         );
@@ -1053,8 +1046,7 @@ export class SavedChartModel {
                         `${OrganizationTableName}.organization_id`,
                         `${ProjectTableName}.organization_id`,
                     )
-                    // Lateral join fetches only the target version instead of
-                    // joining every historical version and sorting afterwards
+                    // Lateral fetches only the target version per chart
                     .joinRaw(
                         versionUuid
                             ? `CROSS JOIN LATERAL (
@@ -1154,6 +1146,9 @@ export class SavedChartModel {
                 }
 
                 if (isUuid) {
+                    // ANY(ARRAY(...)) folds the candidate ids into a constant so
+                    // the lookup stays an index probe; IN (subquery) plans as a
+                    // full-table semi-join instead.
                     void chartQuery
                         .with('chart_lookup', (queryBuilder) =>
                             this.buildChartLookupCte(
@@ -1162,14 +1157,8 @@ export class SavedChartModel {
                                 options,
                             ),
                         )
-                        .where(
-                            `${SavedChartsTableName}.saved_query_id`,
-                            '=',
-                            this.database
-                                .select('saved_query_id')
-                                .from('chart_lookup')
-                                .orderBy('match_priority')
-                                .limit(1),
+                        .whereRaw(
+                            `${SavedChartsTableName}.saved_query_id = ANY(ARRAY(SELECT saved_query_id FROM chart_lookup))`,
                         );
                 } else {
                     void chartQuery.where(

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -945,6 +945,77 @@ export class SavedChartModel {
         }));
     }
 
+    /**
+     * Resolves the saved_query_id for a uuid-or-slug lookup using two
+     * single-column index probes combined in a CTE. A combined
+     * `saved_query_uuid = ? OR slug = ?` filter lets the planner mis-estimate
+     * the slug match under degraded statistics and fall back to scanning the
+     * whole table; single-predicate probes always stay on their indexes.
+     * A uuid match takes priority over a slug that happens to be uuid-shaped.
+     */
+    private buildChartLookupCte(
+        queryBuilder: Knex.QueryBuilder,
+        savedChartUuidOrSlug: string,
+        options?: { deleted?: boolean | 'any'; projectUuid?: string },
+    ): void {
+        const withDeletedFilter = (lookupQuery: Knex.QueryBuilder) => {
+            if (options?.deleted === 'any') {
+                return lookupQuery;
+            }
+            if (options?.deleted) {
+                return lookupQuery.whereNotNull(
+                    `${SavedChartsTableName}.deleted_at`,
+                );
+            }
+            return lookupQuery.whereNull(`${SavedChartsTableName}.deleted_at`);
+        };
+
+        const lookupByUuid = withDeletedFilter(
+            this.database(SavedChartsTableName)
+                .select(
+                    `${SavedChartsTableName}.saved_query_id`,
+                    this.database.raw('1 as match_priority'),
+                )
+                .where(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    savedChartUuidOrSlug,
+                )
+                .limit(1),
+        );
+
+        const lookupBySlug = withDeletedFilter(
+            this.database(SavedChartsTableName)
+                .select(
+                    `${SavedChartsTableName}.saved_query_id`,
+                    this.database.raw('2 as match_priority'),
+                )
+                .where(`${SavedChartsTableName}.slug`, savedChartUuidOrSlug)
+                .limit(1),
+        );
+
+        // Slugs are only unique within a project, so scope the slug probe to
+        // the project when one is provided
+        if (options?.projectUuid) {
+            void lookupBySlug
+                .leftJoin(
+                    DashboardsTableName,
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                )
+                .joinRaw(
+                    `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
+                )
+                .innerJoin(
+                    ProjectTableName,
+                    `${SpaceTableName}.project_id`,
+                    `${ProjectTableName}.project_id`,
+                )
+                .where(`${ProjectTableName}.project_uuid`, options.projectUuid);
+        }
+
+        void queryBuilder.unionAll([lookupByUuid, lookupBySlug], true);
+    }
+
     async get(
         savedChartUuidOrSlug: string,
         versionUuid?: string,
@@ -957,7 +1028,6 @@ export class SavedChartModel {
             },
             async () => {
                 const isUuid = isValidUuid(savedChartUuidOrSlug);
-                const filterField = isUuid ? 'saved_query_uuid' : 'slug';
 
                 const chartQuery = this.database
                     .from<DbSavedChartDetails>(SavedChartsTableName)
@@ -1080,17 +1150,23 @@ export class SavedChartModel {
                 }
 
                 if (isUuid) {
-                    void chartQuery.where((builder) => {
-                        void builder
-                            .where(
-                                `${SavedChartsTableName}.saved_query_uuid`,
+                    void chartQuery
+                        .with('chart_lookup', (queryBuilder) =>
+                            this.buildChartLookupCte(
+                                queryBuilder,
                                 savedChartUuidOrSlug,
-                            )
-                            .orWhere(
-                                `${SavedChartsTableName}.slug`,
-                                savedChartUuidOrSlug,
-                            );
-                    });
+                                options,
+                            ),
+                        )
+                        .where(
+                            `${SavedChartsTableName}.saved_query_id`,
+                            '=',
+                            this.database
+                                .select('saved_query_id')
+                                .from('chart_lookup')
+                                .orderBy('match_priority')
+                                .limit(1),
+                        );
                 } else {
                     void chartQuery.where(
                         `${SavedChartsTableName}.slug`,

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -958,60 +958,64 @@ export class SavedChartModel {
         savedChartUuidOrSlug: string,
         options?: { deleted?: boolean | 'any'; projectUuid?: string },
     ): void {
-        const withDeletedFilter = (lookupQuery: Knex.QueryBuilder) => {
+        const buildProbe = (matchPriority: number) => {
+            const lookupQuery = this.database(SavedChartsTableName)
+                .select(
+                    `${SavedChartsTableName}.saved_query_id`,
+                    this.database.raw(`${matchPriority} as match_priority`),
+                )
+                .limit(1);
+
             if (options?.deleted === 'any') {
-                return lookupQuery;
-            }
-            if (options?.deleted) {
-                return lookupQuery.whereNotNull(
+                // No filter — match regardless of deleted status
+            } else if (options?.deleted) {
+                void lookupQuery.whereNotNull(
+                    `${SavedChartsTableName}.deleted_at`,
+                );
+            } else {
+                void lookupQuery.whereNull(
                     `${SavedChartsTableName}.deleted_at`,
                 );
             }
-            return lookupQuery.whereNull(`${SavedChartsTableName}.deleted_at`);
+
+            // Scope both probes to the project when one is provided, matching
+            // the outer query's project filter. Slugs are only unique within
+            // a project.
+            if (options?.projectUuid) {
+                void lookupQuery
+                    .leftJoin(
+                        DashboardsTableName,
+                        `${DashboardsTableName}.dashboard_uuid`,
+                        `${SavedChartsTableName}.dashboard_uuid`,
+                    )
+                    .joinRaw(
+                        `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
+                    )
+                    .innerJoin(
+                        ProjectTableName,
+                        `${SpaceTableName}.project_id`,
+                        `${ProjectTableName}.project_id`,
+                    )
+                    .where(
+                        `${ProjectTableName}.project_uuid`,
+                        options.projectUuid,
+                    );
+            }
+
+            return lookupQuery;
         };
 
-        const lookupByUuid = withDeletedFilter(
-            this.database(SavedChartsTableName)
-                .select(
-                    `${SavedChartsTableName}.saved_query_id`,
-                    this.database.raw('1 as match_priority'),
-                )
-                .where(
-                    `${SavedChartsTableName}.saved_query_uuid`,
-                    savedChartUuidOrSlug,
-                )
-                .limit(1),
+        const lookupByUuid = buildProbe(1).where(
+            `${SavedChartsTableName}.saved_query_uuid`,
+            savedChartUuidOrSlug,
         );
 
-        const lookupBySlug = withDeletedFilter(
-            this.database(SavedChartsTableName)
-                .select(
-                    `${SavedChartsTableName}.saved_query_id`,
-                    this.database.raw('2 as match_priority'),
-                )
-                .where(`${SavedChartsTableName}.slug`, savedChartUuidOrSlug)
-                .limit(1),
+        // The slug probe always runs as a uuid-shaped-slug fallback, even
+        // without a projectUuid
+        const lookupBySlug = buildProbe(2).where(
+            `${SavedChartsTableName}.slug`,
+            savedChartUuidOrSlug,
         );
-
-        // Slugs are only unique within a project, so scope the slug probe to
-        // the project when one is provided
-        if (options?.projectUuid) {
-            void lookupBySlug
-                .leftJoin(
-                    DashboardsTableName,
-                    `${DashboardsTableName}.dashboard_uuid`,
-                    `${SavedChartsTableName}.dashboard_uuid`,
-                )
-                .joinRaw(
-                    `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
-                )
-                .innerJoin(
-                    ProjectTableName,
-                    `${SpaceTableName}.project_id`,
-                    `${ProjectTableName}.project_id`,
-                )
-                .where(`${ProjectTableName}.project_uuid`, options.projectUuid);
-        }
 
         void queryBuilder.unionAll([lookupByUuid, lookupBySlug], true);
     }


### PR DESCRIPTION
`SavedChartModel.get()` runs on every chart view, dashboard tile, embed and scheduled delivery. Two problems made it slow and CPU-heavy at scale:

1. The versions join pulled in **every** historical version of the chart, then sorted and took one.
2. The `uuid OR slug` filter let the planner fall back to a parallel seq scan under degraded stats

### Fix

- **Versions** → `CROSS JOIN LATERAL (… ORDER BY created_at DESC LIMIT 1)`: a single index probe instead of joining/sorting all versions (same pattern as #21145). `versionUuid` moves inside the lateral.
- **Space join** → `spaces.space_id = COALESCE(saved_queries.space_id, dashboards.space_id)`.
- **Lookup** → a `chart_lookup` CTE with two single-predicate index probes (uuid, slug) instead of `uuid OR slug`, so there's no seq-scan plan available under bad stats. Candidates are applied as `saved_query_id = ANY(ARRAY(SELECT … FROM chart_lookup))`, which folds to an InitPlan constant and keeps the scan on the index. The outer `ORDER BY versions.created_at DESC LIMIT 1` is unchanged, so uuid/slug collisions and duplicate slugs resolve exactly as before (latest-version wins).

No schema or behavior changes; slug-only lookups untouched.

### Results

1M charts / 2M versions, target chart with 50k versions, same DB:

| | before | after |
|---|---|---|
| query, healthy stats | 57–70 ms | **0.4–1.2 ms** |
| query, missing stats | 877 ms (parallel seq scan) | **43 ms** (on indexes) |
| throughput (8 clients) | 63 tps | **1,850 tps** |
| DB CPU at equal 40 qps load | ~190% | **~28%** |

### Verification

Lock-down tests (#23971, `packages/api-tests`) pass against both the legacy and new query, returning the identical row (executed SQL confirmed via pg log). Two cross-project tests are CI-only. Typecheck/lint clean.

Closes: PROD-8118
Closes: #23862

test-all
