### PR TITLE
feat(preview-deploy): comment preview link on the PR

### DIFF
--- a/packages/common/src/utils/previewDeployWorkflow.test.ts
+++ b/packages/common/src/utils/previewDeployWorkflow.test.ts
@@ -163,13 +163,48 @@ describe('generatePreviewDeployWorkflowFiles', () => {
             expect(content).toMatch(/actions\/checkout@[0-9a-f]{40}/);
             expect(content).toMatch(/actions\/setup-node@[0-9a-f]{40}/);
             expect(content).not.toMatch(/uses: actions\/\S+@v\d/);
-            // Least-privilege token: read-only, and never pull-requests:write
-            // (it would zero `contents` and break checkout on private repos).
-            expect(content).toContain('permissions:\n  contents: read');
-            expect(content).not.toContain('pull-requests: write');
+            // Token always grants contents:read so checkout works on private repos.
+            expect(content).toContain('contents: read');
             // CLI pinned for reproducibility; job bounded by a timeout.
             expect(content).toMatch(/@lightdash\/cli@\d+\.\d+\.\d+/);
             expect(content).toContain('timeout-minutes:');
         });
+    });
+
+    it('grants pull-requests:write only to start-preview (the one that comments)', () => {
+        const files = generatePreviewDeployWorkflowFiles({
+            projectSubPath: 'dbt',
+            cliVersion: '0.3075.2',
+        });
+        const start = files.find((f) => f.path.endsWith('start-preview.yml'));
+        const close = files.find((f) => f.path.endsWith('close-preview.yml'));
+        // start-preview needs contents:read (checkout) AND pull-requests:write
+        // (comment) — an omitted scope defaults to none, so both are explicit.
+        expect(start?.content).toContain('contents: read');
+        expect(start?.content).toContain('pull-requests: write');
+        // close-preview never comments, so it stays least-privilege read-only.
+        expect(close?.content).toContain('permissions:\n  contents: read');
+        expect(close?.content).not.toContain('pull-requests: write');
+    });
+
+    it('comments the preview URL on the PR with a SHA-pinned first-party action', () => {
+        const files = generatePreviewDeployWorkflowFiles({
+            projectSubPath: 'dbt',
+            cliVersion: '0.3075.2',
+        });
+        const start = files.find((f) => f.path.endsWith('start-preview.yml'));
+        // Captures the CLI's url output and posts it back to the PR.
+        expect(start?.content).toContain('id: preview');
+        expect(start?.content).toContain(
+            'PREVIEW_URL: ${{ steps.preview.outputs.url }}',
+        );
+        expect(start?.content).toContain('Comment preview link on PR');
+        // Reuses a first-party action pinned to a commit SHA, never a third
+        // party on a floating tag (the workflow runs with secrets in scope).
+        expect(start?.content).toMatch(/actions\/github-script@[0-9a-f]{40}/);
+        // Sticky comment: an HTML marker lets reruns update one comment.
+        expect(start?.content).toContain('<!-- lightdash-preview -->');
+        expect(start?.content).toContain('updateComment');
+        expect(start?.content).toContain('createComment');
     });
 });

--- a/packages/common/src/utils/previewDeployWorkflow.ts
+++ b/packages/common/src/utils/previewDeployWorkflow.ts
@@ -133,6 +133,8 @@ const CHECKOUT_ACTION =
     'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2';
 const SETUP_NODE_ACTION =
     'actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6';
+const GITHUB_SCRIPT_ACTION =
+    'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8';
 
 /**
  * Generate the canonical Lightdash preview-on-PR workflow pair.
@@ -159,8 +161,11 @@ export const generatePreviewDeployWorkflowFiles = ({
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+# contents:read for checkout; pull-requests:write to post the preview link
+# comment. Both must be listed — an omitted scope defaults to none.
 permissions:
   contents: read
+  pull-requests: write
 concurrency:
   group: lightdash-preview-\${{ github.ref }}
   cancel-in-progress: true
@@ -182,11 +187,42 @@ jobs:
         env:
           DBT_PROFILES: \${{ secrets.DBT_PROFILES }}
       - name: Create preview project
+        id: preview
         run: lightdash start-preview --project-dir "$PROJECT_DIR" --profiles-dir . --name "\${GITHUB_HEAD_REF}"
         env:
           LIGHTDASH_URL: \${{ secrets.LIGHTDASH_URL }}
           LIGHTDASH_PROJECT: \${{ secrets.LIGHTDASH_PROJECT }}
           LIGHTDASH_API_KEY: \${{ secrets.LIGHTDASH_API_KEY }}
+      - name: Comment preview link on PR
+        if: steps.preview.outputs.url != ''
+        uses: ${GITHUB_SCRIPT_ACTION}
+        env:
+          PREVIEW_URL: \${{ steps.preview.outputs.url }}
+        with:
+          script: |
+            const marker = '<!-- lightdash-preview -->';
+            const body = marker + '\\n:zap: Your Lightdash preview project is ready: ' + process.env.PREVIEW_URL;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 `;
 
     const closePreview = `name: lightdash-close-preview


### PR DESCRIPTION
## Summary

Part of the AI "set up preview deploys" agent feature. The agent opens a PR adding a `start-preview` / `close-preview` GitHub Actions workflow pair that spins up a Lightdash preview project per PR. This change makes the generated `start-preview` workflow **post the preview project URL back to the pull request as a comment**, so reviewers get the link directly instead of digging through Action logs.

## What changed

`packages/common/src/utils/previewDeployWorkflow.ts` — the generated `start-preview.yml` now:

- Gives the **Create preview project** step `id: preview` so we can read the URL the CLI already emits via `core.setOutput('url', ...)` (set whenever `CI=true`, which GitHub Actions always sets — no CLI change needed).
- Adds a **Comment preview link on PR** step that posts a sticky comment with the preview URL. It find-or-updates on an HTML marker (`<!-- lightdash-preview -->`) so repeated `synchronize` pushes update one comment rather than spamming.
- Grants `pull-requests: write` to `start-preview` **alongside** `contents: read`. An omitted scope in a `permissions:` block defaults to `none`, so both must be listed explicitly — `contents: read` keeps `checkout` working on private repos while `pull-requests: write` allows the comment.
- `close-preview` never comments, so it stays least-privilege read-only.

### Why `actions/github-script` and not a sticky-comment action?

The reference workflow people hand-write for this uses third-party actions on floating tags (`marocchino/sticky-pull-request-comment@v2`, `jwalton/gh-find-current-pr@v1`). The generated workflow runs with the repo's warehouse + Lightdash secrets in scope, so the existing hardening tests forbid floating tags and only allow `actions/*` org actions pinned to a full commit SHA. This replicates the sticky-comment behavior with `actions/github-script` pinned to the exact SHA the repo already trusts in its own CI — no new supply-chain surface. The `pull_request` trigger also gives us the PR number directly (`context.issue.number`), so `gh-find-current-pr` isn't needed.

## Testing

- Added/updated unit tests in `previewDeployWorkflow.test.ts`: split the hardening test so `start-preview` is asserted to carry both `contents: read` and `pull-requests: write` while `close-preview` stays read-only, plus a new test covering the comment step (URL capture, SHA-pinned action, sticky marker, create/update).
- Verified the generated YAML parses with a real YAML parser, the embedded `script:` body passes `node --check`, and the template-literal escaping renders all `${{ }}` / `${GITHUB_HEAD_REF}` expressions and the literal `\n` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)