### PR TITLE
feat(ai-agents): harden review writeback workflow

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -26,9 +26,14 @@ import {
     TableSelectionType,
     ValidateProjectPayload,
     WarehouseTypes,
+    type AiAgentReviewItemStatus,
+    type AiAgentReviewItemWritebackBlockedReason,
+    type AiAgentReviewItemWritebackStrategy,
+    type AiAgentRootCause,
     type AiRouterDecisionConfidence,
     type AiRouterRouteNextAction,
     type DataAppClaudeModel,
+    type PullRequestProvider,
 } from '@lightdash/common';
 import Analytics, {
     Track as AnalyticsTrack,
@@ -2135,6 +2140,92 @@ export type AiAgentPullRequestViewedEvent = BaseTrack & {
     };
 };
 
+export type AiAgentReviewItemsListedEvent = BaseTrack & {
+    event: 'ai_agent_review_items.listed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        totalCount: number;
+        eligibleCount: number;
+        statuses: AiAgentReviewItemStatus[] | null;
+        blockedReasons: Partial<
+            Record<AiAgentReviewItemWritebackBlockedReason, number>
+        >;
+    };
+};
+
+export type AiAgentReviewItemStatusChangedEvent = BaseTrack & {
+    event: 'ai_agent_review_item.status_changed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        fingerprint: string;
+        rootCause: AiAgentRootCause;
+        previousStatus: AiAgentReviewItemStatus;
+        newStatus: AiAgentReviewItemStatus;
+    };
+};
+
+export type AiAgentReviewItemWritebackQueuedEvent = BaseTrack & {
+    event: 'ai_agent_review_item.writeback_queued';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        fingerprint: string;
+        rootCause: AiAgentRootCause;
+        strategy: AiAgentReviewItemWritebackStrategy;
+        provider: PullRequestProvider;
+    };
+};
+
+export type AiAgentReviewItemWritebackPreviewViewedEvent = BaseTrack & {
+    event: 'ai_agent_review_item.writeback_preview_viewed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string | null;
+        fingerprint: string;
+        rootCause: AiAgentRootCause;
+        available: boolean;
+        strategy: AiAgentReviewItemWritebackStrategy | null;
+    };
+};
+
+export type AiAgentReviewItemWritebackCompletedEvent = BaseTrack & {
+    event: 'ai_agent_review_item.writeback_completed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        fingerprint: string;
+        rootCause: AiAgentRootCause;
+        strategy: AiAgentReviewItemWritebackStrategy;
+        prCreated: boolean;
+    };
+};
+
+export type AiAgentReviewItemWritebackFailedEvent = BaseTrack & {
+    event: 'ai_agent_review_item.writeback_failed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        fingerprint: string;
+        rootCause: AiAgentRootCause;
+        strategy: AiAgentReviewItemWritebackStrategy | null;
+        errorMessage: string;
+    };
+};
+
+export type AiAgentReviewEvent =
+    | AiAgentReviewItemsListedEvent
+    | AiAgentReviewItemStatusChangedEvent
+    | AiAgentReviewItemWritebackQueuedEvent
+    | AiAgentReviewItemWritebackPreviewViewedEvent
+    | AiAgentReviewItemWritebackCompletedEvent
+    | AiAgentReviewItemWritebackFailedEvent;
+
 export type AiRouterConfigUpdatedEvent = BaseTrack & {
     event: 'ai_router.config_updated';
     userId: string;
@@ -2315,6 +2406,7 @@ type TypedEvent =
     | AiAgentSuggestionClickEvent
     | AiAgentSuggestionSubmitEvent
     | AiAgentPullRequestViewedEvent
+    | AiAgentReviewEvent
     | AiRouterConfigUpdatedEvent
     | AiRouterInstructionsUpdatedEvent
     | AiRouterMessageRoutedEvent

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -278,6 +278,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 }),
             aiAgentAdminService: ({ models, repository, context, clients }) =>
                 new AiAgentAdminService({
+                    analytics: context.lightdashAnalytics,
                     aiAgentModel: models.getAiAgentModel(),
                     aiAgentReviewClassifierModel:
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
@@ -290,6 +291,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     pullRequestsModel: models.getPullRequestsModel(),
                     githubAppInstallationsModel:
                         models.getGithubAppInstallationsModel(),
+                    gitlabAppInstallationsModel:
+                        models.getGitlabAppInstallationsModel(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                     userModel: models.getUserModel(),

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -281,13 +281,16 @@ describe('AiAgentReviewClassifierModel', () => {
     describe('listReviewItems', () => {
         it('groups actionable signals into review item projections', async () => {
             tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
-                makeTurnSignalRow(),
-                makeTurnSignalRow({
-                    ai_agent_review_turn_signal_uuid:
-                        '00000000-0000-0000-0000-000000000011',
-                    created_at: new Date('2026-05-26T09:00:00.000Z'),
-                }),
+                {
+                    fingerprint: FINGERPRINT,
+                    first_seen_at: new Date('2026-05-26T09:00:00.000Z'),
+                    last_seen_at: SEEN_AT,
+                    finding_count: '2',
+                },
             ]);
+            tracker.on
+                .select(AiAgentTurnSignalTableName)
+                .responseOnce([makeTurnSignalRow()]);
             tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
 
             const result = await model.listReviewItems({
@@ -322,6 +325,14 @@ describe('AiAgentReviewClassifierModel', () => {
         });
 
         it('overlays persisted human state and PR linkage onto the projection', async () => {
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
+                {
+                    fingerprint: FINGERPRINT,
+                    first_seen_at: SEEN_AT,
+                    last_seen_at: SEEN_AT,
+                    finding_count: '1',
+                },
+            ]);
             tracker.on
                 .select(AiAgentTurnSignalTableName)
                 .responseOnce([makeTurnSignalRow()]);
@@ -361,10 +372,7 @@ describe('AiAgentReviewClassifierModel', () => {
         });
 
         it('filters by overlaid status', async () => {
-            tracker.on
-                .select(AiAgentTurnSignalTableName)
-                .responseOnce([makeTurnSignalRow()]);
-            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([]);
 
             const result = await model.listReviewItems({
                 organizationUuid: ORGANIZATION_UUID,

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -19,6 +19,7 @@ import type {
     AiAgentReviewItemPrState,
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
+    AiAgentReviewItemWritebackEligibility,
     AiAgentReviewItemWritebackStatus,
     AiAgentReviewSignalSummary,
     AiAgentRootCause,
@@ -49,6 +50,20 @@ import {
 
 type Dependencies = {
     database: Knex;
+};
+
+type ReviewItemAggregateRow = {
+    fingerprint: string;
+    first_seen_at: Date | string;
+    last_seen_at: Date | string;
+    finding_count: string | number;
+};
+
+const defaultWritebackEligibility: AiAgentReviewItemWritebackEligibility = {
+    eligible: false,
+    reason: 'reviews_disabled',
+    provider: null,
+    strategy: null,
 };
 
 type CreateRunArgs = {
@@ -797,44 +812,121 @@ export class AiAgentReviewClassifierModel {
     async listReviewItems(
         args: ListReviewItemsArgs,
     ): Promise<AiAgentReviewItemSummary[]> {
-        const rows: DbAiAgentTurnSignal[] =
-            await this.database<AiAgentTurnSignalTable>(
-                AiAgentTurnSignalTableName,
+        const limit = Math.min(args.limit ?? 100, 500);
+        if (args.statuses?.length === 0) {
+            return [];
+        }
+        const baseQuery = this.database<AiAgentTurnSignalTable>(
+            AiAgentTurnSignalTableName,
+        )
+            .where(
+                `${AiAgentTurnSignalTableName}.organization_uuid`,
+                args.organizationUuid,
             )
-                .where('organization_uuid', args.organizationUuid)
-                .where('promoted_to_finding', true)
-                .whereNotNull('fingerprint')
-                .modify((query) => {
-                    if (args.projectUuid) {
-                        void query.where('project_uuid', args.projectUuid);
-                    }
-                    if (args.agentUuid) {
-                        void query.where('agent_uuid', args.agentUuid);
-                    }
-                    if (args.fingerprint) {
-                        void query.where('fingerprint', args.fingerprint);
-                    }
-                })
-                .orderBy('created_at', 'desc')
-                .limit(Math.min((args.limit ?? 100) * 10, 1000));
+            .where(`${AiAgentTurnSignalTableName}.promoted_to_finding`, true)
+            .whereNotNull(`${AiAgentTurnSignalTableName}.fingerprint`)
+            .modify((query) => {
+                if (args.projectUuid) {
+                    void query.where(
+                        `${AiAgentTurnSignalTableName}.project_uuid`,
+                        args.projectUuid,
+                    );
+                }
+                if (args.agentUuid) {
+                    void query.where(
+                        `${AiAgentTurnSignalTableName}.agent_uuid`,
+                        args.agentUuid,
+                    );
+                }
+                if (args.fingerprint) {
+                    void query.where(
+                        `${AiAgentTurnSignalTableName}.fingerprint`,
+                        args.fingerprint,
+                    );
+                }
+                if (args.statuses) {
+                    void query
+                        .leftJoin(
+                            AiAgentReviewItemTableName,
+                            function joinReviewItems() {
+                                this.on(
+                                    `${AiAgentReviewItemTableName}.fingerprint`,
+                                    `${AiAgentTurnSignalTableName}.fingerprint`,
+                                ).andOn(
+                                    `${AiAgentReviewItemTableName}.organization_uuid`,
+                                    `${AiAgentTurnSignalTableName}.organization_uuid`,
+                                );
+                            },
+                        )
+                        .whereRaw(
+                            `COALESCE(${AiAgentReviewItemTableName}.status, 'open') IN (${args.statuses
+                                .map(() => '?')
+                                .join(', ')})`,
+                            args.statuses,
+                        );
+                }
+            });
 
-        const byFingerprint = new Map<string, DbAiAgentTurnSignal[]>();
-        rows.forEach((row) => {
-            if (!row.fingerprint) return;
-            const group = byFingerprint.get(row.fingerprint) ?? [];
-            group.push(row);
-            byFingerprint.set(row.fingerprint, group);
-        });
+        const aggregateRows = (await baseQuery
+            .clone()
+            .select({
+                fingerprint: `${AiAgentTurnSignalTableName}.fingerprint`,
+            })
+            .min({
+                first_seen_at: `${AiAgentTurnSignalTableName}.created_at`,
+            })
+            .max({
+                last_seen_at: `${AiAgentTurnSignalTableName}.created_at`,
+            })
+            .count({
+                finding_count: '*',
+            })
+            .groupBy(`${AiAgentTurnSignalTableName}.fingerprint`)
+            .orderBy('last_seen_at', 'desc')
+            .limit(limit)) as ReviewItemAggregateRow[];
 
-        const fingerprints = Array.from(byFingerprint.keys());
+        const fingerprints = aggregateRows.map((row) => row.fingerprint);
+        if (fingerprints.length === 0) {
+            return [];
+        }
+
+        const latestRows = (await this.database<AiAgentTurnSignalTable>(
+            AiAgentTurnSignalTableName,
+        )
+            .distinctOn('fingerprint')
+            .select('*')
+            .where('organization_uuid', args.organizationUuid)
+            .whereIn('fingerprint', fingerprints)
+            .modify((query) => {
+                if (args.projectUuid) {
+                    void query.where('project_uuid', args.projectUuid);
+                }
+                if (args.agentUuid) {
+                    void query.where('agent_uuid', args.agentUuid);
+                }
+            })
+            .orderBy('fingerprint')
+            .orderBy('created_at', 'desc')) as DbAiAgentTurnSignal[];
+
+        const latestByFingerprint = new Map(
+            latestRows
+                .filter((row) => row.fingerprint !== null)
+                .map((row) => [row.fingerprint as string, row]),
+        );
+        const aggregateByFingerprint = new Map(
+            aggregateRows.map((row) => [row.fingerprint, row]),
+        );
         const persisted = await this.getReviewItemsByFingerprint(fingerprints);
 
-        return Array.from(byFingerprint.entries())
-            .map(([fingerprint, group]) => {
-                const latest = group[0];
-                const createdAts = group.map((row) => row.created_at.getTime());
-                const firstSeenAt = new Date(Math.min(...createdAts));
-                const lastSeenAt = new Date(Math.max(...createdAts));
+        const reviewItems = fingerprints
+            .map((fingerprint): AiAgentReviewItemSummary | null => {
+                const latest = latestByFingerprint.get(fingerprint);
+                const aggregate = aggregateByFingerprint.get(fingerprint);
+                if (!latest || !aggregate) {
+                    return null;
+                }
+                const firstSeenAt = new Date(aggregate.first_seen_at);
+                const lastSeenAt = new Date(aggregate.last_seen_at);
                 const item = persisted.get(fingerprint) ?? null;
                 return {
                     uuid: fingerprint,
@@ -851,7 +943,7 @@ export class AiAgentReviewClassifierModel {
                     assignedToUserUuid: item?.assigned_to_user_uuid ?? null,
                     firstSeenAt,
                     lastSeenAt,
-                    findingCount: group.length,
+                    findingCount: Number(aggregate.finding_count),
                     statusUpdatedAt: item?.status_updated_at ?? lastSeenAt,
                     statusUpdatedByUserUuid:
                         item?.status_updated_by_user_uuid ?? null,
@@ -861,6 +953,7 @@ export class AiAgentReviewClassifierModel {
                     prWritebackStatus: item?.pr_writeback_status ?? null,
                     prWritebackMessage: item?.pr_writeback_message ?? null,
                     writebackEligible: false,
+                    writebackEligibility: defaultWritebackEligibility,
                     createdAt: item?.created_at ?? firstSeenAt,
                     updatedAt: item?.updated_at ?? lastSeenAt,
                     latestFinding: {
@@ -881,10 +974,11 @@ export class AiAgentReviewClassifierModel {
                 };
             })
             .filter(
-                (reviewItem) =>
-                    !args.statuses || args.statuses.includes(reviewItem.status),
-            )
-            .slice(0, Math.min(args.limit ?? 100, 500));
+                (reviewItem): reviewItem is AiAgentReviewItemSummary =>
+                    reviewItem !== null,
+            );
+
+        return reviewItems;
     }
 
     async getReviewItemsByFingerprint(

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -1,0 +1,150 @@
+import {
+    PullRequestProvider,
+    type AiAgentReviewItemSummary,
+} from '@lightdash/common';
+import { getAiAgentReviewItemWritebackEligibility } from './AiAgentAdminService';
+
+const NOW = new Date('2026-06-08T10:00:00.000Z');
+
+const makeReviewItem = (
+    overrides: Partial<AiAgentReviewItemSummary> = {},
+): AiAgentReviewItemSummary => ({
+    uuid: 'fingerprint-1',
+    fingerprint: 'fingerprint-1',
+    organizationUuid: 'org-1',
+    projectUuid: 'project-1',
+    agentUuid: 'agent-1',
+    title: 'Missing metric',
+    description: 'The agent could not answer because a metric was missing.',
+    primaryRootCause: 'semantic_layer',
+    status: 'open',
+    dismissedReason: null,
+    ownerType: 'semantic_layer_owner',
+    assignedToUserUuid: null,
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+    findingCount: 1,
+    statusUpdatedAt: NOW,
+    statusUpdatedByUserUuid: null,
+    linkedIssueUrl: null,
+    linkedPrUrl: null,
+    prState: null,
+    prWritebackStatus: null,
+    prWritebackMessage: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    writebackEligible: false,
+    writebackEligibility: {
+        eligible: false,
+        reason: 'reviews_disabled',
+        provider: null,
+        strategy: null,
+    },
+    latestFinding: null,
+    ...overrides,
+});
+
+describe('getAiAgentReviewItemWritebackEligibility', () => {
+    it('allows semantic layer writeback on GitHub when configured', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem(),
+                reviewsEnabled: true,
+                projectContextEnabled: false,
+                projectAccess: {
+                    provider: PullRequestProvider.GITHUB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: true,
+            }),
+        ).toEqual({
+            eligible: true,
+            provider: PullRequestProvider.GITHUB,
+            strategy: 'semantic_layer',
+            reason: null,
+        });
+    });
+
+    it('allows semantic layer writeback on GitLab when configured', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem(),
+                reviewsEnabled: true,
+                projectContextEnabled: false,
+                projectAccess: {
+                    provider: PullRequestProvider.GITLAB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: true,
+            }),
+        ).toEqual({
+            eligible: true,
+            provider: PullRequestProvider.GITLAB,
+            strategy: 'semantic_layer',
+            reason: null,
+        });
+    });
+
+    it('blocks project context writeback for GitLab projects', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem({
+                    primaryRootCause: 'project_context',
+                    latestFinding: {
+                        uuid: 'finding-1',
+                        promptUuid: 'prompt-1',
+                        threadUuid: 'thread-1',
+                        projectUuid: 'project-1',
+                        agentUuid: 'agent-1',
+                        subcategories: [],
+                        fixTargets: ['project_context_rule'],
+                        targetRefs: [],
+                        evidenceExcerpts: [],
+                        recommendation: null,
+                        projectContextEntry: {
+                            op: 'create',
+                            id: null,
+                            kind: 'context',
+                            content: 'Use orders for revenue questions.',
+                            terms: ['revenue'],
+                            objects: ['orders'],
+                        },
+                        createdAt: NOW,
+                    },
+                }),
+                reviewsEnabled: true,
+                projectContextEnabled: true,
+                projectAccess: {
+                    provider: PullRequestProvider.GITLAB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: false,
+            }),
+        ).toEqual({
+            eligible: false,
+            provider: PullRequestProvider.GITLAB,
+            strategy: 'project_context',
+            reason: 'unsupported_source_control',
+        });
+    });
+
+    it('returns a reason when semantic writeback config is missing', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem(),
+                reviewsEnabled: true,
+                projectContextEnabled: false,
+                projectAccess: {
+                    provider: PullRequestProvider.GITHUB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: false,
+            }),
+        ).toEqual({
+            eligible: false,
+            provider: PullRequestProvider.GITHUB,
+            strategy: 'semantic_layer',
+            reason: 'missing_writeback_config',
+        });
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -20,16 +20,21 @@ import {
     PullRequestProvider,
     PullRequestSource,
     UpdateAiAgentReviewItemStatus,
+    type AiAgentReviewItemWritebackBlockedReason,
+    type AiAgentReviewItemWritebackEligibility,
     type AiAgentReviewItemWritebackPreview,
+    type AiAgentReviewItemWritebackStrategy,
     type SessionUser,
 } from '@lightdash/common';
 import jwt from 'jsonwebtoken';
+import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import {
     getInstallationToken,
     getPullRequest,
 } from '../../clients/github/Github';
 import { type LightdashConfig } from '../../config/parseConfig';
 import { type GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
+import { type GitlabAppInstallationsModel } from '../../models/GitlabAppInstallations/GitlabAppInstallationsModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { type PullRequestsModel } from '../../models/PullRequestsModel';
 import { type UserModel } from '../../models/UserModel';
@@ -46,6 +51,7 @@ import { type AiWritebackService } from './AiWritebackService/AiWritebackService
 import { type ProjectContextService } from './ProjectContextService/ProjectContextService';
 
 type AiAgentAdminServiceDependencies = {
+    analytics: LightdashAnalytics;
     aiAgentModel: AiAgentModel;
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
     featureFlagService: FeatureFlagService;
@@ -54,6 +60,7 @@ type AiAgentAdminServiceDependencies = {
     projectContextService: ProjectContextService;
     pullRequestsModel: PullRequestsModel;
     githubAppInstallationsModel: GithubAppInstallationsModel;
+    gitlabAppInstallationsModel: GitlabAppInstallationsModel;
     schedulerClient: CommercialSchedulerClient;
     userModel: UserModel;
     lightdashConfig: LightdashConfig;
@@ -72,22 +79,152 @@ const parsePullRequestUrl = (
 // Longer than the worker's 30-min job timeout — past this, a queued/running writeback has lost its worker and is treated as failed so the UI recovers and retries.
 const WRITEBACK_STALE_MS = 35 * 60 * 1000;
 
-// Root causes that can open a writeback PR (both also require a GitHub-connected
-// project). project_context additionally needs the judge-emitted entry.
-const hasWritebackStrategy = (
+type ProjectWritebackAccess =
+    | {
+          provider: PullRequestProvider;
+          hasGitAppInstallation: boolean;
+      }
+    | {
+          provider: null;
+          hasGitAppInstallation: false;
+      };
+
+type ProjectWritebackAccessEntry = [string, ProjectWritebackAccess];
+
+const terminalReviewStatuses = new Set<AiAgentReviewItemStatus>([
+    'resolved',
+    'dismissed',
+    'duplicate',
+]);
+
+const unavailableWritebackEligibility = (
+    reason: AiAgentReviewItemWritebackBlockedReason,
+    strategy: AiAgentReviewItemWritebackStrategy | null = null,
+    provider: PullRequestProvider | null = null,
+): AiAgentReviewItemWritebackEligibility => ({
+    eligible: false,
+    reason,
+    strategy,
+    provider,
+});
+
+const getWritebackStrategy = (
     item: AiAgentReviewItemSummary,
-    { projectContextEnabled }: { projectContextEnabled: boolean },
-): boolean => {
+    projectContextEnabled: boolean,
+):
+    | { strategy: AiAgentReviewItemWritebackStrategy }
+    | { eligibility: AiAgentReviewItemWritebackEligibility } => {
     if (item.primaryRootCause === 'semantic_layer') {
-        return true;
+        return { strategy: 'semantic_layer' };
     }
-    if (item.primaryRootCause === 'project_context') {
-        return (
-            projectContextEnabled &&
-            item.latestFinding?.projectContextEntry != null
+    if (item.primaryRootCause !== 'project_context') {
+        return {
+            eligibility: unavailableWritebackEligibility(
+                'unsupported_root_cause',
+            ),
+        };
+    }
+    if (!projectContextEnabled) {
+        return {
+            eligibility: unavailableWritebackEligibility(
+                'project_context_disabled',
+                'project_context',
+            ),
+        };
+    }
+    if (!item.latestFinding?.projectContextEntry) {
+        return {
+            eligibility: unavailableWritebackEligibility(
+                'missing_project_context_entry',
+                'project_context',
+            ),
+        };
+    }
+    return { strategy: 'project_context' };
+};
+
+const toReviewWritebackStrategy = (
+    strategy: ReturnType<typeof planReviewWriteback>['strategy'],
+): AiAgentReviewItemWritebackStrategy =>
+    strategy === 'project_context' ? 'project_context' : 'semantic_layer';
+
+export const getAiAgentReviewItemWritebackEligibility = (args: {
+    item: AiAgentReviewItemSummary;
+    reviewsEnabled: boolean;
+    projectContextEnabled: boolean;
+    projectAccess: ProjectWritebackAccess | null;
+    hasSemanticWritebackConfig: boolean;
+}): AiAgentReviewItemWritebackEligibility => {
+    const {
+        item,
+        reviewsEnabled,
+        projectContextEnabled,
+        projectAccess,
+        hasSemanticWritebackConfig,
+    } = args;
+
+    if (!reviewsEnabled) {
+        return unavailableWritebackEligibility('reviews_disabled');
+    }
+    if (terminalReviewStatuses.has(item.status)) {
+        return unavailableWritebackEligibility('terminal_state');
+    }
+    if (item.linkedPrUrl && item.prState === 'open') {
+        return unavailableWritebackEligibility('pull_request_open');
+    }
+    if (
+        item.prWritebackStatus === 'queued' ||
+        item.prWritebackStatus === 'running'
+    ) {
+        return unavailableWritebackEligibility('writeback_in_progress');
+    }
+
+    const strategyResult = getWritebackStrategy(item, projectContextEnabled);
+    if ('eligibility' in strategyResult) {
+        return strategyResult.eligibility;
+    }
+    const { strategy } = strategyResult;
+
+    if (!item.projectUuid) {
+        return unavailableWritebackEligibility('missing_project', strategy);
+    }
+    if (!projectAccess || !projectAccess.provider) {
+        return unavailableWritebackEligibility(
+            'unsupported_source_control',
+            strategy,
         );
     }
-    return false;
+    if (
+        strategy === 'project_context' &&
+        projectAccess.provider !== PullRequestProvider.GITHUB
+    ) {
+        return unavailableWritebackEligibility(
+            'unsupported_source_control',
+            strategy,
+            projectAccess.provider,
+        );
+    }
+    if (!projectAccess.hasGitAppInstallation) {
+        return unavailableWritebackEligibility(
+            'git_app_not_installed',
+            strategy,
+            projectAccess.provider,
+        );
+    }
+    if (strategy === 'semantic_layer' && !hasSemanticWritebackConfig) {
+        return unavailableWritebackEligibility(
+            'missing_writeback_config',
+            strategy,
+            projectAccess.provider,
+        );
+    }
+
+    return {
+        eligible: true,
+        reason: null,
+        strategy,
+        provider: projectAccess.provider,
+    };
 };
 
 const isWritebackStale = (
@@ -111,6 +248,8 @@ const withStaleWritebackOverride = (
         : item;
 
 export class AiAgentAdminService extends BaseService {
+    private readonly analytics: LightdashAnalytics;
+
     private readonly aiAgentModel: AiAgentModel;
 
     private readonly lightdashConfig: LightdashConfig;
@@ -129,12 +268,15 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly githubAppInstallationsModel: GithubAppInstallationsModel;
 
+    private readonly gitlabAppInstallationsModel: GitlabAppInstallationsModel;
+
     private readonly schedulerClient: CommercialSchedulerClient;
 
     private readonly userModel: UserModel;
 
     constructor(dependencies: AiAgentAdminServiceDependencies) {
         super();
+        this.analytics = dependencies.analytics;
         this.aiAgentModel = dependencies.aiAgentModel;
         this.aiAgentReviewClassifierModel =
             dependencies.aiAgentReviewClassifierModel;
@@ -145,6 +287,8 @@ export class AiAgentAdminService extends BaseService {
         this.pullRequestsModel = dependencies.pullRequestsModel;
         this.githubAppInstallationsModel =
             dependencies.githubAppInstallationsModel;
+        this.gitlabAppInstallationsModel =
+            dependencies.gitlabAppInstallationsModel;
         this.schedulerClient = dependencies.schedulerClient;
         this.userModel = dependencies.userModel;
         this.lightdashConfig = dependencies.lightdashConfig;
@@ -236,7 +380,7 @@ export class AiAgentAdminService extends BaseService {
             statuses,
         });
 
-        const [writebackEnabled, projectContextEnabled] = await Promise.all([
+        const [reviewsEnabled, projectContextEnabled] = await Promise.all([
             this.isWritebackFeatureEnabled(user),
             this.isProjectContextFeatureEnabled(user),
         ]);
@@ -247,37 +391,71 @@ export class AiAgentAdminService extends BaseService {
             { projectContextEnabled },
         );
 
-        const githubProjects = writebackEnabled
-            ? await this.getGithubProjectUuids(
-                  items
-                      .filter(
-                          (item) =>
-                              hasWritebackStrategy(item, {
-                                  projectContextEnabled,
-                              }) && item.projectUuid !== null,
-                      )
-                      .map((item) => item.projectUuid as string),
-              )
-            : new Set<string>();
+        const projectAccessByUuid = await this.getProjectWritebackAccessByUuid(
+            organizationUuid,
+            items
+                .map((item) => item.projectUuid)
+                .filter((uuid): uuid is string => uuid !== null),
+        );
 
         const now = Date.now();
         const reconciled = items.map((item) => {
             const override = overrides.get(item.fingerprint);
-            const writebackEligible =
-                writebackEnabled &&
-                hasWritebackStrategy(item, { projectContextEnabled }) &&
-                item.projectUuid !== null &&
-                githubProjects.has(item.projectUuid);
-            return withStaleWritebackOverride(
-                { ...item, ...(override ?? {}), writebackEligible },
+            const staleAwareItem = withStaleWritebackOverride(
+                { ...item, ...(override ?? {}) },
                 now,
             );
+            const writebackEligibility =
+                getAiAgentReviewItemWritebackEligibility({
+                    item: staleAwareItem,
+                    reviewsEnabled,
+                    projectContextEnabled,
+                    projectAccess: staleAwareItem.projectUuid
+                        ? (projectAccessByUuid.get(
+                              staleAwareItem.projectUuid,
+                          ) ?? null)
+                        : null,
+                    hasSemanticWritebackConfig:
+                        this.hasSemanticWritebackConfig(),
+                });
+
+            return {
+                ...staleAwareItem,
+                writebackEligible: writebackEligibility.eligible,
+                writebackEligibility,
+            };
         });
 
-        if (statuses) {
-            return reconciled.filter((item) => statuses.includes(item.status));
-        }
-        return reconciled;
+        const filtered = statuses
+            ? reconciled.filter((item) => statuses.includes(item.status))
+            : reconciled;
+
+        const blockedReasons = filtered.reduce<
+            Partial<Record<AiAgentReviewItemWritebackBlockedReason, number>>
+        >((acc, item) => {
+            if (item.writebackEligibility.eligible) {
+                return acc;
+            }
+            acc[item.writebackEligibility.reason] =
+                (acc[item.writebackEligibility.reason] ?? 0) + 1;
+            return acc;
+        }, {});
+
+        this.analytics.track({
+            event: 'ai_agent_review_items.listed',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                totalCount: filtered.length,
+                eligibleCount: filtered.filter(
+                    (item) => item.writebackEligibility.eligible,
+                ).length,
+                statuses: statuses ?? null,
+                blockedReasons,
+            },
+        });
+
+        return filtered;
     }
 
     private async isWritebackFeatureEnabled(
@@ -292,17 +470,11 @@ export class AiAgentAdminService extends BaseService {
             organizationUuid,
             organizationName: user.organizationName ?? '',
         };
-        const [classifier, engine] = await Promise.all([
-            this.featureFlagService.get({
-                featureFlagId: FeatureFlags.AiAgentReviewClassifier,
-                user: flagUser,
-            }),
-            this.featureFlagService.get({
-                featureFlagId: FeatureFlags.AiWriteback,
-                user: flagUser,
-            }),
-        ]);
-        return classifier.enabled && engine.enabled;
+        const classifier = await this.featureFlagService.get({
+            featureFlagId: FeatureFlags.AiAgentReviewClassifier,
+            user: flagUser,
+        });
+        return classifier.enabled;
     }
 
     private async isProjectContextFeatureEnabled(
@@ -323,23 +495,134 @@ export class AiAgentAdminService extends BaseService {
         return flag.enabled;
     }
 
-    private async getGithubProjectUuids(
-        projectUuids: string[],
-    ): Promise<Set<string>> {
-        const distinct = [...new Set(projectUuids)];
-        const results = await Promise.all(
-            distinct.map(async (projectUuid) => {
-                try {
-                    const project = await this.projectModel.get(projectUuid);
-                    return project.dbtConnection.type === DbtProjectType.GITHUB
-                        ? projectUuid
-                        : null;
-                } catch {
-                    return null;
-                }
-            }),
+    private hasSemanticWritebackConfig(): boolean {
+        return Boolean(
+            this.lightdashConfig.appRuntime.e2bApiKey &&
+            this.lightdashConfig.aiWriteback.anthropicApiKey,
         );
-        return new Set(results.filter((uuid): uuid is string => uuid !== null));
+    }
+
+    private async getProjectWritebackAccessByUuid(
+        organizationUuid: string,
+        projectUuids: string[],
+    ): Promise<Map<string, ProjectWritebackAccess>> {
+        const distinct = [...new Set(projectUuids)];
+        const [githubInstallationId, gitlabInstallationId] = await Promise.all([
+            this.githubAppInstallationsModel
+                .findInstallationId(organizationUuid)
+                .catch(() => undefined),
+            this.gitlabAppInstallationsModel
+                .findInstallationId(organizationUuid)
+                .catch(() => undefined),
+        ]);
+
+        const entries = await Promise.all(
+            distinct.map(
+                async (
+                    projectUuid,
+                ): Promise<ProjectWritebackAccessEntry | null> => {
+                    try {
+                        const project =
+                            await this.projectModel.get(projectUuid);
+                        if (
+                            project.dbtConnection.type === DbtProjectType.GITHUB
+                        ) {
+                            return [
+                                projectUuid,
+                                {
+                                    provider: PullRequestProvider.GITHUB,
+                                    hasGitAppInstallation:
+                                        githubInstallationId !== undefined,
+                                },
+                            ];
+                        }
+                        if (
+                            project.dbtConnection.type === DbtProjectType.GITLAB
+                        ) {
+                            return [
+                                projectUuid,
+                                {
+                                    provider: PullRequestProvider.GITLAB,
+                                    hasGitAppInstallation:
+                                        gitlabInstallationId !== undefined,
+                                },
+                            ];
+                        }
+                    } catch {
+                        return null;
+                    }
+                    return [
+                        projectUuid,
+                        {
+                            provider: null,
+                            hasGitAppInstallation: false,
+                        },
+                    ];
+                },
+            ),
+        );
+
+        return new Map(
+            entries.filter(
+                (entry): entry is ProjectWritebackAccessEntry => entry !== null,
+            ),
+        );
+    }
+
+    private static throwWritebackBlocked(
+        eligibility: AiAgentReviewItemWritebackEligibility,
+    ): never {
+        if (eligibility.eligible) {
+            throw new ParameterError('Writeback is available');
+        }
+
+        switch (eligibility.reason) {
+            case 'reviews_disabled':
+                throw new ForbiddenError(
+                    'AI agent review writeback is not enabled',
+                );
+            case 'missing_writeback_config':
+                throw new MissingConfigError(
+                    'AI writeback requires E2B_API_KEY and AI_WRITEBACK_ANTHROPIC_API_KEY',
+                );
+            case 'git_app_not_installed':
+                throw new ParameterError(
+                    `Install the ${eligibility.provider ?? 'Git'} app to open writeback pull requests`,
+                );
+            case 'pull_request_open':
+                throw new ParameterError(
+                    'A pull request is already open for this review item',
+                );
+            case 'writeback_in_progress':
+                throw new ParameterError(
+                    'A writeback is already in progress for this review item',
+                );
+            case 'terminal_state':
+                throw new ParameterError(
+                    'Writeback is not available for terminal review items',
+                );
+            case 'missing_project':
+                throw new ParameterError(
+                    'Writeback requires a project-scoped review item',
+                );
+            case 'missing_project_context_entry':
+                throw new ParameterError(
+                    'Project context writeback requires a generated context entry',
+                );
+            case 'project_context_disabled':
+                throw new ParameterError(
+                    'Project context writeback is not enabled',
+                );
+            case 'unsupported_source_control':
+                throw new ParameterError(
+                    'Writeback requires a GitHub or GitLab connected dbt project',
+                );
+            case 'unsupported_root_cause':
+            default:
+                throw new ParameterError(
+                    'Writeback is not available for this review item',
+                );
+        }
     }
 
     /**
@@ -517,6 +800,11 @@ export class AiAgentAdminService extends BaseService {
         if (!scope) {
             throw new NotFoundError('Review item not found');
         }
+        const previousReviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
 
         await this.aiAgentReviewClassifierModel.upsertReviewItemState({
             fingerprint,
@@ -536,7 +824,20 @@ export class AiAgentAdminService extends BaseService {
         if (!reviewItem) {
             throw new NotFoundError('Review item not found');
         }
-        return reviewItem;
+        if (previousReviewItem?.status !== update.status) {
+            this.analytics.track({
+                event: 'ai_agent_review_item.status_changed',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    fingerprint,
+                    rootCause: reviewItem.primaryRootCause,
+                    previousStatus: previousReviewItem?.status ?? 'open',
+                    newStatus: update.status,
+                },
+            });
+        }
+        return this.getReviewItem(user, fingerprint);
     }
 
     async createReviewItemWriteback(
@@ -563,18 +864,6 @@ export class AiAgentAdminService extends BaseService {
             );
         }
 
-        const engineFlag = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiWriteback,
-            user: {
-                userUuid: user.userUuid,
-                organizationUuid,
-                organizationName: user.organizationName ?? '',
-            },
-        });
-        if (!engineFlag.enabled) {
-            throw new ForbiddenError('AI writeback is not enabled');
-        }
-
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
                 organizationUuid,
@@ -587,39 +876,25 @@ export class AiAgentAdminService extends BaseService {
             reviewItem.primaryRootCause === 'project_context'
                 ? await this.isProjectContextFeatureEnabled(user)
                 : false;
-        if (!hasWritebackStrategy(reviewItem, { projectContextEnabled })) {
-            throw new ParameterError(
-                'Writeback is not available for this review item',
-            );
-        }
-        // The semantic_layer strategy runs in the e2b sandbox with Claude Code,
-        // so fail fast at the click rather than queue → run → fail on the
-        // worker. project_context uses a deterministic GitHub merge — no sandbox,
-        // no Anthropic key — so these checks don't apply to it.
-        if (reviewItem.primaryRootCause === 'semantic_layer') {
-            if (!this.lightdashConfig.appRuntime.e2bApiKey) {
-                throw new MissingConfigError(
-                    'E2B API key is not configured (E2B_API_KEY)',
-                );
-            }
-            if (!this.lightdashConfig.aiWriteback.anthropicApiKey) {
-                throw new MissingConfigError(
-                    'Anthropic API key is not configured (AI_WRITEBACK_ANTHROPIC_API_KEY)',
-                );
-            }
-        }
-        if (reviewItem.linkedPrUrl && reviewItem.prState === 'open') {
-            throw new ParameterError(
-                'A pull request is already open for this review item',
-            );
-        }
-        const writebackInFlight =
-            reviewItem.prWritebackStatus === 'queued' ||
-            reviewItem.prWritebackStatus === 'running';
-        if (writebackInFlight && !isWritebackStale(reviewItem, Date.now())) {
-            throw new ParameterError(
-                'A writeback is already in progress for this review item',
-            );
+        const staleAwareItem = withStaleWritebackOverride(
+            reviewItem,
+            Date.now(),
+        );
+        const projectAccessByUuid = await this.getProjectWritebackAccessByUuid(
+            organizationUuid,
+            staleAwareItem.projectUuid ? [staleAwareItem.projectUuid] : [],
+        );
+        const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
+            item: staleAwareItem,
+            reviewsEnabled: true,
+            projectContextEnabled,
+            projectAccess: staleAwareItem.projectUuid
+                ? (projectAccessByUuid.get(staleAwareItem.projectUuid) ?? null)
+                : null,
+            hasSemanticWritebackConfig: this.hasSemanticWritebackConfig(),
+        });
+        if (!writebackEligibility.eligible) {
+            AiAgentAdminService.throwWritebackBlocked(writebackEligibility);
         }
 
         const scope =
@@ -629,13 +904,6 @@ export class AiAgentAdminService extends BaseService {
             );
         if (!scope) {
             throw new NotFoundError('Review item not found');
-        }
-
-        const project = await this.projectModel.get(scope.projectUuid);
-        if (project.dbtConnection.type !== DbtProjectType.GITHUB) {
-            throw new ParameterError(
-                'Writeback requires a GitHub-connected dbt project',
-            );
         }
 
         await this.aiAgentReviewClassifierModel.setReviewItemWritebackStatus({
@@ -654,11 +922,20 @@ export class AiAgentAdminService extends BaseService {
             userUuid: user.userUuid,
         });
 
-        const updated = await this.aiAgentReviewClassifierModel.getReviewItem(
-            organizationUuid,
-            fingerprint,
-        );
-        return updated ?? reviewItem;
+        this.analytics.track({
+            event: 'ai_agent_review_item.writeback_queued',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: scope.projectUuid,
+                fingerprint,
+                rootCause: reviewItem.primaryRootCause,
+                strategy: writebackEligibility.strategy,
+                provider: writebackEligibility.provider,
+            },
+        });
+
+        return this.getReviewItem(user, fingerprint);
     }
 
     /**
@@ -709,6 +986,7 @@ export class AiAgentAdminService extends BaseService {
                 message,
             });
 
+        let strategy: AiAgentReviewItemWritebackStrategy | null = null;
         try {
             const user = await this.userModel.findSessionUserByUUID(userUuid);
             await setProgress('Starting writeback…');
@@ -721,6 +999,8 @@ export class AiAgentAdminService extends BaseService {
                 reviewItem,
                 buildYmlPathByModel(Object.values(explores)),
             );
+            const planStrategy = toReviewWritebackStrategy(plan.strategy);
+            strategy = planStrategy;
 
             let prUrl: string | null;
             if (plan.strategy === 'project_context') {
@@ -783,8 +1063,32 @@ export class AiAgentAdminService extends BaseService {
                     'Writeback ran — no changes were needed',
                 );
             }
+            this.analytics.track({
+                event: 'ai_agent_review_item.writeback_completed',
+                userId: userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    fingerprint,
+                    rootCause: reviewItem.primaryRootCause,
+                    strategy: planStrategy,
+                    prCreated: prUrl !== null,
+                },
+            });
         } catch (error) {
             await setTerminal('failed', getErrorMessage(error));
+            this.analytics.track({
+                event: 'ai_agent_review_item.writeback_failed',
+                userId: userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    fingerprint,
+                    rootCause: reviewItem.primaryRootCause,
+                    strategy,
+                    errorMessage: getErrorMessage(error),
+                },
+            });
             throw error;
         }
     }
@@ -816,21 +1120,33 @@ export class AiAgentAdminService extends BaseService {
             throw new NotFoundError('Review item not found');
         }
 
-        const [writebackEnabled, projectContextEnabled] = await Promise.all([
+        const [reviewsEnabled, projectContextEnabled] = await Promise.all([
             this.isWritebackFeatureEnabled(user),
             this.isProjectContextFeatureEnabled(user),
         ]);
-        const writebackEligible =
-            writebackEnabled &&
-            hasWritebackStrategy(reviewItem, { projectContextEnabled }) &&
-            reviewItem.projectUuid !== null &&
-            (await this.getGithubProjectUuids([reviewItem.projectUuid])).has(
-                reviewItem.projectUuid,
-            );
-        return withStaleWritebackOverride(
-            { ...reviewItem, writebackEligible },
+        const projectAccessByUuid = await this.getProjectWritebackAccessByUuid(
+            organizationUuid,
+            reviewItem.projectUuid ? [reviewItem.projectUuid] : [],
+        );
+        const staleAwareItem = withStaleWritebackOverride(
+            reviewItem,
             Date.now(),
         );
+        const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
+            item: staleAwareItem,
+            reviewsEnabled,
+            projectContextEnabled,
+            projectAccess: staleAwareItem.projectUuid
+                ? (projectAccessByUuid.get(staleAwareItem.projectUuid) ?? null)
+                : null,
+            hasSemanticWritebackConfig: this.hasSemanticWritebackConfig(),
+        });
+
+        return {
+            ...staleAwareItem,
+            writebackEligible: writebackEligibility.eligible,
+            writebackEligibility,
+        };
     }
 
     /**
@@ -856,7 +1172,25 @@ export class AiAgentAdminService extends BaseService {
         if (!reviewItem) {
             throw new NotFoundError('Review item not found');
         }
+        const trackPreviewViewed = (
+            available: boolean,
+            strategy: AiAgentReviewItemWritebackStrategy | null,
+        ) =>
+            this.analytics.track({
+                event: 'ai_agent_review_item.writeback_preview_viewed',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: reviewItem.projectUuid,
+                    fingerprint,
+                    rootCause: reviewItem.primaryRootCause,
+                    available,
+                    strategy,
+                },
+            });
+
         if (reviewItem.projectUuid === null) {
+            trackPreviewViewed(false, null);
             return { available: false };
         }
 
@@ -864,9 +1198,11 @@ export class AiAgentAdminService extends BaseService {
         try {
             plan = planReviewWriteback(reviewItem);
         } catch {
+            trackPreviewViewed(false, null);
             return { available: false };
         }
         if (plan.strategy !== 'project_context') {
+            trackPreviewViewed(false, toReviewWritebackStrategy(plan.strategy));
             return { available: false };
         }
 
@@ -874,6 +1210,7 @@ export class AiAgentAdminService extends BaseService {
             projectUuid: reviewItem.projectUuid,
             entry: plan.entry,
         });
+        trackPreviewViewed(true, toReviewWritebackStrategy(plan.strategy));
         return { available: true, ...preview };
     }
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -170,7 +170,13 @@ export class AiWritebackService extends BaseService {
         );
     }
 
-    private async assertEnabled(user: SessionUser): Promise<void> {
+    private async assertEnabled(
+        user: SessionUser,
+        source: AiWritebackSource,
+    ): Promise<void> {
+        if (source === 'admin_review') {
+            return;
+        }
         const { enabled } = await this.featureFlagModel.get({
             user,
             featureFlagId: FeatureFlags.AiWriteback,
@@ -372,6 +378,7 @@ export class AiWritebackService extends BaseService {
             user,
             projectUuid,
             aiThreadUuid,
+            source,
         });
 
         this.logger.info('AI writeback run started', {
@@ -600,19 +607,22 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
-     * Pre-flight: enforce the feature flag, the `manage:SourceCode` permission,
-     * and resolve everything from the request that doesn't require a sandbox.
+     * Pre-flight: enforce source-specific rollout gates, the
+     * `manage:SourceCode` permission, and resolve everything from the request
+     * that doesn't require a sandbox.
      */
     private async prepareTurn({
         user,
         projectUuid,
         aiThreadUuid,
+        source,
     }: {
         user: SessionUser;
         projectUuid: string;
         aiThreadUuid: string | undefined;
+        source: AiWritebackSource;
     }): Promise<TurnContext> {
-        await this.assertEnabled(user);
+        await this.assertEnabled(user, source);
 
         const project = await this.projectModel.get(projectUuid);
         // Writeback opens a PR from a freshly created feature branch

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -1,4 +1,7 @@
-import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import {
+    PullRequestProvider,
+    type AiAgentReviewItemSummary,
+} from '@lightdash/common';
 import { planReviewWriteback } from './buildReviewWritebackPrompt';
 
 const baseItem = (
@@ -27,6 +30,12 @@ const baseItem = (
     prWritebackStatus: null,
     prWritebackMessage: null,
     writebackEligible: true,
+    writebackEligibility: {
+        eligible: true,
+        provider: PullRequestProvider.GITHUB,
+        strategy: 'semantic_layer',
+        reason: null,
+    },
     createdAt: new Date('2026-05-26T00:00:00.000Z'),
     updatedAt: new Date('2026-05-26T00:00:00.000Z'),
     latestFinding: {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -19936,6 +19936,64 @@ const models: TsoaRoute.Models = {
                             dataType: 'boolean',
                             required: true,
                         },
+                        writebackEligibility: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                reason: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        {
+                                            dataType: 'enum',
+                                            enums: [
+                                                'reviews_disabled',
+                                                'unsupported_root_cause',
+                                                'missing_project',
+                                                'missing_project_context_entry',
+                                                'project_context_disabled',
+                                                'unsupported_source_control',
+                                                'git_app_not_installed',
+                                                'missing_writeback_config',
+                                                'pull_request_open',
+                                                'terminal_state',
+                                                'writeback_in_progress',
+                                            ],
+                                        },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                strategy: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        {
+                                            dataType: 'enum',
+                                            enums: [
+                                                'semantic_layer',
+                                                'project_context',
+                                            ],
+                                        },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                provider: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        {
+                                            dataType: 'enum',
+                                            enums: ['github', 'gitlab'],
+                                        },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                eligible: {
+                                    dataType: 'boolean',
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
                     },
                 },
             ],

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -20505,10 +20505,58 @@
                             },
                             "writebackEligible": {
                                 "type": "boolean",
-                                "description": "Server-computed: true only when a writeback PR can actually be opened for\nthis item — semantic-layer root cause, a GitHub-connected project, and\nboth the review-writeback and writeback-engine feature flags enabled.\nThe \"Create PR\" action is gated on this."
+                                "description": "Legacy boolean kept for current clients. New clients should use\nwritebackEligibility for the blocking reason and provider."
+                            },
+                            "writebackEligibility": {
+                                "properties": {
+                                    "reason": {
+                                        "type": "string",
+                                        "enum": [
+                                            "reviews_disabled",
+                                            "unsupported_root_cause",
+                                            "missing_project",
+                                            "missing_project_context_entry",
+                                            "project_context_disabled",
+                                            "unsupported_source_control",
+                                            "git_app_not_installed",
+                                            "missing_writeback_config",
+                                            "pull_request_open",
+                                            "terminal_state",
+                                            "writeback_in_progress"
+                                        ],
+                                        "nullable": true
+                                    },
+                                    "strategy": {
+                                        "type": "string",
+                                        "enum": [
+                                            "semantic_layer",
+                                            "project_context"
+                                        ],
+                                        "nullable": true
+                                    },
+                                    "provider": {
+                                        "type": "string",
+                                        "enum": ["github", "gitlab"],
+                                        "nullable": true
+                                    },
+                                    "eligible": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "reason",
+                                    "strategy",
+                                    "provider",
+                                    "eligible"
+                                ],
+                                "type": "object"
                             }
                         },
-                        "required": ["latestFinding", "writebackEligible"],
+                        "required": [
+                            "latestFinding",
+                            "writebackEligible",
+                            "writebackEligibility"
+                        ],
                         "type": "object"
                     }
                 ]

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { ApiSuccess } from '../../types/api/success';
+import type { PullRequestProvider } from '../../types/gitIntegration';
 import type { MetricQuery } from '../../types/metricQuery';
 import type { QueryHistoryStatus } from '../../types/queryHistory';
 import type { AiAgentDocumentStructuredSummary } from './documentTypes';
@@ -320,6 +321,37 @@ export type AiAgentReviewItemWritebackStatus =
     | 'completed'
     | 'failed';
 
+export type AiAgentReviewItemWritebackStrategy =
+    | 'semantic_layer'
+    | 'project_context';
+
+export type AiAgentReviewItemWritebackBlockedReason =
+    | 'reviews_disabled'
+    | 'unsupported_root_cause'
+    | 'missing_project'
+    | 'missing_project_context_entry'
+    | 'project_context_disabled'
+    | 'unsupported_source_control'
+    | 'git_app_not_installed'
+    | 'missing_writeback_config'
+    | 'pull_request_open'
+    | 'terminal_state'
+    | 'writeback_in_progress';
+
+export type AiAgentReviewItemWritebackEligibility =
+    | {
+          eligible: true;
+          provider: PullRequestProvider;
+          strategy: AiAgentReviewItemWritebackStrategy;
+          reason: null;
+      }
+    | {
+          eligible: false;
+          provider: PullRequestProvider | null;
+          strategy: AiAgentReviewItemWritebackStrategy | null;
+          reason: AiAgentReviewItemWritebackBlockedReason;
+      };
+
 const aiAgentConfigurationSettingSchema = z.enum([
     'instructions',
     'knowledge_documents',
@@ -540,12 +572,11 @@ export type AiAgentReviewItem = {
 
 export type AiAgentReviewItemSummary = AiAgentReviewItem & {
     /**
-     * Server-computed: true only when a writeback PR can actually be opened for
-     * this item — semantic-layer root cause, a GitHub-connected project, and
-     * both the review-writeback and writeback-engine feature flags enabled.
-     * The "Create PR" action is gated on this.
+     * Legacy boolean kept for current clients. New clients should use
+     * writebackEligibility for the blocking reason and provider.
      */
     writebackEligible: boolean;
+    writebackEligibility: AiAgentReviewItemWritebackEligibility;
     latestFinding: {
         uuid: string;
         promptUuid: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -2,6 +2,7 @@ import {
     type AiAgentRecommendationAction,
     type AiAgentReviewItemStatus,
     type AiAgentReviewItemSummary,
+    type AiAgentReviewItemWritebackBlockedReason,
     type AiAgentReviewSignalSummary,
     type AiAgentRootCause,
     type AiAgentTargetRef,
@@ -110,6 +111,23 @@ const rootCauseColors: Record<AiAgentRootCause, string> = {
     feedback_quality: 'teal',
     not_a_failure: 'gray',
     ambiguous: 'gray',
+};
+
+const writebackBlockedReasonLabels: Record<
+    AiAgentReviewItemWritebackBlockedReason,
+    string
+> = {
+    reviews_disabled: 'Reviews are not enabled for this organization',
+    unsupported_root_cause: 'No writeback strategy for this root cause',
+    missing_project: 'No project is linked to this finding',
+    missing_project_context_entry: 'No project context entry was generated',
+    project_context_disabled: 'Project context is not enabled',
+    unsupported_source_control: 'Project is not connected to GitHub or GitLab',
+    git_app_not_installed: 'Git app is not installed',
+    missing_writeback_config: 'Writeback runtime is not configured',
+    pull_request_open: 'A pull request is already open',
+    terminal_state: 'Finding is already closed',
+    writeback_in_progress: 'Writeback is already in progress',
 };
 
 const signalLabels: Record<AiAgentTurnSignal, string> = {
@@ -626,12 +644,16 @@ const ReviewItemActionsCell = ({
         current.prWritebackStatus === 'queued' ||
         current.prWritebackStatus === 'running';
     const isTerminal =
-        current.status === 'resolved' || current.status === 'dismissed';
-    const canCreatePr =
-        current.writebackEligible &&
-        !current.linkedPrUrl &&
-        !isTerminal &&
-        !isWritebackInFlight;
+        current.status === 'resolved' ||
+        current.status === 'dismissed' ||
+        current.status === 'duplicate';
+    const canCreatePr = current.writebackEligibility.eligible;
+    const blockedReason = current.writebackEligibility.eligible
+        ? null
+        : current.writebackEligibility.reason;
+    const blockedReasonLabel = blockedReason
+        ? writebackBlockedReasonLabels[blockedReason]
+        : null;
     // project_context findings get a deterministic diff preview modal before the
     // PR is opened; other strategies (sandbox) open the PR directly.
     const previewsDiff = current.primaryRootCause === 'project_context';
@@ -753,6 +775,32 @@ const ReviewItemActionsCell = ({
                             </Text>
                         </Group>
                     )}
+
+                    {!canCreatePr &&
+                        !current.linkedPrUrl &&
+                        !isWritebackInFlight &&
+                        blockedReasonLabel && (
+                            <Tooltip
+                                label={blockedReasonLabel}
+                                withArrow
+                                openDelay={300}
+                            >
+                                <Group gap={4} wrap="nowrap" maw={220}>
+                                    <MantineIcon
+                                        icon={IconInfoCircle}
+                                        size="xs"
+                                    />
+                                    <Text
+                                        fz="xs"
+                                        c="ldGray.6"
+                                        fw={500}
+                                        lineClamp={1}
+                                    >
+                                        {blockedReasonLabel}
+                                    </Text>
+                                </Group>
+                            </Tooltip>
+                        )}
                 </Stack>
             )}
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
@@ -34,6 +34,12 @@ const makeExampleReviewItem = (
     prWritebackStatus: null,
     prWritebackMessage: null,
     writebackEligible: false,
+    writebackEligibility: {
+        eligible: false,
+        reason: 'missing_project',
+        provider: null,
+        strategy: null,
+    },
     createdAt: EXAMPLE_SEEN_AT,
     updatedAt: EXAMPLE_SEEN_AT,
     latestFinding: null,


### PR DESCRIPTION
## Summary
- add structured review-item writeback eligibility with provider, strategy, and blocked reason
- remove `AiWriteback` as a second customer-facing gate for admin review writeback
- support GitLab semantic-layer eligibility while keeping project-context writeback GitHub-only
- move review item listing to SQL aggregation by fingerprint
- add review lifecycle analytics for list, status, preview, queue, complete, fail
- show disabled Create PR reasons in the admin review UI
- add focused backend tests for eligibility, listing, opt-in, and prompt planning

## Validation
- `pnpm -F @lightdash/common build`
- `pnpm -F backend test -- AiAgentAdminService.test.ts AiAgentReviewClassifierService.test.ts AiAgentReviewClassifierModel.test.ts buildReviewWritebackPrompt.test.ts --runInBand`
- `pnpm -F backend typecheck`
- `pnpm -F @lightdash/frontend typecheck`
- `pnpm -F @lightdash/common typecheck`

Stack: 2/2. Base PR: #23983.
