### PR TITLE
fix(pivot-table): force pivot dimensions visible when dragged to columns

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -109,6 +109,13 @@ const GeneralSettings: FC = () => {
                         fieldId,
                         ...columns.slice(destination.index),
                     ]);
+                    // Pivot columns are always visible — a dim hidden as a row
+                    // would otherwise carry visible:false in and blank the table.
+                    if (!isHidePivotDimsEnabled) {
+                        chartConfig.updateColumnProperty(fieldId, {
+                            visible: true,
+                        });
+                    }
                 } else {
                     // Remove pivot
                     const fieldId = columns[source.index];
@@ -144,6 +151,7 @@ const GeneralSettings: FC = () => {
             setPivotDimensions,
             showToastError,
             handleToggleMetricsAsRows,
+            isHidePivotDimsEnabled,
         ],
     );
 


### PR DESCRIPTION
Dragging a dimension from Rows into Columns to pivot on it only updated `pivotDimensions`, never the column's `visible` flag. A dimension hidden while it was a row carried `visible: false` into the pivot, which left `groupByColumns` empty, derivation returned `undefined`, and the pivot table rendered blank.

This forces the dimension visible when it's dragged into Columns, gated on the `hide-pivot-dimensions` flag so the feature that intentionally allows hidden pivot dimensions is unaffected.

**Before**

https://github.com/user-attachments/assets/8d198f6c-0038-491b-b957-790136adfaf2

**After**

https://github.com/user-attachments/assets/baa9de35-4e50-4e8f-aa31-53b69be595ea

Closes #23937