### PR TITLE
fix: guard New Dashboard menu item with create permission

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -111,14 +111,21 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 icon={IconTerminal2}
                             />
                         </Can>
-                        <LargeMenuItem
-                            // Users who manage explores should be able to create dashboards in any space
-                            title="Dashboard"
-                            description="Arrange multiple charts into a single view."
-                            onClick={() => setIsCreateDashboardOpen(true)}
-                            icon={IconLayoutDashboard}
-                            data-testid="ExploreMenu/NewDashboardButton"
-                        />
+                        <Can
+                            I="create"
+                            this={subject('Dashboard', {
+                                organizationUuid: user.data?.organizationUuid,
+                                projectUuid,
+                            })}
+                        >
+                            <LargeMenuItem
+                                title="Dashboard"
+                                description="Arrange multiple charts into a single view."
+                                onClick={() => setIsCreateDashboardOpen(true)}
+                                icon={IconLayoutDashboard}
+                                data-testid="ExploreMenu/NewDashboardButton"
+                            />
+                        </Can>
 
                         {dataAppsFlag.data?.enabled && (
                             <Can


### PR DESCRIPTION
Closes: PROD-2470

### Description:

The **Dashboard** item in the navbar "+ New" menu was the only entry in the dropdown without its own permission guard — it relied solely on the outer `manage`/`Explore` gate, which is not equivalent to dashboard-create permission. With custom roles, a user could hold `manage:Explore` without dashboard-create access and still see "Dashboard". This wraps the item in a `<Can I="create" subject('Dashboard')>` guard matching the sibling menu items, and removes the now-misleading comment.