### PR TITLE
fix: scope changeset operations to project

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4346,7 +4346,10 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        const change = await this.changesetModel.getChange(changeUuid);
+        const change = await this.changesetModel.getChange(
+            changeUuid,
+            agent.projectUuid,
+        );
 
         const originalExplores = await this.projectModel.findExploresFromCache(
             agent.projectUuid,
@@ -4355,7 +4358,7 @@ export class AiAgentService extends BaseService {
             { applyChangeset: false },
         );
 
-        await this.changesetModel.revertChange(changeUuid);
+        await this.changesetModel.revertChange(changeUuid, agent.projectUuid);
 
         await this.catalogModel.indexCatalogReverts({
             projectUuid: agent.projectUuid,

--- a/packages/backend/src/models/ChangesetModel.test.ts
+++ b/packages/backend/src/models/ChangesetModel.test.ts
@@ -1,0 +1,68 @@
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import {
+    ChangesetsTableName,
+    ChangesTableName,
+} from '../database/entities/changesets';
+import { ChangesetModel } from './ChangesetModel';
+
+describe('ChangesetModel tenant scoping', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new ChangesetModel({ database });
+    let tracker: Tracker;
+    const dbChange = {
+        change_uuid: '11111111-1111-4111-8111-111111111111',
+        changeset_uuid: '33333333-3333-4333-8333-333333333333',
+        created_at: new Date('2026-01-01'),
+        created_by_user_uuid: '44444444-4444-4444-8444-444444444444',
+        source_prompt_uuid: null,
+        entity_type: 'table',
+        entity_table_name: 'orders',
+        entity_name: 'Orders',
+        type: 'update',
+        payload: { patches: [] },
+    };
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    test('gets a change scoped through its changeset project', async () => {
+        const { change_uuid: changeUuid } = dbChange;
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+
+        tracker.on
+            .select(({ sql }) => sql.includes(ChangesTableName))
+            .responseOnce(dbChange);
+
+        await model.getChange(changeUuid, projectUuid);
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(ChangesetsTableName);
+        expect(query.bindings).toContain(changeUuid);
+        expect(query.bindings).toContain(projectUuid);
+    });
+
+    test('reverts a single change only within the requested project', async () => {
+        const { change_uuid: changeUuid } = dbChange;
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+
+        tracker.on
+            .select(({ sql }) => sql.includes(ChangesTableName))
+            .responseOnce(dbChange);
+        tracker.on
+            .delete(({ sql }) => sql.includes(ChangesTableName))
+            .responseOnce(1);
+
+        await model.revertChange(changeUuid, projectUuid);
+
+        const [deleteQuery] = tracker.history.delete;
+        expect(deleteQuery.sql).toContain(ChangesetsTableName);
+        expect(deleteQuery.bindings).toContain(changeUuid);
+        expect(deleteQuery.bindings).toContain(projectUuid);
+    });
+});

--- a/packages/backend/src/models/ChangesetModel.ts
+++ b/packages/backend/src/models/ChangesetModel.ts
@@ -169,9 +169,16 @@ export class ChangesetModel {
         });
     }
 
