### PR TITLE
fix(ai-agents): add minimum width to agent selector dropdown

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -40,6 +40,7 @@ type Props = {
 };
 
 const AUTO_VALUE = '__auto__';
+const DROPDOWN_MIN_WIDTH = 260;
 
 export const AgentSelector = ({
     agents,
@@ -134,7 +135,7 @@ export const AgentSelector = ({
                 </UnstyledButton>
             </Combobox.Target>
 
-            <Combobox.Dropdown>
+            <Combobox.Dropdown miw={DROPDOWN_MIN_WIDTH}>
                 {showAutoOption && (
                     <Combobox.Header p={4} pr={6}>
                         <Combobox.Option value={AUTO_VALUE} p={2}>


### PR DESCRIPTION
## Summary
- Add a `260px` minimum width to the AgentSelector dropdown
- Prevent the menu from collapsing too narrow when the selected agent name is short

## Testing
- Not run (not requested)