### PR TITLE
fix: use keyword queries for findExplores

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -119,11 +119,11 @@ Usage Tips:
       "description": "Tool: findExplores
 
 Purpose:
-Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
+Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
-- searchQuery: Full user query for finding relevant explores
+- searchQuery: Keyword terms for finding relevant explores
 
 Output:
 - Matching explores with searchRank scores
@@ -134,7 +134,7 @@ Output:
         "additionalProperties": false,
         "properties": {
           "searchQuery": {
-            "description": "The full user query or search terms to help find the most relevant explore. Use the complete user request for better search results.",
+            "description": "set of high-signal keyword terms for query. Search uses PostgreSQL websearch_to_tsquery after joining whitespace-separated terms with OR. It searches explore and field name, label, and description. Prefer metric/entity/dimension nouns that capture the user's analytical intent.",
             "type": "string",
           },
         },

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
@@ -33,7 +33,7 @@ Execute these steps in order. Do NOT skip steps.
 
 ### Step 1: Context matching
 
-Scan the user's query for a domain word that matches an explore name (singular/plural counts — "order" matches "orders"). Call findExplores with the full user query.
+Scan the user's query for a domain word that matches an explore name (singular/plural counts — "order" matches "orders"). Call findExplores with high-signal metric/entity/dimension keywords.
 
 - If exactly one explore matches with searchRank > ${CONTEXT_MATCH_SEARCH_RANK_MIN} and there's a clear context word match → status: "resolved". Proceed to Step 5.
 - If no clear context match → continue to Step 2.

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -833,11 +833,11 @@ Usage tips:
     "description": "Tool: findExplores
 
 Purpose:
-Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
+Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
-- searchQuery: Full user query for finding relevant explores
+- searchQuery: Keyword terms for finding relevant explores
 
 Output:
 - Matching explores with searchRank scores
@@ -848,7 +848,7 @@ Output:
       "additionalProperties": false,
       "properties": {
         "searchQuery": {
-          "description": "The full user query or search terms to help find the most relevant explore. Use the complete user request for better search results.",
+          "description": "set of high-signal keyword terms for query. Search uses PostgreSQL websearch_to_tsquery after joining whitespace-separated terms with OR. It searches explore and field name, label, and description. Prefer metric/entity/dimension nouns that capture the user's analytical intent.",
           "type": "string",
         },
       },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -5,11 +5,11 @@ import { createToolSchema } from '../toolSchemaBuilder';
 export const TOOL_FIND_EXPLORES_DESCRIPTION = `Tool: findExplores
 
 Purpose:
-Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
+Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
-- searchQuery: Full user query for finding relevant explores
+- searchQuery: Keyword terms for finding relevant explores
 
 Output:
 - Matching explores with searchRank scores
@@ -40,7 +40,7 @@ export const toolFindExploresArgsSchemaV3 = createToolSchema()
         searchQuery: z
             .string()
             .describe(
-                'The full user query or search terms to help find the most relevant explore. Use the complete user request for better search results.',
+                "set of high-signal keyword terms for query. Search uses PostgreSQL websearch_to_tsquery after joining whitespace-separated terms with OR. It searches explore and field name, label, and description. Prefer metric/entity/dimension nouns that capture the user's analytical intent.",
             ),
     })
     .build();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-7748: Use keyword queries for `findExplores` search](https://linear.app/lightdash/issue/PROD-7748/use-keyword-queries-for-findexplores-search)<!-- reference the related issue e.g. #150 -->

### Description:

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->