### PR TITLE
feat(ai-agents): @-mention dashboard tiles in pinned-context threads

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
@@ -7,6 +7,8 @@ import {
     fuzzyContentMentionLabelMatch,
     getContentMentionEmptyMessage,
     mergeAiPromptContextInput,
+    mergeContentMentionSuggestionItems,
+    type ContentMentionSuggestionItem,
 } from './contentMentions';
 
 vi.mock('../../../../../api', () => ({
@@ -55,6 +57,40 @@ describe('contentMentions', () => {
                 chartSlug: 'revenue-chart',
             },
         ]);
+    });
+
+    it('merges mention suggestions deduping charts by uuid, first wins', () => {
+        const threadChart: ContentMentionSuggestionItem = {
+            id: 'thread:chart:chart-1',
+            label: 'Revenue',
+            contentType: ContentType.CHART,
+            uuid: 'chart-1',
+            slug: 'revenue-chart',
+            group: 'thread',
+        };
+        const tileChart: ContentMentionSuggestionItem = {
+            id: 'dashboardTile:chart:chart-1',
+            label: 'Revenue by month (tile title)',
+            contentType: ContentType.CHART,
+            uuid: 'chart-1',
+            slug: 'revenue-chart',
+            group: 'dashboardTile',
+        };
+        const tileChart2: ContentMentionSuggestionItem = {
+            id: 'dashboardTile:chart:chart-2',
+            label: 'Active users',
+            contentType: ContentType.CHART,
+            uuid: 'chart-2',
+            slug: 'active-users',
+            group: 'dashboardTile',
+        };
+
+        expect(
+            mergeContentMentionSuggestionItems(
+                [threadChart],
+                [tileChart, tileChart2],
+            ),
+        ).toEqual([threadChart, tileChart2]);
     });
 
     it('maps existing context into mention suggestions', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -163,6 +163,20 @@ export const mergeAiPromptContextItems = (
     return merged.length > 0 ? merged : undefined;
 };
 
+export const mergeContentMentionSuggestionItems = (
+    ...groups: Array<ContentMentionSuggestionItem[] | undefined>
+): ContentMentionSuggestionItem[] => {
+    const seen = new Set<string>();
+    return groups
+        .flatMap((group) => group ?? [])
+        .filter((item) => {
+            const key = `${item.contentType}:${item.uuid}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
+};
+
 export const contextItemsToContentMentionSuggestions = (
     context: AiPromptContextItem[],
     group: ContentMentionGroup,

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -4,12 +4,16 @@ import { useOutletContext, useParams } from 'react-router';
 import useApp from '../../../providers/App/useApp';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
-import { contextItemsToContentMentionSuggestions } from '../../features/aiCopilot/components/ChatElements/contentMentions';
+import {
+    contextItemsToContentMentionSuggestions,
+    mergeContentMentionSuggestionItems,
+} from '../../features/aiCopilot/components/ChatElements/contentMentions';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { useAiAgentThreadArtifact } from '../../features/aiCopilot/hooks/useAiAgentThreadArtifact';
 import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
 import { usePendingThreadRefetch } from '../../features/aiCopilot/hooks/usePendingThreadRefetch';
+import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
 import {
     useProjectAiAgent as useAiAgent,
     useAiAgentThread,
@@ -156,7 +160,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const activeDisabledReason = disabledReasons.find((r) => r.when);
     const inputDisabled = !!activeDisabledReason;
     const inputDisabledReason = activeDisabledReason?.message;
-    const contentMentionItems = useMemo(
+    const threadMentionItems = useMemo(
         () =>
             contextItemsToContentMentionSuggestions(
                 thread?.messages.flatMap((message) =>
@@ -165,6 +169,31 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                 'thread',
             ),
         [thread?.messages],
+    );
+
+    // Expand the thread's pinned dashboard into tiles, mentionable by tile name.
+    const pinnedDashboardUuid = useMemo(() => {
+        for (const message of thread?.messages ?? []) {
+            if (message.role !== 'user') continue;
+            for (const item of message.context ?? []) {
+                if (item.type === 'dashboard') return item.dashboardUuid;
+            }
+        }
+        return null;
+    }, [thread?.messages]);
+
+    const { contentMentionItems: pinnedDashboardTileItems } = usePinnedContext({
+        projectUuid,
+        dashboardUuidOrSlug: pinnedDashboardUuid,
+    });
+
+    const contentMentionItems = useMemo(
+        () =>
+            mergeContentMentionSuggestionItems(
+                threadMentionItems,
+                pinnedDashboardTileItems,
+            ),
+        [threadMentionItems, pinnedDashboardTileItems],
     );
 
     const handleSubmit = ({


### PR DESCRIPTION
## What

On the **ongoing AI agent thread page**, a dashboard pinned to the thread now expands into per-tile `@`-mention suggestions, labeled by **tile title** (falling back to the chart name). Previously, mid-conversation you could only `@` the dashboard and charts already mentioned — not individual tiles, whose names often differ from the underlying chart.

The new-thread page and Launcher already did this (via `usePinnedContext`); this closes the gap on the ongoing thread page.

## How

- `contentMentions.tsx` — `mergeContentMentionSuggestionItems(...)`: merges suggestion groups, deduping by `contentType:uuid` (first wins).
- `AgentThreadPage.tsx` — derive the thread's primary pinned dashboard from message context, run it through the existing `usePinnedContext` (which already builds tile items), and merge those tiles into the mention priority list.
- `contentMentions.test.ts` — unit test for the merge/dedupe.

No backend, API, or type changes. A tile mention attaches the same `{ chart + dashboard }` context as before — only discoverability by tile name changes.

## Deliberate decisions
- **Dedup order:** if a chart is both already-mentioned and a tile, the "already mentioned" entry wins; tiles not yet mentioned still surface by tile name.
- **Scope:** only the thread's *primary* pinned dashboard expands. Multiple dashboards in one thread would need a `useQueries` variant — left out as a rare case.

## How to test
1. Open a dashboard and start an AI agent thread pinned to it (or pin a dashboard as context).
2. Send a message, then in the same thread type `@` — the dashboard's tiles should appear under **Dashboard tiles**, labeled by tile title (including tiles with titles that differ from the chart name).
3. Mention a tile and confirm the agent receives the underlying chart + dashboard context.

## Validation
- `pnpm -F frontend typecheck:fast` — clean
- `pnpm -F frontend lint` — 0 errors
- `pnpm -F frontend test` (contentMentions) — 7 passed
- `pnpm -F frontend build` — ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
