### PR TITLE
feat: add ai thread share frontend

### DIFF
--- a/packages/frontend/src/components/common/ShareLinkButton.tsx
+++ b/packages/frontend/src/components/common/ShareLinkButton.tsx
@@ -27,6 +27,7 @@ export const ShareLinkButton: FC<ShareLinkButtonProps> = ({
                         onClick={copy}
                         size="md"
                         radius="md"
+                        aria-label={copied ? 'Link copied' : label}
                     >
                         <MantineIcon
                             icon={copied ? IconCheck : IconLink}

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -10,6 +10,7 @@ import AiAgentThreadPage from './pages/AiAgents/AgentThreadPage';
 import AiAgentNewThreadPage from './pages/AiAgents/AiAgentNewThreadPage';
 import AiAgentsNotAuthorizedPage from './pages/AiAgents/AiAgentsNotAuthorizedPage';
 import { AiAgentsRootLayout } from './pages/AiAgents/AiAgentsRootLayout';
+import AiAgentThreadSharePage from './pages/AiAgents/AiAgentThreadSharePage';
 import ProjectAiAgentEditPage from './pages/AiAgents/ProjectAiAgentEditPage';
 import EmbedChart from './pages/EmbedChart';
 import EmbedDashboard from './pages/EmbedDashboard';
@@ -103,6 +104,10 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
             {
                 path: 'new',
                 element: <ProjectAiAgentEditPage isCreateMode />,
+            },
+            {
+                path: 'share/:aiThreadShareUuid',
+                element: <AiAgentThreadSharePage />,
             },
             {
                 path: ':agentUuid/edit',

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
@@ -1,5 +1,9 @@
-import { Box, Button, Group } from '@mantine-8/core';
-import { IconSettings, IconWindowMinimize } from '@tabler/icons-react';
+import { ActionIcon, Box, Button, Group, Tooltip } from '@mantine-8/core';
+import {
+    IconSettings,
+    IconShare2,
+    IconWindowMinimize,
+} from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -8,17 +12,41 @@ import styles from './agentPageHeader.module.css';
 type Props = {
     leftSection?: ReactNode;
     onMinimize?: () => void;
+    onShare?: () => void;
+    isSharing?: boolean;
     settingsHref?: string;
 };
 
 export const AgentPageHeader: FC<Props> = ({
     leftSection,
     onMinimize,
+    onShare,
+    isSharing,
     settingsHref,
 }) => (
     <Group align="center" justify="space-between" className={styles.root}>
         <Box>{leftSection}</Box>
         <Group gap={4}>
+            {onShare && (
+                <Tooltip label="Share thread" position="bottom">
+                    <ActionIcon
+                        variant="default"
+                        className={styles.action}
+                        onClick={onShare}
+                        loading={isSharing}
+                        aria-label="Share thread"
+                        styles={(theme) => ({
+                            root: {
+                                borderColor: theme.colors.ldGray[2],
+                                boxShadow: `var(--mantine-shadow-subtle)`,
+                                color: theme.colors.ldGray[9],
+                            },
+                        })}
+                    >
+                        <MantineIcon icon={IconShare2} size={14} stroke={1.8} />
+                    </ActionIcon>
+                </Tooltip>
+            )}
             {onMinimize && (
                 <Button
                     variant="default"

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -11,6 +11,7 @@ import type {
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQuery,
     ApiAiAgentThreadResponse,
+    ApiAiAgentThreadShareResponse,
     ApiAiAgentVerifiedQuestionsResponse,
     ApiAppendInstructionRequest,
     ApiAppendInstructionResponse,
@@ -19,6 +20,7 @@ import type {
     AiPromptContextItemInput,
     ApiCreateAiAgent,
     ApiCreateAiAgentResponse,
+    ApiCloneAiAgentThreadShareResponse,
     ApiError,
     ApiAiMcpServerListResponse,
     ApiRevertChangeRequest,
@@ -335,6 +337,83 @@ const getAgentThread = async (
         method: 'GET',
         body: undefined,
     });
+
+const createAgentThreadShare = async (
+    projectUuid: string,
+    agentUuid: string,
+    threadUuid: string,
+) =>
+    lightdashApi<ApiAiAgentThreadShareResponse['results']>({
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}/shares`,
+        method: 'POST',
+        body: JSON.stringify({}),
+    });
+
+export const useCreateAgentThreadShareMutation = () => {
+    const { showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiAiAgentThreadShareResponse['results'],
+        ApiError,
+        { projectUuid: string; agentUuid: string; threadUuid: string }
+    >({
+        mutationFn: ({ projectUuid, agentUuid, threadUuid }) =>
+            createAgentThreadShare(projectUuid, agentUuid, threadUuid),
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to create AI agent thread share',
+                apiError: error,
+            });
+        },
+    });
+};
+
+const cloneAgentThreadShare = async (
+    projectUuid: string,
+    aiThreadShareUuid: string,
+) =>
+    lightdashApi<ApiCloneAiAgentThreadShareResponse['results']>({
+        url: `/projects/${projectUuid}/aiAgents/thread-shares/${aiThreadShareUuid}/clone`,
+        method: 'POST',
+        body: JSON.stringify({}),
+    });
+
+export const useCloneAgentThreadShareMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const navigate = useNavigate();
+    const { showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiCloneAiAgentThreadShareResponse['results'],
+        ApiError,
+        string
+    >({
+        mutationFn: (aiThreadShareUuid) =>
+            cloneAgentThreadShare(projectUuid, aiThreadShareUuid),
+        onSuccess: async (thread) => {
+            await queryClient.invalidateQueries({
+                queryKey: [AI_AGENTS_KEY, projectUuid, PROJECT_THREADS_KEY],
+            });
+            void navigate(
+                `/projects/${projectUuid}/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`,
+                { replace: true },
+            );
+        },
+        onError: ({ error }) => {
+            if (error.statusCode === 403) {
+                void navigate(
+                    `/projects/${projectUuid}/ai-agents/not-authorized`,
+                    { replace: true },
+                );
+                return;
+            }
+            showToastApiError({
+                title: 'Failed to open shared AI thread',
+                apiError: error,
+            });
+        },
+    });
+};
 
 const PROJECT_THREADS_KEY = 'project-threads';
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.module.css
@@ -1,0 +1,19 @@
+.shareCopyBar {
+    background-color: var(--mantine-color-background);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+
+    @mixin dark {
+        border-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.shareLinkInput {
+    flex: 1;
+    min-width: 0;
+
+    input {
+        color: var(--mantine-color-foreground);
+        text-overflow: ellipsis;
+    }
+}

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -1,5 +1,6 @@
 import { type AiAgent } from '@lightdash/common';
-import { Box, Loader } from '@mantine-8/core';
+import { Box, Group, Loader, Stack, Text, TextInput } from '@mantine-8/core';
+import { IconShare2 } from '@tabler/icons-react';
 import { useCallback, useState } from 'react';
 import {
     Navigate,
@@ -8,6 +9,8 @@ import {
     useParams,
     useSearchParams,
 } from 'react-router';
+import MantineModal from '../../../components/common/MantineModal';
+import { ShareLinkButton } from '../../../components/common/ShareLinkButton';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -21,10 +24,12 @@ import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentP
 import {
     useProjectAiAgent as useAiAgent,
     useAiAgentThread,
+    useCreateAgentThreadShareMutation,
     useProjectAiAgents,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
 import { store as aiAgentStore } from '../../features/aiCopilot/store';
 import { openPanel } from '../../features/aiCopilot/store/aiAgentLauncherSlice';
+import styles from './AgentPage.module.css';
 
 type NavigateFromAgentChatOptions = {
     threadUuid?: string;
@@ -62,6 +67,10 @@ const AgentPage = () => {
     const { addItem: addDockItem } = useLauncherDock(projectUuid);
     const { track } = useTracking();
     const { user } = useApp();
+    const { mutateAsync: createThreadShare, isLoading: isCreatingShare } =
+        useCreateAgentThreadShareMutation();
+    const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+    const [shareUrl, setShareUrl] = useState<string | null>(null);
 
     const handleMinimize = useCallback(
         (targetUrl?: string, options?: NavigateFromAgentChatOptions) => {
@@ -134,6 +143,33 @@ const AgentPage = () => {
         ],
     );
 
+    const closeShareModal = useCallback(() => {
+        setIsShareModalOpen(false);
+        setShareUrl(null);
+    }, []);
+
+    const handleShare = useCallback(async () => {
+        if (!projectUuid || !agentUuid || !threadUuid) return;
+        setIsShareModalOpen(true);
+        setShareUrl(null);
+        try {
+            const share = await createThreadShare({
+                projectUuid,
+                agentUuid,
+                threadUuid,
+            });
+            setShareUrl(share.shareUrl);
+        } catch {
+            closeShareModal();
+        }
+    }, [
+        agentUuid,
+        closeShareModal,
+        createThreadShare,
+        projectUuid,
+        threadUuid,
+    ]);
+
     if (isLoadingAgent) {
         return (
             <Box
@@ -176,6 +212,12 @@ const AgentPage = () => {
                                 variant="header"
                             />
                         }
+                        onShare={
+                            thread?.createdFrom === 'web_app'
+                                ? handleShare
+                                : undefined
+                        }
+                        isSharing={isCreatingShare}
                         onMinimize={() => handleMinimize()}
                         settingsHref={
                             canManageAgents
@@ -186,6 +228,47 @@ const AgentPage = () => {
                 ) : undefined
             }
         >
+            <MantineModal
+                opened={isShareModalOpen}
+                onClose={closeShareModal}
+                title="Share thread"
+                icon={IconShare2}
+                size={560}
+                cancelLabel={false}
+            >
+                <Stack gap="md">
+                    <Stack gap="xs">
+                        <Text size="sm">
+                            Anyone with the link and access to this AI agent can
+                            open this conversation as their own copy.
+                        </Text>
+                        <Text size="sm" c="dimmed">
+                            New messages you send later won't be included.
+                        </Text>
+                    </Stack>
+
+                    <Group
+                        wrap="nowrap"
+                        gap="sm"
+                        p="sm"
+                        className={styles.shareCopyBar}
+                    >
+                        <TextInput
+                            value={
+                                isCreatingShare
+                                    ? 'Creating link...'
+                                    : (shareUrl ?? '')
+                            }
+                            readOnly
+                            variant="unstyled"
+                            className={styles.shareLinkInput}
+                        />
+                        {shareUrl && !isCreatingShare ? (
+                            <ShareLinkButton url={shareUrl} />
+                        ) : null}
+                    </Group>
+                </Stack>
+            </MantineModal>
             <Outlet
                 context={{
                     agent,

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentThreadSharePage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentThreadSharePage.tsx
@@ -1,0 +1,39 @@
+import { Box } from '@mantine-8/core';
+import { IconLinkOff } from '@tabler/icons-react';
+import { useEffect, type FC } from 'react';
+import { useParams } from 'react-router';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import { useCloneAgentThreadShareMutation } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+
+const AiAgentThreadSharePage: FC = () => {
+    const { projectUuid, aiThreadShareUuid } = useParams<{
+        projectUuid: string;
+        aiThreadShareUuid: string;
+    }>();
+    const { mutate, isLoading, error } = useCloneAgentThreadShareMutation(
+        projectUuid!,
+    );
+
+    useEffect(() => {
+        if (aiThreadShareUuid) mutate(aiThreadShareUuid);
+    }, [aiThreadShareUuid, mutate]);
+
+    if (error?.error?.statusCode && error.error.statusCode !== 403) {
+        return (
+            <Box mt={50}>
+                <SuboptimalState
+                    title="Shared AI thread link does not exist"
+                    icon={IconLinkOff}
+                />
+            </Box>
+        );
+    }
+
+    return (
+        <Box mt={50}>
+            <SuboptimalState title="Loading..." loading={isLoading} />
+        </Box>
+    );
+};
+
+export default AiAgentThreadSharePage;


### PR DESCRIPTION
### Description
- Add share action and modal for web AI agent threads.
- Add shared-thread open flow that clones a snapshot into the recipient account.
- Add copy-link accessibility updates and route wiring.

Closes: PROD-8013