### PR TITLE
fix(bigquery): reject empty SSO keyfiles and hide Save for OAuth credential types

### DIFF
--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -1,10 +1,13 @@
 import {
     assertUnreachable,
+    bigquerySsoUserCredentialsSchema,
+    BigqueryTokenError,
     CreateWarehouseCredentials,
     DatabricksAuthenticationType,
     databricksOauthU2mUserCredentialsSchema,
     DatabricksTokenError,
     NotFoundError,
+    ParameterError,
     ProjectType,
     SnowflakeAuthenticationType,
     snowflakeSsoUserCredentialsSchema,
@@ -377,6 +380,25 @@ export class UserWarehouseCredentialsModel {
                 }
             }
 
+            // Reject empty BigQuery keyfiles before they reach the warehouse
+            // client (where they surface as "does not contain a client_email
+            // field"), so the user is prompted to reauthenticate instead.
+            // Per-user BigQuery credentials are always SSO, so the refresh_token
+            // requirement applies to every BigQuery user credential.
+            if (
+                credentialsWithSecrets.credentials.type ===
+                WarehouseTypes.BIGQUERY
+            ) {
+                const result = bigquerySsoUserCredentialsSchema.safeParse(
+                    credentialsWithSecrets.credentials,
+                );
+                if (!result.success) {
+                    throw new BigqueryTokenError(
+                        `Please reauthenticate to access BigQuery`,
+                    );
+                }
+            }
+
             return credentialsWithSecrets;
         }
 
@@ -405,11 +427,31 @@ export class UserWarehouseCredentialsModel {
         }
     }
 
