### PR TITLE
fix(ai-agents): polish new-thread composer (SQL toggle placement + input size)

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -39,7 +39,7 @@
 
     @mixin light {
         background-color: var(--mantine-color-white);
-        border: 1px solid var(--mantine-color-gray-3);
+        border: 1px solid var(--mantine-color-ldGray-2);
         box-shadow:
             0 8px 24px rgba(15, 23, 42, 0.05),
             0 1px 4px rgba(15, 23, 42, 0.04);
@@ -286,7 +286,7 @@
 
     @mixin light {
         background-color: var(--mantine-color-white);
-        border: 1px solid var(--mantine-color-ldGray-3);
+        border: 1px solid var(--mantine-color-ldGray-2);
     }
 
     @mixin dark {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -387,7 +387,7 @@
 
 .editorContent {
     padding: rem(22px) rem(24px) rem(10px);
-    font-size: rem(18px);
+    font-size: var(--mantine-font-size-md);
     line-height: 1.5;
     min-height: rem(118px);
     max-height: 240px;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -538,12 +538,6 @@ export const AgentChatInput = ({
                             <RichTextEditor.Content />
                         </RichTextEditor>
 
-                        {!isThreadInput &&
-                            renderSqlModeControl({
-                                actionSize: 'md',
-                                iconSize: 16,
-                            })}
-
                         <ActionIcon
                             right={12}
                             bottom={10}
@@ -565,20 +559,21 @@ export const AgentChatInput = ({
                     </Box>
                 </Box>
 
-                {isThreadInput
-                    ? showSqlModeControl && (
-                          <Box className={styles.threadBelowControls}>
-                              {renderSqlModeControl({
-                                  actionSize: 'sm',
-                                  iconSize: 14,
-                                  labelPosition: 'before',
-                              })}
-                          </Box>
-                      )
-                    : renderChipRow(
-                          styles.chipTray,
-                          shouldReserveEmptyStateSuggestions,
-                      )}
+                {showSqlModeControl && (
+                    <Box className={styles.threadBelowControls}>
+                        {renderSqlModeControl({
+                            actionSize: 'sm',
+                            iconSize: 14,
+                            labelPosition: 'before',
+                        })}
+                    </Box>
+                )}
+
+                {!isThreadInput &&
+                    renderChipRow(
+                        styles.chipTray,
+                        shouldReserveEmptyStateSuggestions,
+                    )}
 
                 {showDisabledBanner && (
                     <Text size="xs" c="dimmed" ta="right" mt="xs" px="sm">


### PR DESCRIPTION
Two small polish tweaks to the Ask AI new-thread composer.

## SQL mode toggle placement
Moves the SQL mode toggle out of the chat input on the **minimal new-thread composer** (e.g. the minimized launcher). It previously sat *inside* the rounded input next to the send button; now it renders in the right-aligned row **below** the input — matching the ongoing-thread composer.

## Input font size
Reduces the full new-thread chat input font from `18px` to Mantine's `md` (`16px`) — the input read too large.

CSS/markup only — no behavior change.

## Test
- Minimized Ask AI launcher, new thread (agent with SQL mode available): the terminal/SQL toggle sits at the bottom-right *outside* the input, not next to the send arrow; suggestion chips still render below.
- Full new-thread page: the input/placeholder text is noticeably smaller.

> Quick visual sanity check wanted: chip tray sits cleanly under the new control row at narrow widths.

## Validation
- `pnpm -F frontend typecheck:fast` — clean
- `pnpm -F frontend lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
