### PR TITLE
feat(changesets): add button to download changeset as JSON

### DIFF
--- a/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
+++ b/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
@@ -29,6 +29,7 @@ import {
     IconArrowBackUp,
     IconChartBar,
     IconClock,
+    IconDownload,
     IconLayoutDashboard,
     IconTable,
 } from '@tabler/icons-react';
@@ -50,6 +51,7 @@ import {
     useRevertAllChanges,
     useRevertChange,
 } from '../hooks';
+import { downloadChangesetJson } from '../utils/downloadChangeset';
 
 dayjs.extend(relativeTime);
 
@@ -661,16 +663,34 @@ export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
                         </Text>
                     </Stack>
                     {allChanges.length > 0 && (
-                        <Button
-                            variant="default"
-                            radius="md"
-                            size="compact-sm"
-                            onClick={handleRevertAllChanges}
-                            loading={revertAllChangesMutation.isLoading}
-                            leftSection={<MantineIcon icon={IconArrowBackUp} />}
-                        >
-                            Revert All
-                        </Button>
+                        <Group gap="xs">
+                            <Button
+                                variant="default"
+                                radius="md"
+                                size="compact-sm"
+                                onClick={() =>
+                                    changesets &&
+                                    downloadChangesetJson(changesets)
+                                }
+                                leftSection={
+                                    <MantineIcon icon={IconDownload} />
+                                }
+                            >
+                                Download
+                            </Button>
+                            <Button
+                                variant="default"
+                                radius="md"
+                                size="compact-sm"
+                                onClick={handleRevertAllChanges}
+                                loading={revertAllChangesMutation.isLoading}
+                                leftSection={
+                                    <MantineIcon icon={IconArrowBackUp} />
+                                }
+                            >
+                                Revert All
+                            </Button>
+                        </Group>
                     )}
                 </Group>
                 <ContentTable table={table} />

--- a/packages/frontend/src/features/changesets/utils/downloadChangeset.ts
+++ b/packages/frontend/src/features/changesets/utils/downloadChangeset.ts
@@ -1,0 +1,40 @@
+import { type ChangesetWithChangesAndDependencies } from '@lightdash/common';
+
+const CHANGESET_EXPORT_SCHEMA_VERSION = 1;
+
+type ChangesetExport = {
+    schemaVersion: number;
+    exportedAt: string;
+    projectUuid: string;
+    changeset: ChangesetWithChangesAndDependencies;
+};
+
+const buildChangesetExport = (
+    changeset: ChangesetWithChangesAndDependencies,
+): ChangesetExport => ({
+    schemaVersion: CHANGESET_EXPORT_SCHEMA_VERSION,
+    exportedAt: new Date().toISOString(),
+    projectUuid: changeset.projectUuid,
+    changeset,
+});
+
+const slugifyForFileName = (value: string): string =>
+    value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '') || 'changeset';
+
+export const downloadChangesetJson = (
+    changeset: ChangesetWithChangesAndDependencies,
+): void => {
+    const data = JSON.stringify(buildChangesetExport(changeset), null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `changeset-${slugifyForFileName(changeset.name)}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8135/add-an-option-to-manually-download-changeset-file

## Description

Adds a **Download** button next to "Revert All" on the Changesets settings page. It exports the active changeset as a pretty-printed JSON file so an LLM can read it and raise a PR against the semantic layer. The button only appears when there's a changeset with at least one change (it lives inside the existing `allChanges.length > 0` guard).

The export wraps the raw changeset in a metadata envelope and keeps the change payloads intact, so no fidelity is lost:

```
changeset-<slug>.json
├─ schemaVersion : 1
├─ exportedAt    : 2026-06-04T14:29:26.958Z   (ISO)
├─ projectUuid   : 3675b69e-…
└─ changeset     : ChangesetWithChangesAndDependencies
                   ├─ name, status, createdAt, updatedAt
                   └─ changes[] ─ entityType / entityName / type / payload / dependencies
```

Frontend-only: `useActiveChangesets` already returns the full `ChangesetWithChangesAndDependencies`, so there's no backend or schema change.

## Test plan

- `pnpm -F frontend typecheck:fast` — clean
- `oxlint` on `src/features/changesets/` — 0 warnings, 0 errors
- Manual: logged in, opened the Changesets settings page, clicked **Download**. Captured the generated blob and confirmed valid JSON — `schemaVersion: 1`, correct `projectUuid`, changeset name/status, all 6 changes with full payloads and dependencies, filename `changeset-experiment-changeset.json`.
- Button is hidden when the changeset has no changes (shares the existing Revert All guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)