### PR TITLE
fix: scope validation operations to project

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -2108,7 +2108,10 @@ chartConfig:
 
         // Clear stale validation errors for this chart — the fix should resolve them.
         // If the fix was incomplete, the next validateProject run will re-create them.
-        await this.validationModel.deleteChartValidations(chartUuid);
+        await this.validationModel.deleteChartValidations(
+            chartUuid,
+            projectUuid,
+        );
 
         const action = await this.managedAgentModel.createAction({
             projectUuid,

--- a/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
@@ -1,7 +1,54 @@
 import { DashboardFilterValidationErrorType } from '@lightdash/common';
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { ValidationTableName } from '../../database/entities/validation';
 import { ValidationModel } from './ValidationModel';
 
 describe('ValidationModel', () => {
+    describe('tenant-scoped cleanup', () => {
+        const database = knex({ client: MockClient, dialect: 'pg' });
+        const model = new ValidationModel({ database });
+        let tracker: Tracker;
+
+        beforeAll(() => {
+            tracker = getTracker();
+        });
+
+        afterEach(() => {
+            tracker.reset();
+        });
+
+        it('deletes chart validations only in the requested project', async () => {
+            const chartUuid = '11111111-1111-4111-8111-111111111111';
+            const projectUuid = '22222222-2222-4222-8222-222222222222';
+
+            tracker.on
+                .delete(({ sql }) => sql.includes(ValidationTableName))
+                .responseOnce(1);
+
+            await model.deleteChartValidations(chartUuid, projectUuid);
+
+            const [query] = tracker.history.delete;
+            expect(query.bindings).toContain(chartUuid);
+            expect(query.bindings).toContain(projectUuid);
+        });
+
+        it('deletes dashboard validations only in the requested project', async () => {
+            const dashboardUuid = '33333333-3333-4333-8333-333333333333';
+            const projectUuid = '22222222-2222-4222-8222-222222222222';
+
+            tracker.on
+                .delete(({ sql }) => sql.includes(ValidationTableName))
+                .responseOnce(1);
+
+            await model.deleteDashboardValidations(dashboardUuid, projectUuid);
+
+            const [query] = tracker.history.delete;
+            expect(query.bindings).toContain(dashboardUuid);
+            expect(query.bindings).toContain(projectUuid);
+        });
+    });
+
     describe('parseDashboardFilterError', () => {
         it('Should parse "table not used by any chart" error', () => {
             const error =

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -223,15 +223,23 @@ export class ValidationModel {
         }
     }
 
-    async deleteChartValidations(chartUuid: string): Promise<void> {
+    async deleteChartValidations(
+        chartUuid: string,
+        projectUuid: string,
+    ): Promise<void> {
         await this.database(ValidationTableName)
             .where('saved_chart_uuid', chartUuid)
+            .where('project_uuid', projectUuid)
             .delete();
     }
 
-    async deleteDashboardValidations(dashboardUuid: string): Promise<void> {
+    async deleteDashboardValidations(
+        dashboardUuid: string,
+        projectUuid: string,
+    ): Promise<void> {
         await this.database(ValidationTableName)
             .where('dashboard_uuid', dashboardUuid)
+            .where('project_uuid', projectUuid)
             .delete();
     }
 

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -1,4 +1,7 @@
+import { Ability } from '@casl/ability';
 import {
+    AbilityAction,
+    AnyType,
     FilterOperator,
     TableCalculationTemplateType,
     TableSelectionType,
@@ -30,25 +33,52 @@ import {
     exploreWithoutMetric,
     project,
     tableConfiguration,
+    user,
 } from './ValidationService.mock';
 
 const savedChartModel = {
     findChartsForValidation: jest.fn(async () => [chartForValidation]),
+    get: jest.fn(async () => ({
+        ...chartForValidation,
+        spaceUuid: 'spaceUuid',
+        organizationUuid: 'orgUuid',
+        projectUuid: 'projectUuid',
+    })),
 };
 const projectModel = {
     findExploresFromCache: jest.fn(async () => ({
         [explore.name]: explore,
     })),
+    getExploreFromCache: jest.fn(async () => explore),
+    getAllExploresFromCache: jest.fn(async () => ({
+        [explore.name]: explore,
+    })),
     get: jest.fn(async () => project),
+    getSummary: jest.fn(async () => project),
     getTablesConfiguration: jest.fn(async () => tableConfiguration),
 };
 const validationModel = {
     delete: jest.fn(async () => {}),
+    deleteChartValidations: jest.fn(async () => {}),
+    deleteDashboardValidations: jest.fn(async () => {}),
     create: jest.fn(async () => {}),
     get: jest.fn(async () => []),
 };
 const dashboardModel = {
     findDashboardsForValidation: jest.fn(async () => [dashboardForValidation]),
+    getByIdOrSlug: jest.fn(async () => ({
+        ...dashboardForValidation,
+        uuid: dashboardForValidation.dashboardUuid,
+        spaceUuid: 'spaceUuid',
+        organizationUuid: 'orgUuid',
+        projectUuid: 'projectUuid',
+    })),
+};
+const spacePermissionService = {
+    getSpaceAccessContext: jest.fn(async () => ({
+        inheritsFromOrgOrProject: false,
+        access: [],
+    })),
 };
 describe('validation', () => {
     const validationService = new ValidationService({
@@ -60,12 +90,56 @@ describe('validation', () => {
         lightdashConfig: config,
         spaceModel: {} as SpaceModel,
         schedulerClient: {} as SchedulerClient,
-        spacePermissionService: {} as SpacePermissionService,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
         featureFlagModel: {} as FeatureFlagModel,
     });
+    const allAccessUser = {
+        ...user,
+        ability: new Ability<[AbilityAction, AnyType]>([
+            { subject: 'Validation', action: ['manage'] },
+            { subject: 'SavedChart', action: ['view'] },
+            { subject: 'Dashboard', action: ['view'] },
+        ]),
+    };
 
     afterEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('scopes single chart validation lookups and cleanup to the requested project', async () => {
+        await validationService.validateAndUpdateChart(
+            allAccessUser,
+            'projectUuid',
+            'chartUuid',
+        );
+
+        expect(savedChartModel.get).toHaveBeenCalledWith(
+            'chartUuid',
+            undefined,
+            { projectUuid: 'projectUuid' },
+        );
+        expect(validationModel.deleteChartValidations).toHaveBeenCalledWith(
+            'chartUuid',
+            'projectUuid',
+        );
+    });
+
+    it('scopes single dashboard validation lookups and cleanup to the requested project', async () => {
+        await validationService.validateAndUpdateDashboard(
+            allAccessUser,
+            'projectUuid',
+            'dashboardUuid',
+        );
+
+        expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledWith(
+            'dashboardUuid',
+            { projectUuid: 'projectUuid' },
+        );
+        expect(validationModel.deleteDashboardValidations).toHaveBeenCalledWith(
+            'dashboardUuid',
+            'projectUuid',
+        );
     });
 
     it('Should validate project without errors', async () => {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -1483,7 +1483,9 @@ export class ValidationService extends BaseService {
         }
 
         // Get the chart to find which explore it uses
-        const chart = await this.savedChartModel.get(chartUuid);
+        const chart = await this.savedChartModel.get(chartUuid, undefined, {
+            projectUuid,
+        });
 
         // Check user permissions
         const { inheritsFromOrgOrProject, access } =
@@ -1532,7 +1534,10 @@ export class ValidationService extends BaseService {
         );
 
         // Delete existing validations for this chart
-        await this.validationModel.deleteChartValidations(chartUuid);
+        await this.validationModel.deleteChartValidations(
+            chartUuid,
+            projectUuid,
+        );
 
         // Store new validation errors if any
         if (validationErrors.length > 0) {
@@ -1569,8 +1574,12 @@ export class ValidationService extends BaseService {
         }
 
         // Get the dashboard to check permissions
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            {
+                projectUuid,
+            },
+        );
 
         // Check user permissions
         const { inheritsFromOrgOrProject, access } =
@@ -1639,7 +1648,10 @@ export class ValidationService extends BaseService {
         );
 
         // Delete existing validations for this dashboard
-        await this.validationModel.deleteDashboardValidations(dashboardUuid);
+        await this.validationModel.deleteDashboardValidations(
+            dashboardUuid,
+            projectUuid,
+        );
 
         // Store new validation errors if any
         if (validationErrors.length > 0) {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8170/rename-and-validation-scoping

## Summary

Relates: #23889


This PR narrows the IDOR fix to the validation endpoints:

- `POST /api/v1/projects/:projectUuid/validate/chart/:chartUuid`
- `POST /api/v1/projects/:projectUuid/validate/dashboard/:dashboardUuid`
