### PR TITLE
refactor(frontend): migrate access token tables to Mantine 8 Table

### DIFF
--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -55,100 +55,96 @@ const TokenItem: FC<{
     const { description, expiresAt, rotatedAt, lastUsedAt } = token;
 
     return (
-        <>
-            <Table.Tr>
-                <Table.Td>
-                    <Text fw={500} size="sm">
-                        {description}
-                    </Text>
-                </Table.Td>
-                <Table.Td>
-                    <Group align="center" justify="flex-start" gap="xs">
-                        <span>
-                            {expiresAt ? (
-                                <Tooltip
-                                    withinPortal
-                                    position="top"
-                                    maw={350}
-                                    label={formatTimestamp(expiresAt)}
-                                >
-                                    <span>{formatDate(expiresAt)}</span>
-                                </Tooltip>
-                            ) : (
-                                'No expiration date'
-                            )}
-                        </span>
-
-                        {rotatedAt && (
+        <Table.Tr>
+            <Table.Td>
+                <Text fw={500} fz="sm">
+                    {description}
+                </Text>
+            </Table.Td>
+            <Table.Td>
+                <Group gap="xs">
+                    <span>
+                        {expiresAt ? (
                             <Tooltip
                                 withinPortal
                                 position="top"
                                 maw={350}
-                                label={`Last rotated at ${formatTimestamp(
-                                    rotatedAt,
-                                )}`}
+                                label={formatTimestamp(expiresAt)}
                             >
-                                <MantineIcon
-                                    icon={IconInfoCircle}
-                                    color="ldGray.6"
-                                    size="md"
-                                />
+                                <span>{formatDate(expiresAt)}</span>
                             </Tooltip>
+                        ) : (
+                            'No expiration date'
                         )}
-                    </Group>
-                </Table.Td>
-                <Table.Td>
-                    {lastUsedAt && (
+                    </span>
+
+                    {rotatedAt && (
                         <Tooltip
                             withinPortal
                             position="top"
                             maw={350}
-                            label={formatTimestamp(lastUsedAt)}
+                            label={`Last rotated at ${formatTimestamp(
+                                rotatedAt,
+                            )}`}
                         >
-                            <span>{formatDate(lastUsedAt)}</span>
+                            <MantineIcon
+                                icon={IconInfoCircle}
+                                color="ldGray.6"
+                                size="md"
+                            />
                         </Tooltip>
                     )}
-                </Table.Td>
-                <Table.Td w="1%">
-                    <Menu withinPortal position="bottom-end">
-                        <Menu.Target>
-                            <ActionIcon
-                                variant="transparent"
-                                size="sm"
-                                color="ldGray.6"
-                            >
-                                <MantineIcon icon={IconDots} />
-                            </ActionIcon>
-                        </Menu.Target>
-                        <Menu.Dropdown>
+                </Group>
+            </Table.Td>
+            <Table.Td>
+                {lastUsedAt && (
+                    <Tooltip
+                        withinPortal
+                        position="top"
+                        maw={350}
+                        label={formatTimestamp(lastUsedAt)}
+                    >
+                        <span>{formatDate(lastUsedAt)}</span>
+                    </Tooltip>
+                )}
+            </Table.Td>
+            <Table.Td w="1%">
+                <Menu withinPortal position="bottom-end">
+                    <Menu.Target>
+                        <ActionIcon
+                            variant="transparent"
+                            size="sm"
+                            color="ldGray.6"
+                        >
+                            <MantineIcon icon={IconDots} />
+                        </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconCopy} />}
+                            onClick={() => setTokenToCopy(token)}
+                        >
+                            Copy token UUID
+                        </Menu.Item>
+                        {token.expiresAt && (
                             <Menu.Item
-                                leftSection={<MantineIcon icon={IconCopy} />}
-                                onClick={() => setTokenToCopy(token)}
+                                leftSection={<MantineIcon icon={IconRefresh} />}
+                                onClick={() => setTokenToRotate(token)}
                             >
-                                Copy token UUID
+                                Rotate token
                             </Menu.Item>
-                            {token.expiresAt && (
-                                <Menu.Item
-                                    leftSection={
-                                        <MantineIcon icon={IconRefresh} />
-                                    }
-                                    onClick={() => setTokenToRotate(token)}
-                                >
-                                    Rotate token
-                                </Menu.Item>
-                            )}
-                            <Menu.Item
-                                leftSection={<MantineIcon icon={IconTrash} />}
-                                color="red"
-                                onClick={() => setTokenToDelete(token)}
-                            >
-                                Delete
-                            </Menu.Item>
-                        </Menu.Dropdown>
-                    </Menu>
-                </Table.Td>
-            </Table.Tr>
-        </>
+                        )}
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconTrash} />}
+                            color="red"
+                            onClick={() => setTokenToDelete(token)}
+                        >
+                            Delete
+                        </Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
+            </Table.Td>
+        </Table.Tr>
     );
 };
 

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.module.css
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.module.css
@@ -1,7 +1,3 @@
-.table thead tr th {
-    text-align: left;
-}
-
 .uuid {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
     user-select: all;

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
@@ -5,7 +5,6 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
-    Button,
     CopyButton,
     Group,
     Paper,
@@ -41,107 +40,92 @@ const TokenItem: FC<{
 }> = ({ token, setTokenToDelete }) => {
     const { description, expiresAt, rotatedAt, lastUsedAt, uuid } = token;
     return (
-        <>
-            <tr>
-                <Text
-                    component="td"
-                    fw={500}
-                    className={classesModule.nameColumn}
-                >
+        <Table.Tr>
+            <Table.Td>
+                <Text fw={500} fz="sm">
                     {description}
                 </Text>
+            </Table.Td>
 
-                <td>
-                    <Group align="center" justify="flex-start" gap="xs">
-                        <span>
-                            {expiresAt
-                                ? formatDate(expiresAt)
-                                : 'No expiration date'}
-                        </span>
-                        {rotatedAt && (
+            <Table.Td>
+                <Group gap="xs">
+                    <span>
+                        {expiresAt
+                            ? formatDate(expiresAt)
+                            : 'No expiration date'}
+                    </span>
+                    {rotatedAt && (
+                        <Tooltip
+                            withinPortal
+                            position="top"
+                            maw={350}
+                            label={`Last rotated at ${formatTimestamp(
+                                rotatedAt,
+                            )}`}
+                        >
+                            <MantineIcon
+                                icon={IconInfoCircle}
+                                color="ldGray.6"
+                                size="md"
+                            />
+                        </Tooltip>
+                    )}
+                </Group>
+            </Table.Td>
+            <Table.Td>
+                {lastUsedAt ? (
+                    <Tooltip
+                        withinPortal
+                        position="top"
+                        maw={350}
+                        label={formatTimestamp(lastUsedAt)}
+                    >
+                        <span>{formatDate(lastUsedAt)}</span>
+                    </Tooltip>
+                ) : (
+                    <span>Never used</span>
+                )}
+            </Table.Td>
+            <Table.Td>
+                <Group gap="xs" wrap="nowrap">
+                    <Tooltip withinPortal position="top" maw={350} label={uuid}>
+                        <Text fz="sm" className={classesModule.uuid}>
+                            ...{uuid.slice(-8)}
+                        </Text>
+                    </Tooltip>
+                    <CopyButton value={uuid}>
+                        {({ copied, copy }) => (
                             <Tooltip
-                                withinPortal
-                                position="top"
-                                maw={350}
-                                label={`Last rotated at ${formatTimestamp(
-                                    rotatedAt,
-                                )}`}
+                                label={copied ? 'Copied' : 'Copy'}
+                                withArrow
+                                position="right"
                             >
-                                <MantineIcon
-                                    icon={IconInfoCircle}
+                                <ActionIcon
+                                    size="xs"
+                                    onClick={copy}
+                                    variant="transparent"
                                     color="ldGray.6"
-                                    size="md"
-                                />
+                                >
+                                    <MantineIcon
+                                        icon={copied ? IconCheck : IconCopy}
+                                    />
+                                </ActionIcon>
                             </Tooltip>
                         )}
-                    </Group>
-                </td>
-                <td>
-                    {lastUsedAt ? (
-                        <Tooltip
-                            withinPortal
-                            position="top"
-                            maw={350}
-                            label={formatTimestamp(lastUsedAt)}
-                        >
-                            <span>{formatDate(lastUsedAt)}</span>
-                        </Tooltip>
-                    ) : (
-                        <span>Never used</span>
-                    )}
-                </td>
-                <td>
-                    <Group
-                        align="center"
-                        justify="flex-start"
-                        gap="xs"
-                        wrap="nowrap"
-                    >
-                        <Tooltip
-                            withinPortal
-                            position="top"
-                            maw={350}
-                            label={uuid}
-                        >
-                            <span className={classesModule.uuid}>
-                                ...{uuid.slice(-8)}
-                            </span>
-                        </Tooltip>
-                        <CopyButton value={uuid}>
-                            {({ copied, copy }) => (
-                                <Tooltip
-                                    label={copied ? 'Copied' : 'Copy'}
-                                    withArrow
-                                    position="right"
-                                >
-                                    <ActionIcon
-                                        size="xs"
-                                        onClick={copy}
-                                        variant="transparent"
-                                    >
-                                        <MantineIcon
-                                            color="ldGray.6"
-                                            icon={copied ? IconCheck : IconCopy}
-                                        />
-                                    </ActionIcon>
-                                </Tooltip>
-                            )}
-                        </CopyButton>
-                    </Group>
-                </td>
-                <td width="1%">
-                    <Button
-                        px="xs"
-                        variant="outline"
-                        size="xs"
-                        color="red"
-                        onClick={() => setTokenToDelete(token)}
-                    >
-                        <MantineIcon icon={IconTrash} />
-                    </Button>
-                </td>
-            </tr>
-        </>
+                    </CopyButton>
+                </Group>
+            </Table.Td>
+            <Table.Td w="1%">
+                <ActionIcon
+                    variant="outline"
+                    size="md"
+                    color="red"
+                    onClick={() => setTokenToDelete(token)}
+                >
+                    <MantineIcon icon={IconTrash} />
+                </ActionIcon>
+            </Table.Td>
+        </Table.Tr>
     );
 };
 
@@ -164,27 +148,23 @@ export const TokensTable = () => {
     return (
         <>
             <Paper withBorder style={{ overflow: 'hidden' }}>
-                <Table
-                    className={cx(
-                        classes.root,
-                        classes.alignLastTdRight,
-                        classesModule.table,
-                    )}
-                >
-                    <thead>
-                        <tr>
-                            <th className={classesModule.nameColumn}>Name</th>
-                            <th className={classesModule.dateColumn}>
+                <Table className={cx(classes.root, classes.alignLastTdRight)}>
+                    <Table.Thead>
+                        <Table.Tr>
+                            <Table.Th className={classesModule.nameColumn}>
+                                Name
+                            </Table.Th>
+                            <Table.Th className={classesModule.dateColumn}>
                                 Expiration date
-                            </th>
-                            <th className={classesModule.dateColumn}>
+                            </Table.Th>
+                            <Table.Th className={classesModule.dateColumn}>
                                 Last used at
-                            </th>
-                            <th>UUID</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
+                            </Table.Th>
+                            <Table.Th>UUID</Table.Th>
+                            <Table.Th></Table.Th>
+                        </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody>
                         {data?.map((token) => (
                             <TokenItem
                                 key={token.uuid}
@@ -192,7 +172,7 @@ export const TokensTable = () => {
                                 setTokenToDelete={setTokenToDelete}
                             />
                         ))}
-                    </tbody>
+                    </Table.Tbody>
                 </Table>
             </Paper>
 


### PR DESCRIPTION
Migrates the **SCIM access tokens** and **personal access tokens** tables from raw HTML table elements / Mantine 6 idioms to Mantine 8 `Table.*` subcomponents, following the frontend style guide. Same behaviour, cleaner structure — both tables now match the established pattern in `CustomRolesTable`.

## Pattern

```
Before:                          After:
  <thead><tr><th>             →   <Table.Thead><Table.Tr><Table.Th>
  <tbody><tr><td>             →   <Table.Tbody><Table.Tr><Table.Td>
  <Text component="td">       →   <Table.Td><Text>
  <td width="1%">             →   <Table.Td w="1%">
```

## Files touched

- `ee/features/scim/.../ScimAccessTokensPanel/TokensTable.tsx`
  - Raw `<tr>/<td>/<th>` → `Table.*` subcomponents.
  - Removed the `<Text component="td">` antipattern (now `Table.Td` wrapping `Text`).
  - Icon-only delete `Button` → `ActionIcon` (idiomatic for icon-only controls).
  - Dropped redundant default `Group` props (`align="center" justify="flex-start"`).
- `ee/features/scim/.../ScimAccessTokensPanel/TokensTable.module.css`
  - Removed `.table thead tr th { text-align: left }` — Mantine 8 `Table.Th` left-aligns by default (confirmed by sibling tables that never carried this rule). Column-width and monospace-UUID rules retained.
- `components/UserSettings/AccessTokensPanel/TokensTable.tsx`
  - Removed the single-child `<>` fragment around `Table.Tr`.
  - Dropped redundant default `Group` props; `size="sm"` → `fz="sm"` for consistency.

The personal-tokens table was already on Mantine 8 `Table.*`, so its changes are smaller cleanups; the SCIM table carried the full migration.

## Notes

- `useTableStyles` (v6 `createStyles`) and `Paper ... style={{ overflow: 'hidden' }}` are left as-is — they're the shared convention across every sibling table; changing them here would diverge rather than align.
- Column min-width now lives only on the header `Table.Th`; with `table-layout: auto` this still constrains the whole column, so layout is preserved.

## Test plan

- [x] `pnpm -F frontend typecheck:fast` passes.
- [x] Lint/format clean (lint-staged on commit).
- [ ] Not yet checked in a running browser — recommend a quick visual pass on Settings → Access Tokens and SCIM tokens (light + dark) to confirm header alignment and action-button sizing before merge.