### PR TITLE
fix(dashboard): keep date zoom granularities across tab switches

### DIFF
--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -1,8 +1,4 @@
-import {
-    DateGranularity,
-    isStandardDateGranularity,
-    isSubDayGranularity,
-} from '@lightdash/common';
+import { DateGranularity, isStandardDateGranularity } from '@lightdash/common';
 import {
     ActionIcon,
     Button,
@@ -148,42 +144,17 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
     const availableCustomGranularities = useDashboardTileStatusContext(
         (c) => c.availableCustomGranularities,
     );
-    const dashboardHasTimestampDimension = useDashboardTileStatusContext(
-        (c) => c.dashboardHasTimestampDimension,
-    );
     const { track } = useTracking();
 
     useEffect(() => {
         if (isEditMode) setDateZoomGranularity(undefined);
     }, [isEditMode, setDateZoomGranularity]);
 
-    // Reset active sub-day granularity when no TIMESTAMP dimensions exist
-    // (e.g., saved config or URL param on DATE-only dashboard)
-    useEffect(() => {
-        if (
-            !dashboardHasTimestampDimension &&
-            dateZoomGranularity &&
-            isStandardDateGranularity(dateZoomGranularity) &&
-            isSubDayGranularity(dateZoomGranularity)
-        ) {
-            setDateZoomGranularity(undefined);
-        }
-    }, [
-        dashboardHasTimestampDimension,
-        dateZoomGranularity,
-        setDateZoomGranularity,
-    ]);
-
-    // Split available granularities into standard and custom for rendering with a divider.
-    // Exclude sub-day granularities when no TIMESTAMP dimensions exist on the dashboard.
+    // All standard granularities are offered to editors regardless of the
+    // dashboard's dimensions; the editor's enabled list is what viewers see.
     const standardGranularities = useMemo(
-        () =>
-            dashboardHasTimestampDimension
-                ? Object.values(DateGranularity)
-                : Object.values(DateGranularity).filter(
-                      (g) => !isSubDayGranularity(g),
-                  ),
-        [dashboardHasTimestampDimension],
+        () => Object.values(DateGranularity),
+        [],
     );
 
     const customGranularities = useMemo(

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -113,9 +113,6 @@ export const useDashboardChartReadyQuery = (
     const addAvailableCustomGranularities = useDashboardTileStatusContext(
         (c) => c.addAvailableCustomGranularities,
     );
-    const setTileHasTimestampDimension = useDashboardTileStatusContext(
-        (c) => c.setTileHasTimestampDimension,
-    );
 
     useEffect(() => {
         if (explore) {
@@ -150,14 +147,6 @@ export const useDashboardChartReadyQuery = (
         ? dateZoomCapabilities.hasDateDimension ||
           dateZoomCapabilities.hasTimestampDimension
         : false;
-    const hasTimestampDimension =
-        dateZoomCapabilities?.hasTimestampDimension ?? false;
-
-    // Report TIMESTAMP dimension presence to dashboard context per tile
-    useEffect(() => {
-        setTileHasTimestampDimension(tileUuid, hasTimestampDimension);
-        return () => setTileHasTimestampDimension(tileUuid, false);
-    }, [tileUuid, hasTimestampDimension, setTileHasTimestampDimension]);
 
     const chartParameterValues = useMemo(() => {
         if (!tileParameterReferences || !tileParameterReferences[tileUuid])

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -262,15 +262,20 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     const [hasParameterOrderChanged, setHasParameterOrderChanged] =
         useState<boolean>(false);
 
-    // Date zoom granularities state
-    const allStandardGranularities = useMemo(
-        () => Object.values(DateGranularity),
+    // Date zoom granularities state.
+    // Default offers every standard granularity except sub-day ones; editors can
+    // still enable sub-day granularities (Second/Minute/Hour) explicitly.
+    const defaultStandardGranularities = useMemo(
+        () =>
+            Object.values(DateGranularity).filter(
+                (g) => !isSubDayGranularity(g),
+            ),
         [],
     );
 
     const [dateZoomGranularities, setDateZoomGranularitiesState] = useState<
         (DateGranularity | string)[]
-    >(allStandardGranularities);
+    >(defaultStandardGranularities);
     const [
         haveDateZoomGranularitiesChanged,
         setHaveDateZoomGranularitiesChanged,
@@ -317,9 +322,12 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 dashboard.config.dateZoomGranularities,
             );
         } else {
-            setDateZoomGranularitiesState(allStandardGranularities);
+            setDateZoomGranularitiesState(defaultStandardGranularities);
         }
-    }, [dashboard?.config?.dateZoomGranularities, allStandardGranularities]);
+    }, [
+        dashboard?.config?.dateZoomGranularities,
+        defaultStandardGranularities,
+    ]);
 
     // Sync default date zoom granularity from dashboard config
     useEffect(() => {
@@ -1610,9 +1618,6 @@ const DashboardGranularitySync: React.FC = () => {
     const availableCustomGranularities = useDashboardTileStatusContext(
         (c) => c.availableCustomGranularities,
     );
-    const dashboardHasTimestampDimension = useDashboardTileStatusContext(
-        (c) => c.dashboardHasTimestampDimension,
-    );
 
     // Use refs for values we read but should NOT trigger re-runs of the effect.
     // Reading dateZoomGranularities directly in the dep array would cause an
@@ -1647,9 +1652,9 @@ const DashboardGranularitySync: React.FC = () => {
         (c) => c.setDateZoomGranularity,
     );
 
-    // Once all charts have loaded, clean up stale granularities:
-    // - Custom granularities no longer provided by any explore
-    // - Sub-day granularities when no TIMESTAMP dimensions exist
+    // Once all charts have loaded, clean up stale custom granularities no longer
+    // provided by any explore. Standard granularities (incl. sub-day) are never
+    // pruned — the editor-defined list is preserved across tab switches.
     // Also resets the active dateZoomGranularity if it's a stale custom value
     // (custom granularities are not validated earlier to avoid a race condition
     // where the URL param is cleared before charts finish loading).
@@ -1666,10 +1671,6 @@ const DashboardGranularitySync: React.FC = () => {
         const isAvailable = (g: string) => {
             if (!isStandardDateGranularity(g)) {
                 return availableCustomGranularityKeys.has(g);
-            }
-            // Strip sub-day standard granularities when no timestamp dims
-            if (!dashboardHasTimestampDimension && isSubDayGranularity(g)) {
-                return false;
             }
             return true;
         };
@@ -1697,7 +1698,6 @@ const DashboardGranularitySync: React.FC = () => {
     }, [
         areAllChartsLoaded,
         availableCustomGranularities,
-        dashboardHasTimestampDimension,
         setDateZoomGranularities,
         setDefaultDateZoomGranularity,
         setDateZoomGranularity,

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -83,30 +83,6 @@ const DashboardTileStatusProvider: React.FC<
         return chartTileUuids.every((tileUuid) => loadedTiles.has(tileUuid));
     }, [dashboardTiles, loadedTiles, activeTab, dashboardTabs]);
 
-    // Track which tiles have TIMESTAMP dimensions; derive boolean from set size
-    const [tilesWithTimestampDimension, setTilesWithTimestampDimension] =
-        useState<Set<string>>(new Set());
-    const dashboardHasTimestampDimension = tilesWithTimestampDimension.size > 0;
-
-    const setTileHasTimestampDimension = useCallback(
-        (tileUuid: string, hasTimestamp: boolean) => {
-            setTilesWithTimestampDimension((prev) => {
-                // If the current state already matches the desired, return it
-                if (prev.has(tileUuid) === hasTimestamp) {
-                    return prev;
-                }
-                const next = new Set(prev);
-                if (hasTimestamp) {
-                    next.add(tileUuid);
-                } else {
-                    next.delete(tileUuid);
-                }
-                return next;
-            });
-        },
-        [],
-    );
-
     // Custom granularities discovered from explores: key -> label (e.g., "fiscal_quarter" -> "Fiscal Quarter")
     const [availableCustomGranularities, setAvailableCustomGranularities] =
         useState<Record<string, string>>({});
@@ -288,8 +264,6 @@ const DashboardTileStatusProvider: React.FC<
             updateSqlChartTilesMetadata,
             markTileLoaded,
             areAllChartsLoaded,
-            dashboardHasTimestampDimension,
-            setTileHasTimestampDimension,
             availableCustomGranularities,
             addAvailableCustomGranularities,
             tileNamesById,
@@ -315,8 +289,6 @@ const DashboardTileStatusProvider: React.FC<
             updateSqlChartTilesMetadata,
             markTileLoaded,
             areAllChartsLoaded,
-            dashboardHasTimestampDimension,
-            setTileHasTimestampDimension,
             availableCustomGranularities,
             addAvailableCustomGranularities,
             tileNamesById,

--- a/packages/frontend/src/providers/Dashboard/tileStatusTypes.ts
+++ b/packages/frontend/src/providers/Dashboard/tileStatusTypes.ts
@@ -27,11 +27,6 @@ export type DashboardTileStatusContextType = {
     ) => void;
     markTileLoaded: (tileUuid: string) => void;
     areAllChartsLoaded: boolean;
-    dashboardHasTimestampDimension: boolean;
-    setTileHasTimestampDimension: (
-        tileUuid: string,
-        hasTimestamp: boolean,
-    ) => void;
     availableCustomGranularities: Record<string, string>;
     addAvailableCustomGranularities: (
         granularities: Record<string, string>,


### PR DESCRIPTION
Closes: PROD-8071
Closes: #23773

### Description:

An editor-enabled sub-day Date Zoom granularity (e.g. Hour) silently disappeared after switching dashboard tabs, because `DashboardGranularitySync` destructively pruned sub-day standard granularities whenever the active tab had no TIMESTAMP dimension — a one-way prune that never restored them. This removes all the show/hide logic: the editor-defined granularity list is now preserved across tab switches and always displayed, and the dead per-tile TIMESTAMP-tracking machinery is dropped. The default list (dashboards with no saved config) now offers every standard granularity except sub-day ones, which editors can still enable explicitly.