### PR TITLE
fix: scope space move operations to project

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -840,7 +840,7 @@ export class SpaceModel {
 
     async getSpaceSummary(
         spaceUuid: string,
-        options?: { deleted?: boolean },
+        options?: { deleted?: boolean; projectUuid?: string },
     ): Promise<SpaceSummaryBase> {
         return wrapSentryTransaction(
             'SpaceModel.getSpaceSummary',
@@ -849,6 +849,7 @@ export class SpaceModel {
                 const [space] = await this.find({
                     spaceUuid,
                     deleted: options?.deleted,
+                    projectUuid: options?.projectUuid,
                 });
                 if (space === undefined)
                     throw new NotFoundError(

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -48,6 +48,59 @@ describe('SpaceService', () => {
         jest.clearAllMocks();
     });
 
+    describe('moveToSpace', () => {
+        it('loads the source space scoped to the requested project', async () => {
+            const spaceModel = {
+                getSpaceSummary: jest.fn(async () => ({
+                    uuid: 'spaceUuid',
+                    name: 'Space',
+                    projectUuid: 'projectUuid',
+                    parentSpaceUuid: 'parentSpaceUuid',
+                })),
+                moveToSpace: jest.fn(async () => undefined),
+            };
+            const spacePermissionService = {
+                can: jest.fn(async () => true),
+            };
+            const moveService = new SpaceService({
+                analytics: analyticsMock,
+                lightdashConfig: lightdashConfigMock,
+                projectModel: {} as ProjectModel,
+                spaceModel: spaceModel as unknown as SpaceModel,
+                organizationModel: {} as OrganizationModel,
+                pinnedListModel: {} as PinnedListModel,
+                spacePermissionService:
+                    spacePermissionService as unknown as SpacePermissionService,
+                savedChartService: {} as SavedChartService,
+                dashboardService: {} as DashboardService,
+                appGenerateService: undefined,
+            });
+
+            await moveService.moveToSpace(
+                createTestUser() as SessionUser,
+                {
+                    projectUuid: 'projectUuid',
+                    itemUuid: 'spaceUuid',
+                    targetSpaceUuid: null,
+                },
+                { trackEvent: false },
+            );
+
+            expect(spaceModel.getSpaceSummary).toHaveBeenCalledWith(
+                'spaceUuid',
+                { projectUuid: 'projectUuid' },
+            );
+            expect(spaceModel.moveToSpace).toHaveBeenCalledWith(
+                {
+                    projectUuid: 'projectUuid',
+                    itemUuid: 'spaceUuid',
+                    targetSpaceUuid: null,
+                },
+                { tx: undefined },
+            );
+        });
+    });
+
     describe('_userCanActionSpace', () => {
         describe('organization admins', () => {
             it.each([

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -469,7 +469,9 @@ export class SpaceService
             trackEvent?: boolean;
         } = {},
     ) {
-        const space = await this.spaceModel.getSpaceSummary(spaceUuid);
+        const space = await this.spaceModel.getSpaceSummary(spaceUuid, {
+            projectUuid,
+        });
 
         if (!space) {
             throw new NotFoundError('Space not found');
@@ -494,7 +496,7 @@ export class SpaceService
 
         await this.spaceModel.moveToSpace(
             {
-                projectUuid: space.projectUuid,
+                projectUuid,
                 itemUuid: spaceUuid,
                 targetSpaceUuid,
             },


### PR DESCRIPTION
## Summary

Closes:  https://linear.app/lightdash/issue/PROD-8168/content-move-scoping
Relates: #23889


The fix scopes the source space lookup to the URL project and passes the URL project through to the model:

- `SpaceModel.getSpaceSummary` accepts an optional `projectUuid`
- `SpaceService.moveToSpace` uses `getSpaceSummary(spaceUuid, { projectUuid })`
- `SpaceService.moveToSpace` passes the authorized URL project to `SpaceModel.moveToSpace`
