### PR TITLE
fix(pivot): clear stale re-run prompt when a sort-only pivot dim is hidden

### DIFF
--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -215,8 +215,18 @@ const useTableConfig = (
             resultsData?.pivotDetails?.groupByColumns?.map(
                 (col) => col.reference,
             ) ?? [];
-        return !isEqual(pivotDimensions ?? [], resultsPivotDimensions);
-    }, [pivotDimensions, resultsData?.pivotDetails?.groupByColumns]);
+        // Compare only VISIBLE configured dims — a hidden sort-only pivot dim is
+        // routed to sortOnlyDimensions and never appears in results.groupByColumns,
+        // so including it here would keep the re-run prompt permanently stale.
+        const visiblePivotDimensions = (pivotDimensions ?? []).filter(
+            isColumnVisible,
+        );
+        return !isEqual(visiblePivotDimensions, resultsPivotDimensions);
+    }, [
+        pivotDimensions,
+        resultsData?.pivotDetails?.groupByColumns,
+        isColumnVisible,
+    ]);
 
     const dimensions = useMemo(() => {
         if (!itemsMap) return [];


### PR DESCRIPTION
Closes: PROD-8158

### Description:

Fixes a bug where the "re-run query" prompt would remain permanently stale when a pivot dimension was configured as sort-only (hidden). Hidden sort-only pivot dimensions are routed to `sortOnlyDimensions` and never appear in `resultsData.pivotDetails.groupByColumns`, so comparing the full `pivotDimensions` array against the results would always produce a mismatch.

The fix filters `pivotDimensions` down to only visible columns before comparing against the results, ensuring the stale query indicator accurately reflects only the dimensions that actually appear in the pivot output.