### PR TITLE
fix: scope bulk chart updates to project

### DIFF
--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -2,6 +2,7 @@ import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { lightdashConfigMock } from '../config/lightdashConfig.mock';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SpaceTableName } from '../database/entities/spaces';
 import { SavedChartModel } from './SavedChartModel';
 import { chartSummary } from './SavedChartModel.mock';
 
@@ -57,5 +58,68 @@ describe('getLatestVersionSummaries', () => {
 
         expect(response).toHaveLength(1);
         expect(response[0].chartUuid).toEqual(chartSummary.saved_query_uuid);
+    });
+});
+
+describe('updateMultiple', () => {
+    const model = new SavedChartModel({
+        database: knex({ client: MockClient, dialect: 'pg' }),
+        lightdashConfig: lightdashConfigMock,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    test('requires the destination space to belong to the requested project', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const spaceUuid = '33333333-3333-4333-8333-333333333333';
+
+        tracker.on.select(SpaceTableName).responseOnce([]);
+
+        await expect(
+            model.updateMultiple(projectUuid, [
+                {
+                    uuid: '11111111-1111-4111-8111-111111111111',
+                    name: 'Chart name',
+                    description: 'Chart description',
+                    spaceUuid,
+                },
+            ]),
+        ).rejects.toThrow('Space not found');
+
+        const [spaceQuery] = tracker.history.select;
+        expect(spaceQuery.bindings).toContain(projectUuid);
+        expect(spaceQuery.bindings).toContain(spaceUuid);
+        expect(tracker.history.update).toHaveLength(0);
+    });
+
+    test('updates only charts that already belong to the requested project', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const spaceUuid = '33333333-3333-4333-8333-333333333333';
+        const chartUuid = '11111111-1111-4111-8111-111111111111';
+
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 1 }]);
+        tracker.on.update(SavedChartsTableName).responseOnce(0);
+
+        await expect(
+            model.updateMultiple(projectUuid, [
+                {
+                    uuid: chartUuid,
+                    name: 'Chart name',
+                    description: 'Chart description',
+                    spaceUuid,
+                },
+            ]),
+        ).rejects.toThrow('Saved query not found');
+
+        const [updateQuery] = tracker.history.update;
+        expect(updateQuery.bindings).toContain(chartUuid);
+        expect(updateQuery.bindings).toContain(projectUuid);
     });
 });

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -780,28 +780,59 @@ export class SavedChartModel {
     }
 
     async updateMultiple(
+        projectUuid: string,
         data: UpdateMultipleSavedChart[],
     ): Promise<SavedChartDAO[]> {
         await this.database.transaction(async (trx) => {
-            const promises = data.map(async (savedChart) =>
-                trx(SavedChartsTableName)
+            const promises = data.map(async (savedChart) => {
+                const space = await trx(SpaceTableName)
+                    .select(`${SpaceTableName}.space_id`)
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
+                    )
+                    .where(`${SpaceTableName}.space_uuid`, savedChart.spaceUuid)
+                    .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                    .first();
+
+                if (!space) {
+                    throw new NotFoundError('Space not found');
+                }
+
+                const updateCount = await trx(SavedChartsTableName)
                     .update({
                         name: savedChart.name,
                         description: savedChart.description,
-                        space_id: (
-                            await SpaceModel.getSpaceIdAndName(
-                                trx,
-                                savedChart.spaceUuid,
-                            )
-                        )?.spaceId,
+                        space_id: space.space_id,
                     })
                     .where('saved_query_uuid', savedChart.uuid)
-                    .whereNull('deleted_at'),
-            );
+                    .whereIn(
+                        'space_id',
+                        trx(SpaceTableName)
+                            .select(`${SpaceTableName}.space_id`)
+                            .innerJoin(
+                                ProjectTableName,
+                                `${ProjectTableName}.project_id`,
+                                `${SpaceTableName}.project_id`,
+                            )
+                            .where(
+                                `${ProjectTableName}.project_uuid`,
+                                projectUuid,
+                            ),
+                    )
+                    .whereNull('deleted_at');
+
+                if (updateCount !== 1) {
+                    throw new NotFoundError('Saved query not found');
+                }
+            });
             await Promise.all(promises);
         });
         return Promise.all(
-            data.map(async (savedChart) => this.get(savedChart.uuid)),
+            data.map(async (savedChart) =>
+                this.get(savedChart.uuid, undefined, { projectUuid }),
+            ),
         );
     }
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -922,7 +922,10 @@ export class SavedChartService
             throw new ForbiddenError();
         }
 
-        const savedChartsDaos = await this.savedChartModel.updateMultiple(data);
+        const savedChartsDaos = await this.savedChartModel.updateMultiple(
+            projectUuid,
+            data,
+        );
         const savedCharts = await Promise.all(
             savedChartsDaos.map(async (savedChart) => {
                 const { inheritsFromOrgOrProject, access } =


### PR DESCRIPTION
Partially fixes: https://linear.app/lightdash/issue/PROD-8168/content-move-scoping

## Summary

Relates: #23889

No Linear ticket id was provided for this split security PR.

This PR narrows the IDOR fix to bulk saved-chart updates:

- `PATCH /api/v1/projects/:projectUuid/saved`