-    async getChange(changeUuid: string): Promise<Change> {
+    async getChange(changeUuid: string, projectUuid: string): Promise<Change> {
         const change = await this.database(ChangesTableName)
+            .innerJoin(
+                ChangesetsTableName,
+                `${ChangesetsTableName}.changeset_uuid`,
+                `${ChangesTableName}.changeset_uuid`,
+            )
+            .select(`${ChangesTableName}.*`)
             .where('change_uuid', changeUuid)
+            .where(`${ChangesetsTableName}.project_uuid`, projectUuid)
             .first();
 
         if (!change) {
@@ -206,9 +213,17 @@ export class ChangesetModel {
             .delete();
     }
 
-    async revertChange(changeUuid: string): Promise<void> {
-        await this.getChange(changeUuid);
+    async revertChange(changeUuid: string, projectUuid: string): Promise<void> {
+        await this.getChange(changeUuid, projectUuid);
 
-        await this.revertChanges({ changeUuids: [changeUuid] });
+        await this.database(ChangesTableName)
+            .where('change_uuid', changeUuid)
+            .whereIn(
+                'changeset_uuid',
+                this.database(ChangesetsTableName)
+                    .select('changeset_uuid')
+                    .where('project_uuid', projectUuid),
+            )
+            .delete();
     }
 }

--- a/packages/backend/src/services/ChangesetService.test.ts
+++ b/packages/backend/src/services/ChangesetService.test.ts
@@ -1,0 +1,77 @@
+import { buildAccount } from '../auth/account/account.mock';
+import { ChangesetService } from './ChangesetService';
+
+const projectUuid = '11111111-1111-4111-8111-111111111111';
+const changeUuid = '22222222-2222-4222-8222-222222222222';
+const account = buildAccount();
+
+const changesetModel = {
+    getChange: jest.fn(),
+    revertChange: jest.fn(),
+    findActiveChangesetWithChangesByProjectUuid: jest.fn(),
+};
+
+const projectModel = {
+    findExploresFromCache: jest.fn(),
+};
+
+const catalogModel = {
+    indexCatalogReverts: jest.fn(),
+};
+
+const service = new ChangesetService({
+    changesetModel: changesetModel as never,
+    catalogModel: catalogModel as never,
+    projectModel: projectModel as never,
+    savedChartModel: {} as never,
+    dashboardModel: {} as never,
+});
+
+describe('ChangesetService tenant scoping', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('gets a change scoped to the authorized project', async () => {
+        changesetModel.getChange.mockResolvedValue({
+            changeUuid,
+            dependencies: [],
+        });
+
+        await service.getChange(account, projectUuid, changeUuid);
+
+        expect(changesetModel.getChange).toHaveBeenCalledWith(
+            changeUuid,
+            projectUuid,
+        );
+    });
+
+    test('reverts a change scoped to the authorized project', async () => {
+        changesetModel.findActiveChangesetWithChangesByProjectUuid.mockResolvedValue(
+            {
+                changes: [
+                    {
+                        changeUuid,
+                        entityTableName: 'orders',
+                    },
+                ],
+            },
+        );
+        changesetModel.getChange.mockResolvedValue({
+            changeUuid,
+            entityTableName: 'orders',
+        });
+        projectModel.findExploresFromCache.mockResolvedValue([]);
+
+        await service.revertChange(account, projectUuid, changeUuid);
+
+        expect(changesetModel.getChange).toHaveBeenCalledWith(
+            changeUuid,
+            projectUuid,
+        );
+        expect(changesetModel.revertChange).toHaveBeenCalledWith(
+            changeUuid,
+            projectUuid,
+        );
+    });
+});

--- a/packages/backend/src/services/ChangesetService.ts
+++ b/packages/backend/src/services/ChangesetService.ts
@@ -176,7 +176,7 @@ export class ChangesetService extends BaseService {
             );
         }
 
-        return this.changesetModel.getChange(changeUuid);
+        return this.changesetModel.getChange(changeUuid, projectUuid);
     }
 
     async revertChange(
@@ -210,7 +210,10 @@ export class ChangesetService extends BaseService {
             return;
         }
 
-        const change = await this.changesetModel.getChange(changeUuid);
+        const change = await this.changesetModel.getChange(
+            changeUuid,
+            projectUuid,
+        );
 
         // Get original explores WITHOUT any changes for revert reconstruction
         const originalExplores = await this.projectModel.findExploresFromCache(
@@ -221,7 +224,7 @@ export class ChangesetService extends BaseService {
         );
 
         // Delete the change
-        await this.changesetModel.revertChange(changeUuid);
+        await this.changesetModel.revertChange(changeUuid, projectUuid);
 
         // Update catalog using revert logic
         await this.catalogModel.indexCatalogReverts({


### PR DESCRIPTION
### Closes: [https://linear.app/lightdash/issue/PROD-8166/changeset-idor](https://linear.app/lightdash/issue/PROD-8166/changeset-idor)

### Description

This narrows the multi-tenant content-management IDOR fix to the changeset surface.

Changeset read and revert operations now pass the authorized project UUID down into the model layer. The model scopes `changeUuid` lookups through the owning `changesets.project_uuid`, and single-change reverts delete only when the change belongs to the authorized project.

