### PR TITLE
fix: preserve AI agent integrations on partial agent updates

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -68,6 +68,7 @@ import {
     UpdateSlackResponseTs,
     UpdateWebAppResponse,
     type AiAgent,
+    type AiAgentIntegration,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import moment from 'moment';
@@ -1906,72 +1907,101 @@ export class AiAgentModel {
                 })
                 .returning('*');
 
-            // Reset all integrations
-            // we cannot relay on cascade deletes because might run into race condition
-            // delete child records first to avoid unique constraint violations
-            const integrationUuids = await trx(AiAgentIntegrationTableName)
-                .select('ai_agent_integration_uuid')
-                .where('ai_agent_uuid', args.agentUuid);
+            // `integrations` is optional on the update payload (PATCH
+            // semantics). Only rebuild integrations when the caller explicitly
+            // provides them — an omitted value must leave existing integrations
+            // untouched. Otherwise partial updates (e.g. changing MCP servers
+            // via the agent update endpoint) would silently delete the agent's
+            // Slack channel assignments and unassign it from its channels.
+            let integrations: AiAgentIntegration[];
+            if (args.integrations !== undefined) {
+                // Reset all integrations
+                // we cannot relay on cascade deletes because might run into race condition
+                // delete child records first to avoid unique constraint violations
+                const integrationUuids = await trx(AiAgentIntegrationTableName)
+                    .select('ai_agent_integration_uuid')
+                    .where('ai_agent_uuid', args.agentUuid);
 
-            if (integrationUuids.length > 0) {
-                await trx(AiAgentSlackIntegrationTableName)
-                    .whereIn(
-                        'ai_agent_integration_uuid',
-                        integrationUuids.map(
-                            (i) => i.ai_agent_integration_uuid,
-                        ),
-                    )
+                if (integrationUuids.length > 0) {
+                    await trx(AiAgentSlackIntegrationTableName)
+                        .whereIn(
+                            'ai_agent_integration_uuid',
+                            integrationUuids.map(
+                                (i) => i.ai_agent_integration_uuid,
+                            ),
+                        )
+                        .delete();
+                }
+
+                // Then delete parent integration records
+                await trx(AiAgentIntegrationTableName)
+                    .where('ai_agent_uuid', args.agentUuid)
                     .delete();
-            }
 
-            // Then delete parent integration records
-            await trx(AiAgentIntegrationTableName)
-                .where('ai_agent_uuid', args.agentUuid)
-                .delete();
+                integrations = await Promise.all(
+                    args.integrations.map(async (integration) => {
+                        switch (integration.type) {
+                            case 'slack':
+                                try {
+                                    const [baseIntegration] = await trx(
+                                        AiAgentIntegrationTableName,
+                                    )
+                                        .insert({
+                                            ai_agent_uuid: agent.ai_agent_uuid,
+                                            integration_type: integration.type,
+                                        })
+                                        .returning('*');
 
-            const integrationPromises =
-                args.integrations?.map(async (integration) => {
-                    switch (integration.type) {
-                        case 'slack':
-                            try {
-                                const [baseIntegration] = await trx(
-                                    AiAgentIntegrationTableName,
-                                )
-                                    .insert({
-                                        ai_agent_uuid: agent.ai_agent_uuid,
-                                        integration_type: integration.type,
-                                    })
-                                    .returning('*');
-
-                                await trx(
-                                    AiAgentSlackIntegrationTableName,
-                                ).insert({
-                                    ai_agent_integration_uuid:
-                                        baseIntegration.ai_agent_integration_uuid,
-                                    organization_uuid: agent.organization_uuid,
-                                    slack_channel_id: integration.channelId,
-                                });
-                            } catch (error) {
-                                if (isUniqueConstraintViolation(error)) {
-                                    throw new AlreadyExistsError(
-                                        'This Slack channel is already assigned to another AI agent',
-                                    );
+                                    await trx(
+                                        AiAgentSlackIntegrationTableName,
+                                    ).insert({
+                                        ai_agent_integration_uuid:
+                                            baseIntegration.ai_agent_integration_uuid,
+                                        organization_uuid:
+                                            agent.organization_uuid,
+                                        slack_channel_id: integration.channelId,
+                                    });
+                                } catch (error) {
+                                    if (isUniqueConstraintViolation(error)) {
+                                        throw new AlreadyExistsError(
+                                            'This Slack channel is already assigned to another AI agent',
+                                        );
+                                    }
+                                    throw error;
                                 }
-                                throw error;
-                            }
 
-                            return {
-                                type: integration.type,
-                                channelId: integration.channelId,
-                            };
-                        default:
-                            return assertUnreachable(
-                                integration.type,
-                                `Unknown integration type ${integration.type} in updateAgent`,
-                            );
-                    }
-                }) || [];
-            const integrations = await Promise.all(integrationPromises);
+                                return {
+                                    type: integration.type,
+                                    channelId: integration.channelId,
+                                };
+                            default:
+                                return assertUnreachable(
+                                    integration.type,
+                                    `Unknown integration type ${integration.type} in updateAgent`,
+                                );
+                        }
+                    }),
+                );
+            } else {
+                // Leave existing integrations untouched and return them as-is.
+                integrations = await trx(AiAgentIntegrationTableName)
+                    .leftJoin(
+                        AiAgentSlackIntegrationTableName,
+                        `${AiAgentIntegrationTableName}.ai_agent_integration_uuid`,
+                        `${AiAgentSlackIntegrationTableName}.ai_agent_integration_uuid`,
+                    )
+                    .where(
+                        `${AiAgentIntegrationTableName}.ai_agent_uuid`,
+                        args.agentUuid,
+                    )
+                    .whereNotNull(
+                        `${AiAgentIntegrationTableName}.integration_type`,
+                    )
+                    .select({
+                        type: `${AiAgentIntegrationTableName}.integration_type`,
+                        channelId: `${AiAgentSlackIntegrationTableName}.slack_channel_id`,
+                    });
+            }
 
             let instruction = await this.getAgentLastInstruction(
                 {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -497,6 +497,74 @@ describe('AiAgentService MCP support', () => {
         expect(updatedAgentMcpServers).toEqual([]);
     });
 
+    it('preserves Slack channel integrations when updating an agent without an integrations field', async () => {
+        const services = getServices(context.app);
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const slackChannelId = `C_TEST_${suffix}`;
+
+        const agent = await services.aiAgentService.createAgent(
+            context.testUser,
+            {
+                name: `Slack Integration Agent ${suffix}`,
+                description: null,
+                projectUuid: SEED_PROJECT.project_uuid,
+                tags: null,
+                integrations: [{ type: 'slack', channelId: slackChannelId }],
+                instruction: '',
+                groupAccess: [],
+                userAccess: [],
+                spaceAccess: [],
+                mcpServerUuids: [],
+                imageUrl: null,
+                enableDataAccess: true,
+                enableSelfImprovement: false,
+                version: 2,
+            },
+        );
+
+        expect(agent.integrations).toEqual([
+            { type: 'slack', channelId: slackChannelId },
+        ]);
+
+        // A partial update (e.g. changing MCP servers) omits `integrations`.
+        // It must NOT wipe the agent's Slack channel assignments.
+        const updatedAgent = await services.aiAgentService.updateAgent(
+            context.testUser,
+            agent.uuid,
+            {
+                uuid: agent.uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                mcpServerUuids: [],
+            },
+        );
+
+        expect(updatedAgent.integrations).toEqual([
+            { type: 'slack', channelId: slackChannelId },
+        ]);
+
+        const refetchedAgent = await services.aiAgentService.getAgent(
+            context.testUser,
+            agent.uuid,
+        );
+
+        expect(refetchedAgent.integrations).toEqual([
+            { type: 'slack', channelId: slackChannelId },
+        ]);
+
+        // Explicitly providing `integrations` still replaces them.
+        const clearedAgent = await services.aiAgentService.updateAgent(
+            context.testUser,
+            agent.uuid,
+            {
+                uuid: agent.uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                integrations: [],
+            },
+        );
+
+        expect(clearedAgent.integrations).toEqual([]);
+    });
+
     it('creates OAuth MCP servers without credentials and disables sharing by default', async () => {
         const services = getServices(context.app);
         const models = getModels(context.app);


### PR DESCRIPTION
## Problem

We had a report that AI agents kept losing their Slack channel assignment — mentioning the bot in a previously-working channel returned _"It seems like there is no AI agent configured for this channel."_ Re-assigning the channel worked, but it would get unassigned again with no obvious trigger.

## Root cause

`AiAgentModel.updateAgent` **unconditionally** deletes all of an agent's integration rows (`ai_agent_integration` / `ai_agent_slack_integration`) on every update, and only re-creates them when the request includes an `integrations` field:

```ts
// before — runs on every update
await trx(AiAgentSlackIntegrationTableName).whereIn(...).delete();
await trx(AiAgentIntegrationTableName).where('ai_agent_uuid', ...).delete();
const integrationPromises = args.integrations?.map(...) || []; // only if provided
```

Because the update endpoint is a PATCH (`ApiUpdateAiAgent` is `Partial<...>`), any update that omits `integrations` silently wipes the Slack channel assignment. Every other field in `updateAgent` is guarded with `!== undefined`; `integrations` was the exception.

The trigger in practice is the **MCP-server management UI**, which PATCHes the agent with only `{ uuid, mcpServerUuids }`. Connecting/disconnecting an MCP server (or attaching one from a new thread) would unassign the agent from all of its channels. The normal agent edit form was unaffected because it always re-sends the full `integrations` array — which is why the behaviour looked random and had no clear repro.

This is a latent defect that has existed since the AI Agents feature shipped; it only started biting once partial-body MCP updates began exercising it.

## Fix

Guard the delete/recreate block with `if (args.integrations !== undefined)`, matching how every other field is handled. When `integrations` is omitted, existing integrations are left untouched and returned as-is. Passing `integrations: []` still explicitly clears them.

## Reproduction

1. Create an agent and assign it to a Slack channel.
2. Connect or disconnect an MCP server on that agent (or attach a GitHub MCP server from a new thread).
3. Before this fix: the Slack channel assignment is gone.

## Testing

- Added an integration test that creates an agent with a Slack integration, performs a partial update (only `mcpServerUuids`), and asserts the integration is preserved — and that an explicit `integrations: []` still clears it.
- `pnpm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)