+    // Reject credentials that would be unusable at query time, so we never
+    // persist an empty shell (e.g. a masked BigQuery placeholder keyfile that
+    // overwrites a working credential). Per-user BigQuery credentials are
+    // always SSO, so the refresh_token requirement applies to all of them.
+    private static validateCredentialsForPersistence(
+        data: UpsertUserWarehouseCredentials,
+    ): void {
+        if (data.credentials.type === WarehouseTypes.BIGQUERY) {
+            const result = bigquerySsoUserCredentialsSchema.safeParse(
+                data.credentials,
+            );
+            if (!result.success) {
+                throw new ParameterError(
+                    'BigQuery credentials require a valid keyfile. Please reauthenticate with Google.',
+                );
+            }
+        }
+    }
+
     async create(
         userUuid: string,
         data: UpsertUserWarehouseCredentials,
         projectUuid?: string,
     ): Promise<string> {
+        UserWarehouseCredentialsModel.validateCredentialsForPersistence(data);
         let encryptedCredentials: Buffer;
         try {
             encryptedCredentials = this.encryptionUtil.encrypt(
@@ -439,6 +481,7 @@ export class UserWarehouseCredentialsModel {
         userWarehouseCredentialsUuid: string,
         data: UpsertUserWarehouseCredentials,
     ): Promise<string> {
+        UserWarehouseCredentialsModel.validateCredentialsForPersistence(data);
         let encryptedCredentials: Buffer;
         try {
             encryptedCredentials = this.encryptionUtil.encrypt(

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -675,6 +675,20 @@ export class DatabricksTokenError extends LightdashError {
     }
 }
 
+/* This specific error will be used in the frontend
+to show a "reauthenticate" button in the UI
+*/
+export class BigqueryTokenError extends LightdashError {
+    constructor(message: string) {
+        super({
+            message,
+            name: 'BigqueryTokenError',
+            statusCode: 401,
+            data: {},
+        });
+    }
+}
+
 export class CustomSqlQueryForbiddenError extends LightdashError {
     constructor(
         message: string = 'User cannot run queries with custom SQL dimensions',

--- a/packages/common/src/types/userWarehouseCredentials.test.ts
+++ b/packages/common/src/types/userWarehouseCredentials.test.ts
@@ -1,0 +1,38 @@
+import { bigquerySsoUserCredentialsSchema } from './userWarehouseCredentials';
+
+describe('bigquerySsoUserCredentialsSchema', () => {
+    it('rejects an empty keyfile (the reported bug value)', () => {
+        const result = bigquerySsoUserCredentialsSchema.safeParse({
+            type: 'bigquery',
+            keyfileContents: {},
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects a keyfile with a blank refresh_token', () => {
+        const result = bigquerySsoUserCredentialsSchema.safeParse({
+            type: 'bigquery',
+            keyfileContents: {
+                type: 'authorized_user',
+                client_id: 'client-id',
+                client_secret: 'client-secret',
+                refresh_token: '',
+            },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('accepts a keyfile with a valid refresh_token', () => {
+        const result = bigquerySsoUserCredentialsSchema.safeParse({
+            type: 'bigquery',
+            authenticationType: 'sso',
+            keyfileContents: {
+                type: 'authorized_user',
+                client_id: 'client-id',
+                client_secret: 'client-secret',
+                refresh_token: 'a-real-refresh-token',
+            },
+        });
+        expect(result.success).toBe(true);
+    });
+});

--- a/packages/common/src/types/userWarehouseCredentials.ts
+++ b/packages/common/src/types/userWarehouseCredentials.ts
@@ -119,3 +119,17 @@ export const databricksOauthU2mUserCredentialsSchema = z
         httpPath: z.string().optional(),
     })
     .strict();
+
+// Zod schema for validating BigQuery SSO user warehouse credentials.
+// Per-user BigQuery credentials are always SSO ("authorized_user" keyfile),
+// so a usable keyfile must carry a non-empty refresh_token. This guards
+// against an empty `keyfileContents: {}` being persisted or used, which
+// otherwise surfaces as the opaque "does not contain a client_email field".
+export const bigquerySsoUserCredentialsSchema = z
+    .object({
+        type: z.literal(WarehouseTypes.BIGQUERY),
+        keyfileContents: z
+            .object({ refresh_token: z.string().min(1) })
+            .passthrough(),
+    })
+    .passthrough();

--- a/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
@@ -91,6 +91,17 @@ const UserCredentialsSwitcher = () => {
                         setShowCreateModalOnPageLoad(true);
                         setIsCreatingCredentials(true);
                     }
+                    if (
+                        error?.error?.name === 'BigqueryTokenError' &&
+                        activeProject?.warehouseConnection?.type ===
+                            'bigquery' &&
+                        activeProject?.warehouseConnection
+                            ?.requireUserCredentials
+                    ) {
+                        console.info('Triggering reauth modal for BigQuery');
+                        setShowCreateModalOnPageLoad(true);
+                        setIsCreatingCredentials(true);
+                    }
                 }
             }
         });

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -78,6 +78,15 @@ export const EditCredentialsModal: FC<
         },
     });
 
+    // SSO-based credentials are only ever set through their OAuth popup. They
+    // have no editable secret field, so a generic "Save" would persist the
+    // masked placeholder and wipe the working credential.
+    const showSaveButton = ![
+        WarehouseTypes.BIGQUERY,
+        WarehouseTypes.SNOWFLAKE,
+        WarehouseTypes.DATABRICKS,
+    ].includes(userCredentials.credentials.type);
+
     return (
         <MantineModal
             opened={opened}
@@ -86,14 +95,16 @@ export const EditCredentialsModal: FC<
             icon={IconPencil}
             cancelDisabled={isSaving}
             actions={
-                <Button
-                    type="submit"
-                    form={FORM_ID}
-                    disabled={isSaving}
-                    loading={isSaving}
-                >
-                    Save
-                </Button>
+                showSaveButton ? (
+                    <Button
+                        type="submit"
+                        form={FORM_ID}
+                        disabled={isSaving}
+                        loading={isSaving}
+                    >
+                        Save
+                    </Button>
+                ) : undefined
             }
         >
             <form


### PR DESCRIPTION
Closes: PROD-8137
Closes: #23914

### Description:

Fixes a bug where BigQuery SSO credentials could be persisted as an empty `keyfileContents: {}` placeholder, which would silently overwrite a working credential and later surface as the opaque error "does not contain a client_email field".

**Root cause:** the `EditCredentialsModal` seeds its form with a masked placeholder (the real keyfile is stripped from API responses) but still shows a generic "Save" button. For BigQuery there is no keyfile field to fill in, so clicking Save persisted `{"type":"bigquery","keyfileContents":{}}` — exactly the value observed on affected instances. Re-authenticating via the Google popup fixed it; the next Edit + Save wiped it again.

A new `bigquerySsoUserCredentialsSchema` Zod schema validates that BigQuery keyfiles contain a non-empty `refresh_token`, since per-user BigQuery credentials are always `authorized_user` (SSO) type. It is applied in two places:

- **On write**: both `create` and `update` reject invalid credentials before encryption/persistence, preventing an empty shell from overwriting a working credential (covers the Edit modal and any direct API call).
- **On read**: an invalid BigQuery keyfile throws a typed `BigqueryTokenError` (HTTP 401) prompting reauthentication, instead of the confusing downstream `client_email` error.

The "Save" button is also hidden in `EditCredentialsModal` for SSO-based warehouse types (BigQuery, Snowflake, Databricks), mirroring `CreateCredentialsModal` — their credentials can only be set through the OAuth popup, so a generic save would have no valid secret to persist. This also closes the identical exposure for Snowflake SSO and Databricks U2M edit flows.
