### PR TITLE
fix: scope deleted content operations to project

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -840,7 +840,7 @@ export class SpaceModel {
 
     async getSpaceSummary(
         spaceUuid: string,
-        options?: { deleted?: boolean },
+        options?: { deleted?: boolean; projectUuid?: string },
     ): Promise<SpaceSummaryBase> {
         return wrapSentryTransaction(
             'SpaceModel.getSpaceSummary',
@@ -849,6 +849,7 @@ export class SpaceModel {
                 const [space] = await this.find({
                     spaceUuid,
                     deleted: options?.deleted,
+                    projectUuid: options?.projectUuid,
                 });
                 if (space === undefined)
                     throw new NotFoundError(

--- a/packages/backend/src/services/ContentService/ContentService.test.ts
+++ b/packages/backend/src/services/ContentService/ContentService.test.ts
@@ -1,0 +1,219 @@
+import {
+    ChartSourceType,
+    ContentType,
+    defineUserAbility,
+    OrganizationMemberRole,
+    ProjectMemberRole,
+} from '@lightdash/common';
+import type { DeletedContentItem, SessionUser } from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import type { ContentModel } from '../../models/ContentModel/ContentModel';
+import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import type { SpaceModel } from '../../models/SpaceModel';
+import type { DashboardService } from '../DashboardService/DashboardService';
+import type { SavedChartService } from '../SavedChartsService/SavedChartService';
+import type { SavedSqlService } from '../SavedSqlService/SavedSqlService';
+import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import type { SpaceService } from '../SpaceService/SpaceService';
+import { ContentService } from './ContentService';
+
+const projectUuid = 'project-uuid';
+const organizationUuid = 'organization-uuid';
+const userUuid = 'user-uuid';
+
+const createUser = (): SessionUser =>
+    ({
+        userId: 1,
+        userUuid,
+        organizationUuid,
+        ability: defineUserAbility(
+            {
+                userUuid,
+                role: OrganizationMemberRole.MEMBER,
+                organizationUuid,
+            },
+            [
+                {
+                    projectUuid,
+                    role: ProjectMemberRole.ADMIN,
+                    userUuid,
+                    roleUuid: undefined,
+                },
+            ],
+        ),
+    }) as SessionUser;
+
+const createService = () => {
+    const projectModel = {
+        getSummary: jest.fn().mockResolvedValue({
+            organizationUuid,
+            name: 'Test project',
+        }),
+    };
+    const savedChartService = {
+        restore: jest.fn().mockResolvedValue(undefined),
+        permanentDelete: jest.fn().mockResolvedValue(undefined),
+    };
+    const savedSqlService = {
+        restore: jest.fn().mockResolvedValue(undefined),
+        permanentDelete: jest.fn().mockResolvedValue(undefined),
+    };
+    const dashboardService = {
+        restore: jest.fn().mockResolvedValue(undefined),
+        permanentDelete: jest.fn().mockResolvedValue(undefined),
+    };
+    const spaceService = {
+        restore: jest.fn().mockResolvedValue(undefined),
+        permanentDelete: jest.fn().mockResolvedValue(undefined),
+    };
+
+    return {
+        service: new ContentService({
+            analytics: analyticsMock,
+            projectModel: projectModel as unknown as ProjectModel,
+            contentModel: {} as ContentModel,
+            spaceModel: {} as SpaceModel,
+            spaceService: spaceService as unknown as SpaceService,
+            dashboardService: dashboardService as unknown as DashboardService,
+            savedChartService:
+                savedChartService as unknown as SavedChartService,
+            savedSqlService: savedSqlService as unknown as SavedSqlService,
+            spacePermissionService: {} as SpacePermissionService,
+            appMoveService: undefined,
+            appGenerateService: undefined,
+        }),
+        projectModel,
+        savedChartService,
+        savedSqlService,
+        dashboardService,
+        spaceService,
+    };
+};
+
+describe('ContentService deleted content actions', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('restoreContent', () => {
+        it.each<
+            [
+                string,
+                DeletedContentItem,
+                keyof Pick<
+                    ReturnType<typeof createService>,
+                    | 'savedChartService'
+                    | 'savedSqlService'
+                    | 'dashboardService'
+                    | 'spaceService'
+                >,
+            ]
+        >([
+            [
+                'DBT chart',
+                {
+                    uuid: 'chart-uuid',
+                    contentType: ContentType.CHART,
+                    source: ChartSourceType.DBT_EXPLORE,
+                },
+                'savedChartService',
+            ],
+            [
+                'SQL chart',
+                {
+                    uuid: 'sql-chart-uuid',
+                    contentType: ContentType.CHART,
+                    source: ChartSourceType.SQL,
+                },
+                'savedSqlService',
+            ],
+            [
+                'dashboard',
+                { uuid: 'dashboard-uuid', contentType: ContentType.DASHBOARD },
+                'dashboardService',
+            ],
+            [
+                'space',
+                { uuid: 'space-uuid', contentType: ContentType.SPACE },
+                'spaceService',
+            ],
+        ])(
+            'passes authorized projectUuid for %s restore',
+            async (_, item, key) => {
+                const deps = createService();
+                const user = createUser();
+
+                await deps.service.restoreContent(user, projectUuid, item);
+
+                expect(deps[key].restore).toHaveBeenCalledWith(
+                    user,
+                    item.uuid,
+                    { projectUuid },
+                );
+            },
+        );
+    });
+
+    describe('permanentlyDeleteContent', () => {
+        it.each<
+            [
+                string,
+                DeletedContentItem,
+                keyof Pick<
+                    ReturnType<typeof createService>,
+                    | 'savedChartService'
+                    | 'savedSqlService'
+                    | 'dashboardService'
+                    | 'spaceService'
+                >,
+            ]
+        >([
+            [
+                'DBT chart',
+                {
+                    uuid: 'chart-uuid',
+                    contentType: ContentType.CHART,
+                    source: ChartSourceType.DBT_EXPLORE,
+                },
+                'savedChartService',
+            ],
+            [
+                'SQL chart',
+                {
+                    uuid: 'sql-chart-uuid',
+                    contentType: ContentType.CHART,
+                    source: ChartSourceType.SQL,
+                },
+                'savedSqlService',
+            ],
+            [
+                'dashboard',
+                { uuid: 'dashboard-uuid', contentType: ContentType.DASHBOARD },
+                'dashboardService',
+            ],
+            [
+                'space',
+                { uuid: 'space-uuid', contentType: ContentType.SPACE },
+                'spaceService',
+            ],
+        ])(
+            'passes authorized projectUuid for %s permanent delete',
+            async (_, item, key) => {
+                const deps = createService();
+                const user = createUser();
+
+                await deps.service.permanentlyDeleteContent(
+                    user,
+                    projectUuid,
+                    item,
+                );
+
+                expect(deps[key].permanentDelete).toHaveBeenCalledWith(
+                    user,
+                    item.uuid,
+                    { projectUuid },
+                );
+            },
+        );
+    });
+});

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -502,9 +502,13 @@ export class ContentService extends BaseService {
             case ContentType.CHART:
                 switch (item.source) {
                     case ChartSourceType.DBT_EXPLORE:
-                        return this.savedChartService.restore(user, item.uuid);
+                        return this.savedChartService.restore(user, item.uuid, {
+                            projectUuid,
+                        });
                     case ChartSourceType.SQL:
-                        return this.savedSqlService.restore(user, item.uuid);
+                        return this.savedSqlService.restore(user, item.uuid, {
+                            projectUuid,
+                        });
                     default:
                         return assertUnreachable(
                             item.source,
@@ -512,9 +516,13 @@ export class ContentService extends BaseService {
                         );
                 }
             case ContentType.DASHBOARD:
-                return this.dashboardService.restore(user, item.uuid);
+                return this.dashboardService.restore(user, item.uuid, {
+                    projectUuid,
+                });
             case ContentType.SPACE:
-                return this.spaceService.restore(user, item.uuid);
+                return this.spaceService.restore(user, item.uuid, {
+                    projectUuid,
+                });
             case ContentType.DATA_APP:
                 return this.getAppGenerateService().restoreApp(
                     user,
@@ -561,11 +569,13 @@ export class ContentService extends BaseService {
                         return this.savedChartService.permanentDelete(
                             user,
                             item.uuid,
+                            { projectUuid },
                         );
                     case ChartSourceType.SQL:
                         return this.savedSqlService.permanentDelete(
                             user,
                             item.uuid,
+                            { projectUuid },
                         );
                     default:
                         return assertUnreachable(
@@ -574,9 +584,13 @@ export class ContentService extends BaseService {
                         );
                 }
             case ContentType.DASHBOARD:
-                return this.dashboardService.permanentDelete(user, item.uuid);
+                return this.dashboardService.permanentDelete(user, item.uuid, {
+                    projectUuid,
+                });
             case ContentType.SPACE:
-                return this.spaceService.permanentDelete(user, item.uuid);
+                return this.spaceService.permanentDelete(user, item.uuid, {
+                    projectUuid,
+                });
             case ContentType.DATA_APP:
                 return this.getAppGenerateService().permanentDeleteApp(
                     user,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -1556,7 +1556,7 @@ export class DashboardService
     ): Promise<void> {
         const dashboard = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
-            { deleted: true },
+            { deleted: true, projectUuid: options?.projectUuid },
         );
 
         if (options?.bypassPermissions) {
@@ -1614,7 +1614,7 @@ export class DashboardService
         // not-yet-deleted dashboard (when softDelete config is off).
         const dashboard = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
-            { deleted: 'any' },
+            { deleted: 'any', projectUuid: options?.projectUuid },
         );
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -2255,7 +2255,7 @@ export class SavedChartService
         const deletedChart = await this.savedChartModel.get(
             chartUuid,
             undefined,
-            { deleted: true },
+            { deleted: true, projectUuid: options?.projectUuid },
         );
         const { organizationUuid, projectUuid } = deletedChart;
 
@@ -2341,7 +2341,7 @@ export class SavedChartService
             const deletedChart = await this.savedChartModel.get(
                 chartUuid,
                 undefined,
-                { deleted: true },
+                { deleted: true, projectUuid: options?.projectUuid },
             );
             const { organizationUuid, projectUuid } = deletedChart;
 

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -481,6 +481,7 @@ export class SavedSqlService
     ): Promise<void> {
         const savedChart = await this.savedSqlModel.getByUuid(savedSqlUuid, {
             deleted: true,
+            projectUuid: options?.projectUuid,
         });
         const { projectUuid } = savedChart.project;
         const { organizationUuid } = savedChart.organization;
@@ -550,7 +551,7 @@ export class SavedSqlService
         } else {
             const savedChart = await this.savedSqlModel.getByUuid(
                 savedSqlUuid,
-                { deleted: true },
+                { deleted: true, projectUuid: options?.projectUuid },
             );
             const { projectUuid } = savedChart.project;
             const { organizationUuid } = savedChart.organization;

--- a/packages/backend/src/services/SoftDeletableService.ts
+++ b/packages/backend/src/services/SoftDeletableService.ts
@@ -7,6 +7,7 @@ import type { SessionUser } from '@lightdash/common';
  */
 export type SoftDeleteOptions = {
     bypassPermissions?: boolean;
+    projectUuid?: string;
 };
 
 /**

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -690,6 +690,7 @@ export class SpaceService
     ): Promise<void> {
         const space = await this.spaceModel.getSpaceSummary(spaceUuid, {
             deleted: true,
+            projectUuid: options?.projectUuid,
         });
 
         if (options?.bypassPermissions) {
@@ -739,6 +740,7 @@ export class SpaceService
                 // eslint-disable-next-line no-await-in-loop
                 await this.savedChartService.restore(user, chartUuid, {
                     bypassPermissions: true, // space restore authorized above
+                    projectUuid: space.projectUuid,
                 });
             }
 
@@ -751,6 +753,7 @@ export class SpaceService
                 // eslint-disable-next-line no-await-in-loop
                 await this.dashboardService.restore(user, dashboardUuid, {
                     bypassPermissions: true, // space restore authorized above
+                    projectUuid: space.projectUuid,
                 });
             }
 
@@ -782,6 +785,7 @@ export class SpaceService
                 // eslint-disable-next-line no-await-in-loop
                 await this.restore(user, childSpaceUuid, {
                     bypassPermissions: true, // space restore authorized above
+                    projectUuid: space.projectUuid,
                 });
             }
         }
@@ -811,6 +815,7 @@ export class SpaceService
         } else {
             const space = await this.spaceModel.getSpaceSummary(spaceUuid, {
                 deleted: true,
+                projectUuid: options?.projectUuid,
             });
             const auditedAbility = this.createAuditedAbility(user);
             if (


### PR DESCRIPTION
Closes:  https://linear.app/lightdash/issue/PROD-8169/deleted-content-restorepermanent-delete-scoping
Relates: #23889

## Summary
- scope deleted-content restore and permanent-delete lookups to the authorized project
- pass projectUuid through chart, SQL chart, dashboard, and space soft-delete lifecycle services
- add regression coverage that ContentService preserves project scope for restore/permanent-delete actions

