### PR TITLE
fix(docker-dev): reconcile stale env ports on slot change

### DIFF
--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -107,8 +107,38 @@ fi
 
 # ---------------------------------------------------------------------------
 step "Ensure .env.development.local"
+ENV_PORTS_CHANGED=0
 if test -f .env.development.local; then
-    echo "SKIP: env file exists"
+    # Reconcile slot-derived ports. The claimed slot can differ from when the file
+    # was first written (e.g. after stop-all the next start lands on a free slot).
+    # A stale PGPORT/PORT silently points PM2 at a dead container, and the API
+    # crash-loops on "Error migrating graphile worker" (its first DB op at boot).
+    reconcile_env() {
+        local key="$1" val="$2" cur
+        grep -q "^${key}=" .env.development.local || return 0
+        cur="$(grep "^${key}=" .env.development.local | head -1 | cut -d= -f2-)"
+        [ "$cur" = "$val" ] && return 0
+        awk -v k="$key" -v v="$val" 'BEGIN{FS=OFS="="} $1==k{print k"="v; next} {print}' \
+            .env.development.local > .env.development.local.tmp \
+            && mv .env.development.local.tmp .env.development.local
+        ENV_PORTS_CHANGED=1
+    }
+    reconcile_env PGPORT "${LD_PG_PORT}"
+    reconcile_env PORT "${PORT}"
+    reconcile_env FE_PORT "${FE_PORT}"
+    reconcile_env SCHEDULER_PORT "${SCHEDULER_PORT}"
+    reconcile_env DEBUG_PORT "${DEBUG_PORT}"
+    reconcile_env SDK_TEST_PORT "${SDK_TEST_PORT}"
+    reconcile_env SPOTLIGHT_PORT "${SPOTLIGHT_PORT}"
+    reconcile_env LIGHTDASH_PROMETHEUS_PORT "${LIGHTDASH_PROMETHEUS_PORT}"
+    reconcile_env SITE_URL "http://localhost:${FE_PORT}"
+    reconcile_env INTERNAL_LIGHTDASH_HOST "http://localhost:${FE_PORT}"
+    reconcile_env LIGHTDASH_API_URL "http://localhost:${PORT}"
+    if [ "$ENV_PORTS_CHANGED" = 1 ]; then
+        echo "OK: env file reconciled to slot ports (PGPORT=${LD_PG_PORT} PORT=${PORT} FE_PORT=${FE_PORT})"
+    else
+        echo "SKIP: env file exists and ports match slot"
+    fi
 else
     cat > .env.development.local << EOF
 # Local development overrides (instance: ${LD_INSTANCE_ID})
@@ -287,6 +317,13 @@ if mine:
 " 2>/dev/null || true)"
 if [ -n "$RUNNING_CWD" ] && [ "$RUNNING_CWD" != "$(pwd)" ]; then
     echo "Instance PM2 was running from $RUNNING_CWD — switching to this worktree"
+    # shellcheck disable=SC2046
+    pm2 delete $(instance_pm2_names) >/dev/null 2>&1 || true
+elif [ "${ENV_PORTS_CHANGED:-0}" = 1 ]; then
+    # Ports were reconciled but procs may already be online with the stale env.
+    # PM2 caches env at spawn time, so delete+start is required (restart --update-env
+    # only inherits the current shell, not the .env file).
+    echo "Env ports changed — recycling PM2 so the new env is picked up"
     # shellcheck disable=SC2046
     pm2 delete $(instance_pm2_names) >/dev/null 2>&1 || true
 fi


### PR DESCRIPTION
## Summary

The `/docker-dev` fast-start script could leave the API crash-looping after a `stop-all` + `start` cycle when the worktree landed on a different port slot.

**Root cause:** `.env.development.local` is a worktree file that survives `stop-all` and volume wipes, but the port slot is re-claimed fresh on each `start` (via `dev-ports.sh`) and often differs. The script's env step only checked the file's *existence*, not whether its slot-derived ports still matched the claimed slot — so PM2 read a stale `PGPORT` pointing at a dead container. `migrate`/`seed` still passed (they use `$LD_PG_PORT` directly); only the long-lived PM2 processes failed, crash-looping on `Error migrating graphile worker` (the API's first DB op at boot) with `/api/v1/health` returning `000`.

## Changes

- **`scripts/dev-fast-start.sh`**
  - Env step now **reconciles slot-derived port keys in place** when the file exists (instead of blind-skipping), reporting `OK: env file reconciled to slot ports`.
  - PM2 step now **force-respawns** (`delete` + `start`) when those ports change — PM2 caches env at spawn time, so `restart --update-env` won't pick up the edited file.

## Test plan

- [x] Reproduced: `stop-all` (different prior slot) → `start` → API crash-loop on graphile migration, `health` `000`.
- [x] Verified the three-source mismatch (claimed slot vs. env file vs. live container port).
- [x] Applied fix → `health` 200, 0 restarts.
- [x] Re-ran `dev-fast-start.sh`: reports `SKIP: env file exists and ports match slot`, reaches `READY` idempotently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)