### PR TITLE
fix(ai-agents): restyle MCP connect notice as a rounded card

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.module.css
@@ -1,9 +1,9 @@
 .connectionStrip {
     align-self: center;
-    width: fit-content;
+    width: 100%;
     max-width: min(100%, rem(760px));
-    padding: rem(5px) rem(8px);
-    border-radius: 999px;
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+    border-radius: var(--mantine-radius-lg);
 
     @mixin light {
         background-color: var(--mantine-color-ldGray-0);
@@ -16,6 +16,7 @@
     }
 }
 
-.connectionCopy {
-    min-width: 0;
+.connectionIcon {
+    flex-shrink: 0;
+    margin-top: rem(1px);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
@@ -362,18 +362,15 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
             aria-labelledby={sectionTitleId}
             aria-busy={isStartingMcpOAuthConnection}
         >
-            {isSingleApp ? (
-                <Group justify="center" align="center" gap="xs" wrap="wrap">
-                    <Group
-                        align="center"
-                        gap={6}
-                        className={styles.connectionCopy}
-                    >
-                        <MantineIcon
-                            icon={IconInfoCircle}
-                            size={13}
-                            color="ldGray.5"
-                        />
+            <Group align="flex-start" gap="sm" wrap="nowrap">
+                <MantineIcon
+                    icon={IconInfoCircle}
+                    size={14}
+                    color="ldGray.5"
+                    className={styles.connectionIcon}
+                />
+                <Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
+                    <Stack gap={2}>
                         <Text id={sectionTitleId} size="xs" c="ldGray.6">
                             {sectionSummary}
                         </Text>
@@ -382,57 +379,8 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
                                 {connectionNote}
                             </Text>
                         )}
-                    </Group>
-                    {mcpServersNeedingConnection.map((mcpServer) => {
-                        const isConnecting =
-                            isStartingMcpOAuthConnection &&
-                            startingMcpOAuthConnection?.mcpServerUuid ===
-                                mcpServer.uuid;
-                        const iconColor = getConnectionIconColor(mcpServer);
-
-                        return (
-                            <Button
-                                key={mcpServer.uuid}
-                                size="compact-xs"
-                                variant="subtle"
-                                color="gray"
-                                leftSection={
-                                    <AiMcpServerIcon
-                                        color={iconColor}
-                                        name={mcpServer.name}
-                                        size={16}
-                                        src={mcpServer.iconUrl}
-                                    />
-                                }
-                                loading={isConnecting}
-                                onClick={() =>
-                                    void handleStartConnection(mcpServer.uuid)
-                                }
-                            >
-                                {getConnectionActionLabel(mcpServer)}
-                            </Button>
-                        );
-                    })}
-                    {githubConnectButton}
-                </Group>
-            ) : (
-                <Stack gap={4} align="center">
-                    <Group gap={6} justify="center" wrap="wrap">
-                        <MantineIcon
-                            icon={IconInfoCircle}
-                            size={13}
-                            color="ldGray.5"
-                        />
-                        <Text id={sectionTitleId} size="xs" c="ldGray.6">
-                            {sectionSummary}
-                        </Text>
-                        {connectionNote && (
-                            <Text size="xs" c="ldGray.5">
-                                {connectionNote}
-                            </Text>
-                        )}
-                    </Group>
-                    <Group gap={4} justify="center">
+                    </Stack>
+                    <Group gap="xs" wrap="wrap">
                         {mcpServersNeedingConnection.map((mcpServer) => {
                             const isConnecting =
                                 isStartingMcpOAuthConnection &&
@@ -461,16 +409,18 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
                                         )
                                     }
                                 >
-                                    {getMultiAppConnectionActionLabel(
-                                        mcpServer,
-                                    )}
+                                    {isSingleApp
+                                        ? getConnectionActionLabel(mcpServer)
+                                        : getMultiAppConnectionActionLabel(
+                                              mcpServer,
+                                          )}
                                 </Button>
                             );
                         })}
                         {githubConnectButton}
                     </Group>
                 </Stack>
-            )}
+            </Group>
             <GithubMcpConnectModal
                 opened={isGithubConfirmModalOpen}
                 onClose={githubConfirmModalHandlers.close}


### PR DESCRIPTION
## What
Restyles the "Connect GitHub" MCP notice on the Ask AI new-thread page so it reads cleanly in narrow panels (e.g. the minimized launcher).

Previously it was a `999px` stadium pill that, once the copy wrapped to two lines, looked like an oversized rounded box with the info icon stranded at the top-left and the connect button floating on its own centered line.

## How
- Swap the `999px` border-radius for Mantine's `lg` radius (a proper notice card).
- Replace the centered, wrapping layout with a left-aligned **icon → text → action buttons** stack (icon top-aligned to the first line).
- Unify the previously-duplicated single-app and multi-app branches into one layout (the only difference is the button label).

CSS/markup only — no behavior, API, or context changes.

## Test
On the Ask AI new-thread page (including the minimized launcher) for an agent with an available-but-unconnected GitHub MCP, the notice should render as a tidy rounded card with the GitHub button left-aligned under the text, at both narrow and wide widths.

## Validation
- `pnpm -F frontend typecheck:fast` — clean
- `pnpm -F frontend lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
