### PR TITLE
fix(pull-requests): show error when a PR's live details fail to load

### DIFF
--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -46,7 +46,6 @@ import { ThreadPreviewSidebar } from '../../../ee/features/aiCopilot/components/
 import { usePullRequestsTable } from '../hooks/usePullRequestsTable';
 import { type PullRequestRow } from '../types';
 import {
-    EMPTY_VALUE,
     getProviderLabel,
     getSourceColor,
     getSourceLabel,
@@ -171,9 +170,39 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                 size: 520,
                 Cell: ({ row }) => {
                     const pr = row.original;
+                    // title/state are both null when the live lookup from the
+                    // provider failed (PR deleted, access revoked, API down).
+                    const liveLookupFailed =
+                        pr.title === null && pr.state === null;
                     return (
                         <Stack gap={2} className={classes.title}>
-                            {pr.title ? (
+                            {liveLookupFailed ? (
+                                <Tooltip
+                                    label={`Couldn't load this pull request from ${getProviderLabel(
+                                        pr.provider,
+                                    )}. It may have been deleted, or access was revoked.`}
+                                    openDelay={300}
+                                    multiline
+                                    maw={420}
+                                    withinPortal
+                                >
+                                    <Group gap="two" wrap="nowrap">
+                                        <MantineIcon
+                                            icon={IconAlertCircle}
+                                            color="red"
+                                            size="sm"
+                                        />
+                                        <Text
+                                            size="sm"
+                                            fw={500}
+                                            c="red"
+                                            truncate
+                                        >
+                                            Couldn't load pull request
+                                        </Text>
+                                    </Group>
+                                </Tooltip>
+                            ) : (
                                 <Tooltip
                                     label={pr.title}
                                     openDelay={400}
@@ -185,10 +214,6 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                                         {pr.title}
                                     </Text>
                                 </Tooltip>
-                            ) : (
-                                <Text size="sm" fw={500} c="dimmed">
-                                    {EMPTY_VALUE}
-                                </Text>
                             )}
                             <Tooltip
                                 label={formatTimestamp(

--- a/packages/frontend/src/features/pullRequests/utils.ts
+++ b/packages/frontend/src/features/pullRequests/utils.ts
@@ -8,9 +8,6 @@ import { type PullRequestRow } from './types';
 
 export const DEFAULT_PULL_REQUESTS_PAGE_SIZE = 25;
 
-/** Empty-cell placeholder used when live title/state can't be resolved. */
-export const EMPTY_VALUE = '—';
-
 export const getSourceLabel = (source: PullRequestSource): string => {
     switch (source) {
         case PullRequestSource.CUSTOM_METRIC:


### PR DESCRIPTION
## Description:

When the provider lookup for a pull request fails, the API returns `title` and `state` as null. The Pull request list rendered this as a dimmed em-dash (`—`) placeholder with a gray medallion, which read as broken UI. This PR replaces that with a clear inline error — a red alert icon plus "Couldn't load pull request", and a tooltip explaining why ("It may have been deleted, or access was revoked"). The "opened … by …" metadata line still shows, since that comes from stored values. The now-unused `EMPTY_VALUE` constant is removed.

```
Before:  —                          (dimmed, looks like missing data)
         opened 2 days ago by …

After:   ⚠ Couldn't load pull request   (red, tooltip: deleted / access revoked)
         opened 2 days ago by …
```

## Test plan

- [ ] PR with a failed live lookup (null title/state) — shows the red error row with tooltip, visible under the "All" filter.
- [ ] PR with a resolved title/state — renders normally, unchanged.
- [ ] Verify both light and dark modes match the existing palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)