### PR TITLE
fix: clean shared turbo cache

### DIFF
--- a/scripts/clean-build-cache.sh
+++ b/scripts/clean-build-cache.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
+set -euo pipefail
 
 # Remove tsbuildinfo files (incl. nested workspace members)
 find packages -name "*.tsbuildinfo" -not -path "*/node_modules/*" -delete
 
-# Remove turbo cache (root + per-package)
+# Remove turbo cache/logs from this worktree and nested package dirs.
 rm -rf .turbo
 rm -rf packages/*/.turbo
+
+# In git worktrees, Turbo uses the primary checkout's .turbo/cache.
+git_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+if [[ -n "$git_common_dir" ]]; then
+    rm -rf "$(dirname "$git_common_dir")/.turbo"
+fi
 
 # Remove build/dist/.next under packages (incl. nested workspace members)
 find packages -type d \( -name node_modules -prune \) -o \


### PR DESCRIPTION
## Summary
- Clean the shared Turbo cache used by git worktrees
- Keep deleting current worktree `.turbo` dirs and per-package `.turbo` logs

## Root cause
Turbo 2 reports `Remote caching disabled, using shared worktree cache` in git worktrees. That cache lives in the primary checkout (`dirname $(git rev-parse --git-common-dir)/.turbo`), not just the active worktree. The old cleaner only removed `.turbo` from the current worktree, so cached task artifacts survived.

## Validation
- `bash -n scripts/clean-build-cache.sh`
- `pnpm clean:build-cache` removed `/Users/irakli/code/lightdash/.turbo` from this worktree setup
- `pnpm build:fast` after clean reported `Cached: 0 cached, 5 total` without `TURBO_FORCE`
- Fast clean build time after true cache clean: `12.66s real`
