### PR TITLE
refactor(frontend): apply Mantine 8 style guide to service accounts

### DIFF
--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.module.css
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.module.css
@@ -1,0 +1,3 @@
+.addProjectButton {
+    align-self: flex-start;
+}

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
@@ -35,6 +35,7 @@ import { useProjects } from '../../../hooks/useProjects';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import { useCustomRoles } from '../customRoles/useCustomRoles';
+import classes from './ServiceAccountsCreateModal.module.css';
 
 // Organization-mode role options. `Member` is intentionally hidden — it's
 // the backend marker for "Project-scope SA" (see the SegmentedControl
@@ -439,7 +440,7 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
                                             projects.length
                                     }
                                     onClick={addProjectRow}
-                                    style={{ alignSelf: 'flex-start' }}
+                                    className={classes.addProjectButton}
                                 >
                                     Add project
                                 </Button>

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -24,7 +24,6 @@ import {
     Text,
     TextInput,
     Tooltip,
-    useMantineTheme,
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
@@ -151,7 +150,6 @@ export const ServiceAccountsTable: FC<Props> = ({
     onDelete,
     isDeleting,
 }) => {
-    const theme = useMantineTheme();
     const [opened, { open, close }] = useDisclosure(false);
     const [rotateOpened, { open: openRotate, close: closeRotate }] =
         useDisclosure(false);
@@ -283,7 +281,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                                             color="red"
                                             size="xs"
                                             radius="md"
-                                            style={{ textTransform: 'none' }}
+                                            tt="none"
                                         >
                                             Stale
                                         </Badge>
@@ -327,7 +325,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                                     color="teal"
                                     radius="xs"
                                     size="sm"
-                                    style={{ textTransform: 'none' }}
+                                    tt="none"
                                 >
                                     {count}{' '}
                                     {count === 1 ? 'project' : 'projects'}
@@ -359,7 +357,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                                     color="indigo"
                                     radius="xs"
                                     size="sm"
-                                    style={{ textTransform: 'none' }}
+                                    tt="none"
                                 >
                                     {role?.name ?? 'Custom role'}
                                 </Badge>
@@ -385,9 +383,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                                                     color="gray"
                                                     radius="xs"
                                                     size="sm"
-                                                    style={{
-                                                        textTransform: 'none',
-                                                    }}
+                                                    tt="none"
                                                 >
                                                     {SCOPE_LABEL[scope] ??
                                                         scope}
@@ -407,7 +403,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                                         color="gray"
                                         radius="xs"
                                         size="sm"
-                                        style={{ textTransform: 'none' }}
+                                        tt="none"
                                     >
                                         {SCOPE_LABEL[scope] ?? scope}
                                     </Badge>
@@ -645,34 +641,9 @@ export const ServiceAccountsTable: FC<Props> = ({
         enableTopToolbar: true,
         enableBottomToolbar: false,
         enableGlobalFilter: false,
-        mantinePaperProps: {
-            shadow: undefined,
-            style: {
-                border: `1px solid ${theme.colors.ldGray[2]}`,
-                borderRadius: theme.radius.md,
-                boxShadow: theme.shadows.subtle,
-                display: 'flex',
-                flexDirection: 'column' as const,
-                overflow: 'hidden',
-            },
-        },
-        mantineTableHeadRowProps: { sx: { boxShadow: 'none' } },
-        mantineTableHeadCellProps: {
-            bg: 'ldGray.0',
-            style: {
-                userSelect: 'none',
-                padding: `${theme.spacing.xs} ${theme.spacing.md}`,
-                borderTop: `1px solid ${theme.colors.ldGray[2]}`,
-                borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
-            },
-        },
-        mantineTableBodyCellProps: {
-            style: {
-                padding: `${theme.spacing.sm} ${theme.spacing.md}`,
-                borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
-                borderTop: 'none',
-            },
-        },
+        mantinePaperProps: { className: classes.tablePaper },
+        mantineTableHeadCellProps: { className: classes.headCell },
+        mantineTableBodyCellProps: { className: classes.bodyCell },
         mantineTableProps: { highlightOnHover: true },
         state: { isLoading },
         renderEmptyRowsFallback: () => (
@@ -706,11 +677,12 @@ export const ServiceAccountsTable: FC<Props> = ({
         renderTopToolbar: () => (
             <Group
                 justify="space-between"
-                p={`${theme.spacing.sm} ${theme.spacing.md}`}
+                py="sm"
+                px="md"
                 wrap="nowrap"
                 className={classes.toolbar}
             >
-                <Group gap="xs" wrap="nowrap" style={{ flex: 1, minWidth: 0 }}>
+                <Group gap="xs" wrap="nowrap" flex={1} miw={0}>
                     <Tooltip
                         withinPortal
                         variant="xs"
@@ -755,7 +727,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                         orientation="vertical"
                         w={1}
                         h={20}
-                        style={{ alignSelf: 'center' }}
+                        className={classes.verticalDivider}
                     />
 
                     <SegmentedControl
@@ -788,7 +760,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                                 orientation="vertical"
                                 w={1}
                                 h={20}
-                                style={{ alignSelf: 'center' }}
+                                className={classes.verticalDivider}
                             />
                             <Popover width={250} position="bottom-start">
                                 <Popover.Target>
@@ -820,14 +792,9 @@ export const ServiceAccountsTable: FC<Props> = ({
                                                         variant="filled"
                                                         color="indigo.6"
                                                         circle
-                                                        styles={{
-                                                            root: {
-                                                                minWidth: 18,
-                                                                height: 18,
-                                                                padding:
-                                                                    '0 4px',
-                                                            },
-                                                        }}
+                                                        className={
+                                                            classes.creatorCountBadge
+                                                        }
                                                     >
                                                         {
                                                             selectedCreators.length

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsToolbar.module.css
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsToolbar.module.css
@@ -90,6 +90,29 @@
     border-bottom: 1px solid var(--mantine-color-ldGray-2);
 }
 
+.tablePaper {
+    border-radius: var(--mantine-radius-md);
+}
+
+.headCell {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.bodyCell {
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+}
+
+.verticalDivider {
+    align-self: center;
+}
+
+.creatorCountBadge {
+    min-width: 18px;
+    height: 18px;
+    padding: 0 4px;
+}
+
 /* Created-by filter button — mirrors the projectManagement toolbar styling
  * so settings tables look consistent across the app. */
 .filterButton {

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1220,7 +1220,7 @@ const Settings: FC = () => {
                                 {user.ability.can('manage', 'Organization') &&
                                     isScimTokenManagementEnabled?.enabled && (
                                         <RouterNavLink
-                                            label="SCIM Access Tokens"
+                                            label="SCIM access tokens"
                                             exact
                                             to="/generalSettings/scimAccessTokens"
                                             leftSection={

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1231,7 +1231,7 @@ const Settings: FC = () => {
                                 {user.ability.can('manage', 'Organization') &&
                                     isServiceAccountsEnabled && (
                                         <RouterNavLink
-                                            label="Service Accounts"
+                                            label="Service accounts"
                                             exact
                                             to="/generalSettings/serviceAccounts"
                                             leftSection={


### PR DESCRIPTION
## Summary

Brings the service accounts settings UI in line with the [frontend style guide](packages/frontend/STYLE_GUIDE.md): swaps inline `style` / `styles` / `sx` props for Mantine style props and CSS-module classes, and lowercases two settings nav labels. No behaviour or visual change.

## Why

The style guide forbids `style`, `styles`, and `sx` (the last a Mantine v6 leftover) in favour of component style props and CSS modules. The service accounts table and create modal still used all three.

## Files touched (5)

- `ServiceAccountsTable.tsx` — badges → `tt="none"`, toolbar groups → style props, table-config `style`/`sx` blocks → CSS classes, drop `useMantineTheme`
- `ServiceAccountsToolbar.module.css` — new `.tablePaper` / `.headCell` / `.bodyCell` / `.verticalDivider` / `.creatorCountBadge` classes
- `ServiceAccountsCreateModal.tsx` — "Add project" button → CSS class
- `ServiceAccountsCreateModal.module.css` — new file for the one alignment rule
- `Settings.tsx` — nav labels "Service Accounts" → "Service accounts" and "SCIM Access Tokens" → "SCIM access tokens" (matches the panel titles)

## Pattern

1. `style={{ textTransform: 'none' }}` → `tt="none"` (5 badges)
2. `style={{ flex: 1, minWidth: 0 }}` → `flex={1} miw={0}`; `p={\`${theme.spacing.sm} ${theme.spacing.md}\`}` → `py="sm" px="md"`
3. inline `style`/`styles`/`sx` needing >3 props or an unsupported property → CSS-module `className`
4. drop `useMantineTheme` once no `theme.*` reads remain

```
Before:                                    After:
  style={{ textTransform: 'none' }}          tt="none"
  style={{ flex: 1, minWidth: 0 }}           flex={1} miw={0}
  styles={{ root: { minWidth, height } }}    className={classes.creatorCountBadge}
  mantineTableHeadRowProps:{ sx:{...} }      (dropped — default already matches)
  mantine*Props:{ style:{ theme.* } }        className={classes.headCell / .bodyCell}
```

## Non-trivial bits

- The `mantinePaperProps` / `mantineTableHeadCellProps` / `mantineTableBodyCellProps` overrides largely duplicated `ContentTable`'s own default classes. The CSS classes keep only the genuine deltas — `md` paper radius, roomier header/body padding, header top border — so the table renders identically. The fully-redundant `mantineTableHeadRowProps` (`boxShadow: none`) and paper border/shadow were dropped.
- The override classes win over `ContentTable`'s defaults because `ServiceAccountsTable.tsx` imports `ContentTable` (and its CSS) before the toolbar CSS module, so the toolbar rules come later in the bundle at equal specificity.

## Test plan

- [x] `pnpm -F frontend typecheck:fast`
- [x] `pnpm -F frontend lint` (0 errors, no service-accounts warnings)
- [ ] Service accounts table renders unchanged (badges, toolbar filters, create/rotate/delete modals)
- [ ] Settings nav shows "Service accounts" and "SCIM access tokens"
- [ ] CI green

## Diff size

5 files, +46 / -52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)