### PR TITLE
fix(access-tokens): match Last used at font size to Expiration date

### DIFF
--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -105,7 +105,7 @@ const TokenItem: FC<{
                             maw={350}
                             label={formatTimestamp(lastUsedAt)}
                         >
-                            <Text>{formatDate(lastUsedAt)}</Text>
+                            <span>{formatDate(lastUsedAt)}</span>
                         </Tooltip>
                     )}
                 </Table.Td>


### PR DESCRIPTION
## Description:

The personal access tokens table rendered the **Last used at** date in a Mantine `<Text>` (default `md` size), while the **Expiration date** column used a plain `<span>` inheriting the table's smaller font. The two columns looked mismatched. This switches the **Last used at** cell to the same plain `<span>`, so both date columns render at identical size.

```
Before:   Expiration date   Last used at
          2026-06-21        2026-06-05   ← larger (Text, md)

After:    Expiration date   Last used at
          2026-06-21        2026-06-05   ← same size (span, sm)
```

### Test plan

- Open Settings → Personal access tokens.
- Confirm the **Last used at** and **Expiration date** values now share the same font size.
- Hover a **Last used at** value — the timestamp tooltip still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)