### PR TITLE
fix: surface partial field compilation errors

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -83,6 +83,41 @@ const buildQuery = (
         parameterDefinitions: {},
     }).compileQuery();
 
+describe('field compilation errors', () => {
+    const exploreWithErroredDimension: Explore = {
+        ...EXPLORE,
+        tables: {
+            ...EXPLORE.tables,
+            table1: {
+                ...EXPLORE.tables.table1,
+                dimensions: {
+                    ...EXPLORE.tables.table1.dimensions,
+                    dim1: {
+                        ...EXPLORE.tables.table1.dimensions.dim1,
+                        compiledSql: 'NULL',
+                        compilationError: {
+                            message:
+                                'Dimension "dim1" failed to compile: Missing parameters: missing_parameter',
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    it('throws when a selected field has a partial compilation error', () => {
+        expect(() =>
+            buildQuery({
+                explore: exploreWithErroredDimension,
+                compiledMetricQuery: METRIC_QUERY,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: {},
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            }),
+        ).toThrow('Missing parameters: missing_parameter');
+    });
+});
+
 const POP_TEST_POP_METRIC_NAME = 'total_order_amount__pop__year_1__testpop';
 const POP_TEST_POP_METRIC_ID = `orders_${POP_TEST_POP_METRIC_NAME}`;
 const POP_TEST_FANOUT_POP_METRIC_NAME = 'metric_amount__pop__year_1__fanout';

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -25,6 +25,7 @@ import {
     getFieldsFromMetricQuery,
     getFilterRulesFromGroup,
     getItemId,
+    getItemMap,
     getMetricsMapFromTables,
     getParsedReference,
     getPopComparisonConfigKey,
@@ -468,6 +469,35 @@ export class MetricQueryBuilder {
             );
         }
         return metric;
+    }
+
+    private getUsedFieldCompilationErrors(): string[] {
+        const { explore, compiledMetricQuery } = this.args;
+        const itemMap = getItemMap(
+            explore,
+            compiledMetricQuery.compiledAdditionalMetrics,
+            compiledMetricQuery.compiledTableCalculations,
+            compiledMetricQuery.compiledCustomDimensions,
+        );
+        const usedFieldIds = new Set<string>([
+            ...compiledMetricQuery.dimensions,
+            ...compiledMetricQuery.metrics,
+            ...compiledMetricQuery.sorts.map((sort) => sort.fieldId),
+            ...getFilterRulesFromGroup(compiledMetricQuery.filters.dimensions)
+                .map((filter) => filter.target.fieldId)
+                .filter((fieldId): fieldId is string => fieldId !== undefined),
+            ...getFilterRulesFromGroup(compiledMetricQuery.filters.metrics)
+                .map((filter) => filter.target.fieldId)
+                .filter((fieldId): fieldId is string => fieldId !== undefined),
+        ]);
+
+        return Array.from(usedFieldIds).flatMap((fieldId) => {
+            const item = itemMap[fieldId];
+            if (item && 'compilationError' in item && item.compilationError) {
+                return (item.compilationError as { message: string }).message;
+            }
+            return [];
+        });
     }
 
     private isFilterOnPopComparisonTimeDimension(
@@ -4110,6 +4140,15 @@ export class MetricQueryBuilder {
     public compileQuery(): CompiledQuery {
         const { explore, compiledMetricQuery } = this.args;
         const fields = getFieldsFromMetricQuery(compiledMetricQuery, explore);
+        const usedFieldCompilationErrors = this.getUsedFieldCompilationErrors();
+
+        if (usedFieldCompilationErrors.length > 0) {
+            if (this.args.continueOnError) {
+                this.compilationErrors.push(...usedFieldCompilationErrors);
+            } else {
+                throw new CompileError(usedFieldCompilationErrors.join('\n'));
+            }
+        }
 
         const dimensionsSQL = this.getDimensionsSQL();
         const metricsSQL = this.getMetricsSQL();


### PR DESCRIPTION
### Description
- Surface field-level partial compilation errors during metric query compilation.
- Prevent queries from silently generating SQL for selected, sorted, or filtered fields compiled as `NULL`.
- Add regression coverage for selected fields with partial compilation errors.

### Repro steps
Using the Jaffle shop project:

1. Add a model dimension that references a project-level parameter that does not exist in `lightdash.config.yml`.

   ```yaml
   - name: missing_parameter_cli_verify
     description: Missing parameter verification dimension
     meta:
       dimension:
         sql: ${lightdash.parameters.missing_parameter}
     type: string
   ```

2. Deploy the semantic layer with the Lightdash CLI:

   ```bash
   lightdash deploy --project <project_uuid> --select orders
   ```

3. Confirm the CLI reports a partial compile, not a hard deploy failure:

   ```text
   PARTIAL_SUCCESS> orders
   Dimension "missing_parameter_cli_verify" failed to compile: Missing parameters: missing_parameter.
   ```

4. In Lightdash, create or open a chart on the `orders` explore that selects:
   - Dimension: `orders_missing_parameter_cli_verify`
   - Metric: `orders_unique_order_count`

5. Add that chart to a dashboard and load the dashboard.

Before this fix, the dashboard tile query succeeds and generates SQL like:

```sql
SELECT
  NULL AS "orders_missing_parameter_cli_verify",
  COUNT(DISTINCT "orders".order_id) AS "orders_unique_order_count"
FROM ...
```

The tile can then render empty/wrong data without surfacing the field compilation error.

After this fix, the dashboard tile query fails visibly at query time with:

```text
Dimension "missing_parameter_cli_verify" failed to compile: Missing parameters: missing_parameter.
```

<details>
<summary>Screenshots</summary>
Before:

<img width="886" height="833" alt="image" src="https://github.com/user-attachments/assets/c3997cbf-29ef-447c-85b3-cef67584e74c" />

After:

<img width="791" height="935" alt="image" src="https://github.com/user-attachments/assets/1addb55d-c509-4c1c-b3f4-1aea08a6c638" />

</details>

### Testing
- `pnpm -F backend test -- MetricQueryBuilder.test.ts --runInBand`
- `pnpm -F backend typecheck:fast`
- `pnpm -F backend format`
- Verified through a Jaffle shop CLI partial deploy and dashboard tile query.

Closes: PROD-8010
Closes: #23673
