### PR TITLE
fix(ai-agents): correct review writeback success toast

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { getReviewItemWritebackSuccessToast } from './useAiAgentAdmin';
+
+describe('getReviewItemWritebackSuccessToast', () => {
+    it('shows queued copy when the async writeback request has no PR yet', () => {
+        const toast = getReviewItemWritebackSuccessToast({
+            linkedPrUrl: null,
+            prWritebackMessage: 'Queued',
+            prWritebackStatus: 'queued',
+        });
+
+        expect(toast.title).toBe('Writeback queued');
+        expect(toast.subtitle).toBe('The review item will update as it runs.');
+        expect(toast.title).not.toContain('changes');
+    });
+
+    it('shows PR copy when the response includes a PR URL', () => {
+        expect(
+            getReviewItemWritebackSuccessToast({
+                linkedPrUrl: 'https://github.com/acme/analytics/pull/42',
+                prWritebackMessage: 'Opened pull request',
+                prWritebackStatus: 'completed',
+            }),
+        ).toEqual({ title: 'Pull request opened' });
+    });
+
+    it('prefers queued copy over a stale PR URL while writeback is in progress', () => {
+        expect(
+            getReviewItemWritebackSuccessToast({
+                linkedPrUrl: 'https://github.com/acme/analytics/pull/41',
+                prWritebackMessage: 'Queued',
+                prWritebackStatus: 'queued',
+            }),
+        ).toEqual({
+            title: 'Writeback queued',
+            subtitle: 'The review item will update as it runs.',
+        });
+    });
+
+    it('uses terminal copy for a completed no-PR writeback', () => {
+        expect(
+            getReviewItemWritebackSuccessToast({
+                linkedPrUrl: null,
+                prWritebackMessage: 'Writeback ran - no changes were needed',
+                prWritebackStatus: 'completed',
+            }),
+        ).toEqual({
+            title: 'Writeback completed',
+            subtitle: 'Writeback ran - no changes were needed',
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -1,6 +1,7 @@
 import {
     type AiAgentAdminFilters,
     type AiAgentAdminSort,
+    type AiAgentReviewItemSummary,
     type AiAgentReviewItemStatus,
     type ApiAiAgentAdminConversationsResponse,
     type ApiAiAgentReviewItemResponse,
@@ -251,6 +252,36 @@ const createAiAgentReviewItemWriteback = async (fingerprint: string) => {
     });
 };
 
+export const getReviewItemWritebackSuccessToast = (
+    reviewItem: Pick<
+        AiAgentReviewItemSummary,
+        'linkedPrUrl' | 'prWritebackMessage' | 'prWritebackStatus'
+    >,
+): { title: string; subtitle?: string } => {
+    const isInProgress =
+        reviewItem.prWritebackStatus === 'queued' ||
+        reviewItem.prWritebackStatus === 'running';
+    if (isInProgress) {
+        return {
+            title: 'Writeback queued',
+            subtitle: 'The review item will update as it runs.',
+        };
+    }
+
+    if (reviewItem.linkedPrUrl) {
+        return { title: 'Pull request opened' };
+    }
+
+    if (reviewItem.prWritebackStatus === 'completed') {
+        return {
+            title: 'Writeback completed',
+            subtitle: reviewItem.prWritebackMessage ?? undefined,
+        };
+    }
+
+    return { title: 'Writeback queued' };
+};
+
 export const useCreateAiAgentReviewItemWriteback = () => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError } = useToaster();
@@ -262,11 +293,14 @@ export const useCreateAiAgentReviewItemWriteback = () => {
     >({
         mutationFn: createAiAgentReviewItemWriteback,
         onSuccess: (reviewItem) => {
+            const toast = getReviewItemWritebackSuccessToast(reviewItem);
+            const showPrAction =
+                Boolean(reviewItem.linkedPrUrl) &&
+                reviewItem.prWritebackStatus !== 'queued' &&
+                reviewItem.prWritebackStatus !== 'running';
             showToastSuccess({
-                title: reviewItem.linkedPrUrl
-                    ? 'Pull request opened'
-                    : 'Writeback ran — no changes were needed',
-                ...(reviewItem.linkedPrUrl && {
+                ...toast,
+                ...(showPrAction && {
                     action: {
                         children: 'View pull request',
                         icon: IconArrowRight,


### PR DESCRIPTION
## Summary

Fixes the AI agent review-item writeback success toast so the immediate POST response no longer claims "no changes were needed" while the background writeback worker is only queued.

## Root Cause

`createReviewItemWriteback` returns after enqueueing the background job. At that point `linkedPrUrl` is normally `null`, and the frontend treated a missing PR URL as a terminal no-change result.

## Changes

- Adds a small toast-copy helper for review-item writeback responses.
- Shows `Writeback queued` for queued/running responses.
- Keeps the PR action hidden while writeback is in flight.
- Adds focused regression coverage for queued, PR-opened, stale-PR, and completed/no-PR cases.

## Validation

- `git diff --check`
- Focused vitest not run locally: this worktree has no `node_modules`, so `vitest` is unavailable.