### PR TITLE
fix(frontend): polish pull requests table row layout

### DIFF
--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
@@ -1,11 +1,15 @@
-/* Artsy pull-request medallion: a soft shadow gives it a little lift */
-.medallion {
-    box-shadow: 0 1px 3px
-        light-dark(rgba(15, 18, 20, 0.08), rgba(0, 0, 0, 0.35));
+/* Icon + title row: let the text block shrink so the title can truncate */
+.titleCell {
+    min-width: 0;
 }
 
-/* Title text truncates (but doesn't grow) so the source tag sits inline
-   immediately after it rather than being pushed to the right edge */
+/* Match the validator's icon: theme Paper border + subtle shadow */
+.medallion {
+    border: 1px solid var(--mantine-color-ldGray-2);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+/* Title text truncates (but doesn't grow) so it doesn't push the row wider */
 .title {
     min-width: 0;
 }

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -134,40 +134,10 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
     const columns = useMemo<MRT_ColumnDef<PullRequestRow>[]>(
         () => [
             {
-                id: 'medallion',
-                header: '',
-                enableSorting: false,
-                size: 56,
-                Cell: ({ row }) => (
-                    <ThemeIcon
-                        variant="light"
-                        color={getStateColor(row.original.state)}
-                        radius="xl"
-                        size={34}
-                        className={classes.medallion}
-                    >
-                        <MantineIcon icon={IconGitPullRequest} size="md" />
-                    </ThemeIcon>
-                ),
-            },
-            {
-                id: 'source',
-                header: 'Source',
-                enableSorting: false,
-                size: 120,
-                Cell: ({ row }) => (
-                    <CategoryBadge
-                        label={getSourceLabel(row.original.source)}
-                        color={getSourceColor(row.original.source)}
-                        variant="dot"
-                    />
-                ),
-            },
-            {
                 accessorKey: 'title',
                 header: 'Pull request',
                 enableSorting: false,
-                size: 520,
+                size: 620,
                 Cell: ({ row }) => {
                     const pr = row.original;
                     // title/state are both null when the live lookup from the
@@ -175,62 +145,102 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                     const liveLookupFailed =
                         pr.title === null && pr.state === null;
                     return (
-                        <Stack gap={2} className={classes.title}>
-                            {liveLookupFailed ? (
-                                <Tooltip
-                                    label={`Couldn't load this pull request from ${getProviderLabel(
-                                        pr.provider,
-                                    )}. It may have been deleted, or access was revoked.`}
-                                    openDelay={300}
-                                    multiline
-                                    maw={420}
-                                    withinPortal
-                                >
-                                    <Group gap="two" wrap="nowrap">
-                                        <MantineIcon
-                                            icon={IconAlertCircle}
-                                            color="red"
-                                            size="sm"
-                                        />
-                                        <Text
-                                            size="sm"
-                                            fw={500}
-                                            c="red"
-                                            truncate
-                                        >
-                                            Couldn't load pull request
+                        <Group
+                            gap="sm"
+                            wrap="nowrap"
+                            className={classes.titleCell}
+                        >
+                            <ThemeIcon
+                                variant="light"
+                                color={getStateColor(pr.state)}
+                                radius="md"
+                                size={32}
+                                className={classes.medallion}
+                            >
+                                <MantineIcon
+                                    icon={IconGitPullRequest}
+                                    size="md"
+                                />
+                            </ThemeIcon>
+                            <Stack gap={2} className={classes.title}>
+                                {liveLookupFailed ? (
+                                    <Tooltip
+                                        label={`Couldn't load this pull request from ${getProviderLabel(
+                                            pr.provider,
+                                        )}. It may have been deleted, or access was revoked.`}
+                                        openDelay={300}
+                                        multiline
+                                        maw={420}
+                                        withinPortal
+                                    >
+                                        <Group gap="two" wrap="nowrap">
+                                            <MantineIcon
+                                                icon={IconAlertCircle}
+                                                color="red"
+                                                size="sm"
+                                            />
+                                            <Text
+                                                fz="sm"
+                                                fw={600}
+                                                c="red"
+                                                truncate
+                                            >
+                                                Couldn't load pull request
+                                            </Text>
+                                        </Group>
+                                    </Tooltip>
+                                ) : (
+                                    <Tooltip
+                                        label={pr.title}
+                                        openDelay={400}
+                                        multiline
+                                        maw={420}
+                                        withinPortal
+                                    >
+                                        <Text fz="sm" fw={600} truncate>
+                                            {pr.title}
                                         </Text>
-                                    </Group>
-                                </Tooltip>
-                            ) : (
+                                    </Tooltip>
+                                )}
                                 <Tooltip
-                                    label={pr.title}
-                                    openDelay={400}
-                                    multiline
-                                    maw={420}
+                                    label={formatTimestamp(
+                                        pr.createdAt,
+                                        TimeFrames.MINUTE,
+                                    )}
+                                    openDelay={300}
                                     withinPortal
                                 >
-                                    <Text size="sm" fw={500} truncate>
-                                        {pr.title}
+                                    <Text fz="xs" c="ldGray.6" truncate span>
+                                        opened {dayjs(pr.createdAt).fromNow()}
+                                        {pr.author ? (
+                                            <>
+                                                {' by '}
+                                                <Text span fw={700} fz="xs">
+                                                    {pr.author.name}
+                                                </Text>
+                                            </>
+                                        ) : (
+                                            ''
+                                        )}
                                     </Text>
                                 </Tooltip>
-                            )}
-                            <Tooltip
-                                label={formatTimestamp(
-                                    pr.createdAt,
-                                    TimeFrames.MINUTE,
-                                )}
-                                openDelay={300}
-                                withinPortal
-                            >
-                                <Text fz="xs" c="dimmed" truncate span>
-                                    opened {dayjs(pr.createdAt).fromNow()}
-                                    {pr.author ? ` by ${pr.author.name}` : ''}
-                                </Text>
-                            </Tooltip>
-                        </Stack>
+                            </Stack>
+                        </Group>
                     );
                 },
+            },
+            {
+                id: 'source',
+                header: 'Source',
+                enableSorting: false,
+                size: 140,
+                Cell: ({ row }) => (
+                    <CategoryBadge
+                        label={getSourceLabel(row.original.source)}
+                        color={getSourceColor(row.original.source)}
+                        variant="dot"
+                    />
+                ),
             },
         ],
         [],


### PR DESCRIPTION
## Summary

The pull requests table row didn't match the sibling settings tables: the state icon sat in its own leading column, Source was wedged between the icon and the title, and the icon was a circle with a hand-rolled shadow. This reworks each row to mirror the project validator table so the two settings screens read consistently.

### Row layout

- Merge the state icon into the **Pull request** cell (icon + title + subtitle), matching the validator's Name cell.
- Move **Source** to a trailing column, so the table is `Pull request | Source` — the same two-column shape as the validator's `Name | Error`.
- Icon: circle → rounded square (`radius="md"`, `size={32}`), now carrying the theme `Paper` border (`ldGray-2`) + `subtle` shadow instead of a bespoke `box-shadow`.

### Typography

- Subtitle reads from `ldGray.6` instead of `dimmed`.
- Author name is bold (`fw={700}`) so "opened … by **Name**" scans at a glance.
- Title/subtitle keep Lightdash's standard `sm`/`xs` sizes (the validator's 12/10px felt too small for a list people actually read).

## Visual

```
Before:  [ ◯ icon ] [ • Source ] Title……………………………
                                  opened a day ago by Name

After:   [ ▢ icon ] Title…………………………………  [ • Source ]
                    opened a day ago by **Name**
```

- `◯` circle, custom shadow  →  `▢` rounded square, theme border + subtle shadow
- Source column: position 2 (mid-row)  →  position 2 (trailing)
- Author name: regular weight  →  bold

## Regression analysis

- **Icon styling** — moved from an inline `box-shadow` to the `.medallion` CSS-module class using `var(--mantine-color-ldGray-2)` + `var(--mantine-shadow-subtle)`; same tokens the global `Paper` default applies to the validator icon. State color via `getStateColor` is unchanged.
- **Columns** — `medallion` column removed; its icon now renders inside the `title` cell. `source` column unchanged except for order and width.
- **Group default** — the icon row relies on `Group`'s default `align="center"`; no explicit override needed.
- No backend/API surface touched.

## Test plan

- [ ] Pull requests settings page — each row shows the icon inline with the title, Source on the right.
- [ ] Icon has a 1px `ldGray-2` border and the subtle shadow; shape is a rounded square.
- [ ] Long PR titles truncate without pushing the row wider.
- [ ] The "Couldn't load pull request" failed-lookup state still renders inline with its red icon.
- [ ] Verify both light and dark modes match the validator table's icon palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)