### PR TITLE
feat(ai-agents): onboard users to the Reviews page

### DIFF
--- a/.claude/skills/add-onboarding-tour/SKILL.md
+++ b/.claude/skills/add-onboarding-tour/SKILL.md
@@ -16,7 +16,21 @@ A zero-dependency, centralised kit for first-run onboarding in `packages/fronten
 | `GuidedTour` | `src/components/common/GuidedTour` | Spotlight rendering. Dims the page, highlights a `data-tour` target, anchors a Next/Back/Skip card. `target: null` → centered card. |
 | `useOnboardingMock` | `src/hooks/useOnboardingMock.ts` | A react-query `select` that swaps real data for deterministic mock rows while a flag is on. |
 
-**Reference implementation:** `src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx` (wiring) and `AiAgentAdminReviewItemsTable.tsx` (mock rows). Read these first — copying them is the fastest path.
+**Reference implementation:** the Reviews page — `src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx` (wiring), `AiAgentAdminReviewItemsTable.tsx` (mock rows), and `Admin/onboarding/` (the content). Read these first — copying them is the fastest path.
+
+## Where content lives
+
+**Kit = global, content = per-feature.** The three building blocks above are shared. Everything specific to one feature — its steps, copy, sample rows, and any onboarding-only visuals — goes in a co-located `onboarding/` folder next to the feature, with the same fixed layout every time:
+
+```
+<feature-dir>/onboarding/
+  index.ts          public surface (re-exports)
+  steps.tsx         TOUR_STEPS: GuidedTourStep[]   (all the step copy)
+  exampleData.ts    EXAMPLE_*, isExample*()         (only if the feature shows mock rows)
+  <Visual>.tsx      onboarding-only visuals, e.g. a diagram (+ .module.css)
+```
+
+The feature imports from `./onboarding`. Do **not** put feature content in a global folder, and do **not** inline steps or mock data in the page/table — keep components about rendering. Only re-export from `index.ts` what's consumed outside the folder (`ts-unused-exports` is enforced).
 
 ## Recipe
 
@@ -27,14 +41,15 @@ A zero-dependency, centralised kit for first-run onboarding in `packages/fronten
    });
    ```
 
-2. **Define steps** (memoised). Each `target` is a CSS selector resolved when the step is reached, or `null` for a centered explainer:
+2. **Define steps** in `onboarding/steps.tsx` as a module constant (they're static — no `useMemo` needed). Each `target` is a CSS selector resolved when the step is reached, or `null` for a centered explainer:
    ```tsx
-   const steps: GuidedTourStep[] = useMemo(() => [
+   export const TOUR_STEPS: GuidedTourStep[] = [
        { target: '[data-tour="<feature>-intro"]', title: '…', body: '…' },
        { target: '[data-tour="<feature>-row"]',   title: '…', body: '…' },
        { target: null, title: '…', body: <SomeDiagram /> }, // centered
-   ], []);
+   ];
    ```
+   The page imports `{ TOUR_STEPS }` from `./onboarding` and passes it to `<GuidedTour>`.
 
 3. **Add `data-tour` anchors** to the elements each step points at. For a **table row**, add it in the row props so the whole row is spotlit:
    ```tsx
@@ -50,7 +65,7 @@ A zero-dependency, centralised kit for first-run onboarding in `packages/fronten
    <GuidedTour steps={steps} opened={isOpen} onClose={closeTour} />
    ```
 
