### PR TITLE
feat(scim): polish SCIM access tokens table layout

### DIFF
--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.module.css
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.module.css
@@ -1,0 +1,17 @@
+.table thead tr th {
+    text-align: left;
+}
+
+.uuid {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    user-select: all;
+}
+
+.nameColumn {
+    width: 40%;
+    min-width: 240px;
+}
+
+.dateColumn {
+    width: 20%;
+}

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
@@ -33,6 +33,7 @@ import {
     useDeleteScimToken,
     useScimTokenList,
 } from '../../hooks/useScimAccessToken';
+import classesModule from './TokensTable.module.css';
 
 const TokenItem: FC<{
     token: ServiceAccount;
@@ -42,7 +43,11 @@ const TokenItem: FC<{
     return (
         <>
             <tr>
-                <Text component="td" fw={500}>
+                <Text
+                    component="td"
+                    fw={500}
+                    className={classesModule.nameColumn}
+                >
                     {description}
                 </Text>
 
@@ -72,26 +77,35 @@ const TokenItem: FC<{
                     </Group>
                 </td>
                 <td>
-                    {lastUsedAt && (
+                    {lastUsedAt ? (
                         <Tooltip
                             withinPortal
                             position="top"
                             maw={350}
                             label={formatTimestamp(lastUsedAt)}
                         >
-                            <Text>{formatDate(lastUsedAt)}</Text>
+                            <span>{formatDate(lastUsedAt)}</span>
                         </Tooltip>
+                    ) : (
+                        <span>Never used</span>
                     )}
                 </td>
                 <td>
-                    <Group align="center" justify="flex-start" gap="xs">
+                    <Group
+                        align="center"
+                        justify="flex-start"
+                        gap="xs"
+                        wrap="nowrap"
+                    >
                         <Tooltip
                             withinPortal
                             position="top"
                             maw={350}
                             label={uuid}
                         >
-                            <span>{uuid.substring(0, 4)}...</span>
+                            <span className={classesModule.uuid}>
+                                ...{uuid.slice(-8)}
+                            </span>
                         </Tooltip>
                         <CopyButton value={uuid}>
                             {({ copied, copy }) => (
@@ -150,12 +164,22 @@ export const TokensTable = () => {
     return (
         <>
             <Paper withBorder style={{ overflow: 'hidden' }}>
-                <Table className={cx(classes.root, classes.alignLastTdRight)}>
+                <Table
+                    className={cx(
+                        classes.root,
+                        classes.alignLastTdRight,
+                        classesModule.table,
+                    )}
+                >
                     <thead>
                         <tr>
-                            <th>Name</th>
-                            <th>Expiration date</th>
-                            <th>Last used at</th>
+                            <th className={classesModule.nameColumn}>Name</th>
+                            <th className={classesModule.dateColumn}>
+                                Expiration date
+                            </th>
+                            <th className={classesModule.dateColumn}>
+                                Last used at
+                            </th>
                             <th>UUID</th>
                             <th></th>
                         </tr>


### PR DESCRIPTION
## Before

<img width="1838" height="336" alt="CleanShot 2026-06-05 at 10 42 42@2x" src="https://github.com/user-attachments/assets/fad9e946-5804-45eb-872e-a4fa9b2316f2" />

## After

<img width="1836" height="556" alt="CleanShot 2026-06-05 at 11 00 28@2x" src="https://github.com/user-attachments/assets/9d16c745-b371-4b65-8f3b-101ba17ee13e" />


## Summary

The SCIM access tokens table had three rough edges: never-used tokens showed a blank "Last used at" cell (inconsistent with the "No expiration date" placeholder next to it), column headers rendered centered (native `<th>` default) while the data cells were left-aligned, and the UUID was truncated to its first 4 characters with no width guarantees. This pass tightens the layout and makes the columns read consistently.

### Layout & alignment

- **Left-align headers** — a local CSS module forces `th` to `text-align: left`, matching the left-aligned cells. Scoped to this table, not the shared `useTableStyles`.
- **Name column** — reserves `40%` width with a `240px` minimum so longer token names have room.
- **Date columns** — "Expiration date" and "Last used at" share an equal `20%` width.

### Cell content

- **"Never used" placeholder** — empty "Last used at" now renders `Never used`, mirroring the `No expiration date` empty state. Used tokens keep the formatted date + full-timestamp tooltip.
- **UUID** — shows the last 8 characters (`...7a537f86`) in a monospace font with `user-select: all`, full UUID in the hover tooltip, and `wrap="nowrap"` so the value and copy button never stack.

## Layout

```
Before:                                          After:
   Name   Expiration date  Last used at  UUID       Name      Expiration date  Last used at  UUID
  (centered headers, left cells)                  (all left-aligned)
  test    No expiration     <blank>      65fb…     test       No expiration     Never used    …a042dd26 [copy]
  ─ UUID first-4, copy wraps to 2nd line ─        ─ UUID last-8 monospace, single line ─
```

## Regression analysis

- **Header alignment** — new CSS module class applied only to this table's `Table`; no other table affected.
- **`Text` → `span`** in the Last-used cell — purely presentational, keeps tooltip behaviour.
- **Column widths** — percentages on `th`; the table still flexes within its container.
- No backend/API surface touched.

## Test plan

- [ ] Column headers are left-aligned and flush with the cells below them.
- [ ] A never-used token shows `Never used`; a used token shows the date with a timestamp tooltip on hover.
- [ ] UUID shows `...` + last 8 chars, monospace; hover reveals the full UUID; copy button copies the full value.
- [ ] UUID and copy icon stay on one line; long token names don't squash the other columns.
- [ ] Verify both light and dark modes match the existing palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)