### PR TITLE
feat(explorer): collapsible sidebar to maximize chart/results area (#23930)

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -50,15 +50,17 @@ import PageBreadcrumbs from '../../common/PageBreadcrumbs';
 import ExploreTree from '../ExploreTree';
 import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider';
+import { CollapseSidebarButton } from '../SidebarToggleButtons';
 import WarningsHoverCardContent from '../WarningsHoverCardContent';
 import { useIsGitProject } from '../WriteBackModal/hooks';
 import { VisualizationConfigPortalId } from './constants';
 
 interface ExplorePanelProps {
     onBack?: () => void;
+    onCollapse?: () => void;
 }
 
-const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
+const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack, onCollapse }) => {
     const { track } = useTracking();
     const { user } = useApp();
     const [isEditVirtualViewOpen, setIsEditVirtualViewOpen] = useState(false);
@@ -235,62 +237,11 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                             </HoverCard>
                         )}
                     </Group>
-                    {explore.type === ExploreType.VIRTUAL && (
-                        <Can
-                            I="create"
-                            this={subject('VirtualView', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid,
-                            })}
-                        >
-                            <Menu withArrow offset={-2}>
-                                <Menu.Target>
-                                    <ActionIcon variant="transparent">
-                                        <MantineIcon icon={IconDots} />
-                                    </ActionIcon>
-                                </Menu.Target>
-                                <Menu.Dropdown>
-                                    <Menu.Item
-                                        leftSection={
-                                            <MantineIcon icon={IconPencil} />
-                                        }
-                                        onClick={handleEditVirtualView}
-                                    >
-                                        <Text fz="xs" fw={500}>
-                                            Edit virtual view
-                                        </Text>
-                                    </Menu.Item>
-                                    <Can
-                                        I="delete"
-                                        this={subject('VirtualView', {
-                                            organizationUuid:
-                                                user.data?.organizationUuid,
-                                            projectUuid,
-                                        })}
-                                    >
-                                        <Menu.Item
-                                            leftSection={
-                                                <MantineIcon icon={IconTrash} />
-                                            }
-                                            color="red"
-                                            onClick={handleDeleteVirtualView}
-                                        >
-                                            <Text fz="xs" fw={500}>
-                                                Delete
-                                            </Text>
-                                        </Menu.Item>
-                                    </Can>
-                                </Menu.Dropdown>
-                            </Menu>
-                        </Can>
-                    )}
-                    {explore.type !== ExploreType.VIRTUAL &&
-                        isGitProject &&
-                        explore.ymlPath &&
-                        editYamlInUiFlag?.enabled && (
+                    <Group spacing="xs">
+                        {explore.type === ExploreType.VIRTUAL && (
                             <Can
-                                I="view"
-                                this={subject('SourceCode', {
+                                I="create"
+                                this={subject('VirtualView', {
                                     organizationUuid:
                                         user.data?.organizationUuid,
                                     projectUuid,
@@ -305,18 +256,83 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                                     <Menu.Dropdown>
                                         <Menu.Item
                                             leftSection={
-                                                <MantineIcon icon={IconCode} />
+                                                <MantineIcon
+                                                    icon={IconPencil}
+                                                />
                                             }
-                                            onClick={handleViewSourceCode}
+                                            onClick={handleEditVirtualView}
                                         >
                                             <Text fz="xs" fw={500}>
-                                                View source code
+                                                Edit virtual view
                                             </Text>
                                         </Menu.Item>
+                                        <Can
+                                            I="delete"
+                                            this={subject('VirtualView', {
+                                                organizationUuid:
+                                                    user.data?.organizationUuid,
+                                                projectUuid,
+                                            })}
+                                        >
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                    />
+                                                }
+                                                color="red"
+                                                onClick={
+                                                    handleDeleteVirtualView
+                                                }
+                                            >
+                                                <Text fz="xs" fw={500}>
+                                                    Delete
+                                                </Text>
+                                            </Menu.Item>
+                                        </Can>
                                     </Menu.Dropdown>
                                 </Menu>
                             </Can>
                         )}
+                        {explore.type !== ExploreType.VIRTUAL &&
+                            isGitProject &&
+                            explore.ymlPath &&
+                            editYamlInUiFlag?.enabled && (
+                                <Can
+                                    I="view"
+                                    this={subject('SourceCode', {
+                                        organizationUuid:
+                                            user.data?.organizationUuid,
+                                        projectUuid,
+                                    })}
+                                >
+                                    <Menu withArrow offset={-2}>
+                                        <Menu.Target>
+                                            <ActionIcon variant="transparent">
+                                                <MantineIcon icon={IconDots} />
+                                            </ActionIcon>
+                                        </Menu.Target>
+                                        <Menu.Dropdown>
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconCode}
+                                                    />
+                                                }
+                                                onClick={handleViewSourceCode}
+                                            >
+                                                <Text fz="xs" fw={500}>
+                                                    View source code
+                                                </Text>
+                                            </Menu.Item>
+                                        </Menu.Dropdown>
+                                    </Menu>
+                                </Can>
+                            )}
+                        {onCollapse && (
+                            <CollapseSidebarButton onClick={onCollapse} />
+                        )}
+                    </Group>
                 </Group>
 
                 <ItemDetailProvider>

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { ExploreType, type SummaryExplore } from '@lightdash/common';
-import { ActionIcon, Stack, TextInput } from '@mantine/core';
+import { ActionIcon, Group, Stack, TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import {
     IconAlertCircle,
@@ -21,6 +21,7 @@ import PageBreadcrumbs from '../../common/PageBreadcrumbs';
 import SuboptimalState from '../../common/SuboptimalState/SuboptimalState';
 import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider';
+import { CollapseSidebarButton } from '../SidebarToggleButtons';
 import { buildExploreTree, sortExploreTree } from './exploreTree';
 import VirtualizedExploreList from './VirtualizedExploreList';
 
@@ -32,7 +33,11 @@ const getPreAggregateName = (explore: SummaryExplore) =>
 const exploreHasGroups = (explore: SummaryExplore): boolean =>
     !!(explore.groups && explore.groups.length > 0) || !!explore.groupLabel;
 
-const BasePanel = () => {
+interface BasePanelProps {
+    onCollapse?: () => void;
+}
+
+const BasePanel = ({ onCollapse }: BasePanelProps) => {
     const navigate = useNavigate();
     const location = useLocation();
     const projectUuid = useProjectUuid();
@@ -157,18 +162,23 @@ const BasePanel = () => {
             <>
                 <ItemDetailProvider>
                     <Stack h="100%" sx={{ flexGrow: 1 }}>
-                        <Can
-                            I="manage"
-                            this={subject('Explore', {
-                                organizationUuid: org?.organizationUuid,
-                                projectUuid,
-                            })}
-                        >
-                            <PageBreadcrumbs
-                                size="md"
-                                items={[{ title: 'Tables', active: true }]}
-                            />
-                        </Can>
+                        <Group position="apart" align="center">
+                            <Can
+                                I="manage"
+                                this={subject('Explore', {
+                                    organizationUuid: org?.organizationUuid,
+                                    projectUuid,
+                                })}
+                            >
+                                <PageBreadcrumbs
+                                    size="md"
+                                    items={[{ title: 'Tables', active: true }]}
+                                />
+                            </Can>
+                            {onCollapse && (
+                                <CollapseSidebarButton onClick={onCollapse} />
+                            )}
+                        </Group>
 
                         <TextInput
                             icon={<MantineIcon icon={IconSearch} />}

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -26,7 +26,11 @@ import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 const LazyExplorePanel = lazy(() => import('../ExplorePanel'));
 const LazyBasePanel = lazy(() => import('./BasePanel'));
 
-const ExploreSideBar = memo(() => {
+interface ExploreSideBarProps {
+    onCollapse?: () => void;
+}
+
+const ExploreSideBar = memo(({ onCollapse }: ExploreSideBarProps) => {
     const projectUuid = useProjectUuid();
 
     const tableName = useExplorerSelector(selectTableName);
@@ -71,12 +75,13 @@ const ExploreSideBar = memo(() => {
                 <LoadingSkeleton />
             ) : !tableName ? (
                 <Suspense fallback={<LoadingSkeleton />}>
-                    <LazyBasePanel />
+                    <LazyBasePanel onCollapse={onCollapse} />
                 </Suspense>
             ) : (
                 <Suspense fallback={<LoadingSkeleton />}>
                     <LazyExplorePanel
                         onBack={canManageExplore ? handleBack : undefined}
+                        onCollapse={onCollapse}
                     />
                 </Suspense>
             )}

--- a/packages/frontend/src/components/Explorer/SidebarToggleButtons.tsx
+++ b/packages/frontend/src/components/Explorer/SidebarToggleButtons.tsx
@@ -1,0 +1,47 @@
+import { ActionIcon, Paper, Tooltip } from '@mantine-8/core';
+import {
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+
+type Props = {
+    onClick: () => void;
+};
+
+/** Collapses the Explore sidebar — lives in the sidebar panel header. */
+export const CollapseSidebarButton: FC<Props> = ({ onClick }) => (
+    <Tooltip label="Collapse sidebar" variant="xs" position="right">
+        <ActionIcon
+            variant="subtle"
+            color="gray"
+            size="lg"
+            onClick={onClick}
+            aria-label="Collapse sidebar"
+        >
+            <MantineIcon icon={IconLayoutSidebarLeftCollapse} />
+        </ActionIcon>
+    </Tooltip>
+);
+
+/**
+ * Thin full-height gutter holding the "open sidebar" control. Shown in the
+ * content area while the sidebar is collapsed (SqlRunner-style clean toggle —
+ * the sidebar stays hidden until reopened, no floating/hover reveal).
+ */
+export const SidebarOpenGutter: FC<Props> = ({ onClick }) => (
+    <Paper shadow="none" radius={0} px="xs" py="md" style={{ flexShrink: 0 }}>
+        <Tooltip label="Open sidebar" variant="xs" position="right">
+            <ActionIcon
+                variant="subtle"
+                color="gray"
+                size="lg"
+                onClick={onClick}
+                aria-label="Open sidebar"
+            >
+                <MantineIcon icon={IconLayoutSidebarLeftExpand} />
+            </ActionIcon>
+        </Tooltip>
+    </Paper>
+);

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -233,12 +233,25 @@ const VisualizationCard: FC<Props> = memo((props) => {
     } = useElementSize();
 
     useLayoutEffect(() => {
-        if (isVisualizationConfigOpen) {
-            const target = document.getElementById(VisualizationConfigPortalId);
-            setPortalTarget(target);
-        } else {
+        if (!isVisualizationConfigOpen) {
             setPortalTarget(null);
+            return;
         }
+        // The portal target lives in the sidebar, which may still be mounting
+        // (e.g. reopening after a collapse — Mantine's Transition renders its
+        // children a frame later), so retry until the element appears.
+        let frame: number;
+        let attempts = 0;
+        const acquire = () => {
+            const target = document.getElementById(VisualizationConfigPortalId);
+            if (target) {
+                setPortalTarget(target);
+            } else if (attempts++ < 60) {
+                frame = requestAnimationFrame(acquire);
+            }
+        };
+        acquire();
+        return () => cancelAnimationFrame(frame);
     }, [isVisualizationConfigOpen]);
 
     useLayoutEffect(() => {

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { Group } from '@mantine-8/core';
 import { useHotkeys } from '@mantine/hooks';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Provider } from 'react-redux';
 import { useNavigate, useParams } from 'react-router';
 import Page from '../components/common/Page/Page';
@@ -13,6 +13,7 @@ import {
     buildInitialExplorerState,
     createExplorerStore,
     explorerActions,
+    selectIsVisualizationConfigOpen,
     selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
@@ -37,6 +38,21 @@ const ExplorerContent = memo(() => {
     const navigate = useNavigate();
 
     const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
+    // The chart config panel renders inside the sidebar (via a portal). Opening
+    // it while the sidebar is collapsed must reveal the sidebar, otherwise the
+    // panel has nowhere to render. Fire only on the open transition so a manual
+    // collapse afterwards still works.
+    const isVizConfigOpen = useExplorerSelector(
+        selectIsVisualizationConfigOpen,
+    );
+    const prevVizConfigOpen = useRef(isVizConfigOpen);
+    useEffect(() => {
+        if (isVizConfigOpen && !prevVizConfigOpen.current) {
+            setIsSidebarOpen(true);
+        }
+        prevVizConfigOpen.current = isVizConfigOpen;
+    }, [isVizConfigOpen]);
 
     // Get table name from Redux
     const tableId = useExplorerSelector(selectTableName);

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { Group } from '@mantine-8/core';
 import { useHotkeys } from '@mantine/hooks';
 import { memo, useCallback, useState } from 'react';
 import { Provider } from 'react-redux';
@@ -6,6 +7,7 @@ import { useNavigate, useParams } from 'react-router';
 import Page from '../components/common/Page/Page';
 import Explorer from '../components/Explorer';
 import ExploreSideBar from '../components/Explorer/ExploreSideBar/index';
+import { SidebarOpenGutter } from '../components/Explorer/SidebarToggleButtons';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import {
     buildInitialExplorerState,
@@ -34,6 +36,8 @@ const ExplorerContent = memo(() => {
     const dispatch = useExplorerDispatch();
     const navigate = useNavigate();
 
+    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
     // Get table name from Redux
     const tableId = useExplorerSelector(selectTableName);
     const { data } = useExplore(tableId);
@@ -54,11 +58,27 @@ const ExplorerContent = memo(() => {
     return (
         <Page
             title={data ? data?.label : 'Tables'}
-            sidebar={<ExploreSideBar />}
+            sidebar={
+                <ExploreSideBar onCollapse={() => setIsSidebarOpen(false)} />
+            }
+            isSidebarOpen={isSidebarOpen}
             withFullHeight
             withPaddedContent
         >
-            <Explorer />
+            <Group
+                h="100%"
+                align="stretch"
+                wrap="nowrap"
+                gap="xs"
+                style={{ flexGrow: 1 }}
+            >
+                {!isSidebarOpen && (
+                    <SidebarOpenGutter onClick={() => setIsSidebarOpen(true)} />
+                )}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <Explorer />
+                </div>
+            </Group>
         </Page>
     );
 });

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { Group } from '@mantine-8/core';
 import { useHotkeys } from '@mantine/hooks';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { Provider } from 'react-redux';
 import { useNavigate, useParams } from 'react-router';
 import Page from '../components/common/Page/Page';
@@ -39,20 +39,14 @@ const ExplorerContent = memo(() => {
 
     const [isSidebarOpen, setIsSidebarOpen] = useState(true);
 
-    // The chart config panel renders inside the sidebar (via a portal). Opening
-    // it while the sidebar is collapsed must reveal the sidebar, otherwise the
-    // panel has nowhere to render. Fire only on the open transition so a manual
-    // collapse afterwards still works.
+    // The chart config panel renders inside the sidebar (via a portal), so the
+    // sidebar must be visible whenever config is open — even if collapsed.
+    // Deriving it (rather than reacting in an effect) keeps the portal target
+    // mounted in the same render the config opens, so it has somewhere to go.
     const isVizConfigOpen = useExplorerSelector(
         selectIsVisualizationConfigOpen,
     );
-    const prevVizConfigOpen = useRef(isVizConfigOpen);
-    useEffect(() => {
-        if (isVizConfigOpen && !prevVizConfigOpen.current) {
-            setIsSidebarOpen(true);
-        }
-        prevVizConfigOpen.current = isVizConfigOpen;
-    }, [isVizConfigOpen]);
+    const isSidebarVisible = isSidebarOpen || isVizConfigOpen;
 
     // Get table name from Redux
     const tableId = useExplorerSelector(selectTableName);
@@ -77,7 +71,7 @@ const ExplorerContent = memo(() => {
             sidebar={
                 <ExploreSideBar onCollapse={() => setIsSidebarOpen(false)} />
             }
-            isSidebarOpen={isSidebarOpen}
+            isSidebarOpen={isSidebarVisible}
             withFullHeight
             withPaddedContent
         >
@@ -88,7 +82,7 @@ const ExplorerContent = memo(() => {
                 gap="xs"
                 style={{ flexGrow: 1 }}
             >
-                {!isSidebarOpen && (
+                {!isSidebarVisible && (
                     <SidebarOpenGutter onClick={() => setIsSidebarOpen(true)} />
                 )}
                 <div style={{ flex: 1, minWidth: 0 }}>

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,3 +1,4 @@
+import { Group } from '@mantine-8/core';
 import { lazy, memo, Suspense, useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
@@ -7,6 +8,7 @@ import SuboptimalState from '../components/common/SuboptimalState/SuboptimalStat
 import Explorer from '../components/Explorer';
 import LoadingSkeleton from '../components/Explorer/ExploreTree/LoadingSkeleton';
 import SavedChartsHeader from '../components/Explorer/SavedChartsHeader';
+import { SidebarOpenGutter } from '../components/Explorer/SidebarToggleButtons';
 import {
     buildInitialExplorerState,
     createExplorerStore,
@@ -26,8 +28,13 @@ const SavedExplorerContent = memo(() => {
     const { mode } = useParams<{ mode?: string }>();
     const isEditMode = mode === 'edit';
 
+    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
     // Run the query effects hook - orchestrates all query effects
     useExplorerQueryEffects();
+
+    // Sidebar only exists in edit mode
+    const showGutter = isEditMode && !isSidebarOpen;
 
     return (
         <Page
@@ -35,14 +42,29 @@ const SavedExplorerContent = memo(() => {
             header={<SavedChartsHeader />}
             sidebar={
                 <Suspense fallback={<LoadingSkeleton />}>
-                    <LazyExplorePanel />
+                    <LazyExplorePanel
+                        onCollapse={() => setIsSidebarOpen(false)}
+                    />
                 </Suspense>
             }
-            isSidebarOpen={isEditMode}
+            isSidebarOpen={isEditMode && isSidebarOpen}
             withFullHeight
             withPaddedContent
         >
-            <Explorer />
+            <Group
+                h="100%"
+                align="stretch"
+                wrap="nowrap"
+                gap="xs"
+                style={{ flexGrow: 1 }}
+            >
+                {showGutter && (
+                    <SidebarOpenGutter onClick={() => setIsSidebarOpen(true)} />
+                )}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <Explorer />
+                </div>
+            </Group>
         </Page>
     );
 });

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,5 +1,5 @@
 import { Group } from '@mantine-8/core';
-import { lazy, memo, Suspense, useEffect, useState } from 'react';
+import { lazy, memo, Suspense, useEffect, useRef, useState } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
 import ErrorState from '../components/common/ErrorState';
@@ -13,6 +13,8 @@ import {
     buildInitialExplorerState,
     createExplorerStore,
     explorerActions,
+    selectIsVisualizationConfigOpen,
+    useExplorerSelector,
 } from '../features/explorer/store';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
@@ -29,6 +31,21 @@ const SavedExplorerContent = memo(() => {
     const isEditMode = mode === 'edit';
 
     const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
+    // The chart config panel renders inside the sidebar (via a portal). Opening
+    // it while the sidebar is collapsed must reveal the sidebar, otherwise the
+    // panel has nowhere to render. Fire only on the open transition so a manual
+    // collapse afterwards still works.
+    const isVizConfigOpen = useExplorerSelector(
+        selectIsVisualizationConfigOpen,
+    );
+    const prevVizConfigOpen = useRef(isVizConfigOpen);
+    useEffect(() => {
+        if (isVizConfigOpen && !prevVizConfigOpen.current) {
+            setIsSidebarOpen(true);
+        }
+        prevVizConfigOpen.current = isVizConfigOpen;
+    }, [isVizConfigOpen]);
 
     // Run the query effects hook - orchestrates all query effects
     useExplorerQueryEffects();

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,5 +1,5 @@
 import { Group } from '@mantine-8/core';
-import { lazy, memo, Suspense, useEffect, useRef, useState } from 'react';
+import { lazy, memo, Suspense, useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
 import ErrorState from '../components/common/ErrorState';
@@ -32,26 +32,20 @@ const SavedExplorerContent = memo(() => {
 
     const [isSidebarOpen, setIsSidebarOpen] = useState(true);
 
-    // The chart config panel renders inside the sidebar (via a portal). Opening
-    // it while the sidebar is collapsed must reveal the sidebar, otherwise the
-    // panel has nowhere to render. Fire only on the open transition so a manual
-    // collapse afterwards still works.
+    // The chart config panel renders inside the sidebar (via a portal), so the
+    // sidebar must be visible whenever config is open — even if collapsed.
+    // Deriving it (rather than reacting in an effect) keeps the portal target
+    // mounted in the same render the config opens, so it has somewhere to go.
     const isVizConfigOpen = useExplorerSelector(
         selectIsVisualizationConfigOpen,
     );
-    const prevVizConfigOpen = useRef(isVizConfigOpen);
-    useEffect(() => {
-        if (isVizConfigOpen && !prevVizConfigOpen.current) {
-            setIsSidebarOpen(true);
-        }
-        prevVizConfigOpen.current = isVizConfigOpen;
-    }, [isVizConfigOpen]);
 
     // Run the query effects hook - orchestrates all query effects
     useExplorerQueryEffects();
 
     // Sidebar only exists in edit mode
-    const showGutter = isEditMode && !isSidebarOpen;
+    const isSidebarVisible = isEditMode && (isSidebarOpen || isVizConfigOpen);
+    const showGutter = isEditMode && !isSidebarVisible;
 
     return (
         <Page
@@ -64,7 +58,7 @@ const SavedExplorerContent = memo(() => {
                     />
                 </Suspense>
             }
-            isSidebarOpen={isEditMode && isSidebarOpen}
+            isSidebarOpen={isSidebarVisible}
             withFullHeight
             withPaddedContent
         >

--- a/packages/frontend/src/stories/ExplorerSidebarCollapse.stories.tsx
+++ b/packages/frontend/src/stories/ExplorerSidebarCollapse.stories.tsx
@@ -1,0 +1,234 @@
+import {
+    ActionIcon,
+    Box,
+    Group,
+    Paper,
+    SimpleGrid,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine-8/core';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+    IconChevronLeft,
+    IconChevronsLeft,
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
+    IconSearch,
+} from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import MantineIcon from '../components/common/MantineIcon';
+
+/**
+ * Cosmetic exploration for lightdash/lightdash#23930 — a collapse toggle for the
+ * Explore view's left sidebar. These are presentational mockups of the sidebar
+ * header so we can compare button placement and icon choices in isolation; the
+ * real wiring lives on the `Page`/`Sidebar` components.
+ */
+
+const SIDEBAR_WIDTH = 320;
+
+const CollapseButton: FC<{
+    icon: typeof IconLayoutSidebarLeftCollapse;
+}> = ({ icon }) => (
+    <Tooltip label="Collapse sidebar" variant="xs" position="right">
+        <ActionIcon
+            variant="subtle"
+            color="gray"
+            size="lg"
+            aria-label="Collapse sidebar"
+        >
+            <MantineIcon icon={icon} />
+        </ActionIcon>
+    </Tooltip>
+);
+
+const Breadcrumb: FC<{ label: string }> = ({ label }) => (
+    <Text fw={600} size="md">
+        {label}
+    </Text>
+);
+
+/** A faux field tree so the header is shown in a realistic sidebar context. */
+const FakeTree: FC = () => (
+    <Stack gap={4} mt="xs">
+        {['Orders', 'Customers', 'Payments', 'Order items', 'Stores'].map(
+            (t) => (
+                <Text key={t} size="sm" c="dimmed" pl="xs">
+                    {t}
+                </Text>
+            ),
+        )}
+    </Stack>
+);
+
+const SidebarShell: FC<{ title: string; children: ReactNode }> = ({
+    title,
+    children,
+}) => (
+    <Stack gap="xs">
+        <Text size="xs" fw={600} c="dimmed" tt="uppercase">
+            {title}
+        </Text>
+        <Paper
+            withBorder
+            radius={0}
+            p="md"
+            w={SIDEBAR_WIDTH}
+            h={420}
+            bg="background"
+        >
+            {children}
+        </Paper>
+    </Stack>
+);
+
+const meta: Meta = {
+    title: 'Explorer/Collapsible Sidebar (#23930)',
+    decorators: [
+        (Story) => (
+            <Box bg="gray.0" p="xl">
+                <Story />
+            </Box>
+        ),
+    ],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+/** Placement A — toggle pinned to the far right (matches Settings). */
+const PlacementRight: FC = () => (
+    <SidebarShell title="A · Far right (space-between) — matches Settings">
+        <Stack gap="sm" h="100%">
+            <Group justify="space-between" align="center">
+                <Breadcrumb label="Orders" />
+                <CollapseButton icon={IconLayoutSidebarLeftCollapse} />
+            </Group>
+            <TextInput
+                leftSection={<MantineIcon icon={IconSearch} />}
+                placeholder="Search fields"
+                size="xs"
+            />
+            <FakeTree />
+        </Stack>
+    </SidebarShell>
+);
+
+/** Placement B — toggle inline, immediately after the breadcrumb. */
+const PlacementInline: FC = () => (
+    <SidebarShell title="B · Inline, right of breadcrumb">
+        <Stack gap="sm" h="100%">
+            <Group gap="xs" align="center">
+                <Breadcrumb label="Orders" />
+                <CollapseButton icon={IconLayoutSidebarLeftCollapse} />
+            </Group>
+            <TextInput
+                leftSection={<MantineIcon icon={IconSearch} />}
+                placeholder="Search fields"
+                size="xs"
+            />
+            <FakeTree />
+        </Stack>
+    </SidebarShell>
+);
+
+/** Placement C — toggle on the far left, before the breadcrumb. */
+const PlacementLeft: FC = () => (
+    <SidebarShell title="C · Far left, before breadcrumb">
+        <Stack gap="sm" h="100%">
+            <Group gap="xs" align="center">
+                <CollapseButton icon={IconLayoutSidebarLeftCollapse} />
+                <Breadcrumb label="Orders" />
+            </Group>
+            <TextInput
+                leftSection={<MantineIcon icon={IconSearch} />}
+                placeholder="Search fields"
+                size="xs"
+            />
+            <FakeTree />
+        </Stack>
+    </SidebarShell>
+);
+
+export const Placement: Story = {
+    render: () => (
+        <SimpleGrid cols={{ base: 1, md: 3 }} spacing="xl">
+            <PlacementRight />
+            <PlacementInline />
+            <PlacementLeft />
+        </SimpleGrid>
+    ),
+};
+
+export const IconChoice: Story = {
+    render: () => (
+        <Group gap="xl" align="flex-start">
+            {[
+                {
+                    label: 'IconLayoutSidebarLeftCollapse (Settings-consistent)',
+                    icon: IconLayoutSidebarLeftCollapse,
+                },
+                { label: 'IconChevronsLeft', icon: IconChevronsLeft },
+                { label: 'IconChevronLeft', icon: IconChevronLeft },
+            ].map(({ label, icon }) => (
+                <Stack key={label} gap="xs" align="center" w={220}>
+                    <Group
+                        justify="space-between"
+                        align="center"
+                        w={SIDEBAR_WIDTH - 80}
+                        p="xs"
+                        style={{
+                            border: '1px dashed var(--mantine-color-gray-3)',
+                        }}
+                    >
+                        <Breadcrumb label="Orders" />
+                        <CollapseButton icon={icon} />
+                    </Group>
+                    <Text size="xs" c="dimmed" ta="center">
+                        {label}
+                    </Text>
+                </Stack>
+            ))}
+        </Group>
+    ),
+};
+
+/**
+ * Collapsed state — SqlRunner-style clean toggle. The sidebar fully hides and a
+ * thin persistent gutter holding the "Open sidebar" control stays at the left of
+ * the content. No floating overlay, no hover-to-peek — one click to reopen.
+ */
+export const CollapsedOpenGutter: Story = {
+    render: () => (
+        <Stack gap="md">
+            <Text size="sm" c="dimmed">
+                When collapsed, the sidebar is gone and the content reclaims the
+                full width. A persistent gutter keeps the open control visible:
+            </Text>
+            <Paper
+                withBorder
+                radius={0}
+                px="xs"
+                py="md"
+                h={420}
+                w={56}
+                style={{ display: 'inline-block' }}
+                bg="background"
+            >
+                <Tooltip label="Open sidebar" variant="xs" position="right">
+                    <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        size="lg"
+                        aria-label="Open sidebar"
+                    >
+                        <MantineIcon icon={IconLayoutSidebarLeftExpand} />
+                    </ActionIcon>
+                </Tooltip>
+            </Paper>
+        </Stack>
+    ),
+};


### PR DESCRIPTION
## Description

Closes #23930.

Adds a clean collapse toggle for the Explore view's left sidebar so the chart and results area can use the full width.

- **Collapse** button in the sidebar header — works in both the field-selector view (`ExplorePanel`) and the Tables view (`BasePanel`).
- When collapsed, the sidebar fully hides and the content reclaims the width; a persistent **full-height gutter** holds an "Open sidebar" control to bring it back.
- Mirrors the existing **SqlRunner** pattern (plain `isSidebarOpen` show/hide) rather than the Settings pin/peek floating-overlay pattern (#23623) — no hover-to-reveal.
- Saved-chart view keeps this scoped to **edit mode** (view mode behaviour unchanged).

## Implementation

- New `SidebarToggleButtons.tsx`: `CollapseSidebarButton` (header) + `SidebarOpenGutter` (collapsed rail).
- `Explorer.tsx` / `SavedExplorer.tsx`: local `isSidebarOpen` state wired to `Page`'s `isSidebarOpen`; collapse handler threaded through `ExploreSideBar` → `ExplorePanel`/`BasePanel`.
- Storybook story (`ExplorerSidebarCollapse.stories.tsx`) documenting button placement, icon, and the collapsed gutter.

## How to test

1. Open an Explore (`/projects/:uuid/tables` or a saved chart in edit mode).
2. Click the collapse button at the top-right of the sidebar header → sidebar hides, content goes full width, an "Open sidebar" rail appears on the left.
3. Click "Open sidebar" → sidebar returns. Hovering the edge does nothing (no peek).

Verified locally end-to-end (login → collapse → reopen) on the Tables and field-selector views; typecheck + oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)