### PR TITLE
feat(mcp): expose skills with skill URIs

### DIFF
--- a/packages/api-tests/tests/mcpServer.test.ts
+++ b/packages/api-tests/tests/mcpServer.test.ts
@@ -53,9 +53,6 @@ describe('MCP server', () => {
         expect(response.body.result.serverInfo).toHaveProperty('version');
         expect(response.body.result.capabilities).toMatchObject({
             resources: { subscribe: false, listChanged: false },
-            experimental: {
-                'io.modelcontextprotocol/skills': {},
-            },
             extensions: {
                 'io.modelcontextprotocol/skills': {},
             },
@@ -95,6 +92,106 @@ describe('MCP server', () => {
             'Get the current Lightdash version',
         );
         expect(versionTool).toHaveProperty('inputSchema');
+        expect(tools.map((tool) => tool.name)).toEqual(
+            expect.arrayContaining([
+                'list_skills',
+                'read_skill',
+                'read_skill_resource',
+            ]),
+        );
+    });
+
+    it('should expose skill fallback tools', async () => {
+        const listResponse = await admin.post<
+            McpResponse<{
+                content: Array<{ type: string; text: string }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 10,
+                method: 'tools/call',
+                params: {
+                    name: 'list_skills',
+                    arguments: {},
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(listResponse.status).toBe(200);
+        const listSkills = JSON.parse(
+            listResponse.body.result.content[0].text,
+        ) as {
+            skills: Array<{
+                name: string;
+                resources: Array<{ path: string }>;
+            }>;
+        };
+        const skill = listSkills.skills.find(
+            (item) => item.name === 'developing-in-lightdash',
+        );
+        expect(skill).toBeDefined();
+        expect(skill?.resources).toContainEqual({
+            path: 'resources/dashboard-reference.md',
+            uri: expect.any(String),
+            name: expect.any(String),
+            title: expect.any(String),
+            description: expect.any(String),
+            mimeType: 'text/markdown',
+            size: expect.any(Number),
+            digest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        });
+
+        const readSkillResponse = await admin.post<
+            McpResponse<{
+                content: Array<{ type: string; text: string }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 11,
+                method: 'tools/call',
+                params: {
+                    name: 'read_skill',
+                    arguments: { name: 'developing-in-lightdash' },
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(readSkillResponse.status).toBe(200);
+        expect(readSkillResponse.body.result.content[0].text).toContain(
+            '# Developing in Lightdash',
+        );
+
+        const readResourceResponse = await admin.post<
+            McpResponse<{
+                content: Array<{ type: string; text: string }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 12,
+                method: 'tools/call',
+                params: {
+                    name: 'read_skill_resource',
+                    arguments: {
+                        name: 'developing-in-lightdash',
+                        path: 'resources/dashboard-reference.md',
+                    },
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(readResourceResponse.status).toBe(200);
+        expect(readResourceResponse.body.result.content[0].text).toContain(
+            '# Dashboard Reference',
+        );
     });
 
     it('should list the analyst prompt without skill prompts', async () => {

--- a/packages/api-tests/tests/mcpServer.test.ts
+++ b/packages/api-tests/tests/mcpServer.test.ts
@@ -53,6 +53,9 @@ describe('MCP server', () => {
         expect(response.body.result.serverInfo).toHaveProperty('version');
         expect(response.body.result.capabilities).toMatchObject({
             resources: { subscribe: false, listChanged: false },
+            experimental: {
+                'io.modelcontextprotocol/skills': {},
+            },
             extensions: {
                 'io.modelcontextprotocol/skills': {},
             },
@@ -255,11 +258,12 @@ describe('MCP server', () => {
         );
         const overviewResource = response.body.result.resources.find(
             (resource) =>
-                resource.uri === 'skill://developing-in-lightdash/SKILL.md',
+                resource.uri ===
+                'skill://lightdash/developing-in-lightdash/SKILL.md',
         );
         const nestedResource = response.body.result.resources.find((resource) =>
             resource.uri.startsWith(
-                'skill://developing-in-lightdash/resources/',
+                'skill://lightdash/developing-in-lightdash/resources/',
             ),
         );
 
@@ -270,7 +274,7 @@ describe('MCP server', () => {
             mimeType: 'application/json',
         });
         expect(overviewResource).toMatchObject({
-            uri: 'skill://developing-in-lightdash/SKILL.md',
+            uri: 'skill://lightdash/developing-in-lightdash/SKILL.md',
             name: 'developing-in-lightdash',
             title: 'Developing in Lightdash',
             mimeType: 'text/markdown',
@@ -305,7 +309,7 @@ describe('MCP server', () => {
         const nestedResource = listResponse.body.result.resources.find(
             (resource) =>
                 resource.uri.startsWith(
-                    'skill://developing-in-lightdash/resources/',
+                    'skill://lightdash/developing-in-lightdash/resources/',
                 ),
         );
 
@@ -390,7 +394,7 @@ describe('MCP server', () => {
             type: 'skill-md',
             description:
                 'Use when reading, creating, and editing Lightdash dashboards and charts as JSON, including dashboard layout and chart-type-specific configuration.',
-            url: 'skill://developing-in-lightdash/SKILL.md',
+            url: 'skill://lightdash/developing-in-lightdash/SKILL.md',
             digest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
         });
     });
@@ -407,7 +411,7 @@ describe('MCP server', () => {
                 id: 8,
                 method: 'resources/read',
                 params: {
-                    uri: 'skill://developing-in-lightdash/resources/does-not-exist.md',
+                    uri: 'skill://lightdash/developing-in-lightdash/resources/does-not-exist.md',
                 },
             },
             { headers: mcpHeaders },

--- a/packages/api-tests/tests/mcpServer.test.ts
+++ b/packages/api-tests/tests/mcpServer.test.ts
@@ -52,7 +52,13 @@ describe('MCP server', () => {
         );
         expect(response.body.result.serverInfo).toHaveProperty('version');
         expect(response.body.result.capabilities).toMatchObject({
-            resources: { listChanged: false },
+            resources: { subscribe: false, listChanged: false },
+            experimental: {
+                'io.modelcontextprotocol/skills': {},
+            },
+            extensions: {
+                'io.modelcontextprotocol/skills': {},
+            },
         });
     });
 
@@ -147,18 +153,27 @@ describe('MCP server', () => {
         expect(response.body.jsonrpc).toBe('2.0');
         expect(response.body.id).toBe(4);
 
+        const indexResource = response.body.result.resources.find(
+            (resource) => resource.uri === 'skill://index.json',
+        );
         const overviewResource = response.body.result.resources.find(
             (resource) =>
-                resource.uri === 'lightdash://skills/developing-in-lightdash',
+                resource.uri === 'skill://developing-in-lightdash/SKILL.md',
         );
         const nestedResource = response.body.result.resources.find((resource) =>
             resource.uri.startsWith(
-                'lightdash://skills/developing-in-lightdash/resources/',
+                'skill://developing-in-lightdash/resources/',
             ),
         );
 
+        expect(indexResource).toMatchObject({
+            uri: 'skill://index.json',
+            name: 'skills-index',
+            title: 'Lightdash Skills Index',
+            mimeType: 'application/json',
+        });
         expect(overviewResource).toMatchObject({
-            uri: 'lightdash://skills/developing-in-lightdash',
+            uri: 'skill://developing-in-lightdash/SKILL.md',
             name: 'developing-in-lightdash',
             title: 'Developing in Lightdash',
             mimeType: 'text/markdown',
@@ -167,7 +182,7 @@ describe('MCP server', () => {
             mimeType: 'text/markdown',
         });
         expect(nestedResource?.name).toMatch(
-            /^developing-in-lightdash\/[^/]+$/,
+            /^developing-in-lightdash\/resources\/[^/]+$/,
         );
         expect(nestedResource?.title).toMatch(/^Developing in Lightdash \/ /);
     });
@@ -193,7 +208,7 @@ describe('MCP server', () => {
         const nestedResource = listResponse.body.result.resources.find(
             (resource) =>
                 resource.uri.startsWith(
-                    'lightdash://skills/developing-in-lightdash/resources/',
+                    'skill://developing-in-lightdash/resources/',
                 ),
         );
 
@@ -235,6 +250,54 @@ describe('MCP server', () => {
         ).toBeGreaterThan(0);
     });
 
+    it('should read the skills index resource', async () => {
+        const response = await admin.post<
+            McpResponse<{
+                contents: Array<{
+                    uri: string;
+                    mimeType?: string;
+                    text: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 7,
+                method: 'resources/read',
+                params: {
+                    uri: 'skill://index.json',
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.result.contents).toHaveLength(1);
+        expect(response.body.result.contents[0]).toMatchObject({
+            uri: 'skill://index.json',
+            mimeType: 'application/json',
+        });
+
+        const index = JSON.parse(response.body.result.contents[0].text) as {
+            skills: Array<{
+                name: string;
+                type: string;
+                description: string;
+                url: string;
+                digest: string;
+            }>;
+        };
+        expect(index.skills).toContainEqual({
+            name: 'developing-in-lightdash',
+            type: 'skill-md',
+            description:
+                'Use when reading, creating, and editing Lightdash dashboards and charts as JSON, including dashboard layout and chart-type-specific configuration.',
+            url: 'skill://developing-in-lightdash/SKILL.md',
+            digest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        });
+    });
+
     it('should return an MCP error for an unknown skill resource', async () => {
         const response = await admin.post<{
             jsonrpc: string;
@@ -244,10 +307,10 @@ describe('MCP server', () => {
             '/api/v1/mcp',
             {
                 jsonrpc: '2.0',
-                id: 7,
+                id: 8,
                 method: 'resources/read',
                 params: {
-                    uri: 'lightdash://skills/developing-in-lightdash/resources/does-not-exist',
+                    uri: 'skill://developing-in-lightdash/resources/does-not-exist.md',
                 },
             },
             { headers: mcpHeaders },
@@ -255,7 +318,7 @@ describe('MCP server', () => {
 
         expect(response.status).toBe(200);
         expect(response.body.jsonrpc).toBe('2.0');
-        expect(response.body.id).toBe(7);
+        expect(response.body.id).toBe(8);
         expect(response.body.error?.code).toBe(JSON_RPC_INVALID_PARAMS);
     });
 
@@ -264,7 +327,7 @@ describe('MCP server', () => {
             '/api/v1/mcp',
             {
                 jsonrpc: '2.0',
-                id: 8,
+                id: 9,
                 method: 'ping',
                 params: {},
             },
@@ -272,7 +335,7 @@ describe('MCP server', () => {
         );
         expect(response.status).toBe(200);
         expect(response.body.jsonrpc).toBe('2.0');
-        expect(response.body.id).toBe(8);
+        expect(response.body.id).toBe(9);
         expect(response.body.result).toEqual({});
     });
 });

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -2568,6 +2568,11 @@ export class McpService extends BaseService {
         // notifications, so override it to avoid misleading clients.
         mcpServer.server.registerCapabilities({
             resources: { subscribe: false, listChanged: false },
+            // Advertise under both: `extensions` per the final SEP, and
+            // `experimental` for draft-era clients (the de-facto wild form).
+            experimental: {
+                [MCP_SKILLS_EXTENSION_NAME]: {},
+            },
             extensions: {
                 [MCP_SKILLS_EXTENSION_NAME]: {},
             },

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -63,7 +63,6 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 // eslint-disable-next-line import/extensions
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import {
-    ServerCapabilities,
     ServerNotification,
     ServerRequest,
     // eslint-disable-next-line import/extensions
@@ -148,6 +147,9 @@ export enum McpToolName {
     GET_QUERY_RESULT = 'get_query_result',
     SEARCH_FIELD_VALUES = 'search_field_values',
     LIST_VERIFIED_CONTENT = 'list_verified_content',
+    LIST_SKILLS = 'list_skills',
+    READ_SKILL = 'read_skill',
+    READ_SKILL_RESOURCE = 'read_skill_resource',
     RUN_AI_WRITEBACK = 'run_ai_writeback',
 }
 
@@ -171,6 +173,27 @@ const mcpRunSqlTool = runSqlToolDefinition.for('mcp');
 const mcpGetQueryResultTool = getQueryResultToolDefinition.for('mcp');
 const mcpListVerifiedContentTool = listVerifiedContentToolDefinition.for('mcp');
 const MCP_SKILLS_EXTENSION_NAME = 'io.modelcontextprotocol/skills';
+
+const listSkillsToolSchema = z.object({});
+const readSkillToolSchema = z.object({
+    name: z
+        .string()
+        .describe(
+            'Skill name from list_skills, for example developing-in-lightdash',
+        ),
+});
+const readSkillResourceToolSchema = z.object({
+    name: z
+        .string()
+        .describe(
+            'Skill name from list_skills, for example developing-in-lightdash',
+        ),
+    path: z
+        .string()
+        .describe(
+            'Resource path from list_skills, for example resources/dashboard-reference.md',
+        ),
+});
 
 type McpServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -989,6 +1012,117 @@ export class McpService extends BaseService {
         schema: z.ZodObject<TShape>,
     ): TShape {
         return this.mcpCompatLayer.processZodType(schema).shape;
+    }
+
+    private registerSkillToolHandlers(): void {
+        this.mcpServer.registerTool(
+            McpToolName.LIST_SKILLS,
+            {
+                title: 'List Skills',
+                description:
+                    'List Lightdash built-in skills available to this MCP server. Use this when the client does not expose MCP resources directly.',
+                inputSchema: this.getMcpCompatibleSchema(listSkillsToolSchema),
+                annotations: { readOnlyHint: true },
+            },
+            async (_args, extra) => {
+                const ctx = getMcpContext(extra);
+                this.trackToolCall(ctx, McpToolName.LIST_SKILLS);
+
+                const skills = await BuiltInSkills.listSkillToolReferences();
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({ skills }, null, 2),
+                        },
+                    ],
+                    structuredContent: { skills },
+                };
+            },
+        );
+
+        this.mcpServer.registerTool(
+            McpToolName.READ_SKILL,
+            {
+                title: 'Read Skill',
+                description:
+                    'Read the main SKILL.md instructions for a Lightdash built-in skill. Call list_skills first to discover available skill names.',
+                inputSchema: this.getMcpCompatibleSchema(readSkillToolSchema),
+                annotations: { readOnlyHint: true },
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+                this.trackToolCall(ctx, McpToolName.READ_SKILL);
+
+                const result = await BuiltInSkills.readSkillTool(args.name);
+                if (!result) {
+                    throw new NotFoundError(
+                        `Skill "${args.name}" was not found`,
+                    );
+                }
+                const { skill, body } = result;
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: body,
+                        },
+                    ],
+                    structuredContent: {
+                        skill: {
+                            name: skill.name,
+                            uri: skill.uri,
+                            title: skill.title,
+                            description: skill.description,
+                            mimeType: skill.mimeType,
+                            size: skill.size,
+                            digest: skill.digest,
+                        },
+                    },
+                };
+            },
+        );
+
+        this.mcpServer.registerTool(
+            McpToolName.READ_SKILL_RESOURCE,
+            {
+                title: 'Read Skill Resource',
+                description:
+                    'Read a supporting resource file for a Lightdash built-in skill. Use the resource path returned by list_skills.',
+                inputSchema: this.getMcpCompatibleSchema(
+                    readSkillResourceToolSchema,
+                ),
+                annotations: { readOnlyHint: true },
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+                this.trackToolCall(ctx, McpToolName.READ_SKILL_RESOURCE);
+
+                const result = await BuiltInSkills.readSkillToolResource({
+                    name: args.name,
+                    resourcePath: args.path,
+                });
+                if (!result) {
+                    throw new NotFoundError(
+                        `Skill resource "${args.path}" was not found for skill "${args.name}"`,
+                    );
+                }
+
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: result.body,
+                        },
+                    ],
+                    structuredContent: {
+                        skill: { name: result.skillName },
+                        resource: result.resource,
+                    },
+                };
+            },
+        );
     }
 
     /**
@@ -2326,6 +2460,8 @@ export class McpService extends BaseService {
             },
         );
 
+        this.registerSkillToolHandlers();
+
         // Dark-launched: this tool is only registered — and therefore only
         // advertised in tools/list and invocable — when the AiWriteback
         // feature flag is enabled for the caller. Clients without the flag
@@ -2386,12 +2522,12 @@ export class McpService extends BaseService {
                 };
             },
         );
-
-        McpService.setupSkillResourceHandlers(this.mcpServer);
     }
 
-    private static setupSkillResourceHandlers(mcpServer: McpServer): void {
-        const resources = BuiltInSkills.listMcpResourcesSync();
+    private static async setupSkillResourceHandlers(
+        mcpServer: McpServer,
+    ): Promise<void> {
+        const resources = await BuiltInSkills.listMcpResources();
 
         resources.forEach((resource) => {
             mcpServer.registerResource(
@@ -2432,13 +2568,10 @@ export class McpService extends BaseService {
         // notifications, so override it to avoid misleading clients.
         mcpServer.server.registerCapabilities({
             resources: { subscribe: false, listChanged: false },
-            experimental: {
-                [MCP_SKILLS_EXTENSION_NAME]: {},
-            },
             extensions: {
                 [MCP_SKILLS_EXTENSION_NAME]: {},
             },
-        } as ServerCapabilities);
+        });
     }
 
     async getProjectUuidFromContext(context: McpProtocolContext) {
@@ -2711,10 +2844,10 @@ export class McpService extends BaseService {
      * Required for SDK 1.26.0+ stateful mode where each session needs its own server.
      * See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
      */
-    public createServer(options?: {
+    public async createServer(options?: {
         projectPinned?: boolean;
         aiWritebackEnabled?: boolean;
-    }): McpServer {
+    }): Promise<McpServer> {
         const newServer = Sentry.wrapMcpServerWithSentry(
             new McpServer({
                 name: 'Lightdash MCP Server',
@@ -2739,7 +2872,9 @@ export class McpService extends BaseService {
             }),
         );
 
-        // Temporarily swap the server to register handlers on the new instance
+        // Temporarily swap the server to register handlers on the new instance.
+        // This region stays synchronous so concurrent createServer calls can't
+        // observe each other's swapped this.mcpServer across an await.
         const originalServer = this.mcpServer;
         this.mcpServer = newServer;
         try {
@@ -2750,6 +2885,10 @@ export class McpService extends BaseService {
         } finally {
             this.mcpServer = originalServer;
         }
+
+        // Skill resources load asynchronously; register them directly on the
+        // new server so no server swap spans the await.
+        await McpService.setupSkillResourceHandlers(newServer);
 
         return newServer;
     }

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -63,6 +63,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 // eslint-disable-next-line import/extensions
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import {
+    ServerCapabilities,
     ServerNotification,
     ServerRequest,
     // eslint-disable-next-line import/extensions
@@ -169,7 +170,7 @@ const mcpSearchFieldValuesTool = searchFieldValuesToolDefinition.for('mcp');
 const mcpRunSqlTool = runSqlToolDefinition.for('mcp');
 const mcpGetQueryResultTool = getQueryResultToolDefinition.for('mcp');
 const mcpListVerifiedContentTool = listVerifiedContentToolDefinition.for('mcp');
-const MCP_SKILL_RESOURCE_MIME_TYPE = 'text/markdown';
+const MCP_SKILLS_EXTENSION_NAME = 'io.modelcontextprotocol/skills';
 
 type McpServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -335,9 +336,12 @@ export class McpService extends BaseService {
                 ],
             }),
         );
-        void this.setupHandlers().catch((error) => {
+        try {
+            this.setupHandlers();
+        } catch (error) {
             this.logger.error('Error initializing MCP server:', error);
-        });
+            throw error;
+        }
     }
 
     private async getScopeInfo(
@@ -1055,12 +1059,12 @@ export class McpService extends BaseService {
         );
     }
 
-    async setupHandlers(
+    setupHandlers(
         options: { projectPinned: boolean; aiWritebackEnabled: boolean } = {
             projectPinned: false,
             aiWritebackEnabled: false,
         },
-    ): Promise<void> {
+    ): void {
         this.mcpServer.registerTool(
             mcpGetLightdashVersionTool.name,
             {
@@ -2383,20 +2387,21 @@ export class McpService extends BaseService {
             },
         );
 
-        await this.setupSkillResourceHandlers();
+        McpService.setupSkillResourceHandlers(this.mcpServer);
     }
 
-    private async setupSkillResourceHandlers(): Promise<void> {
-        const resources = await BuiltInSkills.listMcpResources();
+    private static setupSkillResourceHandlers(mcpServer: McpServer): void {
+        const resources = BuiltInSkills.listMcpResourcesSync();
 
         resources.forEach((resource) => {
-            this.mcpServer.registerResource(
+            mcpServer.registerResource(
                 resource.name,
                 resource.uri,
                 {
                     title: resource.title,
                     description: resource.description,
-                    mimeType: MCP_SKILL_RESOURCE_MIME_TYPE,
+                    mimeType: resource.mimeType,
+                    size: resource.size,
                 },
                 async () => {
                     const text = await BuiltInSkills.getMcpResourceBody(
@@ -2413,7 +2418,7 @@ export class McpService extends BaseService {
                         contents: [
                             {
                                 uri: resource.uri,
-                                mimeType: MCP_SKILL_RESOURCE_MIME_TYPE,
+                                mimeType: resource.mimeType,
                                 text,
                             },
                         ],
@@ -2425,9 +2430,15 @@ export class McpService extends BaseService {
         // The SDK auto-advertises `resources.listChanged: true` when
         // registerResource is called, but we never emit list_changed
         // notifications, so override it to avoid misleading clients.
-        this.mcpServer.server.registerCapabilities({
-            resources: { listChanged: false },
-        });
+        mcpServer.server.registerCapabilities({
+            resources: { subscribe: false, listChanged: false },
+            experimental: {
+                [MCP_SKILLS_EXTENSION_NAME]: {},
+            },
+            extensions: {
+                [MCP_SKILLS_EXTENSION_NAME]: {},
+            },
+        } as ServerCapabilities);
     }
 
     async getProjectUuidFromContext(context: McpProtocolContext) {
@@ -2700,10 +2711,10 @@ export class McpService extends BaseService {
      * Required for SDK 1.26.0+ stateful mode where each session needs its own server.
      * See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
      */
-    public async createServer(options?: {
+    public createServer(options?: {
         projectPinned?: boolean;
         aiWritebackEnabled?: boolean;
-    }): Promise<McpServer> {
+    }): McpServer {
         const newServer = Sentry.wrapMcpServerWithSentry(
             new McpServer({
                 name: 'Lightdash MCP Server',
@@ -2732,7 +2743,7 @@ export class McpService extends BaseService {
         const originalServer = this.mcpServer;
         this.mcpServer = newServer;
         try {
-            await this.setupHandlers({
+            this.setupHandlers({
                 projectPinned: options?.projectPinned ?? false,
                 aiWritebackEnabled: options?.aiWritebackEnabled ?? false,
             });

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -7367,6 +7367,63 @@ Notes:
     },
     {
       "agentName": null,
+      "description": "List Lightdash built-in skills available to this MCP server. Use this when the client does not expose MCP resources directly.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "list_skills",
+      "title": "List Skills",
+    },
+    {
+      "agentName": null,
+      "description": "Read the main SKILL.md instructions for a Lightdash built-in skill. Call list_skills first to discover available skill names.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "Skill name from list_skills, for example developing-in-lightdash",
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+        ],
+        "type": "object",
+      },
+      "name": "read_skill",
+      "title": "Read Skill",
+    },
+    {
+      "agentName": null,
+      "description": "Read a supporting resource file for a Lightdash built-in skill. Use the resource path returned by list_skills.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "Skill name from list_skills, for example developing-in-lightdash",
+            "type": "string",
+          },
+          "path": {
+            "description": "Resource path from list_skills, for example resources/dashboard-reference.md",
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+          "path",
+        ],
+        "type": "object",
+      },
+      "name": "read_skill_resource",
+      "title": "Read Skill Resource",
+    },
+    {
+      "agentName": null,
       "description": "Tool: run_ai_writeback
 
 Purpose:

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
@@ -1,6 +1,5 @@
 import { ParameterError } from '@lightdash/common';
 import crypto from 'crypto';
-import * as fsSync from 'fs';
 import * as fs from 'fs/promises';
 import matter from 'gray-matter';
 import * as path from 'path';
@@ -12,11 +11,11 @@ import {
 
 type MarkdownMetadata = {
     name: string;
-    title: string;
     description: string;
 };
 
 type ParsedMarkdownFile = MarkdownMetadata & {
+    title: string;
     content: string;
     rawContent: string;
     digest: string;
@@ -30,6 +29,28 @@ export type BuiltInSkillMcpResource = {
     description: string;
     mimeType: string;
     size?: number;
+};
+
+export type BuiltInSkillToolResource = {
+    path: string;
+    uri: string;
+    name: string;
+    title: string;
+    description: string;
+    mimeType: string;
+    size: number;
+    digest: string;
+};
+
+export type BuiltInSkillToolReference = {
+    name: string;
+    uri: string;
+    title: string;
+    description: string;
+    mimeType: string;
+    size: number;
+    digest: string;
+    resources: BuiltInSkillToolResource[];
 };
 
 type CachedMcpResource = BuiltInSkillMcpResource & {
@@ -70,22 +91,36 @@ export class BuiltInSkills {
             .digest('hex')}`;
     }
 
+    private static deriveTitleFromName(name: string): string {
+        return name
+            .split(/[-_/]/)
+            .filter((part) => part.length > 0)
+            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .join(' ');
+    }
+
     private static parseMarkdownContent(
         filePath: string,
         fileContents: string,
     ): ParsedMarkdownFile {
         const { content, data } = matter(fileContents);
-        const { name, title, description } = data as Partial<MarkdownMetadata>;
+        const { name, description, metadata } =
+            data as Partial<MarkdownMetadata> & {
+                metadata?: { title?: string };
+            };
 
-        if (!name || !title || !description) {
+        if (!name || !description) {
             throw new ParameterError(
-                `Missing required skill frontmatter in ${filePath}. Expected "name", "title" and "description".`,
+                `Missing required skill frontmatter in ${filePath}. Expected "name" and "description".`,
             );
         }
 
+        // Agent Skills frontmatter recognizes only name + description at the top
+        // level; the display title lives under the optional metadata map and
+        // falls back to a name-derived title.
         return {
             name,
-            title,
+            title: metadata?.title ?? this.deriveTitleFromName(name),
             description,
             content,
             rawContent: fileContents,
@@ -103,29 +138,8 @@ export class BuiltInSkills {
         );
     }
 
-    private static parseMarkdownFileSync(filePath: string): ParsedMarkdownFile {
-        return this.parseMarkdownContent(
-            filePath,
-            fsSync.readFileSync(filePath, 'utf8'),
-        );
-    }
-
     private static getSkillDirectory(skillName: string): string {
         return path.join(this.SKILLS_DIR, skillName);
-    }
-
-    private static getBuiltInSkillNamesSync(): string[] {
-        if (this.skillNames) {
-            return this.skillNames;
-        }
-
-        const names = fsSync
-            .readdirSync(this.SKILLS_DIR, { withFileTypes: true })
-            .filter((entry) => entry.isDirectory())
-            .map((entry) => entry.name)
-            .sort();
-        this.skillNames = names;
-        return names;
     }
 
     private static async getBuiltInSkillNames(): Promise<string[]> {
@@ -268,35 +282,6 @@ export class BuiltInSkills {
         return [...resources, ...nestedResources];
     }
 
-    private static loadMcpResourcesForSkillSync(
-        skillName: string,
-    ): CachedMcpResource[] {
-        const skillFilePath = this.getSkillFilePath(skillName);
-        const skill = this.parseMarkdownFileSync(skillFilePath);
-        const resourcesDir = this.getSkillResourcesDirectory(skillName);
-
-        let resourceFileNames: string[];
-        try {
-            resourceFileNames = fsSync.readdirSync(resourcesDir);
-        } catch (error) {
-            if (this.isNodeErrnoException(error) && error.code === 'ENOENT') {
-                resourceFileNames = [];
-            } else {
-                throw error;
-            }
-        }
-
-        return this.buildSkillMcpResources(
-            skillName,
-            skill,
-            skillFilePath,
-            resourceFileNames,
-            resourcesDir,
-            (fileName) =>
-                this.parseMarkdownFileSync(path.join(resourcesDir, fileName)),
-        );
-    }
-
     private static async loadMcpResourcesForSkill(
         skillName: string,
     ): Promise<CachedMcpResource[]> {
@@ -369,23 +354,6 @@ export class BuiltInSkills {
             size: Buffer.byteLength(content, 'utf8'),
             content,
         };
-    }
-
-    private static loadMcpResourcesSync(): CachedMcpResource[] {
-        if (this.mcpResources) {
-            return this.mcpResources;
-        }
-
-        const skillNames = this.getBuiltInSkillNamesSync();
-        const skillResources = skillNames.flatMap((skillName) =>
-            this.loadMcpResourcesForSkillSync(skillName),
-        );
-        const resources = [
-            this.buildMcpSkillIndex(skillResources),
-            ...skillResources,
-        ];
-        this.mcpResources = resources;
-        return resources;
     }
 
     private static async loadMcpResources(): Promise<CachedMcpResource[]> {
@@ -477,10 +445,134 @@ export class BuiltInSkills {
         );
     }
 
-    static listMcpResourcesSync(): BuiltInSkillMcpResource[] {
-        return this.loadMcpResourcesSync().map(
-            ({ content, digest, filePath, ...resource }) => resource,
+    private static getSkillResourcePath(
+        skillName: string,
+        resource: CachedMcpResource,
+    ): string | undefined {
+        const prefix = `skill://${skillName}/resources/`;
+        if (!resource.uri.startsWith(prefix)) {
+            return undefined;
+        }
+
+        return `resources/${resource.uri.slice(prefix.length)}`;
+    }
+
+    private static toSkillToolResource(
+        skillName: string,
+        resource: CachedMcpResource,
+    ): BuiltInSkillToolResource | undefined {
+        const resourcePath = this.getSkillResourcePath(skillName, resource);
+        if (!resourcePath || !resource.size || !resource.digest) {
+            return undefined;
+        }
+
+        return {
+            path: resourcePath,
+            uri: resource.uri,
+            name: resource.name,
+            title: resource.title,
+            description: resource.description,
+            mimeType: resource.mimeType,
+            size: resource.size,
+            digest: resource.digest,
+        };
+    }
+
+    static async listSkillToolReferences(): Promise<
+        BuiltInSkillToolReference[]
+    > {
+        const resources = await this.loadMcpResources();
+        return resources
+            .filter((resource) => resource.uri.endsWith('/SKILL.md'))
+            .map((skillResource) => {
+                if (!skillResource.size || !skillResource.digest) {
+                    throw new ParameterError(
+                        `Missing metadata for skill resource ${skillResource.uri}`,
+                    );
+                }
+
+                return {
+                    name: skillResource.name,
+                    uri: skillResource.uri,
+                    title: skillResource.title,
+                    description: skillResource.description,
+                    mimeType: skillResource.mimeType,
+                    size: skillResource.size,
+                    digest: skillResource.digest,
+                    resources: resources
+                        .map((resource) =>
+                            this.toSkillToolResource(
+                                skillResource.name,
+                                resource,
+                            ),
+                        )
+                        .filter(
+                            (resource): resource is BuiltInSkillToolResource =>
+                                resource !== undefined,
+                        ),
+                };
+            });
+    }
+
+    static async getSkillToolReference(
+        name: string,
+    ): Promise<BuiltInSkillToolReference | undefined> {
+        return (await this.listSkillToolReferences()).find(
+            (skill) => skill.name.toLowerCase() === name.trim().toLowerCase(),
         );
+    }
+
+    static async readSkillTool(
+        name: string,
+    ): Promise<{ skill: BuiltInSkillToolReference; body: string } | undefined> {
+        const skill = await this.getSkillToolReference(name);
+        if (!skill) {
+            return undefined;
+        }
+
+        const body = await this.getMcpResourceBody(skill.uri);
+        if (body === undefined) {
+            return undefined;
+        }
+
+        return { skill, body };
+    }
+
+    static async readSkillToolResource({
+        name,
+        resourcePath,
+    }: {
+        name: string;
+        resourcePath: string;
+    }): Promise<
+        | {
+              skillName: string;
+              resource: BuiltInSkillToolResource;
+              body: string;
+          }
+        | undefined
+    > {
+        const skill = await this.getSkillToolReference(name);
+        if (!skill) {
+            return undefined;
+        }
+
+        const normalizedPath = resourcePath.startsWith('resources/')
+            ? resourcePath
+            : `resources/${resourcePath}`;
+        const resource = skill.resources.find(
+            (item) => item.path === normalizedPath,
+        );
+        if (!resource) {
+            return undefined;
+        }
+
+        const body = await this.getMcpResourceBody(resource.uri);
+        if (body === undefined) {
+            return undefined;
+        }
+
+        return { skillName: skill.name, resource, body };
     }
 
     static async listMcpResources(): Promise<BuiltInSkillMcpResource[]> {
@@ -489,30 +581,8 @@ export class BuiltInSkills {
         );
     }
 
-    static getMcpResourceBodySync(uri: string): string | undefined {
-        const resource = this.loadMcpResourcesSync().find(
-            (mcpResource) => mcpResource.uri === uri,
-        );
-        if (!resource) {
-            return undefined;
-        }
-        if (resource.content !== undefined) {
-            return resource.content;
-        }
-        const cached = this.mcpResourceBodyCache.get(uri);
-        if (cached !== undefined) {
-            return cached;
-        }
-        if (!resource.filePath) {
-            return undefined;
-        }
-        const body = fsSync.readFileSync(resource.filePath, 'utf8');
-        this.mcpResourceBodyCache.set(uri, body);
-        return body;
-    }
-
     static async getMcpResourceBody(uri: string): Promise<string | undefined> {
-        const resource = this.loadMcpResourcesSync().find(
+        const resource = (await this.loadMcpResources()).find(
             (mcpResource) => mcpResource.uri === uri,
         );
         if (!resource) {

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
@@ -62,6 +62,10 @@ type CachedMcpResource = BuiltInSkillMcpResource & {
 export class BuiltInSkills {
     private static readonly SKILLS_DIR = path.join(__dirname, 'builtInSkills');
 
+    // Vendor prefix (authority segment) for skill:// URIs, so our skills never
+    // collide when a host mounts several servers' skills into one namespace.
+    private static readonly SKILL_NAMESPACE = 'lightdash';
+
     private static skills: AiAgentSkill[] = [];
 
     private static skillsPromise: Promise<AiAgentSkill[]> | undefined;
@@ -179,14 +183,14 @@ export class BuiltInSkills {
     }
 
     private static getSkillUri(skillName: string): string {
-        return `skill://${skillName}/SKILL.md`;
+        return `skill://${this.SKILL_NAMESPACE}/${skillName}/SKILL.md`;
     }
 
     private static getSkillResourceUri(
         skillName: string,
         fileName: string,
     ): string {
-        return `skill://${skillName}/resources/${fileName}`;
+        return `skill://${this.SKILL_NAMESPACE}/${skillName}/resources/${fileName}`;
     }
 
     private static getSkillIndexUri(): string {
@@ -449,7 +453,7 @@ export class BuiltInSkills {
         skillName: string,
         resource: CachedMcpResource,
     ): string | undefined {
-        const prefix = `skill://${skillName}/resources/`;
+        const prefix = `skill://${this.SKILL_NAMESPACE}/${skillName}/resources/`;
         if (!resource.uri.startsWith(prefix)) {
             return undefined;
         }

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
@@ -1,4 +1,6 @@
 import { ParameterError } from '@lightdash/common';
+import crypto from 'crypto';
+import * as fsSync from 'fs';
 import * as fs from 'fs/promises';
 import matter from 'gray-matter';
 import * as path from 'path';
@@ -14,14 +16,27 @@ type MarkdownMetadata = {
     description: string;
 };
 
+type ParsedMarkdownFile = MarkdownMetadata & {
+    content: string;
+    rawContent: string;
+    digest: string;
+    size: number;
+};
+
 export type BuiltInSkillMcpResource = {
     uri: string;
     name: string;
     title: string;
     description: string;
+    mimeType: string;
+    size?: number;
 };
 
-type CachedMcpResource = BuiltInSkillMcpResource & { content: string };
+type CachedMcpResource = BuiltInSkillMcpResource & {
+    content?: string;
+    filePath?: string;
+    digest?: string;
+};
 
 export class BuiltInSkills {
     private static readonly SKILLS_DIR = path.join(__dirname, 'builtInSkills');
@@ -36,6 +51,8 @@ export class BuiltInSkills {
         | Promise<CachedMcpResource[]>
         | undefined;
 
+    private static mcpResourceBodyCache = new Map<string, string>();
+
     private static skillNames: string[] | undefined;
 
     private static skillNamesPromise: Promise<string[]> | undefined;
@@ -46,10 +63,17 @@ export class BuiltInSkills {
         return error instanceof Error && 'code' in error;
     }
 
-    private static async parseMarkdownFile(
+    private static getContentDigest(fileContents: string): string {
+        return `sha256:${crypto
+            .createHash('sha256')
+            .update(fileContents)
+            .digest('hex')}`;
+    }
+
+    private static parseMarkdownContent(
         filePath: string,
-    ): Promise<MarkdownMetadata & { content: string }> {
-        const fileContents = await fs.readFile(filePath, 'utf8');
+        fileContents: string,
+    ): ParsedMarkdownFile {
         const { content, data } = matter(fileContents);
         const { name, title, description } = data as Partial<MarkdownMetadata>;
 
@@ -59,11 +83,49 @@ export class BuiltInSkills {
             );
         }
 
-        return { name, title, description, content };
+        return {
+            name,
+            title,
+            description,
+            content,
+            rawContent: fileContents,
+            digest: this.getContentDigest(fileContents),
+            size: Buffer.byteLength(fileContents, 'utf8'),
+        };
+    }
+
+    private static async parseMarkdownFile(
+        filePath: string,
+    ): Promise<ParsedMarkdownFile> {
+        return this.parseMarkdownContent(
+            filePath,
+            await fs.readFile(filePath, 'utf8'),
+        );
+    }
+
+    private static parseMarkdownFileSync(filePath: string): ParsedMarkdownFile {
+        return this.parseMarkdownContent(
+            filePath,
+            fsSync.readFileSync(filePath, 'utf8'),
+        );
     }
 
     private static getSkillDirectory(skillName: string): string {
         return path.join(this.SKILLS_DIR, skillName);
+    }
+
+    private static getBuiltInSkillNamesSync(): string[] {
+        if (this.skillNames) {
+            return this.skillNames;
+        }
+
+        const names = fsSync
+            .readdirSync(this.SKILLS_DIR, { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => entry.name)
+            .sort();
+        this.skillNames = names;
+        return names;
     }
 
     private static async getBuiltInSkillNames(): Promise<string[]> {
@@ -103,14 +165,18 @@ export class BuiltInSkills {
     }
 
     private static getSkillUri(skillName: string): string {
-        return `lightdash://skills/${skillName}`;
+        return `skill://${skillName}/SKILL.md`;
     }
 
     private static getSkillResourceUri(
         skillName: string,
-        resourceName: string,
+        fileName: string,
     ): string {
-        return `lightdash://skills/${skillName}/resources/${resourceName}`;
+        return `skill://${skillName}/resources/${fileName}`;
+    }
+
+    private static getSkillIndexUri(): string {
+        return 'skill://index.json';
     }
 
     private static async loadSkillResources(
@@ -159,55 +225,167 @@ export class BuiltInSkills {
         };
     }
 
-    private static async loadMcpResourcesForSkill(
+    private static buildSkillMcpResources(
         skillName: string,
-    ): Promise<CachedMcpResource[]> {
-        const skill = await this.parseMarkdownFile(
-            this.getSkillFilePath(skillName),
-        );
-
+        skill: ParsedMarkdownFile,
+        skillFilePath: string,
+        resourceFileNames: string[],
+        resourcesDir: string,
+        readResource: (fileName: string) => ParsedMarkdownFile,
+    ): CachedMcpResource[] {
         const resources: CachedMcpResource[] = [
             {
                 uri: this.getSkillUri(skillName),
                 name: skill.name,
                 title: skill.title,
                 description: skill.description,
-                content: skill.content,
+                mimeType: 'text/markdown',
+                size: skill.size,
+                filePath: skillFilePath,
+                digest: skill.digest,
             },
         ];
 
+        const nestedResources = resourceFileNames
+            .filter((fileName) => fileName.endsWith('.md'))
+            .sort()
+            .map((fileName) => {
+                const resourceName = path.basename(fileName, '.md');
+                const resource = readResource(fileName);
+
+                return {
+                    uri: this.getSkillResourceUri(skillName, fileName),
+                    name: `${skillName}/resources/${resourceName}`,
+                    title: `${skill.title} / ${resource.title}`,
+                    description: resource.description,
+                    mimeType: 'text/markdown',
+                    size: resource.size,
+                    filePath: path.join(resourcesDir, fileName),
+                    digest: resource.digest,
+                };
+            });
+
+        return [...resources, ...nestedResources];
+    }
+
+    private static loadMcpResourcesForSkillSync(
+        skillName: string,
+    ): CachedMcpResource[] {
+        const skillFilePath = this.getSkillFilePath(skillName);
+        const skill = this.parseMarkdownFileSync(skillFilePath);
         const resourcesDir = this.getSkillResourcesDirectory(skillName);
+
+        let resourceFileNames: string[];
+        try {
+            resourceFileNames = fsSync.readdirSync(resourcesDir);
+        } catch (error) {
+            if (this.isNodeErrnoException(error) && error.code === 'ENOENT') {
+                resourceFileNames = [];
+            } else {
+                throw error;
+            }
+        }
+
+        return this.buildSkillMcpResources(
+            skillName,
+            skill,
+            skillFilePath,
+            resourceFileNames,
+            resourcesDir,
+            (fileName) =>
+                this.parseMarkdownFileSync(path.join(resourcesDir, fileName)),
+        );
+    }
+
+    private static async loadMcpResourcesForSkill(
+        skillName: string,
+    ): Promise<CachedMcpResource[]> {
+        const skillFilePath = this.getSkillFilePath(skillName);
+        const skill = await this.parseMarkdownFile(skillFilePath);
+        const resourcesDir = this.getSkillResourcesDirectory(skillName);
+
         let resourceFileNames: string[];
         try {
             resourceFileNames = await fs.readdir(resourcesDir);
         } catch (error) {
             if (this.isNodeErrnoException(error) && error.code === 'ENOENT') {
-                return resources;
+                resourceFileNames = [];
+            } else {
+                throw error;
             }
-            throw error;
         }
 
-        const nestedResources = await Promise.all(
+        const resources = await Promise.all(
             resourceFileNames
                 .filter((fileName) => fileName.endsWith('.md'))
-                .sort()
-                .map(async (fileName) => {
-                    const resourceName = path.basename(fileName, '.md');
-                    const resource = await this.parseMarkdownFile(
+                .map(async (fileName) => ({
+                    fileName,
+                    resource: await this.parseMarkdownFile(
                         path.join(resourcesDir, fileName),
-                    );
-
-                    return {
-                        uri: this.getSkillResourceUri(skillName, resourceName),
-                        name: `${skillName}/${resourceName}`,
-                        title: `${skill.title} / ${resource.title}`,
-                        description: resource.description,
-                        content: resource.content,
-                    };
-                }),
+                    ),
+                })),
         );
 
-        return [...resources, ...nestedResources];
+        return this.buildSkillMcpResources(
+            skillName,
+            skill,
+            skillFilePath,
+            resourceFileNames,
+            resourcesDir,
+            (fileName) =>
+                resources.find((item) => item.fileName === fileName)!.resource,
+        );
+    }
+
+    private static buildMcpSkillIndex(
+        skillResources: CachedMcpResource[],
+    ): CachedMcpResource {
+        const skills = skillResources
+            .filter((resource) => resource.uri.endsWith('/SKILL.md'))
+            .map((resource) => ({
+                name: resource.name,
+                type: 'skill-md',
+                description: resource.description,
+                url: resource.uri,
+                digest: resource.digest,
+            }));
+        const content = JSON.stringify(
+            {
+                $schema:
+                    'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+                skills,
+            },
+            null,
+            2,
+        );
+
+        return {
+            uri: this.getSkillIndexUri(),
+            name: 'skills-index',
+            title: 'Lightdash Skills Index',
+            description:
+                'Index of Lightdash built-in skills exposed as MCP resources.',
+            mimeType: 'application/json',
+            size: Buffer.byteLength(content, 'utf8'),
+            content,
+        };
+    }
+
+    private static loadMcpResourcesSync(): CachedMcpResource[] {
+        if (this.mcpResources) {
+            return this.mcpResources;
+        }
+
+        const skillNames = this.getBuiltInSkillNamesSync();
+        const skillResources = skillNames.flatMap((skillName) =>
+            this.loadMcpResourcesForSkillSync(skillName),
+        );
+        const resources = [
+            this.buildMcpSkillIndex(skillResources),
+            ...skillResources,
+        ];
+        this.mcpResources = resources;
+        return resources;
     }
 
     private static async loadMcpResources(): Promise<CachedMcpResource[]> {
@@ -226,7 +404,11 @@ export class BuiltInSkills {
                         this.loadMcpResourcesForSkill(skillName),
                     ),
                 );
-                const resources = perSkill.flat();
+                const skillResources = perSkill.flat();
+                const resources = [
+                    this.buildMcpSkillIndex(skillResources),
+                    ...skillResources,
+                ];
                 this.mcpResources = resources;
                 return resources;
             } catch (error) {
@@ -295,15 +477,59 @@ export class BuiltInSkills {
         );
     }
 
-    static async listMcpResources(): Promise<BuiltInSkillMcpResource[]> {
-        return (await this.loadMcpResources()).map(
-            ({ content, ...resource }) => resource,
+    static listMcpResourcesSync(): BuiltInSkillMcpResource[] {
+        return this.loadMcpResourcesSync().map(
+            ({ content, digest, filePath, ...resource }) => resource,
         );
     }
 
+    static async listMcpResources(): Promise<BuiltInSkillMcpResource[]> {
+        return (await this.loadMcpResources()).map(
+            ({ content, digest, filePath, ...resource }) => resource,
+        );
+    }
+
+    static getMcpResourceBodySync(uri: string): string | undefined {
+        const resource = this.loadMcpResourcesSync().find(
+            (mcpResource) => mcpResource.uri === uri,
+        );
+        if (!resource) {
+            return undefined;
+        }
+        if (resource.content !== undefined) {
+            return resource.content;
+        }
+        const cached = this.mcpResourceBodyCache.get(uri);
+        if (cached !== undefined) {
+            return cached;
+        }
+        if (!resource.filePath) {
+            return undefined;
+        }
+        const body = fsSync.readFileSync(resource.filePath, 'utf8');
+        this.mcpResourceBodyCache.set(uri, body);
+        return body;
+    }
+
     static async getMcpResourceBody(uri: string): Promise<string | undefined> {
-        return (await this.loadMcpResources()).find(
-            (resource) => resource.uri === uri,
-        )?.content;
+        const resource = this.loadMcpResourcesSync().find(
+            (mcpResource) => mcpResource.uri === uri,
+        );
+        if (!resource) {
+            return undefined;
+        }
+        if (resource.content !== undefined) {
+            return resource.content;
+        }
+        const cached = this.mcpResourceBodyCache.get(uri);
+        if (cached !== undefined) {
+            return cached;
+        }
+        if (!resource.filePath) {
+            return undefined;
+        }
+        const body = await fs.readFile(resource.filePath, 'utf8');
+        this.mcpResourceBodyCache.set(uri, body);
+        return body;
     }
 }

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/SKILL.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: developing-in-lightdash
-title: Developing in Lightdash
 description: Use when reading, creating, and editing Lightdash dashboards and charts as JSON, including dashboard layout and chart-type-specific configuration.
+metadata:
+    title: Developing in Lightdash
 ---
 
 # Developing in Lightdash

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/big-number-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/big-number-chart-reference.md
@@ -1,7 +1,8 @@
 ---
 name: big-number-chart-reference
-title: Big Number Chart Reference
 description: Big number chart configuration, comparisons, conditional formatting, and examples for Lightdash charts.
+metadata:
+    title: Big Number Chart Reference
 ---
 
 # Big Number Chart Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/cartesian-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/cartesian-chart-reference.md
@@ -1,7 +1,8 @@
 ---
 name: cartesian-chart-reference
-title: Cartesian Chart Reference
 description: Bar, line, area, and scatter chart configuration, layout, series options, and examples for Lightdash charts.
+metadata:
+    title: Cartesian Chart Reference
 ---
 
 # Cartesian Chart Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/custom-viz-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/custom-viz-reference.md
@@ -1,7 +1,8 @@
 ---
 name: custom-viz-reference
-title: Custom Visualizations Reference
 description: Custom chart guidance using Vega-Lite specifications in Lightdash charts.
+metadata:
+    title: Custom Visualizations Reference
 ---
 
 # Custom Visualizations Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-best-practices.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-best-practices.md
@@ -1,7 +1,8 @@
 ---
 name: dashboard-best-practices
-title: Dashboard Best Practices
 description: A guide to building effective, user-friendly dashboards in Lightdash based on data visualization principles and BI best practices.
+metadata:
+    title: Dashboard Best Practices
 ---
 
 ## Data Visualization Fundamentals

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-reference.md
@@ -1,7 +1,8 @@
 ---
 name: dashboard-reference
-title: Dashboard Reference
 description: Full dashboard structure, tile types, grid layout, filters, config, examples, and best practices for editing dashboards in Lightdash.
+metadata:
+    title: Dashboard Reference
 ---
 
 # Dashboard Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/funnel-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/funnel-chart-reference.md
@@ -1,7 +1,8 @@
 ---
 name: funnel-chart-reference
-title: Funnel Chart Reference
 description: Funnel chart structure, stage ordering, labels, colors, and examples for Lightdash charts.
+metadata:
+    title: Funnel Chart Reference
 ---
 
 # Funnel Chart Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/gauge-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/gauge-chart-reference.md
@@ -1,7 +1,8 @@
 ---
 name: gauge-chart-reference
-title: Gauge Chart Reference
 description: Gauge chart configuration, ranges, sections, labels, and examples for Lightdash charts.
+metadata:
+    title: Gauge Chart Reference
 ---
 
 # Gauge Chart Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/map-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/map-chart-reference.md
@@ -1,7 +1,8 @@
 ---
 name: map-chart-reference
-title: Map Chart Reference
 description: Map chart configuration for scatter, area, and heatmap layers, plus map-specific examples for Lightdash charts.
+metadata:
+    title: Map Chart Reference
 ---
 
 # Map Chart Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/period-over-period-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/period-over-period-reference.md
@@ -1,7 +1,8 @@
 ---
 name: period-over-period-reference
-title: Period over Period Reference
 description: Period over period comparison configuration for Lightdash chart JSON.
+metadata:
+    title: Period over Period Reference
 ---
 
 # Period over Period (PoP) Comparison Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/pie-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/pie-chart-reference.md
@@ -1,7 +1,8 @@
 ---
 name: pie-chart-reference
-title: Pie Chart Reference
 description: Pie and donut chart structure, grouping, labels, legend options, and examples for Lightdash charts.
+metadata:
+    title: Pie Chart Reference
 ---
 
 # Pie Chart Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/sankey-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/sankey-chart-reference.md
@@ -1,7 +1,8 @@
 ---
 name: sankey-chart-reference
-title: Sankey Chart Reference
 description: Sankey chart structure, source and target flow settings, and examples for Lightdash charts.
+metadata:
+    title: Sankey Chart Reference
 ---
 
 # Sankey Chart Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/table-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/table-chart-reference.md
@@ -1,7 +1,8 @@
 ---
 name: table-chart-reference
-title: Table Chart Reference
 description: Table chart configuration, columns, conditional formatting, pivots, and display options for Lightdash charts.
+metadata:
+    title: Table Chart Reference
 ---
 
 # Table Chart Reference

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/treemap-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/treemap-chart-reference.md
@@ -1,7 +1,8 @@
 ---
 name: treemap-chart-reference
-title: Treemap Chart Reference
 description: Treemap chart configuration, hierarchies, size and color metrics, and examples for Lightdash charts.
+metadata:
+    title: Treemap Chart Reference
 ---
 
 # Treemap Chart Reference

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12453,11 +12453,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12746,11 +12746,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12999,13 +12999,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -13032,13 +13032,13 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: [
                                                                 'not_found',
                                                             ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13134,13 +13134,6 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
                                                                                                         'false',
                                                                                                     ],
                                                                                                 },
@@ -13149,6 +13142,13 @@ const models: TsoaRoute.Models = {
                                                                                                         'enum',
                                                                                                     enums: [
                                                                                                         'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
                                                                                                     ],
                                                                                                 },
                                                                                             ],
@@ -13194,12 +13194,6 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                                 label: {
                                                                                     dataType:
                                                                                         'string',
@@ -13210,6 +13204,12 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                             },
                                                                     },
                                                                     required: true,
@@ -13411,6 +13411,14 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                uuid: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13420,14 +13428,6 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                             },
                                         },
                                         {
@@ -13509,6 +13509,27 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                prAction: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['opened'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['updated'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13530,6 +13551,41 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                errorCode: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'github_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'gitlab_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['unknown'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'unsupported_source_control',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['error'],
@@ -13554,6 +13610,10 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13563,29 +13623,6 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
                                             },
                                         },
                                         {
@@ -13620,10 +13657,29 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13642,11 +13698,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13663,25 +13719,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13771,6 +13808,13 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
+                                                                                    'dimension',
+                                                                                ],
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
                                                                                     'metric',
                                                                                 ],
                                                                             },
@@ -13778,8 +13822,20 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    null,
                                                                                 ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
                                                                             },
                                                                             {
                                                                                 dataType:
@@ -13823,11 +13879,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13842,11 +13898,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13861,11 +13917,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -27470,7 +27526,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27480,7 +27536,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27490,7 +27546,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -27503,7 +27559,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14006,19 +14006,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -14114,8 +14101,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -14232,19 +14219,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "status",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14254,8 +14241,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
-                                                            "not_found"
+                                                            "not_found",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -14298,9 +14285,9 @@
                                                                                 "caseSensitiveFilters": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "true",
                                                                                         "false",
-                                                                                        "not_applicable"
+                                                                                        "not_applicable",
+                                                                                        "true"
                                                                                     ]
                                                                                 },
                                                                                 "fieldFilterType": {
@@ -14319,13 +14306,13 @@
                                                                                 "table": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
@@ -14337,9 +14324,9 @@
                                                                                 "fieldValueType",
                                                                                 "fieldType",
                                                                                 "table",
-                                                                                "fieldId",
                                                                                 "label",
-                                                                                "name"
+                                                                                "name",
+                                                                                "fieldId"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -14490,6 +14477,12 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "uuid": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
@@ -14497,27 +14490,30 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "uuid": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "slug",
-                                                    "status",
                                                     "uuid",
-                                                    "name"
+                                                    "name",
+                                                    "slug",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
                                             {
                                                 "properties": {
+                                                    "prAction": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "opened",
+                                                            "updated",
+                                                            null
+                                                        ],
+                                                        "nullable": true
+                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -14533,7 +14529,32 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "errorCode": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "github_not_installed",
+                                                            "gitlab_not_installed",
+                                                            "unknown",
+                                                            "unsupported_source_control",
+                                                            null
+                                                        ],
+                                                        "nullable": true
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["error"],
+                                                        "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "href": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
                                                         "type": "string"
                                                     },
                                                     "slug": {
@@ -14543,16 +14564,13 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
+                                                    "name",
                                                     "slug",
-                                                    "status",
-                                                    "name"
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14562,8 +14580,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
                                                             "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -14575,10 +14593,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -14618,17 +14632,21 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
+                                                                "nullable": true
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
-                                                            "type"
+                                                            "type",
+                                                            "searchQuery"
                                                         ],
                                                         "type": "object"
                                                     },
@@ -19595,7 +19613,7 @@
                     "output"
                 ],
                 "type": "object",
-                "description": "Result of a (synchronous) AI writeback run.\n\n- `output` is the text the agent produced.\n- `exitCode` is the sandbox command's exit status.\n- `prUrl` is the URL of the pull request opened from the agent's changes, or\n  `null` when the agent made no file changes (nothing to raise a PR for).\n- `projectName` is the Lightdash project the run targeted.\n- `repository` is the GitHub repository (`owner/repo`) the run targeted."
+                "description": "Result of a (synchronous) AI writeback run.\n\n- `output` is the text the agent produced.\n- `exitCode` is the sandbox command's exit status.\n- `prUrl` is the URL of the pull request opened from the agent's changes, or\n  `null` when the agent made no file changes (nothing to raise a PR for).\n- `prAction` is whether that PR was newly opened or an existing one updated,\n  or `null` when no PR was touched.\n- `projectName` is the Lightdash project the run targeted.\n- `repository` is the GitHub repository (`owner/repo`) the run targeted."
             },
             "ApiSuccess_AiWritebackRunResult_": {
                 "properties": {
@@ -28317,22 +28335,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -37805,7 +37823,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3096.0",
+        "version": "0.3104.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -172,7 +172,7 @@ mcpRouter.all(
                 const headerProjectUuid = extractProjectUuidFromHeader(req);
                 const aiWritebackEnabled =
                     await mcpService.isAiWritebackEnabled(req.user!);
-                const mcpServer = await mcpService.createServer({
+                const mcpServer = mcpService.createServer({
                     projectPinned: headerProjectUuid !== undefined,
                     aiWritebackEnabled,
                 });

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -172,7 +172,7 @@ mcpRouter.all(
                 const headerProjectUuid = extractProjectUuidFromHeader(req);
                 const aiWritebackEnabled =
                     await mcpService.isAiWritebackEnabled(req.user!);
-                const mcpServer = mcpService.createServer({
+                const mcpServer = await mcpService.createServer({
                     projectPinned: headerProjectUuid !== undefined,
                     aiWritebackEnabled,
                 });


### PR DESCRIPTION
Closes: ZAP-421

Stacked on #23950.

## Summary
- Switch built-in skill MCP resource URIs to the `skill://...` convention, including nested resource file paths.
- Add a `skill://index.json` discovery resource using the agent skills discovery schema.
- Include skill digests and resource sizes in discovery/resource metadata.
- Advertise the MCP skills extension capability and keep resource registration synchronous for per-session MCP servers.
- Cover the new skill URI/index behavior in MCP API tests.

## Testing
- Not run (PR creation only).
