### PR TITLE
fix(dashboards): reconcile stale filter ids from shared links

### DIFF
--- a/packages/common/src/types/applyDimensionOverrides.test.ts
+++ b/packages/common/src/types/applyDimensionOverrides.test.ts
@@ -506,4 +506,187 @@ describe('applyDimensionOverrides', () => {
             );
         });
     });
+
+    // A shared link carries a filter id that no longer matches the saved filter
+    // (the id is regenerated when a filter is deleted and re-added or its field
+    // is changed). The override must fall back to matching by fieldId +
+    // tableName so it merges into the saved filter and inherits its tileTargets,
+    // instead of being appended as a duplicate that applies to every tile.
+    describe('field-match fallback for stale ids', () => {
+        it('reconciles a stale id by field and inherits the saved tileTargets', () => {
+            const savedFilters: DashboardFilters = {
+                dimensions: [
+                    createBaseDashboardFilter(
+                        'new-id',
+                        'customers_customer_id',
+                        'customers',
+                        ['123'],
+                        {
+                            'tile-1': {
+                                fieldId: 'customers_customer_id',
+                                tableName: 'customers',
+                            },
+                            'tile-2': false,
+                        },
+                    ),
+                ],
+                metrics: [],
+                tableCalculations: [],
+            };
+            const overrides: DashboardFilterRule[] = [
+                createOverrideFilter(
+                    'old-id',
+                    'customers_customer_id',
+                    'customers',
+                    ['789'],
+                ),
+            ];
+
+            const result = applyDimensionOverrides(savedFilters, overrides);
+
+            // Merged into the saved filter, not appended as a duplicate.
+            expect(result).toHaveLength(1);
+            expect(result[0].id).toBe('new-id');
+            expect(result[0].values).toEqual(['789']);
+            expect(result[0].tileTargets?.['tile-2']).toBe(false);
+        });
+
+        it('appends an override that matches no saved filter by id or field', () => {
+            const savedFilters: DashboardFilters = {
+                dimensions: [
+                    createBaseDashboardFilter(
+                        'filter-1',
+                        'customers_customer_id',
+                        'customers',
+                    ),
+                ],
+                metrics: [],
+                tableCalculations: [],
+            };
+            const overrides: DashboardFilterRule[] = [
+                createOverrideFilter('stale', 'orders_status', 'orders', [
+                    'completed',
+                ]),
+            ];
+
+            const result = applyDimensionOverrides(savedFilters, overrides);
+
+            expect(result).toHaveLength(2);
+            expect(result[1]).toEqual(overrides[0]);
+        });
+
+        it('does not reconcile an override targeting a different tableName', () => {
+            const savedFilters: DashboardFilters = {
+                dimensions: [
+                    createBaseDashboardFilter('saved', 'status', 'orders'),
+                ],
+                metrics: [],
+                tableCalculations: [],
+            };
+            const overrides: DashboardFilterRule[] = [
+                createOverrideFilter('stale', 'status', 'returns', ['x']),
+            ];
+
+            const result = applyDimensionOverrides(savedFilters, overrides);
+
+            expect(result).toHaveLength(2);
+            expect(result[0]).toEqual(savedFilters.dimensions[0]);
+            expect(result[1]).toEqual(overrides[0]);
+        });
+
+        it('prefers an id match over a same-field stale override, which is appended', () => {
+            const savedFilters: DashboardFilters = {
+                dimensions: [
+                    createBaseDashboardFilter('filter-1', 'status', 'orders', [
+                        'orig',
+                    ]),
+                ],
+                metrics: [],
+                tableCalculations: [],
+            };
+            const overrides: DashboardFilterRule[] = [
+                createOverrideFilter('filter-1', 'status', 'orders', [
+                    'id-match',
+                ]),
+                createOverrideFilter('stale', 'status', 'orders', [
+                    'field-match',
+                ]),
+            ];
+
+            const result = applyDimensionOverrides(savedFilters, overrides);
+
+            expect(result).toHaveLength(2);
+            expect(result[0].values).toEqual(['id-match']);
+            expect(result[1]).toEqual(overrides[1]);
+        });
+
+        it('reconciles only the first of two saved filters sharing a field', () => {
+            const savedFilters: DashboardFilters = {
+                dimensions: [
+                    createBaseDashboardFilter(
+                        'saved-a',
+                        'customers_customer_id',
+                        'customers',
+                        ['1'],
+                        {
+                            'tile-1': {
+                                fieldId: 'customers_customer_id',
+                                tableName: 'customers',
+                            },
+                        },
+                    ),
+                    createBaseDashboardFilter(
+                        'saved-b',
+                        'customers_customer_id',
+                        'customers',
+                        ['2'],
+                    ),
+                ],
+                metrics: [],
+                tableCalculations: [],
+            };
+            const overrides: DashboardFilterRule[] = [
+                createOverrideFilter(
+                    'stale',
+                    'customers_customer_id',
+                    'customers',
+                    ['99'],
+                ),
+            ];
+
+            const result = applyDimensionOverrides(savedFilters, overrides);
+
+            expect(result).toHaveLength(2);
+            expect(result[0].id).toBe('saved-a');
+            expect(result[0].values).toEqual(['99']);
+            expect(result[1].id).toBe('saved-b');
+            expect(result[1].values).toEqual(['2']);
+        });
+
+        it('propagates the override disabled state when reconciling by field', () => {
+            const savedFilters: DashboardFilters = {
+                dimensions: [
+                    createBaseDashboardFilter('saved', 'status', 'orders', [
+                        'orig',
+                    ]),
+                ],
+                metrics: [],
+                tableCalculations: [],
+            };
+            const overrides: DashboardFilterRule[] = [
+                {
+                    ...createOverrideFilter('stale', 'status', 'orders', [
+                        'new',
+                    ]),
+                    disabled: true,
+                },
+            ];
+
+            const result = applyDimensionOverrides(savedFilters, overrides);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].disabled).toBe(true);
+            expect(result[0].values).toEqual(['new']);
+        });
+    });
 });

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -391,19 +391,34 @@ export const applyDimensionOverrides = (
     const overrideArray =
         overrides instanceof Array ? overrides : overrides.dimensions;
 
-    // Apply overrides to existing dashboard dimensions
+    const savedIds = new Set(dashboardFilters.dimensions.map((d) => d.id));
+    // Track consumed overrides so each is applied to one saved filter and the
+    // rest can be appended afterwards.
+    const appliedOverrideIds = new Set<string>();
+
     const overriddenDimensions = dashboardFilters.dimensions.map(
         (dimension) => {
-            const override = overrideArray.find(
-                (overrideDimension) => overrideDimension.id === dimension.id,
-            );
+            // Match by id, then fall back to the target field so a shared link
+            // keeps working after an edit rotates the filter's id.
+            const override =
+                overrideArray.find((o) => o.id === dimension.id) ??
+                overrideArray.find(
+                    (o) =>
+                        !savedIds.has(o.id) &&
+                        !appliedOverrideIds.has(o.id) &&
+                        o.target.fieldId === dimension.target.fieldId &&
+                        o.target.tableName === dimension.target.tableName,
+                );
+
             if (override) {
+                appliedOverrideIds.add(override.id);
                 return {
                     ...override,
+                    // The saved dashboard owns identity, tile targeting and lock
+                    // state; the override only carries value/operator. Forcing the
+                    // id re-homes a field-matched override onto the saved filter.
+                    id: dimension.id,
                     tileTargets: dimension.tileTargets,
-                    // Lock state belongs to the saved dashboard and must not
-                    // be assertable from URL/scheduler overrides — always
-                    // re-apply the saved rule's lockedTabUuids.
                     lockedTabUuids: dimension.lockedTabUuids,
                 };
             }
@@ -411,10 +426,9 @@ export const applyDimensionOverrides = (
         },
     );
 
-    // Add scheduler filters that don't exist in dashboard saved filters
-    const existingIds = new Set(dashboardFilters.dimensions.map((d) => d.id));
+    // Append overrides that matched no saved filter by id or field.
     const newDimensions = overrideArray.filter(
-        (schedulerFilter) => !existingIds.has(schedulerFilter.id),
+        (o) => !savedIds.has(o.id) && !appliedOverrideIds.has(o.id),
     );
     overriddenDimensions.push(...newDimensions);
 


### PR DESCRIPTION
## What

Shared dashboard links carry saved-filter overrides by `id`. When a saved filter is deleted and re-added, or its target field changes, that `id` no longer matches any saved filter, and the override was appended as a duplicate dimension with no `tileTargets`. The result: the filter applied to **every** tile, ignoring the per-tile configuration on the original filter, so viewers saw segmented data even on tiles explicitly excluded from the filter.

## Fix

`applyDimensionOverrides` now matches a stale override by `target.fieldId` + `target.tableName` when its `id` doesn't match, merging it onto the saved filter and inheriting that filter's `tileTargets` (and `id`, lock state). The function's signature, return type, and append-the-unmatched behavior are unchanged, this is purely a smarter match.

That satisfies the issue's first proposed fix (match by fieldId + tableName) and resolves the reported case where a re-added/renamed filter rotates its id.


Closes #23803
Linear: PROD-8077

🤖 Generated with [Claude Code](https://claude.com/claude-code)