-5. **(Optional) Deterministic example data** so a tour on an empty (or any) page always highlights the same rows. Define stable, clearly-labelled mock rows and inject them via `select` while the tour is open:
+5. **(Optional) Deterministic example data** so a tour on an empty (or any) page always highlights the same rows. Put stable, clearly-labelled mock rows and the `isExample` helper in `onboarding/exampleData.ts`, and inject them via `select` while the tour is open:
    ```tsx
    const select = useOnboardingMock(EXAMPLE_ROWS, isOpen);
    const { data } = useThings(args, { select }); // hook must forward `select` to useQuery

--- a/packages/frontend/src/components/common/GuidedTour/index.ts
+++ b/packages/frontend/src/components/common/GuidedTour/index.ts
@@ -1,3 +1,1 @@
-// Consumed in the Reviews onboarding PR; this ignore is removed there.
-// ts-unused-exports:disable-next-line
 export { GuidedTour, type GuidedTourStep } from './GuidedTour';

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.module.css
@@ -157,3 +157,8 @@
     background-color: var(--mantine-color-ldGray-1);
     color: var(--mantine-color-ldGray-9);
 }
+
+.exampleRow td {
+    opacity: 0.6;
+    cursor: default;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -14,6 +14,7 @@ import {
     Collapse,
     Divider,
     Group,
+    HoverCard,
     Loader,
     Menu,
     SegmentedControl,
@@ -63,6 +64,7 @@ import FilterFacet, {
 } from '../../../../../components/common/FilterFacet';
 import LinkButton from '../../../../../components/common/LinkButton';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useOnboardingMock } from '../../../../../hooks/useOnboardingMock';
 import { useProjects } from '../../../../../hooks/useProjects';
 import {
     useAiAgentAdminAgents,
@@ -74,6 +76,7 @@ import {
 } from '../../hooks/useAiAgentAdmin';
 import { AgentNamePill } from '../AgentNamePill';
 import styles from './AiAgentAdminReviewItemsTable.module.css';
+import { EXAMPLE_REVIEW_ITEMS, isExampleReviewItem } from './onboarding';
 import { ProjectContextWritebackModal } from './ProjectContextWritebackModal';
 import { SearchFilter } from './SearchFilter';
 
@@ -161,6 +164,11 @@ export type AiAgentAdminReviewItemPreviewTarget = {
 type AiAgentAdminReviewItemsTableProps = {
     selectedReviewItemUuid?: string | null;
     onReviewItemSelect?: (target: AiAgentAdminReviewItemPreviewTarget) => void;
+    /**
+     * While true and the queue is empty, sample rows are shown so the onboarding
+     * tour has findings to highlight. Flips to real data once the tour is done.
+     */
+    showOnboardingExamples?: boolean;
 };
 
 const getTargetLabel = (targetRefs: AiAgentTargetRef[]): string | null => {
@@ -380,17 +388,126 @@ const SuggestedStep = ({ children }: { children: string }) => (
     </Tooltip>
 );
 
+// Plain-English gloss for each root cause + which two are fixable from this page.
+const rootCauseHelp: Record<
+    AiAgentRootCause,
+    { desc: string; opensPr: boolean }
+> = {
+    semantic_layer: {
+        desc: 'A metric or field was missing or off',
+        opensPr: true,
+    },
+    project_context: {
+        desc: 'The agent didn’t know something about your data',
+        opensPr: true,
+    },
+    agent_configuration: {
+        desc: 'Its instructions or setup got in the way',
+        opensPr: false,
+    },
+    data_gap: {
+        desc: 'The data to answer this isn’t there yet',
+        opensPr: false,
+    },
+    product_capability: {
+        desc: 'The agent can’t do this yet',
+        opensPr: false,
+    },
+    runtime_reliability: {
+        desc: 'Something broke or timed out',
+        opensPr: false,
+    },
+    feedback_quality: {
+        desc: 'The judge’s read needs a second look',
+        opensPr: false,
+    },
+    not_a_failure: { desc: 'Nothing wrong, it answered fine', opensPr: false },
+    ambiguous: { desc: 'Not clear, worth a look', opensPr: false },
+};
+
+const rootCauseHelpOrder: AiAgentRootCause[] = [
+    'semantic_layer',
+    'project_context',
+    'agent_configuration',
+    'data_gap',
+    'product_capability',
+    'runtime_reliability',
+    'feedback_quality',
+    'not_a_failure',
+    'ambiguous',
+];
+
 const ReviewConceptHelp = () => (
-    <Tooltip
-        label="Turn: one user prompt and assistant response. Signal: the judge's per-turn assessment. Finding: a promoted signal that needs admin review."
+    <HoverCard
+        width={380}
+        shadow="md"
+        position="bottom-start"
         withArrow
-        multiline
-        maw={320}
+        openDelay={150}
     >
-        <Box className={styles.headerHelpIcon}>
-            <MantineIcon icon={IconHelpCircle} color="ldGray.5" size="sm" />
-        </Box>
-    </Tooltip>
+        <HoverCard.Target>
+            <Box className={styles.headerHelpIcon}>
+                <MantineIcon icon={IconHelpCircle} color="ldGray.5" size="sm" />
+            </Box>
+        </HoverCard.Target>
+        <HoverCard.Dropdown>
+            <Stack gap="sm">
+                <Stack gap={4}>
+                    <Text fz="xs" c="dimmed">
+                        A{' '}
+                        <Text span fw={600} c="ldGray.9" fz="inherit">
+                            turn
+                        </Text>{' '}
+                        is one question and answer. A{' '}
+                        <Text span fw={600} c="ldGray.9" fz="inherit">
+                            signal
+                        </Text>{' '}
+                        is what the judge thought of it. A{' '}
+                        <Text span fw={600} c="ldGray.9" fz="inherit">
+                            finding
+                        </Text>{' '}
+                        is one worth your attention.
+                    </Text>
+                </Stack>
+                <Divider />
+                <Stack gap={6}>
+                    <Text fz="xs" fw={600} c="ldGray.9">
+                        What went wrong
+                    </Text>
+                    {rootCauseHelpOrder.map((cause) => (
+                        <Group
+                            key={cause}
+                            gap="xs"
+                            wrap="nowrap"
+                            align="flex-start"
+                        >
+                            <Box miw={110}>
+                                <CategoryBadge
+                                    variant="dot"
+                                    label={rootCauseLabels[cause]}
+                                    color={rootCauseColors[cause]}
+                                />
+                            </Box>
+                            <Text fz="xs" c="dimmed">
+                                {rootCauseHelp[cause].desc}
+                                {rootCauseHelp[cause].opensPr && (
+                                    <Text
+                                        span
+                                        fz="inherit"
+                                        c="ldGray.7"
+                                        fw={600}
+                                    >
+                                        {' '}
+                                        · fixable here
+                                    </Text>
+                                )}
+                            </Text>
+                        </Group>
+                    ))}
+                </Stack>
+            </Stack>
+        </HoverCard.Dropdown>
+    </HoverCard>
 );
 
 const statusColors: Record<AiAgentReviewItemStatus, string> = {
@@ -557,6 +674,7 @@ const ReviewItemActionsCell = ({
                                 maw={260}
                             >
                                 <Button
+                                    data-tour="reviews-create-pr"
                                     size="compact-xs"
                                     radius="md"
                                     variant="default"
@@ -652,6 +770,7 @@ const ReviewItemActionsCell = ({
 const AiAgentAdminReviewItemsTable = ({
     onReviewItemSelect,
     selectedReviewItemUuid,
+    showOnboardingExamples = false,
 }: AiAgentAdminReviewItemsTableProps) => {
     const theme = useMantineTheme();
     const [search, setSearch] = useState<string | undefined>(undefined);
@@ -668,9 +787,17 @@ const AiAgentAdminReviewItemsTable = ({
     );
     const deferredSearch = useDeferredValue(search);
 
-    const { data: reviewItems = [], isLoading } = useAiAgentAdminReviewItems({
-        statuses: ALL_REVIEW_ITEM_STATUSES,
-    });
+    // While the tour is running the table always shows the sample rows so the
+    // tour is deterministic; otherwise it passes real data straight through
+    // (which may be empty or not).
+    const selectReviewItems = useOnboardingMock(
+        EXAMPLE_REVIEW_ITEMS,
+        showOnboardingExamples,
+    );
+    const { data: reviewItems = [], isLoading } = useAiAgentAdminReviewItems(
+        { statuses: ALL_REVIEW_ITEM_STATUSES },
+        { select: selectReviewItems },
+    );
     const { data: reviewSignals = [], isLoading: isSignalsLoading } =
         useAiAgentAdminReviewSignals({
             enabled: reviewSurface === 'signals',
@@ -1018,12 +1145,20 @@ const AiAgentAdminReviewItemsTable = ({
                 ),
                 Cell: ({ row }) => {
                     const reviewItem = row.original;
+                    const isExample = isExampleReviewItem(reviewItem.uuid);
                     const subcategory =
                         reviewItem.latestFinding?.subcategories[0];
                     const contextEntry =
                         reviewItem.latestFinding?.projectContextEntry ?? null;
                     return (
                         <Stack gap={7} align="flex-start">
+                            {isExample && (
+                                <CategoryBadge
+                                    variant="token"
+                                    color="gray"
+                                    label="Example"
+                                />
+                            )}
                             <CategoryBadge
                                 variant="dot"
                                 label={
@@ -1151,9 +1286,24 @@ const AiAgentAdminReviewItemsTable = ({
                         {column.columnDef.header}
                     </Group>
                 ),
-                Cell: ({ row }) => (
-                    <ReviewItemActionsCell reviewItem={row.original} />
-                ),
+                Cell: ({ row }) =>
+                    isExampleReviewItem(row.original.uuid) ? (
+                        <Box data-tour="reviews-create-pr">
+                            <Button
+                                size="compact-xs"
+                                radius="md"
+                                variant="default"
+                                disabled
+                                leftSection={
+                                    <MantineIcon icon={IconGitPullRequest} />
+                                }
+                            >
+                                Create PR
+                            </Button>
+                        </Box>
+                    ) : (
+                        <ReviewItemActionsCell reviewItem={row.original} />
+                    ),
             },
         ],
         [agentsMap, onReviewItemSelect, projectsMap],
@@ -1409,6 +1559,14 @@ const AiAgentAdminReviewItemsTable = ({
             }
 
             const reviewItem = row.original;
+            // Anchor the tour to the first row so it spotlights the whole finding.
+            const rowAnchor =
+                row.index === 0 ? { 'data-tour': 'reviews-row' } : {};
+
+            if (isExampleReviewItem(reviewItem.uuid)) {
+                return { className: styles.exampleRow, ...rowAnchor };
+            }
+
             const isSelected = selectedReviewItemUuid === reviewItem.uuid;
 
             return {
@@ -1418,6 +1576,7 @@ const AiAgentAdminReviewItemsTable = ({
                         ? theme.colors.ldGray[1]
                         : undefined,
                 },
+                ...rowAnchor,
             };
         },
         renderTopToolbar: () =>
@@ -1428,6 +1587,14 @@ const AiAgentAdminReviewItemsTable = ({
                 isLoading,
                 surface: 'findings',
             }),
+        emptyState: {
+            entityName: 'reviews',
+            emptyMessage:
+                'Nothing to review yet. When an agent gets an answer wrong, it shows up here.',
+            search,
+            hasActiveFilters,
+            onClearFilters: clearAllFilters,
+        },
         state: {
             showProgressBars: false,
             showSkeletons: isLoading,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.module.css
@@ -1,0 +1,137 @@
+/* The "what accepting a suggestion does" diagram. Monochrome / shadcn register:
+   neutral surfaces, hairline borders, one inverted "primary" payoff pill.
+   Canonical reference: docs/superpowers reviews-loop-diagram mockup (v5). */
+.diagram {
+    --rld-surface: var(--mantine-color-body);
+    --rld-muted: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-6)
+    );
+    --rld-border: light-dark(
+        var(--mantine-color-ldGray-2),
+        var(--mantine-color-ldDark-4)
+    );
+    --rld-fg: var(--mantine-color-text);
+    --rld-dimmed: var(--mantine-color-dimmed);
+    --rld-icon: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldGray-3)
+    );
+    --rld-primary: light-dark(#18181b, #fafafa);
+    --rld-primary-fg: light-dark(#fafafa, #18181b);
+}
+
+.rail {
+    display: flex;
+    align-items: stretch;
+}
+
+.pill {
+    flex: 1;
+    position: relative;
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-sm)
+        var(--mantine-spacing-sm);
+    background: var(--rld-surface);
+    border: 1px solid var(--rld-border);
+    display: flex;
+    flex-direction: column;
+}
+
+.pill:first-child {
+    border-radius: var(--mantine-radius-md) 0 0 var(--mantine-radius-md);
+}
+
+.pill:last-child {
+    border-radius: 0 var(--mantine-radius-md) var(--mantine-radius-md) 0;
+}
+
+.pill:not(:last-child) {
+    border-right: none;
+}
+
+.iconRow {
+    height: 28px;
+    display: flex;
+    align-items: center;
+    margin-bottom: var(--mantine-spacing-xs);
+}
+
+.iconBox {
+    width: 28px;
+    height: 28px;
+    border-radius: var(--mantine-radius-sm);
+    flex: none;
+    background: var(--rld-muted);
+    border: 1px solid var(--rld-border);
+    display: grid;
+    place-items: center;
+    color: var(--rld-icon);
+}
+
+.title {
+    font-weight: 600;
+    font-size: 12.5px;
+    letter-spacing: -0.005em;
+    color: var(--rld-fg);
+    line-height: 1.3;
+    min-height: 2.6em;
+    margin-bottom: 5px;
+}
+
+.subtitle {
+    font-size: 11px;
+    color: var(--rld-dimmed);
+    line-height: 1.35;
+}
+
+/* payoff pill — inverted shadcn "primary" surface */
+.primary {
+    background: var(--rld-primary);
+    border-color: var(--rld-primary);
+}
+
+.primary .title {
+    color: var(--rld-primary-fg);
+}
+
+.primary .subtitle {
+    color: color-mix(in srgb, var(--rld-primary-fg) 60%, transparent);
+}
+
+.primary .iconBox {
+    background: color-mix(in srgb, var(--rld-primary-fg) 13%, transparent);
+    border-color: transparent;
+    color: var(--rld-primary-fg);
+}
+
+/* connector sits on the icon row so arrows thread icon -> icon */
+.chevron {
+    position: absolute;
+    right: -7px;
+    top: calc(var(--mantine-spacing-sm) + 14px);
+    transform: translateY(-50%);
+    z-index: 3;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--rld-surface);
+    border: 1px solid var(--rld-border);
+    display: grid;
+    place-items: center;
+    color: var(--rld-dimmed);
+}
+
+.loop {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    margin-top: var(--mantine-spacing-sm);
+    font-size: 11.5px;
+    color: var(--rld-fg);
+    font-weight: 500;
+}
+
+.loopMuted {
+    color: var(--rld-dimmed);
+    font-weight: 400;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../../../../testing/testUtils';
+import { ReviewsLoopDiagram } from './ReviewsLoopDiagram';
+
+describe('ReviewsLoopDiagram', () => {
+    it('renders the four steps and the feedback line', () => {
+        renderWithProviders(<ReviewsLoopDiagram />);
+
+        expect(screen.getByText('Finding')).toBeInTheDocument();
+        expect(screen.getByText('Pull request')).toBeInTheDocument();
+        expect(screen.getByText('dbt compile')).toBeInTheDocument();
+        expect(screen.getByText('Future answers')).toBeInTheDocument();
+        expect(screen.getByText(/The agent picks this up/)).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.tsx
@@ -1,0 +1,81 @@
+import { Box, Text } from '@mantine-8/core';
+import {
+    IconBulb,
+    IconCheck,
+    IconChevronRight,
+    IconGitMerge,
+    IconRefresh,
+    IconReload,
+    type Icon as TablerIcon,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
+import styles from './ReviewsLoopDiagram.module.css';
+
+type Step = {
+    icon: TablerIcon;
+    title: string;
+    subtitle: string;
+};
+
+const STEPS: Step[] = [
+    { icon: IconCheck, title: 'Finding', subtitle: 'you say yes' },
+    {
+        icon: IconGitMerge,
+        title: 'Pull request',
+        subtitle: 'opens in your repo',
+    },
+    { icon: IconRefresh, title: 'dbt compile', subtitle: 'your context loads' },
+    { icon: IconBulb, title: 'Future answers', subtitle: 'the agent knows it' },
+];
+
+/**
+ * Explains, at a glance, that accepting a Reviews suggestion teaches the agent:
+ * Finding → Pull request → dbt compile → Future answers, plus the feedback loop.
+ * Used in the first-visit tour's final step and the project-context help popover.
+ */
+export const ReviewsLoopDiagram: FC = () => (
+    <Box className={styles.diagram}>
+        <Box className={styles.rail}>
+            {STEPS.map((step, index) => {
+                const isLast = index === STEPS.length - 1;
+                return (
+                    <Box
+                        key={step.title}
+                        className={
+                            isLast
+                                ? `${styles.pill} ${styles.primary}`
+                                : styles.pill
+                        }
+                    >
+                        <Box className={styles.iconRow}>
+                            <Box className={styles.iconBox}>
+                                <MantineIcon icon={step.icon} size={14} />
+                            </Box>
+                        </Box>
+                        <Text className={styles.title}>{step.title}</Text>
+                        <Text className={styles.subtitle}>{step.subtitle}</Text>
+                        {!isLast && (
+                            <Box className={styles.chevron}>
+                                <MantineIcon
+                                    icon={IconChevronRight}
+                                    size={9}
+                                    stroke={2.5}
+                                />
+                            </Box>
+                        )}
+                    </Box>
+                );
+            })}
+        </Box>
+        <Box className={styles.loop}>
+            <MantineIcon icon={IconReload} size={13} />
+            <Text span fz="inherit" c="inherit" fw="inherit">
+                The agent picks this up{' '}
+                <Text span className={styles.loopMuted} fz="inherit">
+                    on its next answer.
+                </Text>
+            </Text>
+        </Box>
+    </Box>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
@@ -1,0 +1,60 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+
+// Sample rows shown while the onboarding tour runs so admins see what findings
+// look like, aligned to the real columns. Identified by a sentinel uuid prefix
+// so the cells can render them inert (no live PR, no status menu, no thread).
+const EXAMPLE_REVIEW_ITEM_PREFIX = 'example:';
+
+export const isExampleReviewItem = (uuid: string): boolean =>
+    uuid.startsWith(EXAMPLE_REVIEW_ITEM_PREFIX);
+
+const EXAMPLE_SEEN_AT = new Date();
+
+const makeExampleReviewItem = (
+    overrides: Pick<
+        AiAgentReviewItemSummary,
+        'uuid' | 'title' | 'description' | 'primaryRootCause' | 'ownerType'
+    >,
+): AiAgentReviewItemSummary => ({
+    fingerprint: overrides.uuid,
+    organizationUuid: '',
+    projectUuid: null,
+    agentUuid: null,
+    status: 'open',
+    dismissedReason: null,
+    assignedToUserUuid: null,
+    firstSeenAt: EXAMPLE_SEEN_AT,
+    lastSeenAt: EXAMPLE_SEEN_AT,
+    findingCount: 1,
+    statusUpdatedAt: EXAMPLE_SEEN_AT,
+    statusUpdatedByUserUuid: null,
+    linkedIssueUrl: null,
+    linkedPrUrl: null,
+    prState: null,
+    prWritebackStatus: null,
+    prWritebackMessage: null,
+    writebackEligible: false,
+    createdAt: EXAMPLE_SEEN_AT,
+    updatedAt: EXAMPLE_SEEN_AT,
+    latestFinding: null,
+    ...overrides,
+});
+
+export const EXAMPLE_REVIEW_ITEMS: AiAgentReviewItemSummary[] = [
+    makeExampleReviewItem({
+        uuid: `${EXAMPLE_REVIEW_ITEM_PREFIX}semantic-layer`,
+        title: 'No metric for weekly active users',
+        description:
+            'Someone asked for weekly active users. There was no metric for it, so the agent estimated.',
+        primaryRootCause: 'semantic_layer',
+        ownerType: 'semantic_layer_owner',
+    }),
+    makeExampleReviewItem({
+        uuid: `${EXAMPLE_REVIEW_ITEM_PREFIX}project-context`,
+        title: 'Agent didn’t know what “active user” means',
+        description:
+            'Someone asked for active users. The agent guessed instead of using your definition.',
+        primaryRootCause: 'project_context',
+        ownerType: 'unknown',
+    }),
+];

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/index.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/index.ts
@@ -1,0 +1,2 @@
+export { EXAMPLE_REVIEW_ITEMS, isExampleReviewItem } from './exampleData';
+export { REVIEWS_TOUR_STEPS } from './steps';

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/steps.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/steps.tsx
@@ -1,0 +1,35 @@
+import { Stack, Text } from '@mantine-8/core';
+import { type GuidedTourStep } from '../../../../../../components/common/GuidedTour';
+import { ReviewsLoopDiagram } from './ReviewsLoopDiagram';
+
+// First-visit tour for the Reviews page. All step copy lives here.
+export const REVIEWS_TOUR_STEPS: GuidedTourStep[] = [
+    {
+        target: '[data-tour="reviews-intro"]',
+        title: 'Start here',
+        body: 'These are answers your agents probably got wrong. We group them by what caused them, so you can see what is worth your time.',
+    },
+    {
+        target: '[data-tour="reviews-row"]',
+        title: 'Each row is a finding',
+        body: 'One answer your agent likely got wrong, tagged by its cause. Two kinds, Semantic layer and Project context, you can fix without leaving this page. The rest tell you where to look.',
+    },
+    {
+        target: '[data-tour="reviews-create-pr"]',
+        title: 'Fix it right here',
+        body: 'When something is fixable, this button opens a pull request. Merge it and the fix reaches your agent.',
+    },
+    {
+        target: null,
+        title: 'What happens after you merge',
+        body: (
+            <Stack gap="sm">
+                <Text fz="sm" c="dimmed">
+                    Merging the PR adds the fix to your project. The agent uses
+                    it on its next answer:
+                </Text>
+                <ReviewsLoopDiagram />
+            </Stack>
+        ),
+    },
+];

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -1,11 +1,16 @@
-import { Drawer, Group, Stack, Text } from '@mantine-8/core';
+import { Button, Drawer, Group, Stack, Text } from '@mantine-8/core';
+import { IconRoute } from '@tabler/icons-react';
 import { useState } from 'react';
+import { GuidedTour } from '../../../../../../components/common/GuidedTour';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
+import { useGuidedTour } from '../../../../../../hooks/useGuidedTour';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import AiAgentAdminReviewItemsTable, {
     type AiAgentAdminReviewItemPreviewTarget,
 } from '../AiAgentAdminReviewItemsTable';
+import { REVIEWS_TOUR_STEPS } from '../onboarding';
 import { ThreadPreviewSidebar } from '../ThreadPreviewSidebar';
 import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
 import drawerClasses from './ThreadPreviewDrawer.module.css';
@@ -16,6 +21,14 @@ export const AiReviewsSettingsPage = () => {
     const [selectedReviewItem, setSelectedReviewItem] =
         useState<AiAgentAdminReviewItemPreviewTarget | null>(null);
     const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+    // While the tour is running, the table always shows sample rows so it
+    // highlights the same findings every time. Closing it flips to real data.
+    const {
+        isOpen: isTourOpen,
+        startTour,
+        closeTour,
+    } = useGuidedTour({ storageKey: 'ld.aiReviews.tour.v1' });
 
     const handleReviewItemSelect = (
         reviewItem: AiAgentAdminReviewItemPreviewTarget,
@@ -31,7 +44,7 @@ export const AiReviewsSettingsPage = () => {
 
     return (
         <Stack mb="lg" gap="md">
-            <Stack gap={4}>
+            <Stack gap={4} data-tour="reviews-intro">
                 <Group justify="space-between" align="flex-start">
                     <PageBreadcrumbs
                         items={[
@@ -42,18 +55,28 @@ export const AiReviewsSettingsPage = () => {
                             { title: 'Reviews', active: true },
                         ]}
                     />
+                    <Button
+                        variant="subtle"
+                        color="gray"
+                        size="compact-xs"
+                        leftSection={<MantineIcon icon={IconRoute} />}
+                        onClick={startTour}
+                    >
+                        Take the tour
+                    </Button>
                 </Group>
 
                 <Text c="dimmed" fz="sm" maw={760}>
-                    Answers an agent probably got wrong, grouped by root cause:{' '}
+                    Answers your agents probably got wrong, grouped by what
+                    caused them.{' '}
                     <Text span fw={600} fz="inherit">
                         Semantic layer
                     </Text>{' '}
-                    findings open a dbt metrics PR, and{' '}
+                    fixes open a dbt PR.{' '}
                     <Text span fw={600} fz="inherit">
                         Project context
                     </Text>{' '}
-                    findings add a definition to your project context file.
+                    fixes add a note your agents read before answering.
                 </Text>
             </Stack>
 
@@ -62,6 +85,13 @@ export const AiReviewsSettingsPage = () => {
             <AiAgentAdminReviewItemsTable
                 selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}
                 onReviewItemSelect={handleReviewItemSelect}
+                showOnboardingExamples={isTourOpen}
+            />
+
+            <GuidedTour
+                steps={REVIEWS_TOUR_STEPS}
+                opened={isTourOpen}
+                onClose={closeTour}
             />
 
             <Drawer

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -133,13 +133,23 @@ const getAiAgentAdminReviewItems = async (args: {
 
 export const useAiAgentAdminReviewItems = (
     args: { statuses?: AiAgentReviewItemStatus[] },
-    options?: { enabled?: boolean },
+    options?: {
+        enabled?: boolean;
+        select?: (
+            data: ApiAiAgentReviewItemsResponse['results'],
+        ) => ApiAiAgentReviewItemsResponse['results'];
+    },
 ) => {
-    return useQuery<ApiAiAgentReviewItemsResponse['results'], ApiError>({
+    return useQuery<
+        ApiAiAgentReviewItemsResponse['results'],
+        ApiError,
+        ApiAiAgentReviewItemsResponse['results']
+    >({
         queryKey: ['ai-agent-admin-review-items', args],
         queryFn: () => getAiAgentAdminReviewItems(args),
         keepPreviousData: true,
         enabled: options?.enabled ?? true,
+        select: options?.select,
     });
 };
 

--- a/packages/frontend/src/hooks/useGuidedTour.ts
+++ b/packages/frontend/src/hooks/useGuidedTour.ts
@@ -40,8 +40,6 @@ const markSeen = (key: string): void => {
  * remembers it was seen (localStorage), and exposes a replay trigger. Pair with
  * the `<GuidedTour>` component for the spotlight rendering.
  */
-// Consumed in the Reviews onboarding PR; this ignore is removed there.
-// ts-unused-exports:disable-next-line
 export const useGuidedTour = ({
     storageKey,
     autoStartOnFirstVisit = true,

--- a/packages/frontend/src/hooks/useOnboardingMock.ts
+++ b/packages/frontend/src/hooks/useOnboardingMock.ts
@@ -8,8 +8,6 @@ import { useCallback } from 'react';
  *   const select = useOnboardingMock(EXAMPLE_ROWS, isTourOpen);
  *   const { data } = useThings(args, { select });
  */
-// Consumed in the Reviews onboarding PR; this ignore is removed there.
-// ts-unused-exports:disable-next-line
 export const useOnboardingMock = <T>(
     mockData: T[],
     enabled: boolean,


### PR DESCRIPTION
Onboards admins to the Ask AI → Reviews page, built on the shared onboarding kit (PR below).

The page is dense with insider vocabulary, and crucially nobody realises that accepting a fix *teaches the agent* (merge PR → dbt compile → used in future answers). This makes that visible.

- **First-visit guided tour** (4 steps): what the page is, what a finding is (spotlights a row), how a fix opens a PR, and what merging does (a small loop diagram). Replayable via a "Take the tour" button.
- **Deterministic example rows** (one Semantic layer, one Project context) shown while the tour runs, so it always highlights the same findings — even on an account with none yet. Rendered as real, muted, inert table rows with an "Example" badge.
- **Root-cause legend** in the help popover: plain-English meaning of each cause and which two can be fixed from this page.
- `useAiAgentAdminReviewItems` gains a `select` passthrough so the mock pattern works.

Gated behind the existing `ai-agent-review-classifier` flag and the `manage AiAgent` ability — no change to who can see the page.

**Regression analysis:** while the tour is open, the table shows sample rows instead of real data (by design, so the tour is deterministic); closing the tour flips straight back to real data. When not touring the `select` passes data through unchanged. Only affects admins with the review-classifier flag enabled.

Closes: PROD-8157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
