### PR TITLE
feat(mcp): expose built-in skill resources

### DIFF
--- a/packages/api-tests/tests/mcpServer.test.ts
+++ b/packages/api-tests/tests/mcpServer.test.ts
@@ -4,6 +4,9 @@ const mcpHeaders = {
     Accept: 'application/json, text/event-stream',
 };
 
+// JSON-RPC 2.0 error codes — see https://www.jsonrpc.org/specification#error_object
+const JSON_RPC_INVALID_PARAMS = -32602;
+
 type McpResponse<T = Record<string, unknown>> = {
     jsonrpc: string;
     id: number;
@@ -48,6 +51,9 @@ describe('MCP server', () => {
             'Lightdash MCP Server',
         );
         expect(response.body.result.serverInfo).toHaveProperty('version');
+        expect(response.body.result.capabilities).toMatchObject({
+            resources: { listChanged: false },
+        });
     });
 
     it('should list available tools', async () => {
@@ -85,12 +91,180 @@ describe('MCP server', () => {
         expect(versionTool).toHaveProperty('inputSchema');
     });
 
+    it('should list the analyst prompt without skill prompts', async () => {
+        const response = await admin.post<
+            McpResponse<{
+                prompts: Array<{
+                    name: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 3,
+                method: 'prompts/list',
+                params: {},
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.jsonrpc).toBe('2.0');
+        expect(response.body.id).toBe(3);
+
+        const promptNames = response.body.result.prompts.map(
+            (prompt) => prompt.name,
+        );
+        expect(promptNames).toContain('lightdash-analyst');
+        expect(
+            promptNames.some((name) => name.startsWith('lightdash-skill-')),
+        ).toBe(false);
+    });
+
+    it('should list built-in skill resources', async () => {
+        const response = await admin.post<
+            McpResponse<{
+                resources: Array<{
+                    uri: string;
+                    name: string;
+                    title: string;
+                    mimeType?: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 4,
+                method: 'resources/list',
+                params: {},
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.jsonrpc).toBe('2.0');
+        expect(response.body.id).toBe(4);
+
+        const overviewResource = response.body.result.resources.find(
+            (resource) =>
+                resource.uri === 'lightdash://skills/developing-in-lightdash',
+        );
+        const nestedResource = response.body.result.resources.find((resource) =>
+            resource.uri.startsWith(
+                'lightdash://skills/developing-in-lightdash/resources/',
+            ),
+        );
+
+        expect(overviewResource).toMatchObject({
+            uri: 'lightdash://skills/developing-in-lightdash',
+            name: 'developing-in-lightdash',
+            title: 'Developing in Lightdash',
+            mimeType: 'text/markdown',
+        });
+        expect(nestedResource).toMatchObject({
+            mimeType: 'text/markdown',
+        });
+        expect(nestedResource?.name).toMatch(
+            /^developing-in-lightdash\/[^/]+$/,
+        );
+        expect(nestedResource?.title).toMatch(/^Developing in Lightdash \/ /);
+    });
+
+    it('should read a listed skill resource', async () => {
+        const listResponse = await admin.post<
+            McpResponse<{
+                resources: Array<{
+                    uri: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 5,
+                method: 'resources/list',
+                params: {},
+            },
+            { headers: mcpHeaders },
+        );
+
+        const nestedResource = listResponse.body.result.resources.find(
+            (resource) =>
+                resource.uri.startsWith(
+                    'lightdash://skills/developing-in-lightdash/resources/',
+                ),
+        );
+
+        if (!nestedResource) {
+            throw new Error(
+                'Expected at least one nested skill resource in listing',
+            );
+        }
+
+        const readResponse = await admin.post<
+            McpResponse<{
+                contents: Array<{
+                    uri: string;
+                    mimeType?: string;
+                    text: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 6,
+                method: 'resources/read',
+                params: {
+                    uri: nestedResource.uri,
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(readResponse.status).toBe(200);
+        expect(readResponse.body.result.contents).toHaveLength(1);
+        expect(readResponse.body.result.contents[0]).toMatchObject({
+            uri: nestedResource.uri,
+            mimeType: 'text/markdown',
+        });
+        expect(
+            readResponse.body.result.contents[0].text.length,
+        ).toBeGreaterThan(0);
+    });
+
+    it('should return an MCP error for an unknown skill resource', async () => {
+        const response = await admin.post<{
+            jsonrpc: string;
+            id: number;
+            error?: { code?: number };
+        }>(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 7,
+                method: 'resources/read',
+                params: {
+                    uri: 'lightdash://skills/developing-in-lightdash/resources/does-not-exist',
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.jsonrpc).toBe('2.0');
+        expect(response.body.id).toBe(7);
+        expect(response.body.error?.code).toBe(JSON_RPC_INVALID_PARAMS);
+    });
+
     it('should handle ping request', async () => {
         const response = await admin.post<McpResponse>(
             '/api/v1/mcp',
             {
                 jsonrpc: '2.0',
-                id: 4,
+                id: 8,
                 method: 'ping',
                 params: {},
             },
@@ -98,7 +272,7 @@ describe('MCP server', () => {
         );
         expect(response.status).toBe(200);
         expect(response.body.jsonrpc).toBe('2.0');
-        expect(response.body.id).toBe(4);
+        expect(response.body.id).toBe(8);
         expect(response.body.result).toEqual({});
     });
 });

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -101,6 +101,7 @@ import {
     getMcpAnalystPromptWithContext,
     MCP_ANALYST_PROMPT,
 } from '../ai/prompts/mcpAnalyst';
+import { BuiltInSkills } from '../ai/skills/builtInSkills';
 import { getFindContent } from '../ai/tools/findContent';
 import { getFindExplores } from '../ai/tools/findExplores';
 import { getFindFields } from '../ai/tools/findFields';
@@ -168,6 +169,7 @@ const mcpSearchFieldValuesTool = searchFieldValuesToolDefinition.for('mcp');
 const mcpRunSqlTool = runSqlToolDefinition.for('mcp');
 const mcpGetQueryResultTool = getQueryResultToolDefinition.for('mcp');
 const mcpListVerifiedContentTool = listVerifiedContentToolDefinition.for('mcp');
+const MCP_SKILL_RESOURCE_MIME_TYPE = 'text/markdown';
 
 type McpServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -310,35 +312,32 @@ export class McpService extends BaseService {
         this.aiAgentToolsService = aiAgentToolsService;
         this.aiWritebackService = aiWritebackService;
         this.mcpCompatLayer = new McpSchemaCompatLayer();
-        try {
-            this.mcpServer = Sentry.wrapMcpServerWithSentry(
-                new McpServer({
-                    name: 'Lightdash MCP Server',
-                    version: VERSION,
-                    websiteUrl: this.lightdashConfig.siteUrl,
-                    icons: [
-                        {
-                            src: `${this.lightdashConfig.siteUrl}/logo-icon.svg`,
-                            mimeType: 'image/svg+xml',
-                        },
-                        {
-                            src: `${this.lightdashConfig.siteUrl}/favicon-32x32.png`,
-                            mimeType: 'image/png',
-                            sizes: ['32x32'],
-                        },
-                        {
-                            src: `${this.lightdashConfig.siteUrl}/apple-touch-icon.png`,
-                            mimeType: 'image/png',
-                            sizes: ['152x152'],
-                        },
-                    ],
-                }),
-            );
-            this.setupHandlers();
-        } catch (error) {
+        this.mcpServer = Sentry.wrapMcpServerWithSentry(
+            new McpServer({
+                name: 'Lightdash MCP Server',
+                version: VERSION,
+                websiteUrl: this.lightdashConfig.siteUrl,
+                icons: [
+                    {
+                        src: `${this.lightdashConfig.siteUrl}/logo-icon.svg`,
+                        mimeType: 'image/svg+xml',
+                    },
+                    {
+                        src: `${this.lightdashConfig.siteUrl}/favicon-32x32.png`,
+                        mimeType: 'image/png',
+                        sizes: ['32x32'],
+                    },
+                    {
+                        src: `${this.lightdashConfig.siteUrl}/apple-touch-icon.png`,
+                        mimeType: 'image/png',
+                        sizes: ['152x152'],
+                    },
+                ],
+            }),
+        );
+        void this.setupHandlers().catch((error) => {
             this.logger.error('Error initializing MCP server:', error);
-            throw error;
-        }
+        });
     }
 
     private async getScopeInfo(
@@ -1056,12 +1055,12 @@ export class McpService extends BaseService {
         );
     }
 
-    setupHandlers(
+    async setupHandlers(
         options: { projectPinned: boolean; aiWritebackEnabled: boolean } = {
             projectPinned: false,
             aiWritebackEnabled: false,
         },
-    ): void {
+    ): Promise<void> {
         this.mcpServer.registerTool(
             mcpGetLightdashVersionTool.name,
             {
@@ -2383,6 +2382,52 @@ export class McpService extends BaseService {
                 };
             },
         );
+
+        await this.setupSkillResourceHandlers();
+    }
+
+    private async setupSkillResourceHandlers(): Promise<void> {
+        const resources = await BuiltInSkills.listMcpResources();
+
+        resources.forEach((resource) => {
+            this.mcpServer.registerResource(
+                resource.name,
+                resource.uri,
+                {
+                    title: resource.title,
+                    description: resource.description,
+                    mimeType: MCP_SKILL_RESOURCE_MIME_TYPE,
+                },
+                async () => {
+                    const text = await BuiltInSkills.getMcpResourceBody(
+                        resource.uri,
+                    );
+
+                    if (text === undefined) {
+                        throw new NotFoundError(
+                            `Resource "${resource.uri}" was not found`,
+                        );
+                    }
+
+                    return {
+                        contents: [
+                            {
+                                uri: resource.uri,
+                                mimeType: MCP_SKILL_RESOURCE_MIME_TYPE,
+                                text,
+                            },
+                        ],
+                    };
+                },
+            );
+        });
+
+        // The SDK auto-advertises `resources.listChanged: true` when
+        // registerResource is called, but we never emit list_changed
+        // notifications, so override it to avoid misleading clients.
+        this.mcpServer.server.registerCapabilities({
+            resources: { listChanged: false },
+        });
     }
 
     async getProjectUuidFromContext(context: McpProtocolContext) {
@@ -2655,10 +2700,10 @@ export class McpService extends BaseService {
      * Required for SDK 1.26.0+ stateful mode where each session needs its own server.
      * See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
      */
-    public createServer(options?: {
+    public async createServer(options?: {
         projectPinned?: boolean;
         aiWritebackEnabled?: boolean;
-    }): McpServer {
+    }): Promise<McpServer> {
         const newServer = Sentry.wrapMcpServerWithSentry(
             new McpServer({
                 name: 'Lightdash MCP Server',
@@ -2686,11 +2731,14 @@ export class McpService extends BaseService {
         // Temporarily swap the server to register handlers on the new instance
         const originalServer = this.mcpServer;
         this.mcpServer = newServer;
-        this.setupHandlers({
-            projectPinned: options?.projectPinned ?? false,
-            aiWritebackEnabled: options?.aiWritebackEnabled ?? false,
-        });
-        this.mcpServer = originalServer;
+        try {
+            await this.setupHandlers({
+                projectPinned: options?.projectPinned ?? false,
+                aiWritebackEnabled: options?.aiWritebackEnabled ?? false,
+            });
+        } finally {
+            this.mcpServer = originalServer;
+        }
 
         return newServer;
     }

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -36,6 +36,9 @@ jest.mock('@sentry/node', () => ({
 
 jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
     McpServer: jest.fn().mockImplementation(() => ({
+        server: {
+            registerCapabilities: jest.fn(),
+        },
         registerResource: jest.fn(),
         registerPrompt: jest.fn(
             (
@@ -115,12 +118,12 @@ describe('MCP tool contracts', () => {
         expect(sharedMcpToolDefinitionNames).toMatchSnapshot();
     });
 
-    it('matches the current MCP tool and prompt contract snapshot', () => {
+    it('matches the current MCP tool and prompt contract snapshot', async () => {
         const mcpService = makeMcpService();
 
         mockRegisteredMcpTools.length = 0;
         mockRegisteredMcpPrompts.length = 0;
-        mcpService.createServer({ aiWritebackEnabled: true });
+        await mcpService.createServer({ aiWritebackEnabled: true });
 
         expect({
             prompts: mockRegisteredMcpPrompts.map(({ name, config }) => ({

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
@@ -10,8 +10,18 @@ import {
 
 type MarkdownMetadata = {
     name: string;
+    title: string;
     description: string;
 };
+
+export type BuiltInSkillMcpResource = {
+    uri: string;
+    name: string;
+    title: string;
+    description: string;
+};
+
+type CachedMcpResource = BuiltInSkillMcpResource & { content: string };
 
 export class BuiltInSkills {
     private static readonly SKILLS_DIR = path.join(__dirname, 'builtInSkills');
@@ -20,24 +30,87 @@ export class BuiltInSkills {
 
     private static skillsPromise: Promise<AiAgentSkill[]> | undefined;
 
+    private static mcpResources: CachedMcpResource[] | undefined;
+
+    private static mcpResourcesPromise:
+        | Promise<CachedMcpResource[]>
+        | undefined;
+
+    private static skillNames: string[] | undefined;
+
+    private static skillNamesPromise: Promise<string[]> | undefined;
+
+    private static isNodeErrnoException(
+        error: unknown,
+    ): error is NodeJS.ErrnoException {
+        return error instanceof Error && 'code' in error;
+    }
+
     private static async parseMarkdownFile(
         filePath: string,
     ): Promise<MarkdownMetadata & { content: string }> {
         const fileContents = await fs.readFile(filePath, 'utf8');
         const { content, data } = matter(fileContents);
-        const { name, description } = data as Partial<MarkdownMetadata>;
+        const { name, title, description } = data as Partial<MarkdownMetadata>;
 
-        if (!name || !description) {
+        if (!name || !title || !description) {
             throw new ParameterError(
-                `Missing required skill frontmatter in ${filePath}. Expected "name" and "description".`,
+                `Missing required skill frontmatter in ${filePath}. Expected "name", "title" and "description".`,
             );
         }
 
-        return {
-            name,
-            description,
-            content,
-        };
+        return { name, title, description, content };
+    }
+
+    private static getSkillDirectory(skillName: string): string {
+        return path.join(this.SKILLS_DIR, skillName);
+    }
+
+    private static async getBuiltInSkillNames(): Promise<string[]> {
+        if (this.skillNames) {
+            return this.skillNames;
+        }
+        if (this.skillNamesPromise) {
+            return this.skillNamesPromise;
+        }
+
+        this.skillNamesPromise = (async () => {
+            try {
+                const entries = await fs.readdir(this.SKILLS_DIR, {
+                    withFileTypes: true,
+                });
+                const names = entries
+                    .filter((entry) => entry.isDirectory())
+                    .map((entry) => entry.name)
+                    .sort();
+                this.skillNames = names;
+                return names;
+            } catch (error) {
+                this.skillNamesPromise = undefined;
+                throw error;
+            }
+        })();
+
+        return this.skillNamesPromise;
+    }
+
+    private static getSkillFilePath(skillName: string): string {
+        return path.join(this.getSkillDirectory(skillName), 'SKILL.md');
+    }
+
+    private static getSkillResourcesDirectory(skillName: string): string {
+        return path.join(this.getSkillDirectory(skillName), 'resources');
+    }
+
+    private static getSkillUri(skillName: string): string {
+        return `lightdash://skills/${skillName}`;
+    }
+
+    private static getSkillResourceUri(
+        skillName: string,
+        resourceName: string,
+    ): string {
+        return `lightdash://skills/${skillName}/resources/${resourceName}`;
     }
 
     private static async loadSkillResources(
@@ -86,6 +159,85 @@ export class BuiltInSkills {
         };
     }
 
+    private static async loadMcpResourcesForSkill(
+        skillName: string,
+    ): Promise<CachedMcpResource[]> {
+        const skill = await this.parseMarkdownFile(
+            this.getSkillFilePath(skillName),
+        );
+
+        const resources: CachedMcpResource[] = [
+            {
+                uri: this.getSkillUri(skillName),
+                name: skill.name,
+                title: skill.title,
+                description: skill.description,
+                content: skill.content,
+            },
+        ];
+
+        const resourcesDir = this.getSkillResourcesDirectory(skillName);
+        let resourceFileNames: string[];
+        try {
+            resourceFileNames = await fs.readdir(resourcesDir);
+        } catch (error) {
+            if (this.isNodeErrnoException(error) && error.code === 'ENOENT') {
+                return resources;
+            }
+            throw error;
+        }
+
+        const nestedResources = await Promise.all(
+            resourceFileNames
+                .filter((fileName) => fileName.endsWith('.md'))
+                .sort()
+                .map(async (fileName) => {
+                    const resourceName = path.basename(fileName, '.md');
+                    const resource = await this.parseMarkdownFile(
+                        path.join(resourcesDir, fileName),
+                    );
+
+                    return {
+                        uri: this.getSkillResourceUri(skillName, resourceName),
+                        name: `${skillName}/${resourceName}`,
+                        title: `${skill.title} / ${resource.title}`,
+                        description: resource.description,
+                        content: resource.content,
+                    };
+                }),
+        );
+
+        return [...resources, ...nestedResources];
+    }
+
+    private static async loadMcpResources(): Promise<CachedMcpResource[]> {
+        if (this.mcpResources) {
+            return this.mcpResources;
+        }
+        if (this.mcpResourcesPromise) {
+            return this.mcpResourcesPromise;
+        }
+
+        this.mcpResourcesPromise = (async () => {
+            try {
+                const skillNames = await this.getBuiltInSkillNames();
+                const perSkill = await Promise.all(
+                    skillNames.map((skillName) =>
+                        this.loadMcpResourcesForSkill(skillName),
+                    ),
+                );
+                const resources = perSkill.flat();
+                this.mcpResources = resources;
+                return resources;
+            } catch (error) {
+                this.mcpResourcesPromise = undefined;
+                throw error;
+            }
+        })();
+
+        return this.mcpResourcesPromise;
+    }
+
     private static async getBuiltInSkills(): Promise<AiAgentSkill[]> {
         if (this.skills.length > 0) {
             return this.skills;
@@ -97,12 +249,14 @@ export class BuiltInSkills {
 
         this.skillsPromise = (async () => {
             try {
-                const skillPromises = [
-                    this.loadSkillFromDirectory(
-                        path.join(this.SKILLS_DIR, 'developing-in-lightdash'),
+                const skillNames = await this.getBuiltInSkillNames();
+                const skills = await Promise.all(
+                    skillNames.map((skillName) =>
+                        this.loadSkillFromDirectory(
+                            this.getSkillDirectory(skillName),
+                        ),
                     ),
-                ];
-                const skills = await Promise.all(skillPromises);
+                );
 
                 this.skills = skills;
                 return skills;
@@ -139,5 +293,17 @@ export class BuiltInSkills {
         return (await this.getBuiltInSkills()).find(
             (skill) => skill.name.toLowerCase() === name.trim().toLowerCase(),
         );
+    }
+
+    static async listMcpResources(): Promise<BuiltInSkillMcpResource[]> {
+        return (await this.loadMcpResources()).map(
+            ({ content, ...resource }) => resource,
+        );
+    }
+
+    static async getMcpResourceBody(uri: string): Promise<string | undefined> {
+        return (await this.loadMcpResources()).find(
+            (resource) => resource.uri === uri,
+        )?.content;
     }
 }

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/SKILL.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: developing-in-lightdash
+title: Developing in Lightdash
 description: Use when reading, creating, and editing Lightdash dashboards and charts as JSON, including dashboard layout and chart-type-specific configuration.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/big-number-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/big-number-chart-reference.md
@@ -1,5 +1,6 @@
 ---
 name: big-number-chart-reference
+title: Big Number Chart Reference
 description: Big number chart configuration, comparisons, conditional formatting, and examples for Lightdash charts.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/cartesian-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/cartesian-chart-reference.md
@@ -1,5 +1,6 @@
 ---
 name: cartesian-chart-reference
+title: Cartesian Chart Reference
 description: Bar, line, area, and scatter chart configuration, layout, series options, and examples for Lightdash charts.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/custom-viz-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/custom-viz-reference.md
@@ -1,5 +1,6 @@
 ---
 name: custom-viz-reference
+title: Custom Visualizations Reference
 description: Custom chart guidance using Vega-Lite specifications in Lightdash charts.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-best-practices.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-best-practices.md
@@ -1,5 +1,6 @@
 ---
 name: dashboard-best-practices
+title: Dashboard Best Practices
 description: A guide to building effective, user-friendly dashboards in Lightdash based on data visualization principles and BI best practices.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-reference.md
@@ -1,5 +1,6 @@
 ---
 name: dashboard-reference
+title: Dashboard Reference
 description: Full dashboard structure, tile types, grid layout, filters, config, examples, and best practices for editing dashboards in Lightdash.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/funnel-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/funnel-chart-reference.md
@@ -1,5 +1,6 @@
 ---
 name: funnel-chart-reference
+title: Funnel Chart Reference
 description: Funnel chart structure, stage ordering, labels, colors, and examples for Lightdash charts.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/gauge-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/gauge-chart-reference.md
@@ -1,5 +1,6 @@
 ---
 name: gauge-chart-reference
+title: Gauge Chart Reference
 description: Gauge chart configuration, ranges, sections, labels, and examples for Lightdash charts.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/map-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/map-chart-reference.md
@@ -1,5 +1,6 @@
 ---
 name: map-chart-reference
+title: Map Chart Reference
 description: Map chart configuration for scatter, area, and heatmap layers, plus map-specific examples for Lightdash charts.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/period-over-period-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/period-over-period-reference.md
@@ -1,5 +1,6 @@
 ---
 name: period-over-period-reference
+title: Period over Period Reference
 description: Period over period comparison configuration for Lightdash chart JSON.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/pie-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/pie-chart-reference.md
@@ -1,5 +1,6 @@
 ---
 name: pie-chart-reference
+title: Pie Chart Reference
 description: Pie and donut chart structure, grouping, labels, legend options, and examples for Lightdash charts.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/sankey-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/sankey-chart-reference.md
@@ -1,5 +1,6 @@
 ---
 name: sankey-chart-reference
+title: Sankey Chart Reference
 description: Sankey chart structure, source and target flow settings, and examples for Lightdash charts.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/table-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/table-chart-reference.md
@@ -1,5 +1,6 @@
 ---
 name: table-chart-reference
+title: Table Chart Reference
 description: Table chart configuration, columns, conditional formatting, pivots, and display options for Lightdash charts.
 ---
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/treemap-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/treemap-chart-reference.md
@@ -1,5 +1,6 @@
 ---
 name: treemap-chart-reference
+title: Treemap Chart Reference
 description: Treemap chart configuration, hierarchies, size and color metrics, and examples for Lightdash charts.
 ---
 

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -170,13 +170,9 @@ mcpRouter.all(
                 // to prevent cross-client response data leaks (CVE-2026-25536)
                 // See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
                 const headerProjectUuid = extractProjectUuidFromHeader(req);
-                // Dark launch: the run_ai_writeback tool is only registered
-                // (and thus only listed/invocable) when the AiWriteback flag is
-                // enabled for this caller. Resolved here because tool
-                // registration in createServer/setupHandlers is synchronous.
                 const aiWritebackEnabled =
                     await mcpService.isAiWritebackEnabled(req.user!);
-                const mcpServer = mcpService.createServer({
+                const mcpServer = await mcpService.createServer({
                     projectPinned: headerProjectUuid !== undefined,
                     aiWritebackEnabled,
                 });


### PR DESCRIPTION
Relates: ZAP-421

Revives #23371.

Rebased onto latest main and resolves MCP SDK/resource conflicts.

## Testing
- pnpm -F common build:fast
- pnpm -F backend typecheck:fast
- pnpm -F backend test -- src/ee/services/McpService/mcpToolContracts.snapshot.test.ts --runInBand
- pnpm -F api-tests typecheck

Note: pnpm -F api-tests test:api -- mcpServer.test.ts timed out locally.
