### PR TITLE
fix(ai-agents): stack writeback PR card actions in minimized chat bubble

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.module.css
@@ -1,0 +1,19 @@
+.card {
+    container-type: inline-size;
+}
+
+.actions {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    gap: var(--mantine-spacing-xs);
+}
+
+/* In the narrow minimized chat bubble the two actions overflow side by side,
+   so stack them and let each fill the column width. */
+@container (max-width: 400px) {
+    .actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeWritebackToolCall.tsx
@@ -1,5 +1,6 @@
 import { type ToolProposeWritebackOutput } from '@lightdash/common';
 import {
+    Box,
     Button,
     Group,
     Loader,
@@ -23,6 +24,7 @@ import {
     isPreviewWaitTimedOut,
     usePullRequestPreview,
 } from '../../../hooks/usePullRequestPreview';
+import styles from './AiProposeWritebackToolCall.module.css';
 
 type Props = {
     metadata: ToolProposeWritebackOutput['metadata'];
@@ -150,7 +152,7 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
             : 'Pull request opened';
 
     return (
-        <Paper withBorder p="sm" radius="md">
+        <Paper withBorder p="sm" radius="md" className={styles.card}>
             <Group
                 gap="sm"
                 align="center"
@@ -177,7 +179,7 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
                         )}
                     </Stack>
                 </Group>
-                <Group gap="xs" wrap="nowrap">
+                <Box className={styles.actions}>
                     {isPreviewDeploySetup ? null : preview?.previewUrl ? (
                         <Button
                             component="a"
@@ -235,7 +237,7 @@ export const AiProposeWritebackToolCall: FC<Props> = ({
                     >
                         View pull request
                     </Button>
-                </Group>
+                </Box>
             </Group>
         </Paper>
     );


### PR DESCRIPTION
## Summary

In the minimized AI chat bubble (the floating launcher panel, ~360px wide), the writeback PR result card rendered its **View preview** and **View pull request** buttons side by side, overflowing the panel and clipping the "View pull request" label.

This lays the action buttons out with a CSS **container query** so they stack vertically when the card is narrow (minimized bubble) and stay side by side in the full-page agent chat. A container query keys off the card's own width rather than the viewport, so it distinguishes the narrow launcher from the full-page chat without threading an `isMinimized` prop through `AgentChatAssistantBubble`.

## Changes
- `AiProposeWritebackToolCall.tsx` — set `container-type` on the card, move the action buttons into a CSS-module flex container.
- `AiProposeWritebackToolCall.module.css` (new) — `@container (max-width: 400px)` stacks the buttons.

## Testing
Verified locally in Chrome:
- **Minimized bubble** → buttons stack vertically, both fully visible.
- **Fullscreen chat** → buttons remain side by side (no regression).

Linear: PROD-8156

🤖 Generated with [Claude Code](https://claude.com/claude-code)