### PR TITLE
fix(ai-agent): label writeback card "updated" when iterating a PR

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -521,6 +521,7 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
             output: 'Done.',
             exitCode: 0,
             prUrl: PR_7,
+            prAction: 'opened',
             repository: 'acme/analytics',
         });
         expect(createPullRequest).toHaveBeenCalledTimes(1);
@@ -534,7 +535,11 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
 
         const result = await runService(sandbox);
 
-        expect(result).toMatchObject({ exitCode: 1, prUrl: null });
+        expect(result).toMatchObject({
+            exitCode: 1,
+            prUrl: null,
+            prAction: null,
+        });
         expect(createPullRequest).not.toHaveBeenCalled();
         expect(sandbox.kill).toHaveBeenCalledTimes(1);
     });
@@ -545,7 +550,11 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
 
         const result = await runService(sandbox);
 
-        expect(result).toMatchObject({ exitCode: 0, prUrl: null });
+        expect(result).toMatchObject({
+            exitCode: 0,
+            prUrl: null,
+            prAction: null,
+        });
         expect(createPullRequest).not.toHaveBeenCalled();
         expect(sandbox.kill).toHaveBeenCalledTimes(1);
     });

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -10,6 +10,7 @@ import {
     PullRequestSource,
     WarehouseTypes,
     type AiWritebackRunResult,
+    type PullRequestWritebackAction,
     type SessionUser,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -81,6 +82,18 @@ import {
 } from './utils';
 
 export type { AiWritebackRunArgs, AiWritebackSource } from './types';
+
+// Maps the applied-changes outcome to the PR action surfaced to the user: a
+// fresh PR is 'opened', a resumed thread or adopted pasted-link PR is
+// 'updated', and no PR touched is null.
+const getPrAction = (
+    applied: AppliedChanges,
+): PullRequestWritebackAction | null => {
+    if (!applied.prUrl) {
+        return null;
+    }
+    return applied.prCreated ? 'opened' : 'updated';
+};
 
 type AiWritebackServiceDeps = {
     lightdashConfig: LightdashConfig;
@@ -494,10 +507,15 @@ export class AiWritebackService extends BaseService {
                     hasChanges,
                     prCreated: false,
                 });
+                const crashPrUrl =
+                    turn.existingRow?.pr_url ?? adoptedPr?.prUrl ?? null;
                 return {
                     output: sanitizedStdout,
                     exitCode: agent.exitCode,
-                    prUrl: turn.existingRow?.pr_url ?? adoptedPr?.prUrl ?? null,
+                    prUrl: crashPrUrl,
+                    // The agent crashed before pushing changes, so any PR here
+                    // is a pre-existing one — never newly opened.
+                    prAction: crashPrUrl ? 'updated' : null,
                     projectName: turn.projectName,
                     repository,
                 };
@@ -543,6 +561,7 @@ export class AiWritebackService extends BaseService {
                 output: sanitizedStdout,
                 exitCode: agent.exitCode,
                 prUrl: applied.prUrl,
+                prAction: getPrAction(applied),
                 projectName: turn.projectName,
                 repository,
             };

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3547,6 +3547,20 @@ Parameters:
             {
               "additionalProperties": false,
               "properties": {
+                "prAction": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "opened",
+                        "updated",
+                      ],
+                      "type": "string",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                },
                 "prUrl": {
                   "type": [
                     "string",

--- a/packages/backend/src/ee/services/ai/tools/proposeWriteback.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeWriteback.ts
@@ -21,6 +21,7 @@ export const getProposeWriteback = ({ proposeWriteback }: Dependencies) =>
             try {
                 const {
                     prUrl,
+                    prAction,
                     output,
                     projectName,
                     repository,
@@ -37,8 +38,9 @@ export const getProposeWriteback = ({ proposeWriteback }: Dependencies) =>
                 // only via the "View pull request" button (built from the
                 // metadata below) — see the instruction in the success branch.
                 const target = `Lightdash project "${projectName}" (repository ${repository})`;
+                const prVerb = prAction === 'updated' ? 'Updated' : 'Opened';
                 const base = prUrl
-                    ? `Opened a pull request against ${target}. A "View pull request" button is shown to the user, so do NOT include the pull request URL or number in your reply — just summarise the change and which project/repository it targeted.\n\nAgent summary:\n${output}`
+                    ? `${prVerb} a pull request against ${target}. A "View pull request" button is shown to the user, so do NOT include the pull request URL or number in your reply — just summarise the change and which project/repository it targeted.\n\nAgent summary:\n${output}`
                     : `The writeback agent ran against ${target} but made no file changes, so no pull request was opened.\n\nAgent summary:\n${output}`;
 
                 // Deterministic offer: when the repo has no Lightdash
@@ -55,6 +57,7 @@ export const getProposeWriteback = ({ proposeWriteback }: Dependencies) =>
                     metadata: {
                         status: 'success' as const,
                         prUrl: prUrl ?? null,
+                        prAction: prAction ?? null,
                     },
                 };
             } catch (error) {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -18940,6 +18940,18 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccessEmpty', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PullRequestWritebackAction: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['opened'] },
+                { dataType: 'enum', enums: ['updated'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiWritebackRunResult: {
         dataType: 'refAlias',
         type: {
@@ -18947,6 +18959,14 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 repository: { dataType: 'string', required: true },
                 projectName: { dataType: 'string', required: true },
+                prAction: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'PullRequestWritebackAction' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 prUrl: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -19541,6 +19541,11 @@
             "ApiRemoveScopeFromRoleResponse": {
                 "$ref": "#/components/schemas/ApiSuccessEmpty"
             },
+            "PullRequestWritebackAction": {
+                "type": "string",
+                "enum": ["opened", "updated"],
+                "description": "Whether a writeback run opened a brand-new pull request or updated an\nexisting one (a resumed thread or a pasted PR link). `null` when no pull\nrequest was touched (the agent made no file changes)."
+            },
             "AiWritebackRunResult": {
                 "properties": {
                     "repository": {
@@ -19548,6 +19553,14 @@
                     },
                     "projectName": {
                         "type": "string"
+                    },
+                    "prAction": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PullRequestWritebackAction"
+                            }
+                        ],
+                        "nullable": true
                     },
                     "prUrl": {
                         "type": "string",
@@ -19564,6 +19577,7 @@
                 "required": [
                     "repository",
                     "projectName",
+                    "prAction",
                     "prUrl",
                     "exitCode",
                     "output"

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolProposeWritebackArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolProposeWritebackArgs.ts
@@ -34,6 +34,10 @@ export const toolProposeWritebackOutputSchema = z.object({
         z.object({
             status: z.literal('success'),
             prUrl: z.string().nullable(),
+            // Nullish, not required: tool-call metadata is persisted, so cards
+            // rendered from rows written before this field existed must still
+            // parse. Absent/null is treated as 'opened' by the renderer.
+            prAction: z.enum(['opened', 'updated']).nullish(),
         }),
         z.object({
             status: z.literal('error'),

--- a/packages/common/src/ee/aiWriteback/types.ts
+++ b/packages/common/src/ee/aiWriteback/types.ts
@@ -15,12 +15,21 @@ export type AiWritebackRequestBody = {
 };
 
 /**
+ * Whether a writeback run opened a brand-new pull request or updated an
+ * existing one (a resumed thread or a pasted PR link). `null` when no pull
+ * request was touched (the agent made no file changes).
+ */
+export type PullRequestWritebackAction = 'opened' | 'updated';
+
+/**
  * Result of a (synchronous) AI writeback run.
  *
  * - `output` is the text the agent produced.
  * - `exitCode` is the sandbox command's exit status.
  * - `prUrl` is the URL of the pull request opened from the agent's changes, or
  *   `null` when the agent made no file changes (nothing to raise a PR for).
+ * - `prAction` is whether that PR was newly opened or an existing one updated,
+ *   or `null` when no PR was touched.
  * - `projectName` is the Lightdash project the run targeted.
  * - `repository` is the GitHub repository (`owner/repo`) the run targeted.
  */
@@ -28,6 +37,7 @@ export type AiWritebackRunResult = {
     output: string;
     exitCode: number;
     prUrl: string | null;
+    prAction: PullRequestWritebackAction | null;
     projectName: string;
     repository: string;
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
@@ -143,6 +143,11 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
     }
 
     const summary = summarisePrUrl(metadata.prUrl);
+    // Older tool-call rows predate `prAction`; treat a missing value as 'opened'.
+    const title =
+        metadata.prAction === 'updated'
+            ? 'Pull request updated'
+            : 'Pull request opened';
 
     return (
         <Paper withBorder p="sm" radius="md">
@@ -163,7 +168,7 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
                     </ThemeIcon>
                     <Stack gap={0}>
                         <Text size="sm" fw={500}>
-                            Pull request opened
+                            {title}
                         </Text>
                         {summary && (
                             <Text size="xs" c="ldGray.6">


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8140/when-you-edit-a-pull-request-it-says-opened

## Summary

In an AI agent chat, the writeback result card always read **"Pull request opened"** — even on a follow-up turn where the agent *updated* an existing pull request (a resumed thread, or a pasted PR link). So asking the agent to "create a PR" and then "change that PR" produced two cards both claiming "opened", pointing at the same PR.

## Root cause

The card derives its label from the `proposeWriteback` tool result metadata, but that metadata only carried `{ status, prUrl }` — no signal for whether the PR was newly opened or updated — and the card hardcoded the verb:

```tsx
// AiProposeWritebackToolCall.tsx
<Text size="sm" fw={500}>
    Pull request opened
</Text>
```

The information existed but was dropped on the floor: `AiWritebackService.applyAgentChanges` already returns `prCreated` (false for a resumed thread / adopted pasted-link PR), it just never reached the frontend.

## Fix

Thread a `prAction` (`'opened' | 'updated' | null`) from the writeback result through the tool metadata to the card, and render the verb from it.

- `common/ee/aiWriteback/types.ts` — new `PullRequestWritebackAction`; added `prAction` to `AiWritebackRunResult`.
- `AiWritebackService.ts` — `getPrAction()` maps `prCreated`/`prUrl` to the action; populated on both `run()` return paths.
- `ai/tools/proposeWriteback.ts` — emit `prAction` in success metadata; agent-facing text now says "Updated…" vs "Opened…".
- `toolProposeWritebackArgs.ts` — `prAction` added to the success metadata schema as `.nullish()` so tool-call rows persisted before this change still parse (and fall back to "opened").
- `AiProposeWritebackToolCall.tsx` — render "Pull request opened" vs "Pull request updated" from `metadata.prAction`.
- Out of scope: the separate `PullRequestsPage` settings list (its own hardcoded "opened" label, not what this ticket is about).

## Before / After

Same chat: open a PR, then ask the agent to change it.

```
Before:                              After:
  turn 1  Pull request opened  #86     turn 1  Pull request opened   #86
  turn 2  Pull request opened  #86     turn 2  Pull request updated  #86   <-
```

Old tool-call rows (no `prAction`) keep showing "opened" — the action can't be reconstructed retroactively.

## Test plan

- [x] `pnpm -F common build`, `pnpm -F backend typecheck:fast`, `pnpm -F frontend typecheck:fast` — clean; lint clean on changed files.
- [x] `npx jest AiWritebackService.test` — 14 pass (added `prAction` assertions: `opened` on a fresh PR, `null` when no PR).
- [x] `npx jest agentToolContracts.snapshot` — updated for the new schema field; MCP contract unaffected.
- [x] Live threads API (`GET /aiAgents/{agent}/threads/{thread}`) against the real demo thread from the screenshot: old metadata (no `prAction`) still passes the zod schema and `isToolProposeWritebackResult`, and falls back to "opened"; synthetic `prAction: 'updated'` parses and renders "Pull request updated"; an invalid value is rejected.
- [ ] Manual: a live writeback that updates an existing PR (needs the GitHub/sandbox infra, not reproducible locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)