### PR TITLE
fix(promotion): vertically align icons with labels in promotion preview

### DIFF
--- a/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
+++ b/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
@@ -250,12 +250,12 @@ export const PromotionConfirmDialog: FC<Props> = ({
                                 <Text fz="sm">
                                     These changes will be applied:
                                 </Text>
-                                <Flex gap="sm">
+                                <Flex gap="xs" align="center">
                                     <MantineIcon
                                         icon={IconFolder}
                                         color="violet.8"
-                                    />{' '}
-                                    <Text fw={600}>Spaces: </Text>{' '}
+                                    />
+                                    <Text fw={600}>Spaces:</Text>
                                 </Flex>
                                 <PromotionChangesAccordion
                                     type="spaces"
@@ -269,14 +269,12 @@ export const PromotionConfirmDialog: FC<Props> = ({
                                 <Text fz="sm">
                                     These changes will be applied:
                                 </Text>
-                                <Flex>
+                                <Flex gap="xs" align="center">
                                     <MantineIcon
                                         icon={IconLayoutDashboard}
                                         color="green.8"
-                                    />{' '}
-                                    <Text ml={10} fw={600}>
-                                        Dashboards:{' '}
-                                    </Text>{' '}
+                                    />
+                                    <Text fw={600}>Dashboards:</Text>
                                 </Flex>
                                 <PromotionChangesAccordion
                                     type="dashboards"
@@ -289,14 +287,12 @@ export const PromotionConfirmDialog: FC<Props> = ({
                                 <Text fz="sm">
                                     These changes will be applied:
                                 </Text>
-                                <Flex>
+                                <Flex gap="xs" align="center">
                                     <MantineIcon
                                         icon={IconChartAreaLine}
                                         color="blue.7"
-                                    />{' '}
-                                    <Text ml={10} fw={600}>
-                                        Charts:{' '}
-                                    </Text>{' '}
+                                    />
+                                    <Text fw={600}>Charts:</Text>
                                 </Flex>
                                 <PromotionChangesAccordion
                                     type="charts"
@@ -309,14 +305,12 @@ export const PromotionConfirmDialog: FC<Props> = ({
                                 <Text fz="sm">
                                     These changes will be applied:
                                 </Text>
-                                <Flex>
+                                <Flex gap="xs" align="center">
                                     <MantineIcon
                                         icon={IconDatabase}
                                         color="cyan.7"
-                                    />{' '}
-                                    <Text ml={10} fw={600}>
-                                        SQL charts:{' '}
-                                    </Text>{' '}
+                                    />
+                                    <Text fw={600}>SQL charts:</Text>
                                 </Flex>
                                 <PromotionChangesAccordion
                                     type="sqlCharts"
@@ -329,14 +323,12 @@ export const PromotionConfirmDialog: FC<Props> = ({
                                 <Text fz="sm">
                                     These changes will be applied:
                                 </Text>
-                                <Flex>
+                                <Flex gap="xs" align="center">
                                     <MantineIcon
                                         icon={IconAppWindow}
                                         color="orange.6"
-                                    />{' '}
-                                    <Text ml={10} fw={600}>
-                                        Data apps:{' '}
-                                    </Text>{' '}
+                                    />
+                                    <Text fw={600}>Data apps:</Text>
                                 </Flex>
                                 <PromotionChangesAccordion
                                     type="dataApps"


### PR DESCRIPTION
### Description:
Add align="center" to the icon+label rows in the promotion confirm dialog so icons center with their bold labels instead of floating to the top. Standardize all five rows to Flex gap="xs" align="center", removing the inconsistent ml={10} and stray whitespace.


Before:
<img width="623" height="822" alt="before" src="https://github.com/user-attachments/assets/b5006bc5-6234-4ace-95a9-4f6c20ab4939" />



After:
<img width="623" height="822" alt="after" src="https://github.com/user-attachments/assets/6e58306c-67ec-435c-924f-2ca5f2fa5938" />
