### PR TITLE
feat(ai-agents): add review collection opt-in

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -273,14 +273,21 @@ export const AiOrganizationSettingsTableName = 'ai_organization_settings';
 export type DbAiOrganizationSettings = {
     organization_uuid: string;
     ai_agents_visible: boolean;
+    ai_agent_reviews_enabled: boolean;
     created_at: Date;
     updated_at: Date;
 };
 
 export type AiOrganizationSettingsTable = Knex.CompositeTableType<
     DbAiOrganizationSettings,
-    Pick<DbAiOrganizationSettings, 'organization_uuid' | 'ai_agents_visible'>,
-    Partial<Pick<DbAiOrganizationSettings, 'ai_agents_visible'>>
+    Pick<DbAiOrganizationSettings, 'organization_uuid' | 'ai_agents_visible'> &
+        Partial<Pick<DbAiOrganizationSettings, 'ai_agent_reviews_enabled'>>,
+    Partial<
+        Pick<
+            DbAiOrganizationSettings,
+            'ai_agents_visible' | 'ai_agent_reviews_enabled'
+        >
+    >
 >;
 
 export const AiSqlApprovalTableName = 'ai_sql_approval';

--- a/packages/backend/src/ee/database/migrations/20260608120000_add_ai_agent_reviews_enabled.ts
+++ b/packages/backend/src/ee/database/migrations/20260608120000_add_ai_agent_reviews_enabled.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const aiOrganizationSettings = 'ai_organization_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiOrganizationSettings, (table) => {
+        table
+            .boolean('ai_agent_reviews_enabled')
+            .notNullable()
+            .defaultTo(false);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiOrganizationSettings, (table) => {
+        table.dropColumn('ai_agent_reviews_enabled');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -319,6 +319,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentReviewClassifierModel:
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
                     aiAgentModel: models.getAiAgentModel<AiAgentModel>(),
+                    aiOrganizationSettingsModel:
+                        models.getAiOrganizationSettingsModel(),
                     catalogModel: models.getCatalogModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                     lightdashConfig: context.lightdashConfig,

--- a/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
+++ b/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
@@ -29,6 +29,7 @@ export class AiOrganizationSettingsModel {
         return {
             organizationUuid: db.organization_uuid,
             aiAgentsVisible: db.ai_agents_visible,
+            aiAgentReviewsEnabled: db.ai_agent_reviews_enabled,
         };
     }
 
@@ -65,6 +66,7 @@ export class AiOrganizationSettingsModel {
             .insert({
                 organization_uuid: data.organizationUuid,
                 ai_agents_visible: data.aiAgentsVisible,
+                ai_agent_reviews_enabled: data.aiAgentReviewsEnabled,
             })
             .returning('*');
 
@@ -75,13 +77,27 @@ export class AiOrganizationSettingsModel {
         organizationUuid: string,
         data: UpdateAiOrganizationSettings,
     ): Promise<AiOrganizationSettings> {
+        const updateData: Partial<
+            Pick<
+                DbAiOrganizationSettings,
+                'ai_agents_visible' | 'ai_agent_reviews_enabled'
+            >
+        > = {};
+        if (data.aiAgentsVisible !== undefined) {
+            updateData.ai_agents_visible = data.aiAgentsVisible;
+        }
+        if (data.aiAgentReviewsEnabled !== undefined) {
+            updateData.ai_agent_reviews_enabled = data.aiAgentReviewsEnabled;
+        }
+        if (Object.keys(updateData).length === 0) {
+            return this.getByOrganizationUuid(organizationUuid);
+        }
+
         const [row] = await this.database<AiOrganizationSettingsTable>(
             AiOrganizationSettingsTableName,
         )
             .where('organization_uuid', organizationUuid)
-            .update({
-                ai_agents_visible: data.aiAgentsVisible,
-            })
+            .update(updateData)
             .returning('*');
 
         if (!row) {
@@ -104,7 +120,8 @@ export class AiOrganizationSettingsModel {
         }
         return this.create({
             organizationUuid,
-            aiAgentsVisible: data.aiAgentsVisible,
+            aiAgentsVisible: data.aiAgentsVisible ?? true,
+            aiAgentReviewsEnabled: data.aiAgentReviewsEnabled ?? false,
         });
     }
 

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
+import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import {
     AiAgentReviewClassifierService,
     resolveReviewJudgeProvider,
@@ -275,6 +276,9 @@ describe('AiAgentReviewClassifierService', () => {
     const aiAgentModel = {
         getAgent: jest.fn(),
     };
+    const aiOrganizationSettingsModel = {
+        findByOrganizationUuid: jest.fn(),
+    } as unknown as jest.Mocked<AiOrganizationSettingsModel>;
     const catalogModel = {
         getCatalogItemsSummary: jest.fn(),
     };
@@ -283,6 +287,7 @@ describe('AiAgentReviewClassifierService', () => {
     const service = new AiAgentReviewClassifierService({
         aiAgentReviewClassifierModel: model,
         aiAgentModel: aiAgentModel as never,
+        aiOrganizationSettingsModel,
         catalogModel: catalogModel as never,
         featureFlagService,
         lightdashConfig: {} as never,
@@ -294,6 +299,11 @@ describe('AiAgentReviewClassifierService', () => {
         featureFlagService.get.mockResolvedValue({
             id: FeatureFlags.AiAgentReviewClassifier,
             enabled: true,
+        });
+        aiOrganizationSettingsModel.findByOrganizationUuid.mockResolvedValue({
+            organizationUuid: ORGANIZATION_UUID,
+            aiAgentsVisible: true,
+            aiAgentReviewsEnabled: true,
         });
         model.createRun.mockResolvedValue(makeRun());
         model.updateRun.mockResolvedValue(makeRun({ status: 'completed' }));
@@ -338,6 +348,26 @@ describe('AiAgentReviewClassifierService', () => {
             id: FeatureFlags.AiAgentReviewClassifier,
             enabled: false,
         });
+
+        await expect(
+            service.run({
+                organizationUuid: ORGANIZATION_UUID,
+                startedAt: NOW,
+                endedAt: NOW,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+
+        expect(model.createRun).not.toHaveBeenCalled();
+    });
+
+    it('throws when review collection is not opted in for the organization', async () => {
+        aiOrganizationSettingsModel.findByOrganizationUuid.mockResolvedValueOnce(
+            {
+                organizationUuid: ORGANIZATION_UUID,
+                aiAgentsVisible: true,
+                aiAgentReviewsEnabled: false,
+            },
+        );
 
         await expect(
             service.run({

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -31,6 +31,7 @@ import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type AiAgentModel } from '../models/AiAgentModel';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
+import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import { defaultAgentOptions } from './ai/agents/agentV2';
 import { getModel } from './ai/models';
 
@@ -60,6 +61,7 @@ type AiAgentReviewClassifierJudgeTargetRef =
 type AiAgentReviewClassifierServiceDependencies = {
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
     aiAgentModel: AiAgentModel;
+    aiOrganizationSettingsModel: AiOrganizationSettingsModel;
     catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
     featureFlagService: FeatureFlagService;
     lightdashConfig: LightdashConfig;
@@ -207,6 +209,8 @@ export class AiAgentReviewClassifierService extends BaseService {
 
     private readonly catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
 
+    private readonly aiOrganizationSettingsModel: AiOrganizationSettingsModel;
+
     private readonly featureFlagService: FeatureFlagService;
 
     private readonly lightdashConfig: LightdashConfig;
@@ -219,6 +223,8 @@ export class AiAgentReviewClassifierService extends BaseService {
             dependencies.aiAgentReviewClassifierModel;
         this.aiAgentModel = dependencies.aiAgentModel;
         this.catalogModel = dependencies.catalogModel;
+        this.aiOrganizationSettingsModel =
+            dependencies.aiOrganizationSettingsModel;
         this.featureFlagService = dependencies.featureFlagService;
         this.lightdashConfig = dependencies.lightdashConfig;
         this.judgeTurn =
@@ -1023,7 +1029,16 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
             },
         });
 
-        return featureFlag.enabled;
+        if (!featureFlag.enabled) {
+            return false;
+        }
+
+        const settings =
+            await this.aiOrganizationSettingsModel.findByOrganizationUuid(
+                args.organizationUuid,
+            );
+
+        return settings?.aiAgentReviewsEnabled ?? false;
     }
 
     private static buildEvidenceExcerpts(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -665,8 +665,15 @@ export class AiAgentService extends BaseService {
                     organizationName: '',
                 },
             })
-            .then((flag) => {
+            .then(async (flag) => {
                 if (!flag.enabled) {
+                    return undefined;
+                }
+                const reviewsEnabled =
+                    await this.aiOrganizationSettingsService.isAiAgentReviewsEnabled(
+                        { organizationUuid },
+                    );
+                if (!reviewsEnabled) {
                     return undefined;
                 }
                 return this.schedulerClient.aiAgentReviewClassifier({

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -129,6 +129,7 @@ export class AiOrganizationSettingsService extends BaseService {
                 organizationUuid: user.organizationUuid,
                 isCopilotEnabled,
                 aiAgentsVisible: true,
+                aiAgentReviewsEnabled: false,
                 isTrial: isTrialEligible,
             };
         }
@@ -154,5 +155,20 @@ export class AiOrganizationSettingsService extends BaseService {
             user.organizationUuid,
             data,
         );
+    }
+
+    async isAiAgentReviewsEnabled(
+        user: Pick<LightdashUser, 'organizationUuid'>,
+    ): Promise<boolean> {
+        if (!user.organizationUuid) {
+            return false;
+        }
+
+        const settings =
+            await this.aiOrganizationSettingsModel.findByOrganizationUuid(
+                user.organizationUuid,
+            );
+
+        return settings?.aiAgentReviewsEnabled ?? false;
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -20341,6 +20341,10 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                aiAgentReviewsEnabled: {
+                    dataType: 'boolean',
+                    required: true,
+                },
                 aiAgentsVisible: { dataType: 'boolean', required: true },
                 organizationUuid: { dataType: 'string', required: true },
             },
@@ -20410,7 +20414,11 @@ const models: TsoaRoute.Models = {
             type: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
-                    aiAgentsVisible: { dataType: 'boolean', required: true },
+                    aiAgentReviewsEnabled: {
+                        dataType: 'boolean',
+                        required: false,
+                    },
+                    aiAgentsVisible: { dataType: 'boolean', required: false },
                 },
                 validators: {},
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -20902,6 +20902,9 @@
             },
             "AiOrganizationSettings": {
                 "properties": {
+                    "aiAgentReviewsEnabled": {
+                        "type": "boolean"
+                    },
                     "aiAgentsVisible": {
                         "type": "boolean"
                     },
@@ -20909,7 +20912,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["aiAgentsVisible", "organizationUuid"],
+                "required": [
+                    "aiAgentReviewsEnabled",
+                    "aiAgentsVisible",
+                    "organizationUuid"
+                ],
                 "type": "object"
             },
             "ComputedAiOrganizationSettings": {
@@ -20967,11 +20974,13 @@
             },
             "Pick_AiOrganizationSettings.Exclude_keyofAiOrganizationSettings.organizationUuid-or-isTrial-or-isCopilotEnabled__": {
                 "properties": {
+                    "aiAgentReviewsEnabled": {
+                        "type": "boolean"
+                    },
                     "aiAgentsVisible": {
                         "type": "boolean"
                     }
                 },
-                "required": ["aiAgentsVisible"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -69,13 +69,13 @@ export type ComputedAiOrganizationSettings = {
 export type AiOrganizationSettings = {
     organizationUuid: string;
     aiAgentsVisible: boolean;
+    aiAgentReviewsEnabled: boolean;
 };
 
 export type CreateAiOrganizationSettings = AiOrganizationSettings;
 
-export type UpdateAiOrganizationSettings = Omit<
-    AiOrganizationSettings,
-    'organizationUuid' | 'isTrial' | 'isCopilotEnabled'
+export type UpdateAiOrganizationSettings = Partial<
+    Omit<AiOrganizationSettings, 'organizationUuid'>
 >;
 
 export type ApiAiOrganizationSettingsResponse = ApiSuccess<

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -10,6 +10,7 @@ import {
     Title,
 } from '@mantine-8/core';
 import { IconSparkles } from '@tabler/icons-react';
+import { BetaBadge } from '../../../../../../components/common/BetaBadge';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { SettingsCard } from '../../../../../../components/common/Settings/SettingsCard';
@@ -95,6 +96,43 @@ export const AiGeneralSettingsPage = () => {
                                 onChange={(event) =>
                                     updateSettings({
                                         aiAgentsVisible:
+                                            event.currentTarget.checked,
+                                    })
+                                }
+                            />
+                        </Group>
+                    </SettingsCard>
+
+                    <SettingsCard>
+                        <Group
+                            justify="space-between"
+                            wrap="nowrap"
+                            align="flex-start"
+                            gap="md"
+                        >
+                            <Box maw={620}>
+                                <Group gap="xs" mb={4}>
+                                    <Title order={5}>
+                                        Review AI agent turns
+                                    </Title>
+                                    <BetaBadge />
+                                </Group>
+                                <Text c="dimmed" fz="xs">
+                                    Process every agent turn to surface semantic
+                                    layer gaps, project context improvements,
+                                    and admin recommendations. For connected
+                                    projects, Lightdash can suggest pull
+                                    requests that improve context and dbt
+                                    definitions.
+                                </Text>
+                            </Box>
+                            <Switch
+                                size="md"
+                                checked={settings.aiAgentReviewsEnabled}
+                                disabled={isUpdatingSettings}
+                                onChange={(event) =>
+                                    updateSettings({
+                                        aiAgentReviewsEnabled:
                                             event.currentTarget.checked,
                                     })
                                 }


### PR DESCRIPTION
## Summary
- add org-level `aiAgentReviewsEnabled` setting and migration, defaulting off
- gate review classifier enqueue and job execution on that opt-in
- expose the admin setting in Ask AI general settings
- update API metadata for partial settings updates

## Validation
- `pnpm -F @lightdash/common build`
- `pnpm -F backend test -- AiAgentReviewClassifierService.test.ts --runInBand`
- `pnpm -F backend typecheck`
- `pnpm -F @lightdash/frontend typecheck`
- `pnpm -F @lightdash/common typecheck`

Stack: 1/2. Next: `joaoviana/ai-review-writeback-hardening-stack`.
