### PR TITLE
fix(permissions): gate data app view at interactive viewer

### DIFF
--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -70,16 +70,6 @@ export const applyOrganizationMemberStaticAbilities: Record<
                 $elemMatch: { userUuid: member.userUuid },
             },
         });
-        can('view', 'DataApp', {
-            organizationUuid: member.organizationUuid,
-            inheritsFromOrgOrProject: true,
-        });
-        can('view', 'DataApp', {
-            organizationUuid: member.organizationUuid,
-            access: {
-                $elemMatch: { userUuid: member.userUuid },
-            },
-        });
         can('view', 'OrganizationDesign', {
             organizationUuid: member.organizationUuid,
         });
@@ -201,6 +191,19 @@ export const applyOrganizationMemberStaticAbilities: Record<
                     userUuid: member.userUuid,
                     role: SpaceMemberRole.ADMIN,
                 },
+            },
+        });
+        // View data apps shared org/project-wide or in spaces the user can
+        // access. Gated at interactive-viewer (not viewer) for parity with
+        // manage:Explore — plain viewers don't get data app access.
+        can('view', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            inheritsFromOrgOrProject: true,
+        });
+        can('view', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            access: {
+                $elemMatch: { userUuid: member.userUuid },
             },
         });
         // Create personal data apps; once created, the user can also view

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -72,16 +72,6 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
             userUuid: member.userUuid,
         });
-        can('view', 'DataApp', {
-            projectUuid: member.projectUuid,
-            inheritsFromOrgOrProject: true,
-        });
-        can('view', 'DataApp', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: { userUuid: member.userUuid },
-            },
-        });
     },
     interactive_viewer(member, { can }) {
         projectMemberAbilities.viewer(member, { can });
@@ -162,6 +152,19 @@ export const projectMemberAbilities: Record<
                     userUuid: member.userUuid,
                     role: SpaceMemberRole.ADMIN,
                 },
+            },
+        });
+        // View data apps shared project-wide or in spaces the user can
+        // access. Gated at interactive-viewer (not viewer) for parity with
+        // manage:Explore — plain viewers don't get data app access.
+        can('view', 'DataApp', {
+            projectUuid: member.projectUuid,
+            inheritsFromOrgOrProject: true,
+        });
+        can('view', 'DataApp', {
+            projectUuid: member.projectUuid,
+            access: {
+                $elemMatch: { userUuid: member.userUuid },
             },
         });
         // Create personal data apps; once created, the user can also view

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -35,7 +35,6 @@ const BASE_ROLE_SCOPES = {
         'view:MetricsTree',
         'view:SpotlightTableConfig',
         'view:AiAgentThread@self',
-        'view:DataApp',
         'view:OrganizationDesign',
     ],
 
@@ -67,6 +66,7 @@ const BASE_ROLE_SCOPES = {
         'view:AiAgent',
         'view:AiAgentDocument',
         'create:AiAgentThread',
+        'view:DataApp', // Project-wide + space-access view (parity with manage:Explore)
         'create:DataApp', // Personal apps (not yet in a space)
         'view:DataApp@self', // Own personal apps
         'manage:DataApp@self', // Own personal apps


### PR DESCRIPTION
### Description:
Move `view:DataApp` from the viewer tier to `interactive_viewer` across the project, organization, and role-to-scope layers so it no longer contradicts `view:Explore`, which is also interactive-viewer-and-higher. Plain viewers no longer get data app view (project-wide or via space access); higher roles inherit it.

Decision based on the Slack convo here: https://lightdash.slack.com/archives/C0AMFDF6VBR/p1780643634413009