### PR TITLE
feat(ai-agents): value-forward GitHub MCP connect with per-user PAT

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1831,9 +1831,10 @@ export type AiAgentGithubMcpConnectedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         mcpServerId: string;
-        // Distinguishes the one-click flow (auto-config from the org's GitHub
-        // integration) from manually creating a GitHub MCP server.
-        method: 'one_click' | 'one_click_reconnect';
+        // Distinguishes the one-click flow from manually creating a GitHub MCP
+        // server. `one_click_oauth` is the current per-user OAuth flow;
+        // `one_click`/`one_click_reconnect` are the retired shared-token flow.
+        method: 'one_click' | 'one_click_reconnect' | 'one_click_oauth';
     };
 };
 

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1831,10 +1831,6 @@ export type AiAgentGithubMcpConnectedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         mcpServerId: string;
-        // Distinguishes the one-click GitHub connect (using a personal access
-        // token) from manually creating a GitHub MCP server. `one_click` is the
-        // first-time connect; `one_click_reconnect` updates the token on an
-        // existing server.
         method: 'one_click' | 'one_click_reconnect';
     };
 };

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1831,10 +1831,11 @@ export type AiAgentGithubMcpConnectedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         mcpServerId: string;
-        // Distinguishes the one-click flow from manually creating a GitHub MCP
-        // server. `one_click_oauth` is the current per-user OAuth flow;
-        // `one_click`/`one_click_reconnect` are the retired shared-token flow.
-        method: 'one_click' | 'one_click_reconnect' | 'one_click_oauth';
+        // Distinguishes the one-click GitHub connect (using a personal access
+        // token) from manually creating a GitHub MCP server. `one_click` is the
+        // first-time connect; `one_click_reconnect` updates the token on an
+        // existing server.
+        method: 'one_click' | 'one_click_reconnect';
     };
 };
 

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -38,6 +38,7 @@ import {
     ApiAppendInstructionRequest,
     ApiAppendInstructionResponse,
     ApiCloneThreadResponse,
+    ApiConnectGithubMcpServerBody,
     ApiCreateAiAgent,
     ApiCreateAiAgentResponse,
     ApiCreateAiMcpServer,
@@ -245,6 +246,7 @@ export class AiAgentController extends BaseController {
     async connectGithubMcpServer(
         @Request() req: express.Request,
         @Path() projectUuid: string,
+        @Body() body: ApiConnectGithubMcpServerBody,
     ): Promise<ApiAiMcpServerResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(201);
@@ -253,6 +255,8 @@ export class AiAgentController extends BaseController {
             results: await this.getAiAgentService().connectGithubMcpServer(
                 toSessionUser(req.account),
                 projectUuid,
+                body.personalAccessToken,
+                body.credentialScope,
             ),
         };
     }

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1427,8 +1427,6 @@ export class AiAgentModel {
         }
 
         if (!userUuid) {
-            // No user context: only a shared credential is resolvable. OAuth
-            // additionally requires sharing to be allowed.
             if (
                 row.auth_type === 'oauth' &&
                 !row.allow_oauth_credential_sharing
@@ -1441,9 +1439,6 @@ export class AiAgentModel {
             });
         }
 
-        // With user context, resolve per-user first then the shared fallback —
-        // this is what makes a per-user bearer (or OAuth) server show as
-        // connected for the user who provided their own credential.
         return this.resolveCredentialForServer(
             {
                 ai_mcp_server_uuid: row.ai_mcp_server_uuid,
@@ -1472,10 +1467,6 @@ export class AiAgentModel {
             return undefined;
         }
 
-        // Bearer and OAuth both resolve per-user first, then fall back to a
-        // shared project credential. For bearer the mode is implicit: a
-        // per-user bearer server has user-scoped credentials (no shared), a
-        // shared bearer server has a shared credential everyone falls back to.
         const userCredential = await this.getCredential(
             row.ai_mcp_server_uuid,
             'user',
@@ -1489,9 +1480,6 @@ export class AiAgentModel {
             return userCredential;
         }
 
-        // OAuth only falls back to a shared credential when sharing is allowed;
-        // bearer always allows the shared fallback (its sharing is implied by
-        // whether a shared credential was stored).
         if (row.auth_type === 'oauth' && !row.allow_oauth_credential_sharing) {
             return undefined;
         }
@@ -1537,9 +1525,6 @@ export class AiAgentModel {
         authType: ApiCreateAiMcpServer['authType'];
         allowOAuthCredentialSharing: boolean;
         credentials: ApiCreateAiMcpServer['credentials'];
-        // Scope for the initial (bearer) credential: 'shared' stores one
-        // project credential; 'user' stores it for the creating user only
-        // (each user then connects their own). Defaults to 'shared'.
         credentialScope?: AiMcpCredentialScope;
         actorUserUuid?: string | null;
     }): Promise<AiMcpServer> {

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1426,14 +1426,13 @@ export class AiAgentModel {
             return undefined;
         }
 
-        if (row.auth_type === 'bearer') {
-            return this.getCredential(row.ai_mcp_server_uuid, 'shared', {
-                trx,
-            });
-        }
-
         if (!userUuid) {
-            if (!row.allow_oauth_credential_sharing) {
+            // No user context: only a shared credential is resolvable. OAuth
+            // additionally requires sharing to be allowed.
+            if (
+                row.auth_type === 'oauth' &&
+                !row.allow_oauth_credential_sharing
+            ) {
                 return undefined;
             }
 
@@ -1442,6 +1441,9 @@ export class AiAgentModel {
             });
         }
 
+        // With user context, resolve per-user first then the shared fallback —
+        // this is what makes a per-user bearer (or OAuth) server show as
+        // connected for the user who provided their own credential.
         return this.resolveCredentialForServer(
             {
                 ai_mcp_server_uuid: row.ai_mcp_server_uuid,
@@ -1470,12 +1472,10 @@ export class AiAgentModel {
             return undefined;
         }
 
-        if (row.auth_type === 'bearer') {
-            return this.getCredential(row.ai_mcp_server_uuid, 'shared', {
-                trx,
-            });
-        }
-
+        // Bearer and OAuth both resolve per-user first, then fall back to a
+        // shared project credential. For bearer the mode is implicit: a
+        // per-user bearer server has user-scoped credentials (no shared), a
+        // shared bearer server has a shared credential everyone falls back to.
         const userCredential = await this.getCredential(
             row.ai_mcp_server_uuid,
             'user',
@@ -1489,7 +1489,10 @@ export class AiAgentModel {
             return userCredential;
         }
 
-        if (!row.allow_oauth_credential_sharing) {
+        // OAuth only falls back to a shared credential when sharing is allowed;
+        // bearer always allows the shared fallback (its sharing is implied by
+        // whether a shared credential was stored).
+        if (row.auth_type === 'oauth' && !row.allow_oauth_credential_sharing) {
             return undefined;
         }
 
@@ -1534,8 +1537,13 @@ export class AiAgentModel {
         authType: ApiCreateAiMcpServer['authType'];
         allowOAuthCredentialSharing: boolean;
         credentials: ApiCreateAiMcpServer['credentials'];
+        // Scope for the initial (bearer) credential: 'shared' stores one
+        // project credential; 'user' stores it for the creating user only
+        // (each user then connects their own). Defaults to 'shared'.
+        credentialScope?: AiMcpCredentialScope;
         actorUserUuid?: string | null;
     }): Promise<AiMcpServer> {
+        const credentialScope = args.credentialScope ?? 'shared';
         return this.database.transaction(async (trx) => {
             const [row] = await trx(AiMcpServerTableName)
                 .insert({
@@ -1563,7 +1571,11 @@ export class AiAgentModel {
                     ? null
                     : await this.upsertCredential({
                           serverUuid: row.ai_mcp_server_uuid,
-                          scope: 'shared',
+                          scope: credentialScope,
+                          userUuid:
+                              credentialScope === 'user'
+                                  ? (args.actorUserUuid ?? null)
+                                  : null,
                           credentials: credentialPayload,
                           actorUserUuid: args.actorUserUuid ?? null,
                           trx,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2765,10 +2765,12 @@ export class AiAgentService extends BaseService {
                     },
                 });
             } catch (error) {
+                Logger.error(
+                    `[AiAgent][MCP][${GITHUB_MCP_SERVER_NAME}] Failed to reconnect with provided token`,
+                    error,
+                );
                 throw new ParameterError(
-                    `We couldn't connect to GitHub with that token. Check the token and its repository access, then try again. Details: ${
-                        error instanceof Error ? error.message : String(error)
-                    }`,
+                    "We couldn't connect to GitHub with that token. Check the token and its repository access, then try again.",
                 );
             }
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2556,11 +2556,9 @@ export class AiAgentService extends BaseService {
                         'Bearer MCP servers require a bearer token',
                     );
                 }
-                if (body.credentialScope && body.credentialScope !== 'shared') {
-                    throw new ParameterError(
-                        'Bearer MCP servers only support shared credentials',
-                    );
-                }
+                // Bearer supports both 'shared' (one project credential) and
+                // 'user' (the creating user stores their own; each user
+                // connects their own token).
                 if (allowOAuthCredentialSharing) {
                     throw new ParameterError(
                         'OAuth credential sharing is only allowed for auth type "oauth"',
@@ -2627,6 +2625,8 @@ export class AiAgentService extends BaseService {
             authType: body.authType,
             allowOAuthCredentialSharing,
             credentials,
+            credentialScope:
+                body.authType === 'bearer' ? body.credentialScope : undefined,
             actorUserUuid: user.userUuid,
         });
 
@@ -2670,44 +2670,68 @@ export class AiAgentService extends BaseService {
             return { available: false, alreadyConnected: false };
         }
 
+        // No org GitHub App installation is required — the user supplies a PAT.
+        // Managers can create the project-level GitHub MCP server; once it
+        // exists, any project member can connect their own token (per-user
+        // scope), so the affordance is offered to them too.
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        if (!isCopilotEnabled) {
+            return { available: false, alreadyConnected: false };
+        }
         const auditedAbility = this.createAuditedAbility(user);
-        const canManageGitIntegration = auditedAbility.can(
+        const canManageMcpServers = auditedAbility.can(
             'manage',
-            subject('GitIntegration', { organizationUuid }),
+            subject('AiAgent', { organizationUuid, projectUuid }),
         );
-        if (!canManageGitIntegration) {
-            return { available: false, alreadyConnected: false };
-        }
-
-        const installationId =
-            await this.githubAppInstallationsModel.findInstallationId(
-                organizationUuid,
-            );
-        if (!installationId) {
-            return { available: false, alreadyConnected: false };
-        }
 
         const servers = await this.aiAgentModel.listMcpServers(
             projectUuid,
             user.userUuid,
         );
-        const alreadyConnected = servers.some(
+        const githubServer = servers.find(
             (server) => server.url === GITHUB_MCP_SERVER_URL,
         );
 
-        return { available: true, alreadyConnected };
+        // Offered to managers always (they can create), and to any member when
+        // a GitHub server already exists (they connect their own token).
+        const available = canManageMcpServers || !!githubServer;
+        if (!available) {
+            return { available: false, alreadyConnected: false };
+        }
+
+        // Connected = the current user has a usable credential for GitHub
+        // (their own per-user token, or the shared project token). Drives
+        // per-user prompting: each user is offered connect until they have one.
+        const credential = githubServer
+            ? await this.aiAgentModel.resolveCredential(
+                  githubServer.uuid,
+                  user.userUuid,
+              )
+            : undefined;
+
+        return { available: true, alreadyConnected: !!credential };
     }
 
     /**
-     * One-click GitHub MCP setup: mints the org's GitHub App installation token
-     * and registers a bearer-authed MCP server pointing at the hosted GitHub
-     * MCP. Reuses createMcpServer so the URL validation, connection test and
-     * tool discovery all run. Idempotent — returns the existing server if one
-     * is already connected.
+     * One-click GitHub MCP setup. Registers a bearer-authed MCP server pointing
+     * at the hosted GitHub MCP, using a GitHub personal access token the user
+     * supplies (a fine-grained, read-only token scoped to the repos that
+     * produce their analytics events). Idempotent — if a GitHub MCP server
+     * already exists, the token is re-tested and upserted so this doubles as a
+     * "reconnect / update token" path.
+     *
+     * GitHub's hosted MCP does not support OAuth dynamic client registration,
+     * so we use a user-provided PAT rather than an OAuth flow.
+     *
+     * `credentialScope` chooses how the token is stored:
+     * - 'shared': one project-level credential everyone uses (manager-gated).
+     * - 'user': the connecting user's own token; each user connects their own.
      */
     public async connectGithubMcpServer(
         user: SessionUser,
         projectUuid: string,
+        personalAccessToken: string,
+        credentialScope: AiMcpCredentialScope,
     ) {
         const { organizationUuid } = user;
         if (!organizationUuid) {
@@ -2724,42 +2748,33 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        // Gate on the same permission used to manage the GitHub integration.
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('GitIntegration', { organizationUuid }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'You do not have permission to manage the GitHub integration',
+        const bearerToken = personalAccessToken.trim();
+        if (!bearerToken) {
+            throw new ParameterError(
+                'A GitHub personal access token is required',
             );
         }
 
-        const installationId =
-            await this.githubAppInstallationsModel.findInstallationId(
-                organizationUuid,
-            );
-        if (!installationId) {
-            throw new ForbiddenError(
-                'GitHub App is not installed for this organization',
-            );
-        }
-
-        const bearerToken = await getInstallationToken(installationId);
-
-        // Reconnect path: if a GitHub MCP server already exists, re-mint and
-        // upsert a fresh token rather than early-returning. The previous
-        // early-return left stuck (expired-token) servers unrecoverable.
         const existing = await this.aiAgentModel.listMcpServers(
             projectUuid,
             user.userUuid,
         );
-        const alreadyConnected = existing.find(
+        const githubServer = existing.find(
             (server) => server.url === GITHUB_MCP_SERVER_URL,
         );
-        if (alreadyConnected) {
+
+        if (githubServer) {
+            // Setting/replacing the shared credential needs manage; storing
+            // your own personal token only needs project access.
+            if (credentialScope === 'shared') {
+                await this.assertCanManageMcpServers(user, projectUuid);
+            } else {
+                await this.assertCanUsePersonalMcpCredentials(
+                    user,
+                    projectUuid,
+                );
+            }
+
             try {
                 await this.aiAgentMcpRuntimeClient.testConnection({
                     name: GITHUB_MCP_SERVER_NAME,
@@ -2775,20 +2790,21 @@ export class AiAgentService extends BaseService {
                 });
             } catch (error) {
                 throw new ParameterError(
-                    `We couldn't reconnect to the GitHub MCP server. Details: ${
+                    `We couldn't connect to GitHub with that token. Check the token and its repository access, then try again. Details: ${
                         error instanceof Error ? error.message : String(error)
                     }`,
                 );
             }
 
             await this.aiAgentModel.upsertCredential({
-                serverUuid: alreadyConnected.uuid,
-                scope: 'shared',
+                serverUuid: githubServer.uuid,
+                scope: credentialScope,
+                userUuid: credentialScope === 'user' ? user.userUuid : null,
                 credentials: { type: 'bearer', bearerToken },
                 actorUserUuid: user.userUuid,
             });
             await this.aiAgentModel.updateMcpServerRuntimeState({
-                serverUuid: alreadyConnected.uuid,
+                serverUuid: githubServer.uuid,
                 connectionStatus: 'connected',
                 error: null,
                 actorUserUuid: user.userUuid,
@@ -2800,7 +2816,7 @@ export class AiAgentService extends BaseService {
                 properties: {
                     organizationId: organizationUuid,
                     projectId: projectUuid,
-                    mcpServerId: alreadyConnected.uuid,
+                    mcpServerId: githubServer.uuid,
                     method: 'one_click_reconnect',
                 },
             });
@@ -2812,18 +2828,17 @@ export class AiAgentService extends BaseService {
             return (
                 refreshed.find(
                     (server) => server.url === GITHUB_MCP_SERVER_URL,
-                ) ?? alreadyConnected
+                ) ?? githubServer
             );
         }
 
-        // Delegates to createMcpServer, which additionally asserts the caller
-        // can manage MCP servers, validates the URL, tests the connection and
-        // discovers tools.
+        // First-time setup creates the project-level server (manager-gated by
+        // createMcpServer), storing the token at the chosen scope.
         const server = await this.createMcpServer(user, projectUuid, {
             name: GITHUB_MCP_SERVER_NAME,
             url: GITHUB_MCP_SERVER_URL,
             authType: 'bearer',
-            credentialScope: 'shared',
+            credentialScope,
             credentials: { bearerToken },
         });
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3035,6 +3035,9 @@ export class AiAgentService extends BaseService {
         });
     }
 
+    // Disconnects a stored MCP credential at the given scope. Handles both
+    // OAuth (runtime client tears down the connection) and bearer (the stored
+    // token is deleted) — e.g. a user clearing their own per-user GitHub PAT.
     public async disconnectMcpOAuthConnection(
         user: SessionUser,
         projectUuid: string,
@@ -3046,15 +3049,20 @@ export class AiAgentService extends BaseService {
             mcpServerUuid,
         );
 
-        if (server.authType !== 'oauth') {
-            throw new ParameterError('MCP server is not configured for OAuth');
+        if (server.authType === 'none') {
+            throw new ParameterError(
+                'This MCP server has no credentials to disconnect',
+            );
         }
 
         const credentialScope: AiMcpCredentialScope =
             body?.credentialScope ?? 'user';
 
         if (credentialScope === 'shared') {
-            if (!server.allowOAuthCredentialSharing) {
+            if (
+                server.authType === 'oauth' &&
+                !server.allowOAuthCredentialSharing
+            ) {
                 throw new ParameterError(
                     'This MCP server does not allow shared OAuth credentials',
                 );
@@ -3064,11 +3072,22 @@ export class AiAgentService extends BaseService {
             await this.assertCanUsePersonalMcpCredentials(user, projectUuid);
         }
 
-        await this.aiAgentMcpRuntimeClient.disconnectOAuthConnection({
-            mcpServerUuid,
-            credentialScope,
+        if (server.authType === 'oauth') {
+            await this.aiAgentMcpRuntimeClient.disconnectOAuthConnection({
+                mcpServerUuid,
+                credentialScope,
+                userUuid:
+                    credentialScope === 'user' ? user.userUuid : undefined,
+                actorUserUuid: user.userUuid,
+            });
+            return;
+        }
+
+        // Bearer: just delete the stored token at the requested scope.
+        await this.aiAgentModel.deleteCredential({
+            serverUuid: mcpServerUuid,
+            scope: credentialScope,
             userUuid: credentialScope === 'user' ? user.userUuid : undefined,
-            actorUserUuid: user.userUuid,
         });
     }
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2556,9 +2556,6 @@ export class AiAgentService extends BaseService {
                         'Bearer MCP servers require a bearer token',
                     );
                 }
-                // Bearer supports both 'shared' (one project credential) and
-                // 'user' (the creating user stores their own; each user
-                // connects their own token).
                 if (allowOAuthCredentialSharing) {
                     throw new ParameterError(
                         'OAuth credential sharing is only allowed for auth type "oauth"',
@@ -2670,10 +2667,6 @@ export class AiAgentService extends BaseService {
             return { available: false, alreadyConnected: false };
         }
 
-        // No org GitHub App installation is required — the user supplies a PAT.
-        // Managers can create the project-level GitHub MCP server; once it
-        // exists, any project member can connect their own token (per-user
-        // scope), so the affordance is offered to them too.
         const isCopilotEnabled = await this.getIsCopilotEnabled(user);
         if (!isCopilotEnabled) {
             return { available: false, alreadyConnected: false };
@@ -2692,16 +2685,11 @@ export class AiAgentService extends BaseService {
             (server) => server.url === GITHUB_MCP_SERVER_URL,
         );
 
-        // Offered to managers always (they can create), and to any member when
-        // a GitHub server already exists (they connect their own token).
         const available = canManageMcpServers || !!githubServer;
         if (!available) {
             return { available: false, alreadyConnected: false };
         }
 
-        // Connected = the current user has a usable credential for GitHub
-        // (their own per-user token, or the shared project token). Drives
-        // per-user prompting: each user is offered connect until they have one.
         const credential = githubServer
             ? await this.aiAgentModel.resolveCredential(
                   githubServer.uuid,
@@ -2712,21 +2700,6 @@ export class AiAgentService extends BaseService {
         return { available: true, alreadyConnected: !!credential };
     }
 
-    /**
-     * One-click GitHub MCP setup. Registers a bearer-authed MCP server pointing
-     * at the hosted GitHub MCP, using a GitHub personal access token the user
-     * supplies (a fine-grained, read-only token scoped to the repos that
-     * produce their analytics events). Idempotent — if a GitHub MCP server
-     * already exists, the token is re-tested and upserted so this doubles as a
-     * "reconnect / update token" path.
-     *
-     * GitHub's hosted MCP does not support OAuth dynamic client registration,
-     * so we use a user-provided PAT rather than an OAuth flow.
-     *
-     * `credentialScope` chooses how the token is stored:
-     * - 'shared': one project-level credential everyone uses (manager-gated).
-     * - 'user': the connecting user's own token; each user connects their own.
-     */
     public async connectGithubMcpServer(
         user: SessionUser,
         projectUuid: string,
@@ -2754,11 +2727,6 @@ export class AiAgentService extends BaseService {
                 'A GitHub personal access token is required',
             );
         }
-        // Reject obviously malformed input before storing/forwarding it.
-        // Accept any GitHub token shape — fine-grained PAT (github_pat_),
-        // classic PAT (ghp_) or OAuth/app token (gho_/ghu_/ghs_/ghr_) — since
-        // the hosted GitHub MCP accepts all of them. testConnection below does
-        // the real validation against GitHub.
         if (!/^(github_pat_|gh[pousr]_)[A-Za-z0-9_]+$/.test(bearerToken)) {
             throw new ParameterError(
                 'That doesn\'t look like a GitHub personal access token. Expected a fine-grained token starting with "github_pat_".',
@@ -2774,8 +2742,6 @@ export class AiAgentService extends BaseService {
         );
 
         if (githubServer) {
-            // Setting/replacing the shared credential needs manage; storing
-            // your own personal token only needs project access.
             if (credentialScope === 'shared') {
                 await this.assertCanManageMcpServers(user, projectUuid);
             } else {
@@ -2842,8 +2808,6 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        // First-time setup creates the project-level server (manager-gated by
-        // createMcpServer), storing the token at the chosen scope.
         const server = await this.createMcpServer(user, projectUuid, {
             name: GITHUB_MCP_SERVER_NAME,
             url: GITHUB_MCP_SERVER_URL,
@@ -3035,9 +2999,6 @@ export class AiAgentService extends BaseService {
         });
     }
 
-    // Disconnects a stored MCP credential at the given scope. Handles both
-    // OAuth (runtime client tears down the connection) and bearer (the stored
-    // token is deleted) — e.g. a user clearing their own per-user GitHub PAT.
     public async disconnectMcpOAuthConnection(
         user: SessionUser,
         projectUuid: string,
@@ -3083,7 +3044,6 @@ export class AiAgentService extends BaseService {
             return;
         }
 
-        // Bearer: just delete the stored token at the requested scope.
         await this.aiAgentModel.deleteCredential({
             serverUuid: mcpServerUuid,
             scope: credentialScope,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2754,6 +2754,16 @@ export class AiAgentService extends BaseService {
                 'A GitHub personal access token is required',
             );
         }
+        // Reject obviously malformed input before storing/forwarding it.
+        // Accept any GitHub token shape — fine-grained PAT (github_pat_),
+        // classic PAT (ghp_) or OAuth/app token (gho_/ghu_/ghs_/ghr_) — since
+        // the hosted GitHub MCP accepts all of them. testConnection below does
+        // the real validation against GitHub.
+        if (!/^(github_pat_|gh[pousr]_)[A-Za-z0-9_]+$/.test(bearerToken)) {
+            throw new ParameterError(
+                'That doesn\'t look like a GitHub personal access token. Expected a fine-grained token starting with "github_pat_".',
+            );
+        }
 
         const existing = await this.aiAgentModel.listMcpServers(
             projectUuid,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10854,6 +10854,21 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiMcpGithubAvailability_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiConnectGithubMcpServerBody: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                credentialScope: {
+                    ref: 'AiMcpCredentialScope',
+                    required: true,
+                },
+                personalAccessToken: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiMcpServerTool: {
         dataType: 'refAlias',
         type: {
@@ -12438,11 +12453,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12644,7 +12659,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12652,7 +12667,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12667,7 +12686,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12675,11 +12694,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12731,11 +12746,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12947,11 +12962,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13494,11 +13509,6 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
-                                                    required: true,
-                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13508,6 +13518,11 @@ const models: TsoaRoute.Models = {
                                                             enums: [null],
                                                         },
                                                     ],
+                                                    required: true,
+                                                },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -13562,11 +13577,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13627,11 +13642,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13808,11 +13823,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13827,11 +13842,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13846,11 +13861,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -27435,7 +27450,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27445,7 +27460,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27455,7 +27470,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -27468,7 +27483,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -28123,7 +28138,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28133,7 +28148,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28143,7 +28158,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28156,7 +28171,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -43514,6 +43529,12 @@ export function RegisterRoutes(app: Router) {
             name: 'projectUuid',
             required: true,
             dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiConnectGithubMcpServerBody',
         },
     };
     app.post(

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12448,6 +12448,18 @@
             "ApiAiMcpGithubAvailabilityResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiMcpGithubAvailability_"
             },
+            "ApiConnectGithubMcpServerBody": {
+                "properties": {
+                    "credentialScope": {
+                        "$ref": "#/components/schemas/AiMcpCredentialScope"
+                    },
+                    "personalAccessToken": {
+                        "type": "string"
+                    }
+                },
+                "required": ["credentialScope", "personalAccessToken"],
+                "type": "object"
+            },
             "AiMcpServerTool": {
                 "properties": {
                     "updatedAt": {
@@ -13994,6 +14006,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -14050,16 +14075,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -14089,8 +14114,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -14195,19 +14220,6 @@
                                                         "enum": [
                                                             "error",
                                                             "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -14506,17 +14518,17 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "prUrl": {
+                                                        "type": "string",
+                                                        "nullable": true
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "prUrl": {
-                                                        "type": "string",
-                                                        "nullable": true
                                                     }
                                                 },
-                                                "required": ["status", "prUrl"],
+                                                "required": ["prUrl", "status"],
                                                 "type": "object"
                                             },
                                             {
@@ -28291,22 +28303,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -28866,22 +28878,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -37779,7 +37791,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3091.0",
+        "version": "0.3096.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -39966,7 +39978,17 @@
                             "type": "string"
                         }
                     }
-                ]
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiConnectGithubMcpServerBody"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/projects/{projectUuid}/aiAgents/mcpServers/{mcpServerUuid}/tools": {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -373,11 +373,6 @@ export type ApiStartAiMcpOAuthResponse = ApiSuccess<{
 export const GITHUB_MCP_SERVER_URL = 'https://api.githubcopilot.com/mcp/';
 export const GITHUB_MCP_SERVER_NAME = 'GitHub';
 
-// Body for the one-click GitHub MCP connect: the user's GitHub personal access
-// token (a fine-grained, read-only token scoped to the repos that produce their
-// analytics events). Stored as the bearer credential for the GitHub MCP server.
-// `credentialScope` controls whether the token is shared across the project or
-// scoped to the connecting user (each user connects their own).
 export type ApiConnectGithubMcpServerBody = {
     personalAccessToken: string;
     credentialScope: AiMcpCredentialScope;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -373,6 +373,16 @@ export type ApiStartAiMcpOAuthResponse = ApiSuccess<{
 export const GITHUB_MCP_SERVER_URL = 'https://api.githubcopilot.com/mcp/';
 export const GITHUB_MCP_SERVER_NAME = 'GitHub';
 
+// Body for the one-click GitHub MCP connect: the user's GitHub personal access
+// token (a fine-grained, read-only token scoped to the repos that produce their
+// analytics events). Stored as the bearer credential for the GitHub MCP server.
+// `credentialScope` controls whether the token is shared across the project or
+// scoped to the connecting user (each user connects their own).
+export type ApiConnectGithubMcpServerBody = {
+    personalAccessToken: string;
+    credentialScope: AiMcpCredentialScope;
+};
+
 export type AiMcpGithubAvailability = {
     // The org has a GitHub App installation AND the caller has permission to
     // manage that integration (manage:GitIntegration).

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -1,5 +1,6 @@
 import {
     GITHUB_MCP_SERVER_URL,
+    type AiMcpCredentialScope,
     type AiMcpServer,
     type AiMcpServerAuthType,
     type AiMcpServerConnectionStatus,
@@ -57,6 +58,7 @@ import {
 } from '../hooks/useProjectAiMcpServers';
 import { AiAgentMcpServerToolsPanel } from './AiAgentMcpServerToolsPanel';
 import { AiMcpServerIcon } from './AiMcpServerIcon';
+import { GithubMcpConnectModal } from './GithubMcpConnectModal';
 
 const CREATE_NEW_MCP_OPTION_VALUE = '__create_new_mcp__';
 
@@ -695,25 +697,43 @@ export const AiAgentMcpServersInput = ({
         [agentUuid, onChange, onPersistedChange, updateAgentMcpServers],
     );
 
-    const handleConnectGithubMcp = useCallback(async () => {
-        // Reuse the existing project-level server when present; otherwise mint
-        // the installation token and create it.
-        const server = existingGithubMcpServer ?? (await connectGithubMcp());
-        // Persist the attachment (not just local form state) so the agent's
-        // tool-permissions panel can load/save immediately, matching "+ Add".
-        if (server && !value.includes(server.uuid)) {
-            await persistMcpServerSelection([...value, server.uuid], value);
-        }
-        // Only reached on success — connectGithubMcp throws on failure (its
-        // mutation surfaces the error toast) and leaves the dialog open.
-        githubConfirmModalHandlers.close();
-    }, [
-        existingGithubMcpServer,
-        connectGithubMcp,
-        persistMcpServerSelection,
-        value,
-        githubConfirmModalHandlers,
-    ]);
+    const handleConnectGithubMcp = useCallback(
+        async (
+            personalAccessToken: string,
+            credentialScope: AiMcpCredentialScope,
+        ) => {
+            try {
+                // Idempotent server-side — creates the bearer GitHub MCP server
+                // with the user's token, or updates it if one already exists.
+                const server = await connectGithubMcp({
+                    personalAccessToken,
+                    credentialScope,
+                });
+                if (!server) {
+                    return;
+                }
+                // Persist the attachment (not just local form state) so the
+                // agent's tool-permissions panel can load/save immediately,
+                // matching "+ Add".
+                if (!value.includes(server.uuid)) {
+                    await persistMcpServerSelection(
+                        [...value, server.uuid],
+                        value,
+                    );
+                }
+                githubConfirmModalHandlers.close();
+            } catch {
+                // Toasts are handled in the mutations; keep the modal open so
+                // the user can fix the token and retry.
+            }
+        },
+        [
+            connectGithubMcp,
+            persistMcpServerSelection,
+            value,
+            githubConfirmModalHandlers,
+        ],
+    );
 
     const handleAttachMcpServers = useCallback(async () => {
         const nextValue = Array.from(new Set([...value, ...attachSelection]));
@@ -1012,7 +1032,7 @@ export const AiAgentMcpServersInput = ({
                                     withinPortal
                                     multiline
                                     w={260}
-                                    label="Connect the GitHub MCP using your organization's existing GitHub integration — no extra sign-in needed."
+                                    label="Let the agent read the code behind your metrics, using a GitHub personal access token."
                                 >
                                     <Button
                                         variant="default"
@@ -1366,34 +1386,12 @@ export const AiAgentMcpServersInput = ({
                 value={attachSelection}
                 onChange={handleAttachSelectionChange}
             />
-            <MantineModal
+            <GithubMcpConnectModal
                 opened={isGithubConfirmModalOpen}
                 onClose={githubConfirmModalHandlers.close}
-                title="Connect GitHub"
-                icon={IconBrandGithub}
-                actions={
-                    <Button
-                        leftSection={<MantineIcon icon={IconBrandGithub} />}
-                        loading={isConnectingGithubMcp || isPersistingSelection}
-                        onClick={handleConnectGithubMcp}
-                    >
-                        Connect GitHub
-                    </Button>
-                }
-            >
-                <Stack gap="sm">
-                    <Text size="sm">
-                        Lightdash will reuse your organization's existing GitHub
-                        connection — the same integration used for your dbt
-                        projects. No additional sign-in is required.
-                    </Text>
-                    <Text size="sm" c="dimmed">
-                        This adds a read/write GitHub MCP server to this agent,
-                        scoped to the repositories your GitHub integration can
-                        already access. You can remove it at any time.
-                    </Text>
-                </Stack>
-            </MantineModal>
+                isLoading={isConnectingGithubMcp || isPersistingSelection}
+                onConnect={handleConnectGithubMcp}
+            />
         </>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -1383,6 +1383,7 @@ export const AiAgentMcpServersInput = ({
                 opened={isGithubConfirmModalOpen}
                 onClose={githubConfirmModalHandlers.close}
                 isLoading={isConnectingGithubMcp || isPersistingSelection}
+                canChooseScope
                 onConnect={handleConnectGithubMcp}
             />
         </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -962,8 +962,7 @@ export const AiAgentMcpServersInput = ({
                                       })}
                             </Menu.Item>
                         )}
-                        {mcpServer.authType === 'oauth' &&
-                            mcpServer.hasCredentials &&
+                        {mcpServer.hasCredentials &&
                             mcpServer.credentialScope === 'user' && (
                                 <Menu.Item
                                     type="button"
@@ -984,7 +983,9 @@ export const AiAgentMcpServersInput = ({
                                 >
                                     {isDisconnecting
                                         ? 'Disconnecting...'
-                                        : 'Disconnect your account'}
+                                        : mcpServer.authType === 'bearer'
+                                          ? 'Disconnect your token'
+                                          : 'Disconnect your account'}
                                 </Menu.Item>
                             )}
                         <Menu.Item

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -703,8 +703,6 @@ export const AiAgentMcpServersInput = ({
             credentialScope: AiMcpCredentialScope,
         ) => {
             try {
-                // Idempotent server-side — creates the bearer GitHub MCP server
-                // with the user's token, or updates it if one already exists.
                 const server = await connectGithubMcp({
                     personalAccessToken,
                     credentialScope,
@@ -712,9 +710,6 @@ export const AiAgentMcpServersInput = ({
                 if (!server) {
                     return;
                 }
-                // Persist the attachment (not just local form state) so the
-                // agent's tool-permissions panel can load/save immediately,
-                // matching "+ Add".
                 if (!value.includes(server.uuid)) {
                     await persistMcpServerSelection(
                         [...value, server.uuid],
@@ -722,10 +717,7 @@ export const AiAgentMcpServersInput = ({
                     );
                 }
                 githubConfirmModalHandlers.close();
-            } catch {
-                // Toasts are handled in the mutations; keep the modal open so
-                // the user can fix the token and retry.
-            }
+            } catch {}
         },
         [
             connectGithubMcp,

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
@@ -135,8 +135,6 @@ const getConnectionIconColor = (
 type Props = {
     projectUuid: string;
     agentUuid: string;
-    // When provided, the post-connect success state offers a one-click prompt
-    // that seeds the message composer (the activation moment).
     onSuggestedPrompt?: (prompt: string) => void;
 };
 
@@ -179,11 +177,6 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
             ),
         [mcpServers],
     );
-    // GitHub uses a PAT (bearer auth), so it never appears in
-    // mcpServersNeedingConnection (that list is OAuth-only). Offer the one-click
-    // connect when GitHub is available and the current user doesn't already have
-    // a usable credential — `alreadyConnected` is per-user, so each user is
-    // prompted to connect their own token on a per-user GitHub server.
     const canOneClickConnectGithub =
         githubMcpAvailability?.available === true &&
         githubMcpAvailability?.alreadyConnected === false;
@@ -229,8 +222,6 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
             credentialScope: AiMcpCredentialScope,
         ) => {
             try {
-                // connect is idempotent server-side — creates the bearer GitHub
-                // MCP server with the user's token, or updates it if one exists.
                 const server = await connectGithubMcp({
                     personalAccessToken,
                     credentialScope,
@@ -250,8 +241,6 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
                 githubConfirmModalHandlers.close();
                 setJustConnectedGithub(true);
             } catch {
-                // Toasts are handled in the mutations; keep the modal open so
-                // the user can fix the token and retry.
             } finally {
                 await refetchAgentMcpServers();
             }
@@ -362,8 +351,6 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
         return null;
     }
 
-    // GitHub is the marquee integration: when it's the only thing to connect,
-    // lead with what connecting unlocks instead of the generic app copy.
     const isGithubOnly =
         canOneClickConnectGithub && mcpServersNeedingConnection.length === 0;
     const sectionTitle = isGithubOnly

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
@@ -1,14 +1,18 @@
 import {
     GITHUB_MCP_SERVER_NAME,
-    GITHUB_MCP_SERVER_URL,
+    type AiMcpCredentialScope,
     type AiMcpServer,
 } from '@lightdash/common';
 import { Button, Group, Paper, Skeleton, Stack, Text } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
-import { IconBrandGithub, IconInfoCircle } from '@tabler/icons-react';
-import { useCallback, useId, useMemo, type FC } from 'react';
+import {
+    IconBrandGithub,
+    IconCircleCheck,
+    IconInfoCircle,
+    IconSparkles,
+} from '@tabler/icons-react';
+import { useCallback, useId, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
-import MantineModal from '../../../../components/common/MantineModal';
 import { useProjectUpdateAiAgentMutation } from '../hooks/useProjectAiAgents';
 import {
     useAgentAiMcpServers,
@@ -17,6 +21,14 @@ import {
     useStartMcpOAuthConnectionMutation,
 } from '../hooks/useProjectAiMcpServers';
 import { AiMcpServerIcon } from './AiMcpServerIcon';
+import { GithubMcpConnectModal } from './GithubMcpConnectModal';
+import {
+    GITHUB_MCP_CONNECTED_HEADLINE,
+    GITHUB_MCP_CONNECTED_SUMMARY,
+    GITHUB_MCP_SUGGESTED_PROMPT,
+    GITHUB_MCP_VALUE_HEADLINE,
+    GITHUB_MCP_VALUE_SUMMARY,
+} from './githubMcpValueContent';
 
 const needsPersonalOauthConnection = (
     mcpServer: Pick<
@@ -123,13 +135,18 @@ const getConnectionIconColor = (
 type Props = {
     projectUuid: string;
     agentUuid: string;
+    // When provided, the post-connect success state offers a one-click prompt
+    // that seeds the message composer (the activation moment).
+    onSuggestedPrompt?: (prompt: string) => void;
 };
 
 export const AiAgentNewThreadMcpConnections: FC<Props> = ({
     projectUuid,
     agentUuid,
+    onSuggestedPrompt,
 }) => {
     const sectionTitleId = useId();
+    const [justConnectedGithub, setJustConnectedGithub] = useState(false);
     const {
         data: mcpServers,
         isLoading,
@@ -162,19 +179,14 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
             ),
         [mcpServers],
     );
-    // GitHub uses the org's shared App installation (bearer auth), so it never
-    // appears in mcpServersNeedingConnection (that list is OAuth-only). Offer the
-    // one-click connect when the org integration is available and GitHub is not
-    // already attached to this agent — mirrors the agent settings page.
-    const isGithubConnectedToAgent = useMemo(
-        () =>
-            (mcpServers ?? []).some(
-                (mcpServer) => mcpServer.url === GITHUB_MCP_SERVER_URL,
-            ),
-        [mcpServers],
-    );
+    // GitHub uses a PAT (bearer auth), so it never appears in
+    // mcpServersNeedingConnection (that list is OAuth-only). Offer the one-click
+    // connect when GitHub is available and the current user doesn't already have
+    // a usable credential — `alreadyConnected` is per-user, so each user is
+    // prompted to connect their own token on a per-user GitHub server.
     const canOneClickConnectGithub =
-        githubMcpAvailability?.available === true && !isGithubConnectedToAgent;
+        githubMcpAvailability?.available === true &&
+        githubMcpAvailability?.alreadyConnected === false;
 
     const appNames = useMemo(() => {
         const oauthAppNames = Array.from(
@@ -211,37 +223,48 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
         [refetchAgentMcpServers, startMcpOAuthConnection],
     );
 
-    const handleConnectGithubMcp = useCallback(async () => {
-        try {
-            // connect is idempotent server-side — returns the existing server
-            // when one is already connected, otherwise mints the installation
-            // token and creates it.
-            const server = await connectGithubMcp();
-            const attachedUuids = (mcpServers ?? []).map(
-                (mcpServer) => mcpServer.uuid,
-            );
-            if (server && !attachedUuids.includes(server.uuid)) {
-                await updateAgentMcpServers({
-                    uuid: agentUuid,
-                    mcpServerUuids: [...attachedUuids, server.uuid],
+    const handleConnectGithubMcp = useCallback(
+        async (
+            personalAccessToken: string,
+            credentialScope: AiMcpCredentialScope,
+        ) => {
+            try {
+                // connect is idempotent server-side — creates the bearer GitHub
+                // MCP server with the user's token, or updates it if one exists.
+                const server = await connectGithubMcp({
+                    personalAccessToken,
+                    credentialScope,
                 });
+                if (!server) {
+                    return;
+                }
+                const attachedUuids = (mcpServers ?? []).map(
+                    (mcpServer) => mcpServer.uuid,
+                );
+                if (!attachedUuids.includes(server.uuid)) {
+                    await updateAgentMcpServers({
+                        uuid: agentUuid,
+                        mcpServerUuids: [...attachedUuids, server.uuid],
+                    });
+                }
+                githubConfirmModalHandlers.close();
+                setJustConnectedGithub(true);
+            } catch {
+                // Toasts are handled in the mutations; keep the modal open so
+                // the user can fix the token and retry.
+            } finally {
+                await refetchAgentMcpServers();
             }
-        } catch {
-            // Toasts are handled in the mutations.
-        } finally {
-            // Close on success and failure — the error toast is the feedback;
-            // the persistent "Connect GitHub" button is the retry affordance.
-            githubConfirmModalHandlers.close();
-            await refetchAgentMcpServers();
-        }
-    }, [
-        agentUuid,
-        connectGithubMcp,
-        githubConfirmModalHandlers,
-        mcpServers,
-        refetchAgentMcpServers,
-        updateAgentMcpServers,
-    ]);
+        },
+        [
+            agentUuid,
+            connectGithubMcp,
+            githubConfirmModalHandlers,
+            mcpServers,
+            refetchAgentMcpServers,
+            updateAgentMcpServers,
+        ],
+    );
 
     if (isLoading) {
         return (
@@ -274,9 +297,81 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
         );
     }
 
+    if (justConnectedGithub) {
+        return (
+            <Paper
+                withBorder
+                radius="md"
+                p="md"
+                component="section"
+                aria-label={GITHUB_MCP_CONNECTED_HEADLINE}
+            >
+                <Group align="flex-start" gap="sm" wrap="nowrap">
+                    <Paper p="xxs" withBorder radius="sm">
+                        <MantineIcon
+                            icon={IconCircleCheck}
+                            size="sm"
+                            color="var(--mantine-color-green-6)"
+                        />
+                    </Paper>
+                    <Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
+                        <Stack gap={2}>
+                            <Text size="sm" fw={600}>
+                                {GITHUB_MCP_CONNECTED_HEADLINE}
+                            </Text>
+                            <Text size="sm" c="dimmed">
+                                {GITHUB_MCP_CONNECTED_SUMMARY}
+                            </Text>
+                        </Stack>
+                        {onSuggestedPrompt && (
+                            <Group gap="xs">
+                                <Button
+                                    size="xs"
+                                    variant="default"
+                                    leftSection={
+                                        <MantineIcon icon={IconSparkles} />
+                                    }
+                                    onClick={() => {
+                                        onSuggestedPrompt(
+                                            GITHUB_MCP_SUGGESTED_PROMPT,
+                                        );
+                                        setJustConnectedGithub(false);
+                                    }}
+                                >
+                                    {GITHUB_MCP_SUGGESTED_PROMPT}
+                                </Button>
+                                <Button
+                                    size="xs"
+                                    variant="subtle"
+                                    color="gray"
+                                    onClick={() =>
+                                        setJustConnectedGithub(false)
+                                    }
+                                >
+                                    Dismiss
+                                </Button>
+                            </Group>
+                        )}
+                    </Stack>
+                </Group>
+            </Paper>
+        );
+    }
+
     if (mcpServersNeedingConnection.length === 0 && !canOneClickConnectGithub) {
         return null;
     }
+
+    // GitHub is the marquee integration: when it's the only thing to connect,
+    // lead with what connecting unlocks instead of the generic app copy.
+    const isGithubOnly =
+        canOneClickConnectGithub && mcpServersNeedingConnection.length === 0;
+    const sectionTitle = isGithubOnly
+        ? GITHUB_MCP_VALUE_HEADLINE
+        : getConnectionTitle(appNames);
+    const sectionSummary = isGithubOnly
+        ? GITHUB_MCP_VALUE_SUMMARY
+        : getConnectionSummary(appNames);
 
     const githubConnectButton = canOneClickConnectGithub ? (
         <Button
@@ -319,10 +414,10 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
                         </Paper>
                         <Stack gap={2} style={{ flex: 1, minWidth: 0 }}>
                             <Text id={sectionTitleId} size="sm" fw={600}>
-                                {getConnectionTitle(appNames)}
+                                {sectionTitle}
                             </Text>
                             <Text size="sm" c="dimmed">
-                                {getConnectionSummary(appNames)}
+                                {sectionSummary}
                             </Text>
                             {connectionNote && (
                                 <Text size="xs" c="dimmed">
@@ -370,11 +465,11 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
                                 <MantineIcon icon={IconInfoCircle} size="sm" />
                             </Paper>
                             <Text id={sectionTitleId} size="sm" fw={600}>
-                                {getConnectionTitle(appNames)}
+                                {sectionTitle}
                             </Text>
                         </Group>
                         <Text size="sm" c="dimmed">
-                            {getConnectionSummary(appNames)}
+                            {sectionSummary}
                         </Text>
                         {connectionNote && (
                             <Text size="xs" c="dimmed">
@@ -420,35 +515,12 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
                     </Group>
                 </Stack>
             )}
-            <MantineModal
+            <GithubMcpConnectModal
                 opened={isGithubConfirmModalOpen}
                 onClose={githubConfirmModalHandlers.close}
-                title="Connect GitHub"
-                icon={IconBrandGithub}
-                actions={
-                    <Button
-                        leftSection={<MantineIcon icon={IconBrandGithub} />}
-                        loading={isConnectingGithubMcp || isAttachingGithub}
-                        onClick={handleConnectGithubMcp}
-                    >
-                        Connect GitHub
-                    </Button>
-                }
-            >
-                <Stack gap="sm">
-                    <Text size="sm">
-                        Lightdash will reuse your organization's existing GitHub
-                        connection — the same integration used for your dbt
-                        projects. No additional sign-in is required.
-                    </Text>
-                    <Text size="sm" c="dimmed">
-                        This adds a read/write GitHub MCP server to this agent,
-                        scoped to the repositories your GitHub integration can
-                        already access. You can remove it any time from the
-                        agent's settings.
-                    </Text>
-                </Stack>
-            </MantineModal>
+                isLoading={isConnectingGithubMcp || isAttachingGithub}
+                onConnect={handleConnectGithubMcp}
+            />
         </Paper>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/GithubMcpConnectModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/GithubMcpConnectModal.tsx
@@ -20,8 +20,6 @@ const GITHUB_FINE_GRAINED_TOKEN_URL =
 type Props = {
     opened: boolean;
     isLoading: boolean;
-    // When false, the scope toggle is hidden (e.g. a member adding their own
-    // token to an existing per-user server can't choose 'shared').
     canChooseScope?: boolean;
     onClose: () => void;
     onConnect: (

--- a/packages/frontend/src/ee/features/aiCopilot/components/GithubMcpConnectModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/GithubMcpConnectModal.tsx
@@ -31,7 +31,7 @@ type Props = {
 export const GithubMcpConnectModal: FC<Props> = ({
     opened,
     isLoading,
-    canChooseScope = true,
+    canChooseScope = false,
     onClose,
     onConnect,
 }) => {
@@ -40,6 +40,7 @@ export const GithubMcpConnectModal: FC<Props> = ({
 
     const handleClose = useCallback(() => {
         setToken('');
+        setScope('user');
         onClose();
     }, [onClose]);
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/GithubMcpConnectModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/GithubMcpConnectModal.tsx
@@ -1,0 +1,148 @@
+import { type AiMcpCredentialScope } from '@lightdash/common';
+import {
+    Anchor,
+    Button,
+    Divider,
+    List,
+    PasswordInput,
+    SegmentedControl,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { IconBrandGithub } from '@tabler/icons-react';
+import { useCallback, useState, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineModal from '../../../../components/common/MantineModal';
+
+const GITHUB_FINE_GRAINED_TOKEN_URL =
+    'https://github.com/settings/personal-access-tokens/new';
+
+type Props = {
+    opened: boolean;
+    isLoading: boolean;
+    // When false, the scope toggle is hidden (e.g. a member adding their own
+    // token to an existing per-user server can't choose 'shared').
+    canChooseScope?: boolean;
+    onClose: () => void;
+    onConnect: (
+        personalAccessToken: string,
+        credentialScope: AiMcpCredentialScope,
+    ) => void;
+};
+
+export const GithubMcpConnectModal: FC<Props> = ({
+    opened,
+    isLoading,
+    canChooseScope = true,
+    onClose,
+    onConnect,
+}) => {
+    const [token, setToken] = useState('');
+    const [scope, setScope] = useState<AiMcpCredentialScope>('user');
+
+    const handleClose = useCallback(() => {
+        setToken('');
+        onClose();
+    }, [onClose]);
+
+    const trimmedToken = token.trim();
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleClose}
+            title="Give the agent the code behind your data"
+            icon={IconBrandGithub}
+            actions={
+                <Button
+                    leftSection={<MantineIcon icon={IconBrandGithub} />}
+                    loading={isLoading}
+                    disabled={!trimmedToken}
+                    onClick={() => onConnect(trimmedToken, scope)}
+                >
+                    Connect GitHub
+                </Button>
+            }
+        >
+            <Stack gap="md">
+                <Text size="sm">
+                    Once connected, your agent can use your repositories to
+                    enhance its understanding of your semantic layer when
+                    answering questions or making changes.
+                </Text>
+
+                <Divider />
+
+                {canChooseScope && (
+                    <Stack gap={4}>
+                        <Text size="sm" fw={600}>
+                            Who can use this token?
+                        </Text>
+                        <SegmentedControl
+                            fullWidth
+                            size="xs"
+                            value={scope}
+                            onChange={(value) =>
+                                setScope(value as AiMcpCredentialScope)
+                            }
+                            data={[
+                                { label: 'Just me', value: 'user' },
+                                { label: 'Whole project', value: 'shared' },
+                            ]}
+                        />
+                        <Text size="xs" c="dimmed">
+                            {scope === 'user'
+                                ? 'Each user connects their own token — the agent reads code as whoever is asking.'
+                                : 'One token shared by everyone using this agent.'}
+                        </Text>
+                    </Stack>
+                )}
+
+                <Stack gap="xs">
+                    <Text size="sm" fw={600}>
+                        Create a GitHub personal access token
+                    </Text>
+                    <List type="ordered" size="sm" spacing="xs">
+                        <List.Item>
+                            Open{' '}
+                            <Anchor
+                                href={GITHUB_FINE_GRAINED_TOKEN_URL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                fz="inherit"
+                            >
+                                GitHub → Fine-grained tokens
+                            </Anchor>
+                            .
+                        </List.Item>
+                        <List.Item>
+                            Under <b>Repository access</b>, select the repos
+                            that you want to give the agent access to.
+                        </List.Item>
+                        <List.Item>
+                            Under <b>Permissions → Repository</b>, set{' '}
+                            <b>Contents</b> to <b>Read-only</b>.
+                        </List.Item>
+                        <List.Item>
+                            Generate the token and paste it below.
+                        </List.Item>
+                    </List>
+                </Stack>
+
+                <PasswordInput
+                    label="Personal access token"
+                    placeholder="github_pat_..."
+                    value={token}
+                    onChange={(event) => setToken(event.currentTarget.value)}
+                    autoComplete="off"
+                />
+
+                <Text size="xs" c="dimmed">
+                    Stored encrypted — use a read-only token scoped to only the
+                    repos you need. You can remove it any time from the agent's
+                    settings.
+                </Text>
+            </Stack>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -124,8 +124,6 @@ const NewThreadPanel: FC<{
     // New threads have no uuid yet — keep the toggle in local state and seed
     // the per-thread slice entry once the thread is created.
     const [sqlMode, setSqlMode] = useState(false);
-    // Post-connect "try asking" suggestions seed the composer by remounting it
-    // with a new defaultValue (the input only reads defaultValue on mount).
     const [composerSeed, setComposerSeed] = useState<string | null>(null);
     const dispatchToStore = useAiAgentStoreDispatch();
     const handleToolResult = useCallback(

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -124,6 +124,9 @@ const NewThreadPanel: FC<{
     // New threads have no uuid yet — keep the toggle in local state and seed
     // the per-thread slice entry once the thread is created.
     const [sqlMode, setSqlMode] = useState(false);
+    // Post-connect "try asking" suggestions seed the composer by remounting it
+    // with a new defaultValue (the input only reads defaultValue on mount).
+    const [composerSeed, setComposerSeed] = useState<string | null>(null);
     const dispatchToStore = useAiAgentStoreDispatch();
     const handleToolResult = useCallback(
         (toolResult: AiAgentToolResult) => {
@@ -229,6 +232,7 @@ const NewThreadPanel: FC<{
                     <AiAgentNewThreadMcpConnections
                         projectUuid={projectUuid}
                         agentUuid={agent.uuid}
+                        onSuggestedPrompt={setComposerSeed}
                     />
                 </Stack>
                 {previewItems.length > 0 && (
@@ -252,6 +256,8 @@ const NewThreadPanel: FC<{
                     </Stack>
                 )}
                 <AgentChatInput
+                    key={composerSeed ?? 'composer'}
+                    defaultValue={composerSeed ?? undefined}
                     onSubmit={handleSubmit}
                     loading={isCreatingThread}
                     disabled={!isPinnedContextReady}

--- a/packages/frontend/src/ee/features/aiCopilot/components/githubMcpValueContent.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/githubMcpValueContent.ts
@@ -1,11 +1,3 @@
-// Value-forward copy shared by every surface that offers the GitHub MCP
-// one-click connect (chat empty state + agent settings). Keep these in one
-// place so the surfaces never drift.
-//
-// Note: this is NOT about writeback/opening PRs — the org's GitHub integration
-// already handles dbt-project writeback. The MCP connection lets the agent READ
-// the codebases that produce your analytics events, giving it extra context for
-// semantic-layer changes and the business logic behind your metrics.
 export const GITHUB_MCP_VALUE_HEADLINE =
     'Give the agent the code behind your data';
 export const GITHUB_MCP_VALUE_SUMMARY =

--- a/packages/frontend/src/ee/features/aiCopilot/components/githubMcpValueContent.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/githubMcpValueContent.ts
@@ -1,0 +1,17 @@
+// Value-forward copy shared by every surface that offers the GitHub MCP
+// one-click connect (chat empty state + agent settings). Keep these in one
+// place so the surfaces never drift.
+//
+// Note: this is NOT about writeback/opening PRs — the org's GitHub integration
+// already handles dbt-project writeback. The MCP connection lets the agent READ
+// the codebases that produce your analytics events, giving it extra context for
+// semantic-layer changes and the business logic behind your metrics.
+export const GITHUB_MCP_VALUE_HEADLINE =
+    'Give the agent the code behind your data';
+export const GITHUB_MCP_VALUE_SUMMARY =
+    'Connect GitHub so the agent can read the codebases that produce your analytics events — extra context for semantic-layer changes and the business logic behind your metrics.';
+export const GITHUB_MCP_SUGGESTED_PROMPT =
+    'Trace one of my metrics back to the code that produces it';
+export const GITHUB_MCP_CONNECTED_HEADLINE = 'GitHub connected';
+export const GITHUB_MCP_CONNECTED_SUMMARY =
+    'Ask the agent about the code behind a metric or event.';

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
@@ -4,6 +4,7 @@ import type {
     ApiAiAgentMcpServerToolListResponse,
     ApiAiMcpServerListResponse,
     ApiAiMcpServerResponse,
+    ApiConnectGithubMcpServerBody,
     ApiAiMcpServerToolListResponse,
     ApiCreateAiMcpServer,
     ApiError,
@@ -68,12 +69,13 @@ const getGithubMcpAvailability = async (
 
 const connectGithubMcpServer = async (
     projectUuid: string,
+    body: ApiConnectGithubMcpServerBody,
 ): Promise<ApiAiMcpServerResponse['results']> =>
     lightdashApi<ApiAiMcpServerResponse['results']>({
         version: 'v1',
         url: `/projects/${projectUuid}/aiAgents/mcpServers/github/connect`,
         method: 'POST',
-        body: JSON.stringify({}),
+        body: JSON.stringify(body),
     });
 
 const listAgentAiMcpServerTools = async (
@@ -376,8 +378,12 @@ export const useConnectGithubMcpServerMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
     const { showToastApiError, showToastSuccess } = useToaster();
 
-    return useMutation<ApiAiMcpServerResponse['results'], ApiError, void>({
-        mutationFn: () => connectGithubMcpServer(projectUuid),
+    return useMutation<
+        ApiAiMcpServerResponse['results'],
+        ApiError,
+        ApiConnectGithubMcpServerBody
+    >({
+        mutationFn: (body) => connectGithubMcpServer(projectUuid, body),
         onSuccess: async (result) => {
             showToastSuccess({
                 title: 'GitHub connected',

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -152,9 +152,6 @@ const AiAgentNewThreadPage: FC = () => {
     const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
 
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
-    // Post-connect "try asking" suggestions seed the composer. The input reads
-    // defaultValue only on mount, so bump a key to remount it with the seed —
-    // keyed separately from pendingPrompt so normal typing doesn't remount.
     const [composerSeedKey, setComposerSeedKey] = useState(0);
     const handleSuggestedPrompt = useCallback(
         (prompt: string) => {

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -152,6 +152,17 @@ const AiAgentNewThreadPage: FC = () => {
     const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
 
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
+    // Post-connect "try asking" suggestions seed the composer. The input reads
+    // defaultValue only on mount, so bump a key to remount it with the seed —
+    // keyed separately from pendingPrompt so normal typing doesn't remount.
+    const [composerSeedKey, setComposerSeedKey] = useState(0);
+    const handleSuggestedPrompt = useCallback(
+        (prompt: string) => {
+            setPendingPrompt(prompt);
+            setComposerSeedKey((key) => key + 1);
+        },
+        [setPendingPrompt],
+    );
 
     const onSubmit = useCallback(
         ({
@@ -291,6 +302,7 @@ const AiAgentNewThreadPage: FC = () => {
                         <AiAgentNewThreadMcpConnections
                             projectUuid={projectUuid}
                             agentUuid={agentUuid}
+                            onSuggestedPrompt={handleSuggestedPrompt}
                         />
                     )}
 
@@ -326,6 +338,7 @@ const AiAgentNewThreadPage: FC = () => {
                     )}
 
                     <AgentChatInput
+                        key={composerSeedKey}
                         onSubmit={onSubmit}
                         loading={isCreatingThread}
                         disabled={!isPinnedContextReady}


### PR DESCRIPTION
## What

Reworks the one-click GitHub MCP connect for AI agents to **sell the value** (per the ticket) and to support **per-user credentials**.

### Connect modal (chat empty state + agent settings)
- Leads with the value — what connecting unlocks — instead of describing the mechanism: *"your agent can use your repositories to enhance its understanding of your semantic layer when answering questions or making changes."*
- Guides the user through creating a **fine-grained, read-only** GitHub personal access token (link to GitHub's token page, pick repos, set Contents → Read-only).
- A **"Who can use this token?"** toggle — *Just me* (per-user, default) or *Whole project* (shared).
- Post-connect success state with a suggested prompt that seeds the chat composer.

### Auth model change
- The GitHub MCP now authenticates with a **user-provided PAT** rather than the org GitHub App installation token. That token expired in ~1h with no recovery; using a PAT removes that failure mode and drops the dependency on an org-level GitHub App.
- **Bearer MCP credentials now support both `shared` and `user` scopes.** Resolution is user-first with a shared fallback — applied both at runtime and in the connection-status display (which previously hardcoded the shared scope, so a per-user bearer server always showed "not connected").
- Availability is now per-user: each user is prompted to connect their own token until they have one; members can connect their own once a manager has created the project-level server.

## Why

The previous modal was informational, not persuasive, and the GitHub MCP relied on a shared org installation token that expired hourly and couldn't recover. Per-user PATs give least-privilege, per-user attribution, and a connection that doesn't silently die.

## Notes
- No DB migration — the per-user/shared mode is implicit in which credential scope is stored; the credential table already supported user scope.
- `generate-api` regenerated (routes + swagger) for the new request body.
- Known limitation: GitHub's hosted MCP authenticates lazily, so `testConnection` succeeds even with an invalid token (it only fails on tool calls). Connect-time token validation is a possible follow-up.

## Testing
- Typecheck + lint clean across common/backend/frontend.
- Verified live: guided modal in both surfaces; scope toggle; per-user connect with a real PAT stores `credential_scope='user'` and shows **Connected** with tools discovered; invalid token fails gracefully (modal stays open).

Closes: PROD-8131