### PR TITLE
feat(frontend): reusable guided-tour onboarding kit

### DIFF
--- a/.claude/skills/add-onboarding-tour/SKILL.md
+++ b/.claude/skills/add-onboarding-tour/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: add-onboarding-tour
+description: Add a first-run guided tour, product walkthrough, coachmarks, or empty-state mock/example data to a Lightdash frontend feature. Use when the user wants to onboard users to a page, add a "Take the tour" flow, explain an unfamiliar UI, or show sample data on an empty page.
+allowed-tools: Read, Edit, Write, Glob, Grep
+---
+
+# Add an Onboarding Tour
+
+A zero-dependency, centralised kit for first-run onboarding in `packages/frontend`. Three reusable pieces do the heavy lifting; each feature only supplies its own steps, copy, anchors, and (optionally) example data.
+
+## Building blocks
+
+| Piece | Path | Job |
+|---|---|---|
+| `useGuidedTour` | `src/hooks/useGuidedTour.ts` | localStorage seen-flag, first-visit auto-open, replay. Returns `{ isOpen, startTour, closeTour }`. |
+| `GuidedTour` | `src/components/common/GuidedTour` | Spotlight rendering. Dims the page, highlights a `data-tour` target, anchors a Next/Back/Skip card. `target: null` → centered card. |
+| `useOnboardingMock` | `src/hooks/useOnboardingMock.ts` | A react-query `select` that swaps real data for deterministic mock rows while a flag is on. |
+
+**Reference implementation:** `src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx` (wiring) and `AiAgentAdminReviewItemsTable.tsx` (mock rows). Read these first — copying them is the fastest path.
+
+## Recipe
+
+1. **Wire the tour state** in the feature page:
+   ```tsx
+   const { isOpen, startTour, closeTour } = useGuidedTour({
+       storageKey: 'ld.<feature>.tour.v1',
+   });
+   ```
+
+2. **Define steps** (memoised). Each `target` is a CSS selector resolved when the step is reached, or `null` for a centered explainer:
+   ```tsx
+   const steps: GuidedTourStep[] = useMemo(() => [
+       { target: '[data-tour="<feature>-intro"]', title: '…', body: '…' },
+       { target: '[data-tour="<feature>-row"]',   title: '…', body: '…' },
+       { target: null, title: '…', body: <SomeDiagram /> }, // centered
+   ], []);
+   ```
+
+3. **Add `data-tour` anchors** to the elements each step points at. For a **table row**, add it in the row props so the whole row is spotlit:
+   ```tsx
+   mantineTableBodyRowProps: ({ row }) =>
+       row.index === 0 ? { 'data-tour': '<feature>-row' } : {},
+   ```
+
+4. **Render** the tour and a replay button:
+   ```tsx
+   <Button variant="subtle" leftSection={<MantineIcon icon={IconRoute} />} onClick={startTour}>
+       Take the tour
+   </Button>
+   <GuidedTour steps={steps} opened={isOpen} onClose={closeTour} />
+   ```
+
+5. **(Optional) Deterministic example data** so a tour on an empty (or any) page always highlights the same rows. Define stable, clearly-labelled mock rows and inject them via `select` while the tour is open:
+   ```tsx
+   const select = useOnboardingMock(EXAMPLE_ROWS, isOpen);
+   const { data } = useThings(args, { select }); // hook must forward `select` to useQuery
+   ```
+   Render example rows muted and inert (disabled actions, no navigation); mark them with an "Example" badge. Gate interactivity off a sentinel id (e.g. `id.startsWith('example:')`).
+
+## Conventions
+
+- **Zero dependencies.** No joyride/driver/intro.js. The spotlight is a `box-shadow: 0 0 0 9999px` dim — already handled by `GuidedTour`.
+- **storageKey:** `ld.<feature>.tour.v<n>`. Bump the version to re-show the tour after a redesign.
+- **Copy:** warm, natural, straight to the point. **No em dashes, no arrows.** Short titles.
+- **Styling:** follow `frontend-style-guide` — no `style` prop (pass runtime geometry via `__vars`), CSS modules, theme tokens / `ldGray`/`ldDark`.
+- **Mock rows must never look or act real:** muted, "Example" badge, disabled actions.
+
+## Gotchas
+
+- **Targets that render late** (data still loading): handled — `GuidedTour` polls for each step's element and shows a centered card until it appears. Do **not** filter steps at open time; that drops steps whose targets haven't rendered yet.
+- **Determinism:** tie mock data to `isOpen` (tour running), not to emptiness, if you want the tour to highlight the same rows every run. Closing the tour flips back to real data.
+- **`select` passthrough:** the data hook must accept and forward a `select` option to `useQuery` (see `useAiAgentAdminReviewItems`). Add it if missing.

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
@@ -1,0 +1,78 @@
+/* Zero-dependency spotlight tour. A full-screen blocker captures clicks, a
+   box-shadow "spotlight" dims everything except the target rect, and a card is
+   anchored beside it. No tour library. */
+.root {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+}
+
+/* transparent layer that blocks interaction with the page underneath */
+.blocker {
+    position: absolute;
+    inset: 0;
+    pointer-events: auto;
+}
+
+/* full dim used when a step has no target (centered explainer) */
+.dim {
+    position: absolute;
+    inset: 0;
+    background: light-dark(rgba(17, 24, 39, 0.55), rgba(0, 0, 0, 0.7));
+}
+
+/* the cutout: its huge box-shadow darkens the rest of the screen */
+.spotlight {
+    position: fixed;
+    top: var(--tour-top);
+    left: var(--tour-left);
+    width: var(--tour-width);
+    height: var(--tour-height);
+    border-radius: var(--mantine-radius-md);
+    box-shadow: 0 0 0 9999px
+        light-dark(rgba(17, 24, 39, 0.55), rgba(0, 0, 0, 0.7));
+    pointer-events: none;
+    transition:
+        top 0.2s ease,
+        left 0.2s ease,
+        width 0.2s ease,
+        height 0.2s ease;
+}
+
+.card {
+    position: fixed;
+    top: var(--tour-card-top);
+    left: var(--tour-card-left);
+    width: 340px;
+    max-width: calc(100vw - 32px);
+    pointer-events: auto;
+    z-index: 1101;
+}
+
+.cardCentered {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 420px;
+    max-width: calc(100vw - 32px);
+    pointer-events: auto;
+    z-index: 1101;
+}
+
+.dots {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
+.dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--mantine-color-ldGray-3);
+}
+
+.dotActive {
+    background: var(--mantine-color-ldGray-7);
+}

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
@@ -1,0 +1,66 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { GuidedTour, type GuidedTourStep } from './GuidedTour';
+
+const steps: GuidedTourStep[] = [
+    { target: null, title: 'Step one', body: 'first body' },
+    { target: null, title: 'Step two', body: 'second body' },
+    { target: null, title: 'Step three', body: 'third body' },
+];
+
+describe('GuidedTour', () => {
+    it('renders nothing when closed', () => {
+        renderWithProviders(
+            <GuidedTour steps={steps} opened={false} onClose={vi.fn()} />,
+        );
+        expect(screen.queryByText('Step one')).not.toBeInTheDocument();
+    });
+
+    it('walks forward and back through steps', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <GuidedTour steps={steps} opened onClose={vi.fn()} />,
+        );
+
+        expect(screen.getByText('Step one')).toBeInTheDocument();
+        // first step has no Back button
+        expect(
+            screen.queryByRole('button', { name: 'Back' }),
+        ).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Next' }));
+        expect(screen.getByText('Step two')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Back' }));
+        expect(screen.getByText('Step one')).toBeInTheDocument();
+    });
+
+    it('closes when skipped', async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        renderWithProviders(
+            <GuidedTour steps={steps} opened onClose={onClose} />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Skip' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows "Got it" on the last step and closes when finished', async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        renderWithProviders(
+            <GuidedTour steps={steps} opened onClose={onClose} />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Next' }));
+        await user.click(screen.getByRole('button', { name: 'Next' }));
+        expect(screen.getByText('Step three')).toBeInTheDocument();
+
+        const finish = screen.getByRole('button', { name: 'Got it' });
+        await user.click(finish);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -1,0 +1,196 @@
+import {
+    Box,
+    Button,
+    Group,
+    Paper,
+    Portal,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { clsx } from '@mantine/core';
+import { type FC, type ReactNode, useEffect, useState } from 'react';
+import styles from './GuidedTour.module.css';
+
+export type GuidedTourStep = {
+    /** CSS selector resolved at step time; null renders a centered explainer. */
+    target: string | null;
+    title: string;
+    body: ReactNode;
+};
+
+type GuidedTourProps = {
+    steps: GuidedTourStep[];
+    opened: boolean;
+    onClose: () => void;
+};
+
+const SPOTLIGHT_PADDING = 6;
+
+/** Track a target element's viewport rect while the tour is open. */
+const useTargetRect = (
+    selector: string | null,
+    active: boolean,
+): DOMRect | null => {
+    const [rect, setRect] = useState<DOMRect | null>(null);
+
+    useEffect(() => {
+        if (!active || !selector) {
+            setRect(null);
+            return;
+        }
+        let el: Element | null = null;
+        const measure = () => {
+            if (el) setRect(el.getBoundingClientRect());
+        };
+        // The target may render after the step is shown (data still loading),
+        // so keep looking for it, then keep its rect in sync with layout.
+        const tick = () => {
+            if (!el) {
+                el = document.querySelector(selector);
+                if (el) {
+                    el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+                }
+            }
+            measure();
+        };
+        tick();
+        const poll = window.setInterval(tick, 150);
+        window.addEventListener('resize', measure);
+        window.addEventListener('scroll', measure, true);
+        return () => {
+            window.clearInterval(poll);
+            window.removeEventListener('resize', measure);
+            window.removeEventListener('scroll', measure, true);
+        };
+    }, [selector, active]);
+
+    return rect;
+};
+
+/** Position the card below the target, flipping above when it would overflow. */
+const cardPosition = (rect: DOMRect): { top: number; left: number } => {
+    const margin = 12;
+    const cardWidth = 340;
+    const estHeight = 200;
+    const below = rect.bottom + margin;
+    const top =
+        below + estHeight > window.innerHeight
+            ? Math.max(margin, rect.top - estHeight - margin)
+            : below;
+    const left = Math.min(
+        Math.max(margin, rect.left),
+        window.innerWidth - cardWidth - margin,
+    );
+    return { top, left };
+};
+
+export const GuidedTour: FC<GuidedTourProps> = ({ steps, opened, onClose }) => {
+    const [stepIndex, setStepIndex] = useState(0);
+
+    const step = steps[stepIndex];
+    // Each step resolves its own target when reached (rows may load late), so a
+    // step with a not-yet-rendered target just shows a centered card until it
+    // appears, rather than being dropped.
+    const rect = useTargetRect(opened ? (step?.target ?? null) : null, opened);
+
+    if (!opened || !step) return null;
+
+    const isFirst = stepIndex === 0;
+    const isLast = stepIndex === steps.length - 1;
+
+    const handleClose = () => {
+        setStepIndex(0);
+        onClose();
+    };
+    const handleNext = () =>
+        isLast ? handleClose() : setStepIndex((i) => i + 1);
+    const handleBack = () => setStepIndex((i) => Math.max(0, i - 1));
+
+    const cardBody = (
+        <Paper withBorder shadow="lg" radius="md" p="md">
+            <Stack gap="sm">
+                <Stack gap={4}>
+                    <Text fw={600} fz="sm">
+                        {step.title}
+                    </Text>
+                    <Box fz="sm" c="dimmed">
+                        {step.body}
+                    </Box>
+                </Stack>
+                <Group justify="space-between" align="center">
+                    <Button
+                        variant="subtle"
+                        color="gray"
+                        size="compact-xs"
+                        onClick={handleClose}
+                    >
+                        Skip
+                    </Button>
+                    <Box className={styles.dots}>
+                        {steps.map((s, i) => (
+                            <Box
+                                key={s.title}
+                                className={clsx(
+                                    styles.dot,
+                                    i === stepIndex && styles.dotActive,
+                                )}
+                            />
+                        ))}
+                    </Box>
+                    <Group gap="xs">
+                        {!isFirst && (
+                            <Button
+                                variant="default"
+                                size="compact-xs"
+                                onClick={handleBack}
+                            >
+                                Back
+                            </Button>
+                        )}
+                        <Button size="compact-xs" onClick={handleNext}>
+                            {isLast ? 'Got it' : 'Next'}
+                        </Button>
+                    </Group>
+                </Group>
+            </Stack>
+        </Paper>
+    );
+
+    return (
+        <Portal>
+            <Box className={styles.root}>
+                <Box className={styles.blocker} />
+                {rect ? (
+                    <Box
+                        className={styles.spotlight}
+                        __vars={{
+                            '--tour-top': `${rect.top - SPOTLIGHT_PADDING}px`,
+                            '--tour-left': `${rect.left - SPOTLIGHT_PADDING}px`,
+                            '--tour-width': `${
+                                rect.width + SPOTLIGHT_PADDING * 2
+                            }px`,
+                            '--tour-height': `${
+                                rect.height + SPOTLIGHT_PADDING * 2
+                            }px`,
+                        }}
+                    />
+                ) : (
+                    <Box className={styles.dim} />
+                )}
+                {rect ? (
+                    <Box
+                        className={styles.card}
+                        __vars={{
+                            '--tour-card-top': `${cardPosition(rect).top}px`,
+                            '--tour-card-left': `${cardPosition(rect).left}px`,
+                        }}
+                    >
+                        {cardBody}
+                    </Box>
+                ) : (
+                    <Box className={styles.cardCentered}>{cardBody}</Box>
+                )}
+            </Box>
+        </Portal>
+    );
+};

--- a/packages/frontend/src/components/common/GuidedTour/index.ts
+++ b/packages/frontend/src/components/common/GuidedTour/index.ts
@@ -1,0 +1,3 @@
+// Consumed in the Reviews onboarding PR; this ignore is removed there.
+// ts-unused-exports:disable-next-line
+export { GuidedTour, type GuidedTourStep } from './GuidedTour';

--- a/packages/frontend/src/hooks/useGuidedTour.ts
+++ b/packages/frontend/src/hooks/useGuidedTour.ts
@@ -1,0 +1,61 @@
+import { useCallback, useState } from 'react';
+
+type UseGuidedTourOptions = {
+    /**
+     * Unique key for the "seen" flag in localStorage. Convention:
+     * `ld.<feature>.tour.v<n>` — bump the version to re-show after a redesign.
+     */
+    storageKey: string;
+    /** Open automatically the first time a user lands on the feature. */
+    autoStartOnFirstVisit?: boolean;
+};
+
+type UseGuidedTourResult = {
+    /** Whether the tour overlay should be shown. */
+    isOpen: boolean;
+    /** Open (or replay) the tour. */
+    startTour: () => void;
+    /** Close the tour and remember it was seen. */
+    closeTour: () => void;
+};
+
+const hasSeen = (key: string): boolean => {
+    try {
+        return localStorage.getItem(key) === '1';
+    } catch {
+        return false;
+    }
+};
+
+const markSeen = (key: string): void => {
+    try {
+        localStorage.setItem(key, '1');
+    } catch {
+        // ignore — a tour that re-shows is better than a crash
+    }
+};
+
+/**
+ * Persistence and lifecycle for a first-visit guided tour: auto-opens once,
+ * remembers it was seen (localStorage), and exposes a replay trigger. Pair with
+ * the `<GuidedTour>` component for the spotlight rendering.
+ */
+// Consumed in the Reviews onboarding PR; this ignore is removed there.
+// ts-unused-exports:disable-next-line
+export const useGuidedTour = ({
+    storageKey,
+    autoStartOnFirstVisit = true,
+}: UseGuidedTourOptions): UseGuidedTourResult => {
+    const [isOpen, setIsOpen] = useState(
+        () => autoStartOnFirstVisit && !hasSeen(storageKey),
+    );
+
+    const startTour = useCallback(() => setIsOpen(true), []);
+
+    const closeTour = useCallback(() => {
+        markSeen(storageKey);
+        setIsOpen(false);
+    }, [storageKey]);
+
+    return { isOpen, startTour, closeTour };
+};

--- a/packages/frontend/src/hooks/useOnboardingMock.ts
+++ b/packages/frontend/src/hooks/useOnboardingMock.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+/**
+ * Returns a react-query `select` that swaps real data for deterministic mock
+ * rows while `enabled` (e.g. a tour is running), so onboarding always shows the
+ * same content. Pass `mockData` as a stable (module-level) reference.
+ *
+ *   const select = useOnboardingMock(EXAMPLE_ROWS, isTourOpen);
+ *   const { data } = useThings(args, { select });
+ */
+// Consumed in the Reviews onboarding PR; this ignore is removed there.
+// ts-unused-exports:disable-next-line
+export const useOnboardingMock = <T>(
+    mockData: T[],
+    enabled: boolean,
+): ((data: T[]) => T[]) =>
+    useCallback(
+        (data: T[]) => (enabled ? mockData : data),
+        [mockData, enabled],
+    );


### PR DESCRIPTION
A zero-dependency onboarding kit, extracted so any feature can add a first-run tour. The Reviews page (next PR up) is the first consumer.

- **`useGuidedTour({ storageKey })`** — localStorage seen-flag, first-visit auto-open, replay. Returns `{ isOpen, startTour, closeTour }`.
- **`GuidedTour`** (`components/common/GuidedTour`) — spotlight overlay (a `box-shadow` dim, no library), Next/Back/Skip card. Anchors to a `data-tour` target or centers when there's none, and polls for targets that render late (e.g. async rows).
- **`useOnboardingMock(mock, enabled)`** — a react-query `select` that swaps real data for deterministic sample rows while `enabled`.
- **`add-onboarding-tour`** agent skill documenting the recipe and conventions.

**Regression analysis:** purely additive — nothing imports these yet, so no existing behavior changes.

Relates: PROD-8157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
