### PR TITLE
style(ai-agents): polish chat composer controls

### DIFF
--- a/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
+++ b/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
@@ -1,6 +1,7 @@
 import type { AiModelOption } from '@lightdash/common';
 import {
     Button,
+    Group,
     Menu,
     ScrollArea,
     Stack,
@@ -16,12 +17,16 @@ interface Props extends Omit<ButtonProps, 'value' | 'onChange'> {
     models: AiModelOption[];
     value: string | null;
     onChange: (modelKey: string) => void;
+    reasoningEnabled?: boolean;
+    onReasoningChange?: (enabled: boolean) => void;
 }
 
 export const ModelSelector: FC<Props> = ({
     models,
     value,
     onChange,
+    reasoningEnabled,
+    onReasoningChange,
     ...buttonProps
 }) => {
     const selectedModel = useMemo(
@@ -43,7 +48,12 @@ export const ModelSelector: FC<Props> = ({
         [groupedModels],
     );
 
-    if (models.length === 1) {
+    const showReasoning =
+        selectedModel?.supportsReasoning === true &&
+        onReasoningChange !== undefined;
+    const reasoningLabel = reasoningEnabled ? 'High' : null;
+
+    if (models.length === 1 && !showReasoning) {
         return null;
     }
 
@@ -51,8 +61,9 @@ export const ModelSelector: FC<Props> = ({
         <Menu
             shadow="md"
             width={280}
-            position="bottom-start"
-            withinPortal={false}
+            position="top-end"
+            offset={8}
+            withinPortal
         >
             <Menu.Target>
                 <Button
@@ -66,13 +77,54 @@ export const ModelSelector: FC<Props> = ({
                         />
                     }
                 >
-                    <Text size="xs" fw={500} c="dimmed">
-                        {selectedModel?.displayName ?? 'Select model'}
-                    </Text>
+                    <Group gap={6} wrap="nowrap">
+                        <Text size="xs" fw={600} c="ldGray.8" span>
+                            {selectedModel?.displayName ?? 'Select model'}
+                        </Text>
+                        {showReasoning && reasoningLabel && (
+                            <Text size="xs" fw={500} c="ldGray.6" span>
+                                {reasoningLabel}
+                            </Text>
+                        )}
+                    </Group>
                 </Button>
             </Menu.Target>
 
             <Menu.Dropdown>
+                {showReasoning && (
+                    <>
+                        <Menu.Label>Reasoning</Menu.Label>
+                        <Menu.Item
+                            onClick={() => onReasoningChange(false)}
+                            rightSection={
+                                !reasoningEnabled ? (
+                                    <MantineIcon
+                                        icon={IconCheck}
+                                        size="sm"
+                                        color="ldGray.7"
+                                    />
+                                ) : null
+                            }
+                        >
+                            Default
+                        </Menu.Item>
+                        <Menu.Item
+                            onClick={() => onReasoningChange(true)}
+                            rightSection={
+                                reasoningEnabled ? (
+                                    <MantineIcon
+                                        icon={IconCheck}
+                                        size="sm"
+                                        color="ldGray.7"
+                                    />
+                                ) : null
+                            }
+                        >
+                            High
+                        </Menu.Item>
+                        {models.length > 1 && <Menu.Divider />}
+                    </>
+                )}
                 <ScrollArea.Autosize mah={200}>
                     {providerGroups.map((provider, groupIndex) => {
                         const providerModels =

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css
@@ -9,6 +9,7 @@
     box-shadow: var(--mantine-shadow-subtle);
     cursor: pointer;
     font-size: var(--mantine-font-size-xs);
+    font-family: var(--mantine-font-family);
     transition:
         background-color 120ms ease,
         border-color 120ms ease;
@@ -26,6 +27,30 @@
 .label {
     flex: 1;
     text-align: left;
+    font-family: var(--mantine-font-family);
+}
+
+.headerTarget {
+    width: auto;
+    min-width: 0;
+    max-width: 260px;
+    padding: 4px 6px;
+    border-color: transparent;
+    box-shadow: none;
+    background: transparent;
+}
+
+.headerTarget:hover,
+.headerTarget:focus-visible,
+.headerTarget[data-open='true'] {
+    border-color: transparent;
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-1);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-4);
+    }
 }
 
 /* Compact: icon-only at rest, no border. On hover / focus / open, the chip
@@ -60,8 +85,18 @@
     transition: width 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+.compact[data-auto='true'] .label {
+    width: auto;
+}
+
 .compact:hover .label,
 .compact:focus-visible .label,
 .compact[data-open='true'] .label {
     width: 140px;
+}
+
+.compact[data-auto='true']:hover .label,
+.compact[data-auto='true']:focus-visible .label,
+.compact[data-auto='true'][data-open='true'] .label {
+    width: auto;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -12,7 +12,6 @@ import {
     IconCheck,
     IconChevronDown,
     IconCirclePlus,
-    IconSparkles,
 } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
@@ -31,6 +30,7 @@ type Props = {
     agents: Agent[];
     selectedAgent: Agent | 'auto';
     projectUuid: string;
+    variant?: 'default' | 'header';
     /**
      * Render the target as an icon-only chip; the label reveals on hover,
      * focus, or while the dropdown is open. Used when toolbar space is
@@ -45,6 +45,7 @@ export const AgentSelector = ({
     agents,
     selectedAgent,
     projectUuid,
+    variant = 'default',
     compact = false,
 }: Props) => {
     const navigate = useNavigate();
@@ -109,19 +110,12 @@ export const AgentSelector = ({
                     onClick={() => combobox.toggleDropdown()}
                     className={`${styles.target} ${
                         compact ? styles.compact : ''
-                    }`}
+                    } ${variant === 'header' ? styles.headerTarget : ''}`}
                     data-open={opened ? 'true' : undefined}
+                    data-auto={isAuto ? 'true' : undefined}
                 >
                     <Group gap={6} wrap="nowrap" align="center" w="100%">
-                        {isAuto ? (
-                            <Avatar size={22} color="ldGray" radius="xl">
-                                <MantineIcon
-                                    icon={IconSparkles}
-                                    size="sm"
-                                    color="ldGray.6"
-                                />
-                            </Avatar>
-                        ) : (
+                        {!isAuto && (
                             <LightdashUserAvatar
                                 size={22}
                                 name={selectedAgent.name}
@@ -146,11 +140,9 @@ export const AgentSelector = ({
                         <Combobox.Option value={AUTO_VALUE} p={2}>
                             <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
                                 <Avatar size={22} color="ldGray" radius="xl">
-                                    <MantineIcon
-                                        icon={IconSparkles}
-                                        size="sm"
-                                        color="ldGray.6"
-                                    />
+                                    <Text size="10px" fw={700} c="ldGray.6">
+                                        AI
+                                    </Text>
                                 </Avatar>
                                 <Stack gap={0} flex={1} miw={0}>
                                     <Text size="xs" fw={600}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -1,44 +1,37 @@
 .container {
     position: relative;
-    padding-bottom: var(--mantine-spacing-lg);
 }
 
-/* Bordered shell that hosts the model selector + thinking toggle as a single
- * segmented control. Inner controls stay borderless (variant="subtle"); the
- * shell owns the outer border and one hairline divider sits between them. */
 .modelGroup {
     display: inline-flex;
     align-items: stretch;
-    border: 1px solid var(--mantine-color-ldGray-2);
-    border-radius: var(--mantine-radius-md);
+    gap: 2px;
+    border: 1px solid transparent;
+    border-radius: var(--mantine-radius-xl);
     background: transparent;
 }
 
 .modelGroup > button {
-    border-radius: 0;
+    border-radius: var(--mantine-radius-xl);
     border: none;
 }
 
-/* Mantine size="xs" Buttons set min-width for label-bearing buttons; the
- * icon-only ActionIcon doesn't need it. Keep both square at the ends. */
 .modelGroup > button:first-child {
-    border-top-left-radius: calc(var(--mantine-radius-md) - 1px);
-    border-bottom-left-radius: calc(var(--mantine-radius-md) - 1px);
+    border-radius: var(--mantine-radius-xl);
 }
 
 .modelGroup > button:last-child {
-    border-top-right-radius: calc(var(--mantine-radius-md) - 1px);
-    border-bottom-right-radius: calc(var(--mantine-radius-md) - 1px);
+    border-radius: var(--mantine-radius-xl);
 }
 
 .modelGroupDivider {
-    width: 1px;
-    background: var(--mantine-color-ldGray-2);
-    align-self: stretch;
+    display: none;
 }
 
 .inputCard {
-    border-radius: var(--mantine-radius-lg);
+    position: relative;
+    z-index: 1;
+    border-radius: rem(24px);
     overflow: hidden;
     transition:
         box-shadow 150ms ease,
@@ -47,24 +40,32 @@
     @mixin light {
         background-color: var(--mantine-color-white);
         border: 1px solid var(--mantine-color-gray-3);
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+        box-shadow:
+            0 8px 24px rgba(15, 23, 42, 0.05),
+            0 1px 4px rgba(15, 23, 42, 0.04);
     }
 
     @mixin dark {
         background-color: var(--mantine-color-dark-6);
         border: 1px solid var(--mantine-color-dark-4);
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+        box-shadow:
+            0 10px 32px rgba(0, 0, 0, 0.22),
+            0 1px 4px rgba(0, 0, 0, 0.18);
     }
 
     &:focus-within {
         @mixin light {
             border-color: var(--mantine-color-gray-4);
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+            box-shadow:
+                0 10px 28px rgba(15, 23, 42, 0.06),
+                0 0 0 2px rgba(15, 23, 42, 0.04);
         }
 
         @mixin dark {
             border-color: var(--mantine-color-dark-3);
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+            box-shadow:
+                0 12px 36px rgba(0, 0, 0, 0.26),
+                0 0 0 2px rgba(255, 255, 255, 0.04);
         }
     }
 }
@@ -91,35 +92,42 @@
 }
 
 .divider {
+    display: none;
     margin: 0;
     border: none;
-    border-top: 1px dashed;
-    border-color: var(--mantine-color-ldGray-3);
 }
 
 .toolbar {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: var(--mantine-spacing-xs);
+    gap: var(--mantine-spacing-xs);
+    min-height: rem(50px);
+    padding: 0 rem(8px) rem(8px);
 }
 
 .toolbarActions {
     display: flex;
     align-items: center;
     gap: var(--mantine-spacing-xs);
+    min-width: 0;
 }
 
 .submitButton {
+    width: rem(40px);
+    height: rem(40px);
+    min-width: rem(40px);
+    min-height: rem(40px);
     border-radius: var(--mantine-radius-xl);
     transition:
         transform 150ms ease,
-        opacity 150ms ease;
+        opacity 150ms ease,
+        background-color 150ms ease;
 
-    background-color: var(--mantine-color-foreground-0);
+    background-color: var(--mantine-color-foreground-0) !important;
 
     &:hover:not(:disabled) {
-        background-color: var(--mantine-color-foreground-1);
+        background-color: var(--mantine-color-foreground-1) !important;
     }
 
     &:disabled {
@@ -170,6 +178,10 @@
     margin: 0;
 }
 
+.threadInputStack {
+    position: relative;
+}
+
 .chipReveal {
     display: grid;
     grid-template-rows: 1fr;
@@ -191,16 +203,39 @@
     pointer-events: none;
 }
 
-/* Full (empty-state) layout: the composer lives in a vertically centered
- * stack, so any chip row added in normal flow re-centers the block and nudges
- * the input. Take the row out of flow instead — absolute with no `top` keeps
- * it at its static position (directly below the input) while carrying zero
- * layout height, so the input holds still no matter how many lines the chips
- * wrap to. `.container` is the positioning context. */
-.chipFloat {
-    position: absolute;
-    left: 0;
-    right: 0;
+.chipTray {
+    position: relative;
+    z-index: 0;
+    margin: rem(-14px) auto 0;
+    padding: rem(24px) rem(16px) rem(12px);
+    border-radius: 0 0 rem(24px) rem(24px);
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+
+    @mixin dark {
+        background-color: var(--mantine-color-dark-7);
+    }
+}
+
+.chipReserved {
+    visibility: hidden;
+}
+
+.chipTrayReserve {
+    min-height: rem(50px);
+}
+
+.threadChipFlow {
+    margin-bottom: rem(8px);
+}
+
+.threadBelowControls {
+    display: flex;
+    justify-content: flex-end;
+    min-height: rem(30px);
+    padding: rem(4px) rem(8px) 0;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -216,11 +251,8 @@
  * ------------------------------------------------------------------ */
 .sqlModeActive {
     border-color: var(--mantine-color-indigo-4) !important;
-    box-shadow:
-        0 0 0 1px var(--mantine-color-indigo-3),
-        0 0 24px -8px var(--mantine-color-indigo-5),
-        0 0 0 4px
-            color-mix(in srgb, var(--mantine-color-indigo-5) 10%, transparent);
+    box-shadow: 0 0 0 2px
+        color-mix(in srgb, var(--mantine-color-indigo-5) 12%, transparent);
 }
 
 /* Long, gentle ease applies both when toggling on *and* off. */
@@ -241,11 +273,13 @@
 
 .minimalInputWrapper {
     position: relative;
+    z-index: 1;
     display: flex;
     align-items: center;
     width: 100%;
-    border-radius: var(--mantine-radius-lg);
+    border-radius: rem(18px);
     padding: 4px var(--mantine-spacing-xs);
+    gap: 4px;
     transition:
         background-color 150ms ease,
         border-color 150ms ease;
@@ -352,17 +386,16 @@
 }
 
 .editorContent {
-    padding: var(--mantine-spacing-md) var(--mantine-spacing-lg);
-    padding-bottom: var(--mantine-spacing-sm);
-    font-size: var(--mantine-font-size-md);
+    padding: rem(22px) rem(24px) rem(10px);
+    font-size: rem(18px);
     line-height: 1.5;
-    min-height: 60px;
+    min-height: rem(118px);
     max-height: 240px;
     overflow-y: auto;
 
     :global(.ProseMirror) {
         outline: none;
-        min-height: 36px;
+        min-height: rem(82px);
     }
 
     :global(p.is-empty.is-editor-empty::before) {
@@ -382,8 +415,7 @@
 }
 
 .minimalEditorContent {
-    padding: 0;
-    padding-right: var(--mantine-spacing-xs);
+    padding: 0 var(--mantine-spacing-xs);
     font-size: var(--mantine-font-size-sm);
     line-height: 1.5;
     min-height: 24px;
@@ -415,6 +447,60 @@
         @mixin dark {
             color: var(--mantine-color-ldGray-7);
         }
+    }
+}
+
+.sqlModeButton {
+    flex-shrink: 0;
+    border-radius: var(--mantine-radius-xl);
+}
+
+.sqlModeControl {
+    flex-shrink: 0;
+}
+
+.sqlModeLabel {
+    line-height: 1;
+    white-space: nowrap;
+
+    @mixin light {
+        color: var(--mantine-color-indigo-6);
+    }
+
+    @mixin dark {
+        color: var(--mantine-color-indigo-3);
+    }
+}
+
+@media (max-width: 48em) {
+    .inputCard {
+        border-radius: rem(22px);
+    }
+
+    .editorContent {
+        padding: rem(20px) rem(18px) rem(12px);
+        font-size: var(--mantine-font-size-md);
+        min-height: rem(112px);
+
+        :global(.ProseMirror) {
+            min-height: rem(70px);
+        }
+    }
+
+    .toolbar {
+        min-height: rem(52px);
+        padding: 0 rem(8px) rem(8px);
+    }
+
+    .toolbarActions {
+        min-width: auto;
+    }
+
+    .submitButton {
+        width: rem(40px);
+        height: rem(40px);
+        min-width: rem(40px);
+        min-height: rem(40px);
     }
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -5,22 +5,9 @@ import {
     type AiPromptContextItem,
     type AiModelOption,
 } from '@lightdash/common';
-import {
-    ActionIcon,
-    Box,
-    Group,
-    Paper,
-    Switch,
-    Text,
-    Tooltip,
-} from '@mantine-8/core';
+import { ActionIcon, Box, Group, Paper, Text, Tooltip } from '@mantine-8/core';
 import { RichTextEditor } from '@mantine/tiptap';
-import {
-    IconArrowUp,
-    IconBulb,
-    IconBulbFilled,
-    IconTerminal2,
-} from '@tabler/icons-react';
+import { IconArrowUp, IconTerminal2 } from '@tabler/icons-react';
 import Mention from '@tiptap/extension-mention';
 import Placeholder from '@tiptap/extension-placeholder';
 import { useEditor, type Editor } from '@tiptap/react';
@@ -416,6 +403,8 @@ export const AgentChatInput = ({
 
     const hasValue = value.trim().length > 0;
     const showDisabledBanner = disabled && disabledReason;
+    const isThreadInput = Boolean(threadUuid);
+    const showSqlModeControl = Boolean(onSqlModeChange && !disabled);
 
     const handleSubmit = () => {
         const ed = editorRef.current;
@@ -443,6 +432,8 @@ export const AgentChatInput = ({
                 chips={chips}
                 onChipClick={handleChipClick}
                 onImpression={handleImpression}
+                align={isThreadInput ? 'left' : 'center'}
+                showPromptAffordance={isThreadInput}
             />
         );
     }, [
@@ -452,19 +443,73 @@ export const AgentChatInput = ({
         suggestionsQuery.data,
         handleChipClick,
         handleImpression,
+        isThreadInput,
     ]);
+    const shouldReserveEmptyStateSuggestions =
+        !isThreadInput &&
+        emptyStateMode &&
+        !chipRow &&
+        !suggestionsQuery.isError &&
+        (suggestionsQuery.isLoading || suggestionsQuery.isFetching);
 
-    const renderChipRow = (extraClassName = '') =>
-        chipRow && (
+    const renderChipRow = (extraClassName = '', reserve = false) =>
+        (chipRow || reserve) && (
             <Box
                 className={`${styles.chipReveal} ${extraClassName} ${
                     chipsNearBottom ? '' : styles.chipHidden
-                }`}
-                aria-hidden={!chipsNearBottom}
+                } ${!chipRow ? styles.chipReserved : ''}`}
+                aria-hidden={!chipsNearBottom || !chipRow}
             >
-                {chipRow}
+                {chipRow ?? <Box className={styles.chipTrayReserve} />}
             </Box>
         );
+
+    const renderSqlModeControl = ({
+        actionSize,
+        iconSize,
+        labelPosition = 'after',
+    }: {
+        actionSize: number | 'sm' | 'md';
+        iconSize: number;
+        labelPosition?: 'before' | 'after';
+    }) => {
+        if (!onSqlModeChange || disabled) return null;
+        const label = sqlMode ? (
+            <Text size="xs" fw={600} className={styles.sqlModeLabel}>
+                SQL mode on
+            </Text>
+        ) : null;
+
+        return (
+            <Tooltip
+                multiline
+                w={260}
+                withArrow
+                position="top"
+                label="Let the agent reach for raw SQL when the question can't be answered from the semantic layer alone. Each query still asks for your approval before running."
+            >
+                <Group gap={6} wrap="nowrap" className={styles.sqlModeControl}>
+                    {labelPosition === 'before' && label}
+                    <ActionIcon
+                        variant={sqlMode ? 'light' : 'subtle'}
+                        color={sqlMode ? 'indigo' : 'gray'}
+                        size={actionSize}
+                        className={styles.sqlModeButton}
+                        onClick={() => onSqlModeChange(!sqlMode)}
+                        aria-label="Toggle SQL mode"
+                        aria-pressed={sqlMode}
+                    >
+                        <MantineIcon
+                            icon={IconTerminal2}
+                            size={iconSize}
+                            color={sqlMode ? 'indigo.5' : 'ldGray.6'}
+                        />
+                    </ActionIcon>
+                    {labelPosition === 'after' && label}
+                </Group>
+            </Tooltip>
+        );
+    };
 
     if (isMinimalMode) {
         return (
@@ -474,79 +519,66 @@ export const AgentChatInput = ({
                 }`}
                 ref={rootRef}
             >
-                {renderChipRow()}
+                {isThreadInput && renderChipRow(styles.threadChipFlow)}
 
-                <Box
-                    className={`${styles.minimalInputWrapper} ${
-                        sqlMode ? styles.sqlModeActive : ''
-                    }`}
-                    pos="relative"
-                >
-                    <RichTextEditor
-                        editor={editor}
-                        classNames={{
-                            root: styles.editorRoot,
-                            content: styles.minimalEditorContent,
-                        }}
+                <Box className={styles.threadInputStack}>
+                    <Box
+                        className={`${styles.minimalInputWrapper} ${
+                            sqlMode ? styles.sqlModeActive : ''
+                        }`}
+                        pos="relative"
                     >
-                        <RichTextEditor.Content />
-                    </RichTextEditor>
+                        <RichTextEditor
+                            editor={editor}
+                            classNames={{
+                                root: styles.editorRoot,
+                                content: styles.minimalEditorContent,
+                            }}
+                        >
+                            <RichTextEditor.Content />
+                        </RichTextEditor>
 
-                    <ActionIcon
-                        right={12}
-                        bottom={10}
-                        variant="filled"
-                        size="md"
-                        className={styles.minimalSubmitButton}
-                        disabled={disabled || !hasValue}
-                        loading={loading}
-                        onClick={handleSubmit}
-                        aria-label="Send message"
-                    >
-                        <MantineIcon
-                            icon={IconArrowUp}
-                            color="ldGray.0"
-                            size={18}
-                            stroke={2}
-                        />
-                    </ActionIcon>
+                        {!isThreadInput &&
+                            renderSqlModeControl({
+                                actionSize: 'md',
+                                iconSize: 16,
+                            })}
+
+                        <ActionIcon
+                            right={12}
+                            bottom={10}
+                            variant="filled"
+                            size="md"
+                            className={styles.minimalSubmitButton}
+                            disabled={disabled || !hasValue}
+                            loading={loading}
+                            onClick={handleSubmit}
+                            aria-label="Send message"
+                        >
+                            <MantineIcon
+                                icon={IconArrowUp}
+                                color="ldGray.0"
+                                size={18}
+                                stroke={2}
+                            />
+                        </ActionIcon>
+                    </Box>
                 </Box>
 
-                {onSqlModeChange && !disabled && (
-                    <Group justify="flex-end" px="xs" pt="xs">
-                        <Tooltip
-                            multiline
-                            w={260}
-                            withArrow
-                            position="top"
-                            label="Let the agent reach for raw SQL when the question can't be answered from the semantic layer alone. Each query still asks for your approval before running."
-                        >
-                            <Group gap={6} align="center" wrap="nowrap">
-                                <MantineIcon
-                                    icon={IconTerminal2}
-                                    size={14}
-                                    color={sqlMode ? 'indigo.5' : 'ldGray.6'}
-                                />
-                                <Text
-                                    size="xs"
-                                    c={sqlMode ? 'indigo.5' : 'dimmed'}
-                                    fw={500}
-                                >
-                                    SQL mode
-                                </Text>
-                                <Switch
-                                    size="xs"
-                                    color="indigo"
-                                    checked={sqlMode}
-                                    onChange={(e) =>
-                                        onSqlModeChange(e.currentTarget.checked)
-                                    }
-                                    aria-label="Toggle SQL mode"
-                                />
-                            </Group>
-                        </Tooltip>
-                    </Group>
-                )}
+                {isThreadInput
+                    ? showSqlModeControl && (
+                          <Box className={styles.threadBelowControls}>
+                              {renderSqlModeControl({
+                                  actionSize: 'sm',
+                                  iconSize: 14,
+                                  labelPosition: 'before',
+                              })}
+                          </Box>
+                      )
+                    : renderChipRow(
+                          styles.chipTray,
+                          shouldReserveEmptyStateSuggestions,
+                      )}
 
                 {showDisabledBanner && (
                     <Text size="xs" c="dimmed" ta="right" mt="xs" px="sm">
@@ -564,6 +596,8 @@ export const AgentChatInput = ({
                 showDisabledBanner ? styles.disabledBannerVisible : ''
             }`}
         >
+            {isThreadInput && renderChipRow(styles.threadChipFlow)}
+
             <Box
                 className={`${styles.inputCard} ${
                     sqlMode ? styles.sqlModeActive : ''
@@ -579,77 +613,16 @@ export const AgentChatInput = ({
                     <RichTextEditor.Content />
                 </RichTextEditor>
 
-                <hr className={styles.divider} />
-
                 <Box className={styles.toolbar}>
                     <Box className={styles.toolbarActions}>
-                        {(showModelSelector || onExtendedThinkingChange) && (
-                            <Box className={styles.modelGroup}>
-                                {showModelSelector && (
-                                    <ModelSelector
-                                        models={models}
-                                        value={selectedModelId ?? null}
-                                        onChange={onModelChange}
-                                        variant="subtle"
-                                        color="gray"
-                                        size="xs"
-                                    />
-                                )}
+                        {!isThreadInput &&
+                            renderSqlModeControl({
+                                actionSize: 30,
+                                iconSize: 15,
+                            })}
+                    </Box>
 
-                                {showModelSelector &&
-                                    onExtendedThinkingChange && (
-                                        <div
-                                            className={styles.modelGroupDivider}
-                                        />
-                                    )}
-
-                                {onExtendedThinkingChange && (
-                                    <Tooltip
-                                        multiline
-                                        w={240}
-                                        withArrow
-                                        position="top"
-                                        label="Let the model spend extra reasoning time before answering. Slower but better on complex questions."
-                                    >
-                                        <ActionIcon
-                                            variant={
-                                                extendedThinking
-                                                    ? 'light'
-                                                    : 'subtle'
-                                            }
-                                            color={
-                                                extendedThinking
-                                                    ? 'indigo'
-                                                    : 'gray'
-                                            }
-                                            size={30}
-                                            onClick={() =>
-                                                onExtendedThinkingChange(
-                                                    !extendedThinking,
-                                                )
-                                            }
-                                            aria-label="Toggle extended thinking"
-                                            aria-pressed={extendedThinking}
-                                        >
-                                            <MantineIcon
-                                                icon={
-                                                    extendedThinking
-                                                        ? IconBulbFilled
-                                                        : IconBulb
-                                                }
-                                                size="sm"
-                                                color={
-                                                    extendedThinking
-                                                        ? 'indigo.5'
-                                                        : 'ldGray.6'
-                                                }
-                                            />
-                                        </ActionIcon>
-                                    </Tooltip>
-                                )}
-                            </Box>
-                        )}
-
+                    <Group gap="xs" align="center" wrap="nowrap">
                         {showAgentSelector && (
                             <AgentSelector
                                 projectUuid={projectUuid!}
@@ -658,46 +631,25 @@ export const AgentChatInput = ({
                                 compact
                             />
                         )}
-                    </Box>
 
-                    <Group gap="md" align="center" wrap="nowrap">
-                        {onSqlModeChange && !disabled && (
-                            <Tooltip
-                                multiline
-                                w={260}
-                                withArrow
-                                position="top"
-                                label="Let the agent reach for raw SQL when the question can't be answered from the semantic layer alone. Each query still asks for your approval before running."
-                            >
-                                <Group gap={6} align="center" wrap="nowrap">
-                                    <MantineIcon
-                                        icon={IconTerminal2}
-                                        size={14}
-                                        color={
-                                            sqlMode ? 'indigo.5' : 'ldGray.6'
+                        {(showModelSelector || onExtendedThinkingChange) &&
+                            models &&
+                            onModelChange && (
+                                <Box className={styles.modelGroup}>
+                                    <ModelSelector
+                                        models={models}
+                                        value={selectedModelId ?? null}
+                                        onChange={onModelChange}
+                                        variant="subtle"
+                                        color="gray"
+                                        size="xs"
+                                        reasoningEnabled={extendedThinking}
+                                        onReasoningChange={
+                                            onExtendedThinkingChange
                                         }
                                     />
-                                    <Text
-                                        size="xs"
-                                        c={sqlMode ? 'indigo.5' : 'dimmed'}
-                                        fw={500}
-                                    >
-                                        SQL mode
-                                    </Text>
-                                    <Switch
-                                        size="xs"
-                                        color="indigo"
-                                        checked={sqlMode}
-                                        onChange={(e) =>
-                                            onSqlModeChange(
-                                                e.currentTarget.checked,
-                                            )
-                                        }
-                                        aria-label="Toggle SQL mode"
-                                    />
-                                </Group>
-                            </Tooltip>
-                        )}
+                                </Box>
+                            )}
 
                         <ActionIcon
                             variant="filled"
@@ -719,7 +671,20 @@ export const AgentChatInput = ({
                 </Box>
             </Box>
 
-            {renderChipRow(styles.chipFloat)}
+            {isThreadInput
+                ? showSqlModeControl && (
+                      <Box className={styles.threadBelowControls}>
+                          {renderSqlModeControl({
+                              actionSize: 'sm',
+                              iconSize: 14,
+                              labelPosition: 'before',
+                          })}
+                      </Box>
+                  )
+                : renderChipRow(
+                      styles.chipTray,
+                      shouldReserveEmptyStateSuggestions,
+                  )}
 
             {showDisabledBanner && (
                 <Paper className={styles.disabledBanner} px="md" py="xs">

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
@@ -1,8 +1,14 @@
 .row {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
     gap: 6px;
-    padding: var(--mantine-spacing-xs);
+    padding: 0;
+}
+
+.rowLeft {
+    justify-content: flex-start;
 }
 
 .chip {
@@ -12,7 +18,7 @@
     font-size: 11px;
     font-weight: 500;
     line-height: 1;
-    letter-spacing: -0.005em;
+    letter-spacing: 0;
     border-radius: 6px;
     border-width: 1px;
     transition:

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.tsx
@@ -9,6 +9,8 @@ type Props = {
     chips: AgentSuggestion[];
     onChipClick: (chip: AgentSuggestion, index: number) => void;
     onImpression?: (chipCount: number) => void;
+    align?: 'center' | 'left';
+    showPromptAffordance?: boolean;
 };
 
 const chipKey = (chip: AgentSuggestion, idx: number) =>
@@ -21,10 +23,20 @@ const renderLeftIcon = (chip: AgentSuggestion) => {
     return <MantineIcon icon={IconArrowUpRight} size={13} stroke={1.75} />;
 };
 
+const renderRightIcon = (
+    chip: AgentSuggestion,
+    showPromptAffordance: boolean,
+) => {
+    if (chip.kind !== 'prompt' || !showPromptAffordance) return undefined;
+    return <MantineIcon icon={IconArrowUpRight} size={12} stroke={1.75} />;
+};
+
 export const AgentSuggestionChips = ({
     chips,
     onChipClick,
     onImpression,
+    align = 'center',
+    showPromptAffordance = false,
 }: Props) => {
     const impressedRef = useRef<string | null>(null);
 
@@ -39,7 +51,9 @@ export const AgentSuggestionChips = ({
     if (chips.length === 0) return null;
 
     return (
-        <Box className={styles.row}>
+        <Box
+            className={`${styles.row} ${align === 'left' ? styles.rowLeft : ''}`}
+        >
             {chips.map((chip, idx) => {
                 const classes = [styles.chip, styles.fadeIn];
                 if (chip.kind === 'navigate') classes.push(styles.navigateChip);
@@ -51,6 +65,10 @@ export const AgentSuggestionChips = ({
                         className={classes.join(' ')}
                         style={{ ['--chip-idx' as string]: idx }}
                         leftSection={renderLeftIcon(chip)}
+                        rightSection={renderRightIcon(
+                            chip,
+                            showPromptAffordance,
+                        )}
                         onClick={() => onChipClick(chip, idx)}
                     >
                         {chip.label}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.module.css
@@ -149,9 +149,14 @@
 }
 
 .body {
-    padding: 2px 0 6px 22px;
+    padding: 1px 0 3px 21px;
     color: var(--mantine-color-ldGray-7);
     animation: bodyReveal 360ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.body :global(.mantine-Text-root),
+.body :global(.mantine-8-Text-root) {
+    line-height: 1.25;
 }
 
 @keyframes toolCallPulse {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
@@ -250,7 +250,7 @@ export const ToolCallRow: FC<Props> = ({
                 transitionDuration={240}
                 transitionTimingFunction="cubic-bezier(0.16, 1, 0.3, 1)"
             >
-                <Stack gap={8} className={styles.body}>
+                <Stack gap={4} className={styles.body}>
                     {toolCalls.map((tc) =>
                         isToolName(tc.toolName) ? (
                             <ToolCallDescription


### PR DESCRIPTION
Rebased onto `main` after the accidental merge into the old base branch.

Changes:
- Flattens the agent chat composer toward the Codex-style input.
- Moves model/reasoning controls close to submit and hides default reasoning text.
- Moves SQL mode into the lower affordance, with active text state.
- Restores left-aligned suggestions and tightens tool-call subactions.
- Renders selected Auto agent as text instead of an avatar.

Validation:
- `pnpm -F @lightdash/frontend run linter ...`
- `git diff --check`