### PR TITLE
fix(pivot): show subtotals when grouped by a date dimension

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -47,8 +47,7 @@ const ISO_DATETIME_RE =
 // Canonicalize a raw index value to a stable string. Date columns serialize
 // differently between the pivot query (`...00Z`) and the flat totals query
 // (`...00.000Z`), so any ISO datetime is normalized to its ISO instant; other
-// values pass through as a plain string. Shared by row-total key building and
-// subtotal cell↔record matching.
+// values pass through as a plain string.
 export const normalizePivotMatchRaw = (raw: unknown): string | null => {
     if (raw === null || raw === undefined) return null;
     const str = String(raw);

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -47,8 +47,9 @@ const ISO_DATETIME_RE =
 // Canonicalize a raw index value to a stable string. Date columns serialize
 // differently between the pivot query (`...00Z`) and the flat totals query
 // (`...00.000Z`), so any ISO datetime is normalized to its ISO instant; other
-// values pass through as a plain string.
-const normalizeRowTotalRaw = (raw: unknown): string | null => {
+// values pass through as a plain string. Shared by row-total key building and
+// subtotal cell↔record matching.
+export const normalizePivotMatchRaw = (raw: unknown): string | null => {
     if (raw === null || raw === undefined) return null;
     const str = String(raw);
     if (ISO_DATETIME_RE.test(str)) {
@@ -68,7 +69,7 @@ export const buildPivotRowTotalKey = (
     JSON.stringify(
         [...indexEntries]
             .sort(([a], [b]) => a.localeCompare(b))
-            .map(([fieldId, raw]) => [fieldId, normalizeRowTotalRaw(raw)]),
+            .map(([fieldId, raw]) => [fieldId, normalizePivotMatchRaw(raw)]),
     );
 
 // Backend `.formatted` strings don't resolve ${ld.parameters.*} placeholders

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -53,6 +53,7 @@ import React, {
     type FC,
 } from 'react';
 import {
+    findMatchingSubtotal,
     getGroupingValuesAndSubtotalKey,
     getSubtotalValueFromGroup,
 } from '../../../hooks/tableVisualization/getDataAndColumns';
@@ -529,36 +530,11 @@ const PivotTable: FC<PivotTableProps> = ({
                                     finalHeaderInfoForColumns[colIndex];
 
                                 // Find the subtotal for the row, this is used to find the subtotal in the groupedSubtotals object
-                                const subtotal = data.groupedSubtotals?.[
-                                    subtotalGroupKey
-                                ]?.find((sub) => {
-                                    try {
-                                        return (
-                                            // All grouping values in the row must match the subtotal values
-                                            Object.keys(groupingValues).every(
-                                                (key) => {
-                                                    return (
-                                                        groupingValues[key]
-                                                            ?.value.raw ===
-                                                        sub[key]
-                                                    );
-                                                },
-                                            ) &&
-                                            // All pivoted header values in the row must match the subtotal values
-                                            Object.keys(
-                                                pivotedHeaderValues,
-                                            ).every((key) => {
-                                                return (
-                                                    pivotedHeaderValues[key]
-                                                        ?.raw === sub[key]
-                                                );
-                                            })
-                                        );
-                                    } catch (e) {
-                                        console.error(e);
-                                        return false;
-                                    }
-                                });
+                                const subtotal = findMatchingSubtotal(
+                                    data.groupedSubtotals?.[subtotalGroupKey],
+                                    groupingValues,
+                                    pivotedHeaderValues,
+                                );
 
                                 const subtotalValue = getSubtotalValueFromGroup(
                                     subtotal,

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.test.ts
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { findMatchingSubtotal } from './getDataAndColumns';
+
+const cell = (raw: unknown) => ({ value: { raw, formatted: String(raw) } });
+const headerValue = (raw: unknown) => ({ raw, formatted: String(raw) });
+
+// Subtotal records carry both dimension raw values (strings/dates) and metric
+// numbers; the shared GroupedSubtotals type widens them to number, so build
+// them through this helper to mirror that runtime shape.
+const records = (...rows: Record<string, unknown>[]) =>
+    rows as unknown as Record<string, number>[];
+
+describe('findMatchingSubtotal', () => {
+    it('matches a date grouping dimension regardless of millisecond serialization', () => {
+        const recs = records({
+            orders_order_date_month: '2018-04-01T00:00:00.000Z',
+            payments_total_revenue: 139,
+        });
+
+        const match = findMatchingSubtotal(
+            recs,
+            // Main pivot query serializes the date without milliseconds
+            { orders_order_date_month: cell('2018-04-01T00:00:00Z') },
+            {},
+        );
+
+        expect(match).toBe(recs[0]);
+    });
+
+    it('matches when the cell raw has milliseconds and the record does not', () => {
+        const recs = records({
+            orders_order_date_month: '2018-04-01T00:00:00Z',
+            payments_total_revenue: 139,
+        });
+
+        const match = findMatchingSubtotal(
+            recs,
+            { orders_order_date_month: cell('2018-04-01T00:00:00.000Z') },
+            {},
+        );
+
+        expect(match).toBe(recs[0]);
+    });
+
+    it('matches a pivoted header dimension value alongside the grouping value', () => {
+        const recs = records(
+            {
+                orders_order_date_month: '2018-01-01T00:00:00.000Z',
+                orders_status: 'completed',
+                payments_total_revenue: 424,
+            },
+            {
+                orders_order_date_month: '2018-01-01T00:00:00.000Z',
+                orders_status: 'returned',
+                payments_total_revenue: 49,
+            },
+        );
+
+        const match = findMatchingSubtotal(
+            recs,
+            { orders_order_date_month: cell('2018-01-01T00:00:00Z') },
+            { orders_status: headerValue('returned') },
+        );
+
+        expect(match).toBe(recs[1]);
+    });
+
+    it('returns undefined when no record matches', () => {
+        const recs = records({
+            orders_order_date_month: '2018-04-01T00:00:00.000Z',
+            payments_total_revenue: 139,
+        });
+
+        const match = findMatchingSubtotal(
+            recs,
+            { orders_order_date_month: cell('2017-01-01T00:00:00Z') },
+            {},
+        );
+
+        expect(match).toBeUndefined();
+    });
+
+    it('returns undefined when there are no records', () => {
+        expect(
+            findMatchingSubtotal(
+                undefined,
+                { orders_order_date_month: cell('2018-04-01T00:00:00Z') },
+                {},
+            ),
+        ).toBeUndefined();
+    });
+});

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.test.ts
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.test.ts
@@ -4,9 +4,6 @@ import { findMatchingSubtotal } from './getDataAndColumns';
 const cell = (raw: unknown) => ({ value: { raw, formatted: String(raw) } });
 const headerValue = (raw: unknown) => ({ raw, formatted: String(raw) });
 
-// Subtotal records carry both dimension raw values (strings/dates) and metric
-// numbers; the shared GroupedSubtotals type widens them to number, so build
-// them through this helper to mirror that runtime shape.
 const records = (...rows: Record<string, unknown>[]) =>
     rows as unknown as Record<string, number>[];
 
@@ -19,7 +16,6 @@ describe('findMatchingSubtotal', () => {
 
         const match = findMatchingSubtotal(
             recs,
-            // Main pivot query serializes the date without milliseconds
             { orders_order_date_month: cell('2018-04-01T00:00:00Z') },
             {},
         );

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -64,10 +64,7 @@ export function getGroupingValuesAndSubtotalKey(
     return { groupingValues, subtotalGroupKey };
 }
 
-// Match a rendered subtotal cell to its backend subtotal record. Raw values are
-// normalized before comparison because date dimensions serialize differently
-// between the main pivot query (`...00Z`) and the flat calculate-total query
-// (`...00.000Z`). Pass `{}` for pivotedHeaderValues in the non-pivoted path.
+// Pass `{}` for pivotedHeaderValues in the non-pivoted path.
 export function findMatchingSubtotal(
     records: Record<string, number>[] | undefined,
     groupingValues: Record<string, { value: ResultValue } | undefined>,

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -4,9 +4,11 @@ import {
     isCustomDimension,
     isDimension,
     isField,
+    normalizePivotMatchRaw,
     type ItemsMap,
     type ParametersValuesMap,
     type ResultRow,
+    type ResultValue,
 } from '@lightdash/common';
 import { Text } from '@mantine/core';
 import { captureException } from '@sentry/react';
@@ -60,6 +62,38 @@ export function getGroupingValuesAndSubtotalKey(
     const subtotalGroupKey = getSubtotalKey(groupingDimensions);
 
     return { groupingValues, subtotalGroupKey };
+}
+
+// Match a rendered subtotal cell to its backend subtotal record. Raw values are
+// normalized before comparison because date dimensions serialize differently
+// between the main pivot query (`...00Z`) and the flat calculate-total query
+// (`...00.000Z`). Pass `{}` for pivotedHeaderValues in the non-pivoted path.
+export function findMatchingSubtotal(
+    records: Record<string, number>[] | undefined,
+    groupingValues: Record<string, { value: ResultValue } | undefined>,
+    pivotedHeaderValues: Record<string, ResultValue>,
+): Record<string, number> | undefined {
+    return records?.find((sub) => {
+        try {
+            return (
+                Object.keys(groupingValues).every(
+                    (key) =>
+                        normalizePivotMatchRaw(
+                            groupingValues[key]?.value.raw,
+                        ) === normalizePivotMatchRaw(sub[key]),
+                ) &&
+                Object.keys(pivotedHeaderValues).every(
+                    (key) =>
+                        normalizePivotMatchRaw(
+                            pivotedHeaderValues[key]?.raw,
+                        ) === normalizePivotMatchRaw(sub[key]),
+                )
+            );
+        } catch (e) {
+            console.error(e);
+            return false;
+        }
+    });
 }
 
 export function getSubtotalValueFromGroup(
@@ -232,23 +266,11 @@ const getDataAndColumns = ({
                                 groupingValuesAndSubtotalKey;
 
                             // Find the subtotal for the row, this is used to find the subtotal in the groupedSubtotals object
-                            const subtotal = groupedSubtotals?.[
-                                subtotalGroupKey
-                            ]?.find((sub) => {
-                                try {
-                                    return Object.keys(groupingValues).every(
-                                        (key) => {
-                                            return (
-                                                groupingValues[key]?.value
-                                                    .raw === sub[key]
-                                            );
-                                        },
-                                    );
-                                } catch (e) {
-                                    console.error(e);
-                                    return false;
-                                }
-                            });
+                            const subtotal = findMatchingSubtotal(
+                                groupedSubtotals?.[subtotalGroupKey],
+                                groupingValues,
+                                {},
+                            );
 
                             const subtotalValue = getSubtotalValueFromGroup(
                                 subtotal,

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -87,7 +87,7 @@ export function findMatchingSubtotal(
                 )
             );
         } catch (e) {
-            console.error(e);
+            captureException(e);
             return false;
         }
     });

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -14,12 +14,7 @@ import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 import { pollForResults } from '../features/queryRunner/executeQuery';
 
-// Read every page of a ready query from the paginated results endpoint. Unlike
-// the raw JSONL stream (`getResultsFromStream`), this endpoint applies the same
-// display formatting as the main query rows — including the temporal timezone
-// shift — so date/datetime dimension raw values match exactly when totals and
-// subtotals are matched back to rendered cells. Reading totals from the stream
-// instead drops the shift and breaks matching for DST-affected periods.
+// Reads every page of a ready query from the paginated results endpoint.
 const fetchAllResultRows = async (
     projectUuid: string,
     queryUuid: string,
@@ -173,9 +168,6 @@ const fetchRowTotals = async (
         throw new Error('Unexpected query status while polling totals');
     }
 
-    // One row per index combination — potentially more than a single page. Read
-    // from the paginated endpoint (not the raw stream) so temporal index values
-    // carry the same timezone shift as the main query rows the worker keys by.
     const rows = await fetchAllResultRows(projectUuid, queryUuid);
 
     const indexFieldIdSet = new Set(indexFieldIds);
@@ -309,9 +301,6 @@ const fetchSubtotals = async (args: {
                     );
                 }
 
-                // Read from the paginated endpoint (not the raw stream) so date
-                // dimension raw values carry the same timezone shift as the main
-                // query rows they're matched against.
                 const rows = await fetchAllResultRows(projectUuid, queryUuid);
 
                 const records = rows.map((row) => {

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -4,14 +4,45 @@ import {
     QueryHistoryStatus,
     type ApiError,
     type ApiExecuteAsyncMetricQueryResults,
+    type ApiGetAsyncQueryResults,
     type CalculateTotalKind,
     type PivotRowTotalsByIndex,
     type RawResultRow,
+    type ResultRow,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 import { pollForResults } from '../features/queryRunner/executeQuery';
-import { getResultsFromStream } from '../utils/request';
+
+// Read every page of a ready query from the paginated results endpoint. Unlike
+// the raw JSONL stream (`getResultsFromStream`), this endpoint applies the same
+// display formatting as the main query rows — including the temporal timezone
+// shift — so date/datetime dimension raw values match exactly when totals and
+// subtotals are matched back to rendered cells. Reading totals from the stream
+// instead drops the shift and breaks matching for DST-affected periods.
+const fetchAllResultRows = async (
+    projectUuid: string,
+    queryUuid: string,
+): Promise<ResultRow[]> => {
+    const rows: ResultRow[] = [];
+    let page = 1;
+    let totalPageCount = 1;
+    do {
+        const result = await lightdashApi<ApiGetAsyncQueryResults>({
+            url: `/projects/${projectUuid}/query/${queryUuid}?page=${page}`,
+            version: 'v2',
+            method: 'GET',
+            body: undefined,
+        });
+        if (result.status !== QueryHistoryStatus.READY) {
+            throw new Error('Unexpected query status while reading results');
+        }
+        rows.push(...result.rows);
+        totalPageCount = result.totalPageCount ?? 1;
+        page += 1;
+    } while (page <= totalPageCount);
+    return rows;
+};
 
 type StartCalculateTotalArgs = {
     projectUuid: string;
@@ -142,21 +173,21 @@ const fetchRowTotals = async (
         throw new Error('Unexpected query status while polling totals');
     }
 
-    // One row per index combination — potentially more than a single page, so
-    // read the whole results file rather than the paginated poll response.
-    const fileUrl = `/api/v2/projects/${projectUuid}/query/${queryUuid}/results`;
-    const rows = await getResultsFromStream<RawResultRow>(fileUrl);
+    // One row per index combination — potentially more than a single page. Read
+    // from the paginated endpoint (not the raw stream) so temporal index values
+    // carry the same timezone shift as the main query rows the worker keys by.
+    const rows = await fetchAllResultRows(projectUuid, queryUuid);
 
     const indexFieldIdSet = new Set(indexFieldIds);
     const map: PivotRowTotalsByIndex = {};
     for (const row of rows) {
         const key = buildPivotRowTotalKey(
-            indexFieldIds.map((fieldId) => [fieldId, row[fieldId]]),
+            indexFieldIds.map((fieldId) => [fieldId, row[fieldId]?.value.raw]),
         );
         const metricTotals: Record<string, number> = {};
-        for (const [fieldId, raw] of Object.entries(row)) {
+        for (const [fieldId, cell] of Object.entries(row)) {
             if (indexFieldIdSet.has(fieldId)) continue;
-            const numeric = Number(raw);
+            const numeric = Number(cell?.value.raw);
             if (Number.isFinite(numeric)) {
                 metricTotals[fieldId] = numeric;
             }
@@ -278,12 +309,15 @@ const fetchSubtotals = async (args: {
                     );
                 }
 
-                const fileUrl = `/api/v2/projects/${projectUuid}/query/${queryUuid}/results`;
-                const rows = await getResultsFromStream<RawResultRow>(fileUrl);
+                // Read from the paginated endpoint (not the raw stream) so date
+                // dimension raw values carry the same timezone shift as the main
+                // query rows they're matched against.
+                const rows = await fetchAllResultRows(projectUuid, queryUuid);
 
                 const records = rows.map((row) => {
                     const record: Record<string, unknown> = {};
-                    for (const [fieldId, raw] of Object.entries(row)) {
+                    for (const [fieldId, cell] of Object.entries(row)) {
+                        const raw = cell?.value.raw;
                         if (dimensionKeys.has(fieldId)) {
                             record[fieldId] = raw;
                         } else {


### PR DESCRIPTION
Closes: PROD-8153
Closes: #23940

### Description:

Pivot-table subtotals (and row totals) rendered as `-` whenever a row-grouping or pivot dimension was a date, because totals are matched back to rendered cells by raw value but the two sides were serialized inconsistently in two ways: (1) **milliseconds** — the totals stream emitted `…00.000Z` vs the main query's `…00Z`; and (2) **timezone** — the raw `/results` stream emits UTC (`…T00:00:00Z`) while the main query rows and column totals read the paginated endpoint, which applies the display-timezone shift (`…T01:00:00Z` for DST periods), so summer months never matched. The fix extracts the match into a shared `findMatchingSubtotal` helper that normalizes both sides via `normalizePivotMatchRaw` (covering the pivoted `PivotTable` and non-pivoted `getDataAndColumns` paths), and reads subtotals/row-totals from the same paginated endpoint as the main query so date raws line up exactly. Adds unit tests.
