### PR TITLE
fix(data-apps): add `view:Explore` to `Viewer` to allow running queries

### DIFF
--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -86,6 +86,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('view', 'Project', {
             organizationUuid: member.organizationUuid,
         });
+        can('view', 'Explore', {
+            organizationUuid: member.organizationUuid,
+        });
         can('view', 'Organization', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -1662,7 +1662,10 @@ describe('Project member permissions', () => {
                     ),
                 ).toEqual(false);
             });
-            it('cannot Explore', () => {
+            it('can view but cannot manage Explore', () => {
+                expect(
+                    ability.can('view', subject('Explore', { projectUuid })),
+                ).toEqual(true);
                 expect(
                     ability.can('manage', subject('Explore', { projectUuid })),
                 ).toEqual(false);

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -50,6 +50,9 @@ export const projectMemberAbilities: Record<
         can('view', 'Project', {
             projectUuid: member.projectUuid,
         });
+        can('view', 'Explore', {
+            projectUuid: member.projectUuid,
+        });
         can('view', 'PinnedItems', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -20,6 +20,7 @@ const BASE_ROLE_SCOPES = {
         'view:SavedChart',
         'view:Space',
         'view:Project',
+        'view:Explore', // Run ad-hoc/data-app queries (metric-query endpoint)
         'view:PinnedItems',
         'view:DashboardComments',
         'view:Tags',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -564,6 +564,13 @@ const scopes: Scope[] = [
         ],
     },
     {
+        name: 'view:Explore',
+        description: 'Run queries against explores',
+        isEnterprise: false,
+        group: ScopeGroup.DATA,
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:Explore',
         description: 'Explore and query data',
         isEnterprise: false,


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/23928

### Description:
Data apps are using the metric-query endpoint which is gated behind `view:Explore`. However, this scope didn't exist yet so we strictly relied on `manage:Explore` (Interactive Viewer+) for being able to run the queries. A simple "Viewer" would experience 403 responses when running any queries via the data apps.
