### PR TITLE
fix: respect column order for metrics in show_underlying_values

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -197,7 +197,8 @@ models:
                 round: 1
                 sql: CASE WHEN ${is_completed} THEN 1 ELSE 0 END
                 show_underlying_values:
-                  - amount
+                  - status
+                  - total_order_amount
                   - customers.first_name
                 spotlight:
                   owner: demo2@lightdash.com

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
@@ -126,7 +126,7 @@ const UnderlyingDataModalContent: FC = () => {
             if (showUnderlyingValues === undefined) return 0;
 
             const indexOfUnderlyingValue = (column: TableColumn): number => {
-                const columnDimension = allDimensions.find(
+                const columnDimension = allFields.find(
                     (dimension) => getItemId(dimension) === column.id,
                 );
                 if (columnDimension === undefined) return -1;
@@ -143,7 +143,7 @@ const UnderlyingDataModalContent: FC = () => {
                 indexOfUnderlyingValue(columnB)
             );
         },
-        [showUnderlyingValues, allDimensions],
+        [showUnderlyingValues, allFields],
     );
 
     const filters = useMemo<Filters>(() => {


### PR DESCRIPTION
Closes: PROD-7521

### Description:
When metrics were listed in a model's `show_underlying_values`, they always appeared on the left of the "View underlying data" table, ignoring their declared position. The sort comparator resolved columns against dimensions only, so metric columns weren't found and fell to the front. It now sorts against all fields (dimensions + metrics), so metrics appear in their declared order — extending the earlier dimensions-only fix (PROD-5087) to cover metrics.


### Demo

```
show_underlying_values:
  - status                # dimension
  - total_order_amount    # metric — declared in the MIDDLE
  - customers.first_name  # dimension
```

<img width="2922" height="2452" alt="CleanShot 2026-06-08 at 14 28 19@2x" src="https://github.com/user-attachments/assets/08b7366e-90fb-4e7a-9a87-9b0c04947c58" />
