### PR TITLE
fix(filters): read async field values from result column key

### DIFF
--- a/packages/frontend/src/hooks/useFieldValues.test.ts
+++ b/packages/frontend/src/hooks/useFieldValues.test.ts
@@ -1,7 +1,11 @@
 import { QueryHistoryStatus } from '@lightdash/common';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { lightdashApi } from '../api';
-import { MAX_POLL_ATTEMPTS, pollForFieldValueResults } from './useFieldValues';
+import {
+    getFieldValuesAsync,
+    MAX_POLL_ATTEMPTS,
+    pollForFieldValueResults,
+} from './useFieldValues';
 
 vi.mock('../api', () => ({
     lightdashApi: vi.fn(),
@@ -122,5 +126,93 @@ describe('pollForFieldValueResults', () => {
         );
 
         expect(lightdashApi).toHaveBeenCalledTimes(MAX_POLL_ATTEMPTS);
+    });
+});
+
+describe('getFieldValuesAsync', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const executeResult = {
+        queryUuid: 'query-uuid',
+        cacheMetadata: { cacheHit: false },
+    };
+
+    it('maps rows using the results column key when the backend rewrites the fieldId', async () => {
+        // Aliased joins resolve to the original explore's field, so rows come
+        // back keyed by the rewritten id (e.g. generated_b_region instead of
+        // the requested join_1_region)
+        const readyResult = {
+            status: QueryHistoryStatus.READY,
+            queryUuid: 'query-uuid',
+            rows: [
+                {
+                    generated_b_region: {
+                        value: { raw: 'Agder', formatted: 'Agder' },
+                    },
+                },
+                {
+                    generated_b_region: {
+                        value: { raw: 'Alsace', formatted: 'Alsace' },
+                    },
+                },
+            ],
+            columns: {
+                generated_b_region: {
+                    type: 'string',
+                    reference: 'generated_b_region',
+                },
+            },
+            metadata: { performance: {} },
+            pivotDetails: null,
+        };
+
+        vi.mocked(lightdashApi)
+            .mockResolvedValueOnce(executeResult as never)
+            .mockResolvedValueOnce(readyResult as never);
+
+        const result = await getFieldValuesAsync(
+            'project-uuid',
+            'join_1',
+            'join_1_region',
+            '',
+            false,
+            undefined,
+        );
+
+        expect(result.results).toEqual(['Agder', 'Alsace']);
+    });
+
+    it('falls back to the requested fieldId when columns are missing', async () => {
+        const readyResult = {
+            status: QueryHistoryStatus.READY,
+            queryUuid: 'query-uuid',
+            rows: [
+                {
+                    orders_status: {
+                        value: { raw: 'completed', formatted: 'completed' },
+                    },
+                },
+            ],
+            columns: {},
+            metadata: { performance: {} },
+            pivotDetails: null,
+        };
+
+        vi.mocked(lightdashApi)
+            .mockResolvedValueOnce(executeResult as never)
+            .mockResolvedValueOnce(readyResult as never);
+
+        const result = await getFieldValuesAsync(
+            'project-uuid',
+            'orders',
+            'orders_status',
+            '',
+            false,
+            undefined,
+        );
+
+        expect(result.results).toEqual(['completed']);
     });
 });

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -134,7 +134,7 @@ export const pollForFieldValueResults = async (
     return results;
 };
 
-const getFieldValuesAsync = async (
+export const getFieldValuesAsync = async (
     projectId: string,
     table: string | undefined,
     fieldId: string,
@@ -180,9 +180,13 @@ const getFieldValuesAsync = async (
         throw new Error('Unexpected query status');
     }
 
+    // The backend may rewrite the fieldId (e.g. aliased joins), so read the
+    // single result column key from the response instead
+    const resultColumn = Object.keys(queryResult.columns)[0] ?? fieldId;
+
     const results: string[] = queryResult.rows
         .map((row) => {
-            const cell = row[fieldId];
+            const cell = row[resultColumn];
             if (!cell?.value) return undefined;
             const { raw } = cell.value;
             if (raw === null || raw === undefined) return undefined;


### PR DESCRIPTION
### Description

Filter value dropdowns showed "No results found" for dimensions on aliased joins when the async query path is enabled (`ResultsCacheEnabled` flag). The backend resolves an aliased join to the original explore and rewrites the fieldId, so result rows come back keyed by the rewritten id (e.g. `generated_b_region`) while the frontend looked rows up by the requested id (`join_1_region`), silently dropping every value. Manually typing values still worked, which is how this was reported.

Fix: read the single result column key from the query results instead of recomputing it client-side, falling back to the requested fieldId. Field value search always selects exactly one dimension, and the columns map is built from the same warehouse fields that key the rows.

Repro: `generated_a` explore in the demo project joins `generated_b` as `join_1`. With the results cache flag enabled, a dashboard or explorer filter on `Join 1 Region` showed an empty dropdown; after the fix it populates and searching works.

**Before**
<img width="838" height="650" alt="CleanShot 2026-06-05 at 15 09 42" src="https://github.com/user-attachments/assets/4abd93dd-9dbf-4752-87d4-96e189d08ade" />

**After**
<img width="576" height="484" alt="CleanShot 2026-06-05 at 15 06 57" src="https://github.com/user-attachments/assets/6a7f2d4e-1dfe-4557-b3f2-1e799ebfd61d" />


Closes: PROD-1148
Closes: #18633
