### PR TITLE
fix(pivot): prompt to re-run query when table pivot config is stale

### DIFF
--- a/packages/frontend/src/components/SimpleTable/PivotRerunState.tsx
+++ b/packages/frontend/src/components/SimpleTable/PivotRerunState.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@mantine-8/core';
+import { IconRefresh } from '@tabler/icons-react';
+import { useCallback, type FC } from 'react';
+import { useExplorerQuery } from '../../hooks/useExplorerQuery';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
+import MantineIcon from '../common/MantineIcon';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
+
+const PivotRerunState: FC = () => {
+    const { isLoading, fetchResults } = useExplorerQuery();
+    const { track } = useTracking();
+
+    const onClick = useCallback(() => {
+        fetchResults();
+        track({ name: EventName.RUN_QUERY_BUTTON_CLICKED });
+    }, [fetchResults, track]);
+
+    return (
+        <SuboptimalState
+            icon={IconRefresh}
+            title="Run query to see your pivot table"
+            description="You've changed the pivot configuration. Re-run the query to load the pivoted results."
+            action={
+                <Button
+                    size="xs"
+                    leftSection={<MantineIcon icon={IconRefresh} />}
+                    loading={isLoading}
+                    onClick={onClick}
+                >
+                    Run query
+                </Button>
+            }
+        />
+    );
+};
+
+export default PivotRerunState;

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -25,6 +25,7 @@ import DashboardCellContextMenu from './DashboardCellContextMenu';
 import DashboardHeaderContextMenu from './DashboardHeaderContextMenu';
 import ExplorerPivotTable from './ExplorerPivotTable';
 import MinimalCellContextMenu from './MinimalCellContextMenu';
+import PivotRerunState from './PivotRerunState';
 
 type SimpleTableProps = {
     isDashboard: boolean;
@@ -227,6 +228,8 @@ const SimpleTable: FC<SimpleTableProps> = ({
         minMaxMap,
         hideRowNumbers,
         pivotTableData,
+        isPivotTableEnabled,
+        isPivotResultStale,
         getFieldLabel,
         getField,
         showResultsTotal,
@@ -282,7 +285,22 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 icon={IconAlertCircle}
             />
         );
-    } else if (pivotTableData.loading || pivotTableData.data) {
+    }
+
+    // Pivot is configured but the current results weren't computed with the same
+    // pivot dimensions (pivot just added, or config changed without re-running).
+    // Prompt a re-run in the editor instead of an empty/stale table.
+    if (
+        isPivotTableEnabled &&
+        isPivotResultStale &&
+        !isDashboard &&
+        isEditMode &&
+        !isLoading
+    ) {
+        return <PivotRerunState />;
+    }
+
+    if (pivotTableData.loading || pivotTableData.data) {
         return (
             <Box
                 p={isDashboard ? 0 : 'xs'}

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -20,6 +20,7 @@ import {
     type TableChart,
 } from '@lightdash/common';
 import { createWorkerFactory, useWorker } from '@shopify/react-web-worker';
+import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -205,6 +206,17 @@ const useTableConfig = (
         resultsData.rows.length &&
         pivotDimensions &&
         pivotDimensions.length > 0;
+
+    // True when the configured pivot dimensions differ from the ones the current
+    // results were computed with (warehouse pivots key on groupByColumns). Mirrors
+    // the mismatch check in VisualizationWarning so a re-run is needed.
+    const isPivotResultStale = useMemo(() => {
+        const resultsPivotDimensions =
+            resultsData?.pivotDetails?.groupByColumns?.map(
+                (col) => col.reference,
+            ) ?? [];
+        return !isEqual(pivotDimensions ?? [], resultsPivotDimensions);
+    }, [pivotDimensions, resultsData?.pivotDetails?.groupByColumns]);
 
     const dimensions = useMemo(() => {
         if (!itemsMap) return [];
@@ -780,6 +792,7 @@ const useTableConfig = (
             metricsAsRows,
             setMetricsAsRows,
             isPivotTableEnabled,
+            isPivotResultStale,
             canUseSubtotals,
             groupedSubtotals,
             rowLimit,
@@ -825,6 +838,7 @@ const useTableConfig = (
             metricsAsRows,
             setMetricsAsRows,
             isPivotTableEnabled,
+            isPivotResultStale,
             canUseSubtotals,
             groupedSubtotals,
             rowLimit,


### PR DESCRIPTION
Closes: PROD-8134
Relates: #9981

### Description:

After the warehouse-computed pivot work, the table viz only renders a pivot once the query has been re-run with the current pivot dimensions (the response carries `pivotDetails`). When the pivot config in the chart editor no longer matched the last-run query — a pivot just added, or pivot dimensions changed without re-running — the table either collapsed to only the row-number column or silently kept showing the *old* pivot (with just a subtle "Results may be incorrect" badge).

This adds an `isPivotResultStale` check (configured pivot dimensions vs the results' `pivotDetails.groupByColumns`, mirroring the existing `VisualizationWarning` mismatch logic) and, in the chart editor only, renders a clear empty state with a one-click **Run query** button instead of the empty/stale table.

**Before** — changing the pivot config silently leaves a stale table (only a subtle badge hints at it):

<img width="2084" height="1006" alt="CleanShot 2026-06-03 at 18 00 12@2x" src="https://github.com/user-attachments/assets/7a2f8621-732c-44f6-a091-a04373c8da1c" />

**After** — a clear prompt to re-run the query:


https://github.com/user-attachments/assets/0ea44d7f-74b3-49d0-9445-cf057a9fa12a


