### PR TITLE
fix: clearer guidance when user warehouse credentials are missing

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1557,7 +1557,9 @@ export class ProjectService extends BaseService {
                         'Please authenticate to access Databricks',
                     );
                 }
-                throw new NotFoundError('User warehouse credentials not found');
+                throw new MissingWarehouseCredentialsError(
+                    "You don't have warehouse credentials set up for this project. Add them under 'User settings' → 'My warehouse connections', or refresh the page to sign in again.",
+                );
             } else if (!organizationWarehouseCredentialsUuid) {
                 // No user credentials, no org credentials, refresh project credentials
                 this.logger.debug(

--- a/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
@@ -68,6 +68,17 @@ const UserCredentialsSwitcher = () => {
 
                 if (query.state.error) {
                     const error = query.state.error as any;
+                    // Re-open the credentials modal whenever a query fails
+                    // because the user has no warehouse credentials
+                    if (
+                        error?.error?.name ===
+                            'MissingWarehouseCredentialsError' &&
+                        activeProject?.warehouseConnection
+                            ?.requireUserCredentials
+                    ) {
+                        setShowCreateModalOnPageLoad(true);
+                        setIsCreatingCredentials(true);
+                    }
                     // Check if this is a SnowflakeTokenError and we have a Snowflake project
                     if (
                         error?.error?.name === 'SnowflakeTokenError' &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2514

### Description:

When a project requires user warehouse credentials and the user has none (e.g. they deleted them), running a query previously failed with the unhelpful "User warehouse credentials not found" message, and the sign-in popup only reappeared after a full page refresh. The backend now throws `MissingWarehouseCredentialsError` with actionable guidance, and the navbar credentials switcher re-opens the credentials modal whenever a query fails for lack of credentials — so users no longer need to refresh the page to recover the sign-in flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)