### PR TITLE
feat(data-apps): include data app tiles in dashboard promotion

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -274,29 +274,51 @@ Implementation: `AppGenerateService.deleteApp` is the entry point. It delegates 
 `permanentDeleteApp`, which each enforce the appropriate manage scope (see [Permissions](#permissions) below) and
 handle sandbox/S3 cleanup.
 
-### Preview environments and promotion
+### Promotion
 
-Data apps are **not yet duplicated** when a project is copied to a preview environment, and **not yet remapped**
-during cross-project promotion. The preview-copy step in `ProjectModel.duplicateContent` does copy
-`dashboard_tile_data_apps` rows — but it leaves their `app_uuid` pointing at the source project's app rather than
-creating a fresh `apps` row in the preview. The preview project ends up with zero `apps` rows of its own; any data
-app dashboard tile in the preview is a read-through window to the source project's app.
+Data apps promote from a preview project into its linked upstream (production) project, mirroring how charts and
+dashboards promote. Two entry points share the same per-app primitive:
 
-What this means in practice:
+**Standalone app promotion.** `AppGenerateService.promoteApp` snapshots an app's latest ready version into the upstream
+project as one new version — a fresh app on first promotion (linked back via `apps.upstream_app_uuid`), or an appended
+version on the already-linked production app on follow-up promotions. Built S3 artifacts are server-side copied into the
+production app's prefix; the source app is untouched beyond recording the link. `getPromoteAppDiff` previews whether a
+promotion will create or update, and which space it lands in.
 
-- **Preview rendering.** If the user opening the preview has view access to the source project's app, the tile
-  renders normally. Otherwise the existing `DashboardDataAppTile` error states show a "Data app not found" or
-  "No access" placeholder; the rest of the dashboard renders fine.
-- **Iterating inside the preview.** Not supported — the preview project has no `apps` row, so the AppGenerate page
-  isn't reachable from within the preview. Iteration still happens on the source project's app.
-- **Promote-back from preview to source.** Works: the tile's `app_uuid` is the source app's UUID, so the upstream
-  insert succeeds.
-- **Cross-project promotion between unrelated projects.** Data app tiles can be promoted but the tile's `app_uuid`
-  is not remapped — it stays pointing at the downstream project's app. Effectively the same read-through behavior
-  as previews.
+**Data app tiles inside a dashboard.** When a dashboard carrying `DATA_APP` tiles is promoted, every referenced app is
+promoted alongside it and the tile's `appUuid` is remapped to the upstream app — exactly how chart / SQL-chart tiles
+remap their `savedChartUuid` / `savedSqlUuid`. The orchestration lives in `PromoteService.promoteDashboard`:
 
-Full preview/promote support (copying `apps` + `app_versions` + S3 artifacts and remapping `app_uuid` during
-promotion) is tracked in [PROD-7778 follow-up](https://linear.app/lightdash/issue/PROD-7778/preview-environments-arent-considering-data-apps).
+- `upsertDataApps` runs after `upsertCharts` / `upsertSqlCharts` and **before** `updateDashboard`, so the upstream
+  `apps` row exists before the `dashboard_tile_data_apps` FK references it.
+- The per-app promotion is delegated to the EE `AppGenerateService.promoteAppsForDashboard` (which reuses `promoteApp`
+  per app), reached through a lazy `getAppGenerateService` accessor injected into `PromoteService`. The accessor is a
+  thunk, not the instance, because `AppGenerateService` depends on `PromoteService` — eager injection would create a
+  construction cycle. Core (non-EE) builds resolve `undefined` and reject `DATA_APP` tile promotion with a clear error.
+- The promote confirmation diff (`getPromoteDashboardDiff` → `getDataAppPromoteChanges`) lists the apps that will be
+  created / updated alongside spaces / charts / SQL charts, rendered as a "Data apps" section in `PromotionConfirmDialog`
+  (`PromotionChanges.dataApps`).
+- Each app promotes into **its own** mirrored space (the app's `space_uuid`, ancestors created as needed), not the
+  dashboard's space — apps are standalone entities the tile merely references. Personal apps (`space_uuid IS NULL`)
+  promote as personal apps owned by the promoting user.
+- Apps the user can't manage block the promotion (the per-app `manage` check inside `promoteApp`), the same gate chart
+  tiles get. Soft-deleted apps behind placeholder tiles are skipped — the tile keeps its original reference and renders
+  the existing "app no longer exists" placeholder upstream.
+
+### Preview environments (copy-on-preview — out of scope)
+
+Data apps are **not yet duplicated** when a project is copied to a preview environment. The preview-copy step in
+`ProjectModel.duplicateContent` copies `dashboard_tile_data_apps` rows but leaves their `app_uuid` pointing at the source
+project's app rather than creating a fresh `apps` row in the preview, so any data app tile in a preview is a read-through
+window to the source project's app:
+
+- **Preview rendering.** If the user opening the preview has view access to the source app, the tile renders normally.
+  Otherwise the `DashboardDataAppTile` error states show a "Data app not found" / "No access" placeholder and the rest
+  of the dashboard renders fine.
+- **Iterating inside the preview.** Not supported — the preview project has no `apps` row of its own.
+
+Copying `apps` + `app_versions` + S3 artifacts into previews is tracked in
+[PROD-7778 follow-up](https://linear.app/lightdash/issue/PROD-7778/preview-environments-arent-considering-data-apps).
 
 ---
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -3985,6 +3985,109 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     }
 
     /**
+     * Promote every data app referenced by a dashboard's `DATA_APP` tiles into
+     * the dashboard's upstream project, returning a source→upstream uuid map so
+     * the caller can remap the tiles. Each app is promoted with the same
+     * single-app `promoteApp` flow (S3 copy, version, upstream link).
+     *
+     * Soft-deleted apps (a tile can still reference one — it renders as a
+     * "no longer exists" placeholder) are skipped rather than failing the whole
+     * dashboard promotion; their tiles keep their original reference.
+     *
+     * Apps are promoted SEQUENTIALLY, not in parallel: each `promoteApp`
+     * resolves and lazily creates the app's upstream space via
+     * `getOrCreateUpstreamSpace`, whose check-then-create is not atomic and is
+     * not backed by a slug/path unique constraint. Two apps sharing an
+     * un-promoted space (or ancestor) run in parallel would both create it,
+     * producing duplicate upstream spaces. Serializing means the second app
+     * sees the space the first one created. Promotion is a cold, user-initiated
+     * path and app counts are small, so the lost parallelism is irrelevant.
+     *
+     * Used by `PromoteService.upsertDataApps` during dashboard promotion.
+     */
+    async promoteAppsForDashboard(
+        user: SessionUser,
+        projectUuid: string,
+        appUuids: string[],
+    ): Promise<{ sourceAppUuid: string; upstreamAppUuid: string }[]> {
+        if (appUuids.length === 0) {
+            return [];
+        }
+        await this.assertDataAppsEnabled(user);
+
+        const results: { sourceAppUuid: string; upstreamAppUuid: string }[] =
+            [];
+        /* eslint-disable no-await-in-loop */
+        for (const appUuid of appUuids) {
+            const sourceApp = await this.appModel.findApp(appUuid, projectUuid);
+            if (sourceApp) {
+                const { appUuid: upstreamAppUuid } = await this.promoteApp(
+                    user,
+                    projectUuid,
+                    appUuid,
+                );
+                results.push({ sourceAppUuid: appUuid, upstreamAppUuid });
+            }
+        }
+        /* eslint-enable no-await-in-loop */
+
+        return results;
+    }
+
+    /**
+     * Read-only counterpart to `promoteAppsForDashboard`: resolve, per referenced
+     * app, whether promotion would create a new production app or update the
+     * linked one (plus its name) so the dashboard promote diff can list apps
+     * alongside charts. Soft-deleted apps are skipped — there is nothing to
+     * promote for a placeholder tile.
+     */
+    async getDataAppPromoteChanges(
+        user: SessionUser,
+        projectUuid: string,
+        appUuids: string[],
+    ): Promise<{ uuid: string; name: string; action: PromoteAppAction }[]> {
+        if (appUuids.length === 0) {
+            return [];
+        }
+        await this.assertDataAppsEnabled(user);
+
+        const { upstreamProjectUuid } =
+            await this.getUpstreamProjectForPromotion(projectUuid);
+
+        const changes = await Promise.all(
+            appUuids.map(async (appUuid) => {
+                const sourceApp = await this.appModel.findApp(
+                    appUuid,
+                    projectUuid,
+                );
+                if (!sourceApp) {
+                    return null;
+                }
+                await this.assertCanManageApp(
+                    user,
+                    sourceApp,
+                    'Insufficient permissions to promote this data app',
+                );
+                const upstreamApp = await this.findLinkedUpstreamApp(
+                    sourceApp,
+                    upstreamProjectUuid,
+                );
+                return {
+                    uuid: sourceApp.app_id,
+                    name: sourceApp.name,
+                    action: (upstreamApp
+                        ? 'update'
+                        : 'create') as PromoteAppAction,
+                };
+            }),
+        );
+
+        return changes.filter(
+            (change): change is NonNullable<typeof change> => change !== null,
+        );
+    }
+
+    /**
      * Duplicate an existing app the user can view into a new personal app
      * owned by the requester. The new app starts at v1 with the source's
      * latest ready version's S3 artifacts (dist.tar + source.tar + any

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12453,11 +12453,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12620,17 +12620,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -12901,17 +12901,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -12962,11 +12962,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13415,11 +13415,6 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
-                                                    required: true,
-                                                },
                                                 uuid: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13428,23 +13423,9 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
                                                 status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                    ],
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -13509,6 +13490,46 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                prAction: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['opened'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['updated'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13530,6 +13551,41 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                errorCode: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['unknown'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'github_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'gitlab_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'unsupported_source_control',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['error'],
@@ -13554,13 +13610,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                slug: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -13577,11 +13633,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13642,11 +13698,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13663,25 +13719,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13762,6 +13799,25 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 type: {
                                                                     dataType:
                                                                         'union',
@@ -13804,25 +13860,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['success'],
                                                         },
                                                         {
@@ -13842,11 +13879,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13861,11 +13898,30 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -23253,11 +23309,33 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PromotedApp: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PromotionChanges: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                dataApps: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            data: { ref: 'PromotedApp', required: true },
+                            action: { ref: 'PromotionAction', required: true },
+                        },
+                    },
+                },
                 sqlCharts: {
                     dataType: 'array',
                     array: {
@@ -27470,7 +27548,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27480,7 +27558,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27490,7 +27568,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -27503,7 +27581,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -28158,7 +28236,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28168,7 +28246,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28178,7 +28256,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28191,7 +28269,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14006,19 +14006,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -14052,10 +14039,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -14064,8 +14051,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -14177,10 +14164,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -14189,8 +14176,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -14220,6 +14207,19 @@
                                                         "enum": [
                                                             "error",
                                                             "success"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -14493,16 +14493,16 @@
                                                     "slug": {
                                                         "type": "string"
                                                     },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
-                                                    },
                                                     "uuid": {
                                                         "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
@@ -14510,14 +14510,23 @@
                                                     "warnings",
                                                     "href",
                                                     "slug",
-                                                    "status",
                                                     "uuid",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
                                             {
                                                 "properties": {
+                                                    "prAction": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "opened",
+                                                            "updated",
+                                                            null
+                                                        ],
+                                                        "nullable": true
+                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -14533,10 +14542,29 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "href": {
-                                                        "type": "string"
+                                                    "errorCode": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "unknown",
+                                                            "github_not_installed",
+                                                            "gitlab_not_installed",
+                                                            "unsupported_source_control",
+                                                            null
+                                                        ],
+                                                        "nullable": true
                                                     },
-                                                    "slug": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["error"],
+                                                        "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "href": {
                                                         "type": "string"
                                                     },
                                                     "status": {
@@ -14544,14 +14572,17 @@
                                                         "enum": ["success"],
                                                         "nullable": false
                                                     },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "name": {
                                                         "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "slug",
                                                     "status",
+                                                    "slug",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -14575,10 +14606,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -14615,6 +14642,10 @@
                                                                 },
                                                                 "type": "array"
                                                             },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
@@ -14626,8 +14657,8 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
+                                                            "searchQuery",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -14635,8 +14666,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -19595,7 +19626,7 @@
                     "output"
                 ],
                 "type": "object",
-                "description": "Result of a (synchronous) AI writeback run.\n\n- `output` is the text the agent produced.\n- `exitCode` is the sandbox command's exit status.\n- `prUrl` is the URL of the pull request opened from the agent's changes, or\n  `null` when the agent made no file changes (nothing to raise a PR for).\n- `projectName` is the Lightdash project the run targeted.\n- `repository` is the GitHub repository (`owner/repo`) the run targeted."
+                "description": "Result of a (synchronous) AI writeback run.\n\n- `output` is the text the agent produced.\n- `exitCode` is the sandbox command's exit status.\n- `prUrl` is the URL of the pull request opened from the agent's changes, or\n  `null` when the agent made no file changes (nothing to raise a PR for).\n- `prAction` is whether that PR was newly opened or an existing one updated,\n  or `null` when no PR was touched.\n- `projectName` is the Lightdash project the run targeted.\n- `repository` is the GitHub repository (`owner/repo`) the run targeted."
             },
             "ApiSuccess_AiWritebackRunResult_": {
                 "properties": {
@@ -23848,8 +23879,35 @@
                 ],
                 "type": "object"
             },
+            "PromotedApp": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "uuid"],
+                "type": "object"
+            },
             "PromotionChanges": {
                 "properties": {
+                    "dataApps": {
+                        "items": {
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/components/schemas/PromotedApp"
+                                },
+                                "action": {
+                                    "$ref": "#/components/schemas/PromotionAction"
+                                }
+                            },
+                            "required": ["data", "action"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
                     "sqlCharts": {
                         "items": {
                             "properties": {
@@ -28317,22 +28375,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -28892,22 +28950,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -37805,7 +37863,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3096.0",
+        "version": "0.3104.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/PromoteService/PromoteService.mock.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.mock.ts
@@ -3,6 +3,7 @@ import {
     ChartKind,
     ChartType,
     DashboardChartTile,
+    DashboardDataAppTile,
     DashboardSqlChartTile,
     DashboardTileTypes,
     getDefaultResolvedColorPalette,
@@ -350,6 +351,32 @@ export const promotedDashboardWithSqlTile = {
     dashboard: {
         ...promotedDashboard.dashboard,
         tiles: [...promotedDashboard.dashboard.tiles, dashboardSqlChartTile],
+    },
+};
+
+export const promotedAppUuid = 'promoted-app-uuid';
+export const upstreamAppUuid = 'upstream-app-uuid';
+
+export const dashboardDataAppTile: DashboardDataAppTile = {
+    uuid: 'data-app-tile-1234',
+    type: DashboardTileTypes.DATA_APP,
+    x: 0,
+    y: 10,
+    h: 10,
+    w: 10,
+    tabUuid: undefined,
+    properties: {
+        title: 'data app tile',
+        appUuid: promotedAppUuid,
+        appDeletedAt: null,
+    },
+};
+
+export const promotedDashboardWithDataAppTile: PromotedDashboard = {
+    ...promotedDashboard,
+    dashboard: {
+        ...promotedDashboard.dashboard,
+        tiles: [dashboardDataAppTile],
     },
 };
 

--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -5,9 +5,11 @@ import {
     PossibleAbilities,
     PromotionAction,
     SessionUser,
+    type PromotionChanges,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
 import { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -22,13 +24,16 @@ import {
     existingUpstreamSqlChart,
     missingUpstreamChart,
     missingUpstreamDashboard,
+    promotedAppUuid,
     promotedChart,
     promotedChartWithinDashboard,
     promotedDashboard,
     promotedDashboardWithChartWithinDashboard,
+    promotedDashboardWithDataAppTile,
     promotedDashboardWithNewPrivateSpace,
     promotedDashboardWithSqlTile,
     promotedSqlChart,
+    upstreamAppUuid,
     upstreamFullSpace,
     upstreamSpace,
     user,
@@ -1415,5 +1420,140 @@ describe('PromoteService permission checks', () => {
                 missingUpstreamDashboard,
             ),
         ).not.toThrow();
+    });
+});
+
+describe('PromoteService data app promotion', () => {
+    const appGenerateService = {
+        promoteAppsForDashboard: jest.fn(async () => [
+            { sourceAppUuid: promotedAppUuid, upstreamAppUuid },
+        ]),
+    };
+
+    const baseArgs = {
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: projectModel as unknown as ProjectModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
+        spaceModel: spaceModel as unknown as SpaceModel,
+        dashboardModel: dashboardModel as unknown as DashboardModel,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+    };
+
+    const serviceWithApps = new PromoteService({
+        ...baseArgs,
+        getAppGenerateService: () =>
+            appGenerateService as unknown as AppGenerateService,
+    });
+
+    const serviceWithoutApps = new PromoteService(baseArgs);
+
+    const dataAppChanges = (): PromotionChanges => ({
+        spaces: [],
+        charts: [],
+        dashboards: [
+            {
+                action: PromotionAction.CREATE,
+                data: {
+                    ...promotedDashboardWithDataAppTile.dashboard,
+                    spaceSlug: promotedDashboard.space.slug,
+                    spacePath: promotedDashboard.space.path,
+                },
+            },
+        ],
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('promotes referenced apps and remaps the DATA_APP tile appUuid', async () => {
+        const newChanges = await serviceWithApps.upsertDataApps(
+            user,
+            dataAppChanges(),
+            promotedDashboard.projectUuid,
+        );
+
+        expect(
+            appGenerateService.promoteAppsForDashboard,
+        ).toHaveBeenCalledTimes(1);
+        expect(appGenerateService.promoteAppsForDashboard).toHaveBeenCalledWith(
+            user,
+            promotedDashboard.projectUuid,
+            [promotedAppUuid],
+        );
+
+        const dataAppTile = newChanges.dashboards[0].data.tiles.find(
+            (tile) => tile.type === DashboardTileTypes.DATA_APP,
+        );
+        expect(
+            dataAppTile?.type === DashboardTileTypes.DATA_APP
+                ? dataAppTile.properties.appUuid
+                : undefined,
+        ).toBe(upstreamAppUuid);
+        expect(
+            dataAppTile?.type === DashboardTileTypes.DATA_APP
+                ? dataAppTile.properties.appDeletedAt
+                : undefined,
+        ).toBeNull();
+    });
+
+    test('leaves the tile untouched when the referenced app was skipped (soft-deleted)', async () => {
+        appGenerateService.promoteAppsForDashboard.mockResolvedValueOnce([]);
+
+        const newChanges = await serviceWithApps.upsertDataApps(
+            user,
+            dataAppChanges(),
+            promotedDashboard.projectUuid,
+        );
+
+        const dataAppTile = newChanges.dashboards[0].data.tiles.find(
+            (tile) => tile.type === DashboardTileTypes.DATA_APP,
+        );
+        expect(
+            dataAppTile?.type === DashboardTileTypes.DATA_APP
+                ? dataAppTile.properties.appUuid
+                : undefined,
+        ).toBe(promotedAppUuid);
+    });
+
+    test('returns changes unchanged and skips the app service when there are no DATA_APP tiles', async () => {
+        const changesWithoutApps: PromotionChanges = {
+            spaces: [],
+            charts: [],
+            dashboards: [
+                {
+                    action: PromotionAction.CREATE,
+                    data: {
+                        ...promotedDashboard.dashboard,
+                        spaceSlug: promotedDashboard.space.slug,
+                        spacePath: promotedDashboard.space.path,
+                    },
+                },
+            ],
+        };
+
+        const newChanges = await serviceWithApps.upsertDataApps(
+            user,
+            changesWithoutApps,
+            promotedDashboard.projectUuid,
+        );
+
+        expect(newChanges).toEqual(changesWithoutApps);
+        expect(
+            appGenerateService.promoteAppsForDashboard,
+        ).not.toHaveBeenCalled();
+    });
+
+    test('throws when a DATA_APP tile is promoted without the EE app service', async () => {
+        await expect(
+            serviceWithoutApps.upsertDataApps(
+                user,
+                dataAppChanges(),
+                promotedDashboard.projectUuid,
+            ),
+        ).rejects.toThrow(/Data apps are not available/);
     });
 });

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -8,6 +8,7 @@ import {
     getDeepestPaths,
     getErrorMessage,
     isDashboardChartTileType,
+    isDashboardDataAppTileType,
     isSubPath,
     NotFoundError,
     ParameterError,
@@ -27,6 +28,7 @@ import {
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
+import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
 import type { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
 import Logger from '../../logging/logger';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
@@ -109,6 +111,11 @@ type PromoteServiceArguments = {
     savedSqlModel: SavedSqlModel;
     dashboardModel: DashboardModel;
     spacePermissionService: SpacePermissionService;
+    // Lazily resolves the EE data-app service so dashboard promotion can promote
+    // embedded DATA_APP tiles. A thunk — not the instance — because
+    // AppGenerateService depends on PromoteService, so eager injection would
+    // create a construction cycle. Resolves undefined in core (non-EE) builds.
+    getAppGenerateService?: () => AppGenerateService | undefined;
 };
 
 type SavedSqlChart = Awaited<ReturnType<SavedSqlModel['getByUuid']>>;
@@ -133,6 +140,10 @@ export class PromoteService extends BaseService {
 
     private readonly spacePermissionService: SpacePermissionService;
 
+    private readonly getAppGenerateService?: () =>
+        | AppGenerateService
+        | undefined;
+
     constructor(args: PromoteServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
@@ -143,6 +154,7 @@ export class PromoteService extends BaseService {
         this.spaceModel = args.spaceModel;
         this.dashboardModel = args.dashboardModel;
         this.spacePermissionService = args.spacePermissionService;
+        this.getAppGenerateService = args.getAppGenerateService;
     }
 
     private async trackAnalytics(
@@ -1073,6 +1085,150 @@ export class PromoteService extends BaseService {
         };
     }
 
+    private static getDataAppUuidsFromChanges(
+        promotionChanges: PromotionChanges,
+    ): string[] {
+        return Array.from(
+            promotionChanges.dashboards.reduce<Set<string>>(
+                (acc, dashboardChange) => {
+                    dashboardChange.data.tiles.forEach((tile) => {
+                        if (
+                            isDashboardDataAppTileType(tile) &&
+                            tile.properties.appUuid
+                        ) {
+                            acc.add(tile.properties.appUuid);
+                        }
+                    });
+                    return acc;
+                },
+                new Set<string>(),
+            ),
+        );
+    }
+
+    /**
+     * Promote the data apps referenced by a dashboard's DATA_APP tiles into the
+     * upstream project, then remap each tile's `appUuid` to the freshly promoted
+     * upstream app — the data-app equivalent of `upsertCharts`/`upsertSqlCharts`.
+     *
+     * Runs after the upstream dashboard exists but before `updateDashboard`
+     * persists the tiles, so the upstream `apps` row is in place before the
+     * `dashboard_tile_data_apps` FK references it.
+     *
+     * The actual app promotion (S3 copy, versioning, permission checks) lives in
+     * the EE AppGenerateService, reached via the injected accessor. Apps whose
+     * referenced row no longer exists (soft-deleted placeholder tiles) are left
+     * untouched rather than failing the whole dashboard promotion.
+     */
+    async upsertDataApps(
+        user: SessionUser,
+        promotionChanges: PromotionChanges,
+        sourceProjectUuid: string,
+    ): Promise<PromotionChanges> {
+        const appUuids =
+            PromoteService.getDataAppUuidsFromChanges(promotionChanges);
+        if (appUuids.length === 0) {
+            return promotionChanges;
+        }
+
+        const appGenerateService = this.getAppGenerateService?.();
+        if (!appGenerateService) {
+            throw new ParameterError(
+                'Data apps are not available in this instance',
+            );
+        }
+
+        const promotedApps = await appGenerateService.promoteAppsForDashboard(
+            user,
+            sourceProjectUuid,
+            appUuids,
+        );
+        const appUuidMap = new Map(
+            promotedApps.map(({ sourceAppUuid, upstreamAppUuid }) => [
+                sourceAppUuid,
+                upstreamAppUuid,
+            ]),
+        );
+
+        const updatedDashboards = promotionChanges.dashboards.map(
+            (dashboardChange) => ({
+                ...dashboardChange,
+                data: {
+                    ...dashboardChange.data,
+                    tiles: dashboardChange.data.tiles.map((tile) => {
+                        if (
+                            !isDashboardDataAppTileType(tile) ||
+                            !tile.properties.appUuid
+                        ) {
+                            return tile;
+                        }
+                        const upstreamAppUuid = appUuidMap.get(
+                            tile.properties.appUuid,
+                        );
+                        // No mapping → the app was soft-deleted and skipped;
+                        // leave the placeholder tile pointing at its original
+                        // reference.
+                        if (!upstreamAppUuid) {
+                            return tile;
+                        }
+                        return {
+                            ...tile,
+                            properties: {
+                                ...tile.properties,
+                                appUuid: upstreamAppUuid,
+                                appDeletedAt: null,
+                            },
+                        };
+                    }),
+                },
+            }),
+        );
+
+        return {
+            ...promotionChanges,
+            dashboards: updatedDashboards,
+        };
+    }
+
+    /**
+     * Read-only diff of the data apps a dashboard promotion would create/update,
+     * for the promote confirmation dialog. Mirrors how `getPromoteDashboardDiff`
+     * surfaces charts and SQL charts. Returns [] when the dashboard has no
+     * DATA_APP tiles.
+     */
+    private async getDataAppDiffChanges(
+        user: SessionUser,
+        sourceProjectUuid: string,
+        promotionChanges: PromotionChanges,
+    ): Promise<NonNullable<PromotionChanges['dataApps']>> {
+        const appUuids =
+            PromoteService.getDataAppUuidsFromChanges(promotionChanges);
+        if (appUuids.length === 0) {
+            return [];
+        }
+
+        const appGenerateService = this.getAppGenerateService?.();
+        if (!appGenerateService) {
+            throw new ParameterError(
+                'Data apps are not available in this instance',
+            );
+        }
+
+        const changes = await appGenerateService.getDataAppPromoteChanges(
+            user,
+            sourceProjectUuid,
+            appUuids,
+        );
+
+        return changes.map(({ uuid, name, action }) => ({
+            action:
+                action === 'create'
+                    ? PromotionAction.CREATE
+                    : PromotionAction.UPDATE,
+            data: { uuid, name },
+        }));
+    }
+
     async promoteChart(user: SessionUser, chartUuid: string) {
         const { projectUuid } =
             await this.savedChartModel.getSummary(chartUuid);
@@ -1343,12 +1499,19 @@ export class PromoteService extends BaseService {
             ),
         );
 
+        const dataApps = await this.getDataAppDiffChanges(
+            user,
+            dashboard.projectUuid,
+            promotionChanges,
+        );
+
         return {
             ...promotionChanges,
             sqlCharts: sqlCharts.map((sqlChartChange) => ({
                 action: sqlChartChange.action,
                 data: PromoteService.toPromotedSqlChartChange(sqlChartChange),
             })),
+            dataApps,
             spaces: PromoteService.sortSpaceChanges(promotionChanges.spaces),
         };
     }
@@ -2352,6 +2515,14 @@ export class PromoteService extends BaseService {
                 user,
                 promotionChanges,
                 sqlChanges,
+            );
+
+            // Promote embedded data apps and remap their tiles. Must run before
+            // updateDashboard so the upstream apps row exists for the tile FK.
+            promotionChanges = await this.upsertDataApps(
+                user,
+                promotionChanges,
+                dashboard.projectUuid,
             );
 
             promotionChanges = await this.updateDashboard(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1144,6 +1144,15 @@ export class ServiceRepository
                     spaceModel: this.models.getSpaceModel(),
                     dashboardModel: this.models.getDashboardModel(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    // Lazy accessor (not the instance) to promote embedded data
+                    // apps during dashboard promotion. AppGenerateService depends
+                    // on PromoteService, so resolving it eagerly here would cycle.
+                    // Only wired when EE license is active; core builds resolve
+                    // undefined and reject DATA_APP tile promotion with an error.
+                    getAppGenerateService: () =>
+                        this.providers.appGenerateService
+                            ? this.getAppGenerateService<AppGenerateService>()
+                            : undefined,
                 }),
         );
     }

--- a/packages/common/src/types/promotion.ts
+++ b/packages/common/src/types/promotion.ts
@@ -32,6 +32,11 @@ export type PromotedSqlChart = {
     spacePath: string;
 };
 
+export type PromotedApp = {
+    uuid: string;
+    name: string;
+};
+
 export type PromotionChanges = {
     spaces: {
         action: PromotionAction;
@@ -48,6 +53,12 @@ export type PromotionChanges = {
     sqlCharts?: {
         action: PromotionAction;
         data: PromotedSqlChart;
+    }[];
+    // Data apps referenced by DATA_APP dashboard tiles. Only populated for
+    // dashboard promotion; charts/SQL charts never carry apps.
+    dataApps?: {
+        action: PromotionAction;
+        data: PromotedApp;
     }[];
 };
 

--- a/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
+++ b/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import { Accordion, Button, Flex, Loader, Stack, Text } from '@mantine-8/core';
 import {
+    IconAppWindow,
     IconChartAreaLine,
     IconDatabase,
     IconFolder,
@@ -32,7 +33,7 @@ type PromotionChange = {
 };
 
 const PromotionChangesAccordion: FC<{
-    type: 'spaces' | 'charts' | 'dashboards' | 'sqlCharts';
+    type: 'spaces' | 'charts' | 'dashboards' | 'sqlCharts' | 'dataApps';
     items: {
         created: PromotionChange[];
         updated: PromotionChange[];
@@ -155,6 +156,20 @@ export const PromotionConfirmDialog: FC<Props> = ({
                     (item) => item.action === PromotionAction.DELETE,
                 ),
             },
+            dataApps: {
+                total: (promotionChanges.dataApps ?? []).filter(
+                    (item) => item.action !== PromotionAction.NO_CHANGES,
+                ).length,
+                created: (promotionChanges.dataApps ?? []).filter(
+                    (item) => item.action === PromotionAction.CREATE,
+                ),
+                updated: (promotionChanges.dataApps ?? []).filter(
+                    (item) => item.action === PromotionAction.UPDATE,
+                ),
+                deleted: (promotionChanges.dataApps ?? []).filter(
+                    (item) => item.action === PromotionAction.DELETE,
+                ),
+            },
             dashboards: {
                 total: promotionChanges.dashboards.filter(
                     (item) => item.action !== PromotionAction.NO_CHANGES,
@@ -175,6 +190,7 @@ export const PromotionConfirmDialog: FC<Props> = ({
             changes.spaces.total +
             changes.charts.total +
             changes.sqlCharts.total +
+            changes.dataApps.total +
             changes.dashboards.total;
         const withoutChangesNum =
             promotionChanges.spaces.filter(
@@ -187,6 +203,9 @@ export const PromotionConfirmDialog: FC<Props> = ({
                 (item) => item.action === PromotionAction.NO_CHANGES,
             ).length +
             (promotionChanges.sqlCharts ?? []).filter(
+                (item) => item.action === PromotionAction.NO_CHANGES,
+            ).length +
+            (promotionChanges.dataApps ?? []).filter(
                 (item) => item.action === PromotionAction.NO_CHANGES,
             ).length;
 
@@ -302,6 +321,26 @@ export const PromotionConfirmDialog: FC<Props> = ({
                                 <PromotionChangesAccordion
                                     type="sqlCharts"
                                     items={groupedChanges.sqlCharts}
+                                />
+                            </>
+                        )}
+                        {groupedChanges.dataApps.total > 0 && (
+                            <>
+                                <Text fz="sm">
+                                    These changes will be applied:
+                                </Text>
+                                <Flex>
+                                    <MantineIcon
+                                        icon={IconAppWindow}
+                                        color="orange.6"
+                                    />{' '}
+                                    <Text ml={10} fw={600}>
+                                        Data apps:{' '}
+                                    </Text>{' '}
+                                </Flex>
+                                <PromotionChangesAccordion
+                                    type="dataApps"
+                                    items={groupedChanges.dataApps}
                                 />
                             </>
                         )}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8040/implement-promotion-flow

### Description:
Dashboard promotion now promotes embedded DATA_APP tiles into the upstream project and remaps each tile's appUuid, mirroring how chart/SQL-chart tiles are handled. The promote confirmation dialog lists the apps to be created/updated.

- PromoteService.upsertDataApps remaps DATA_APP tiles, delegating per-app promotion to the EE AppGenerateService through a lazy accessor (avoids the PromoteService <-> AppGenerateService construction cycle)
- AppGenerateService.promoteAppsForDashboard / getDataAppPromoteChanges
- PromotionChanges.dataApps + "Data apps" section in PromotionConfirmDialog


### Preview
App creation
<img width="618" height="609" alt="promote-preview-create" src="https://github.com/user-attachments/assets/da1c471d-0ca2-437f-b879-fa0cd8485d02" />



App update
<img width="618" height="609" alt="promote-preview-update" src="https://github.com/user-attachments/assets/a76609db-de3a-4b83-a4c0-812755b073bd" />
