### PR TITLE
refactor(frontend): rename content table MRT types

### DIFF
--- a/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
@@ -29,9 +29,9 @@ import {
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
-    type MRT_Virtualizer,
+    type ContentTableColumnDef,
+    type ContentTableSortingState,
+    type ContentTableVirtualizer,
 } from '../common/ContentTable';
 import MantineIcon from '../common/MantineIcon';
 import { CompilationHistoryTopToolbar } from './CompilationHistoryTopToolbar';
@@ -52,11 +52,13 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
     const theme = useMantineTheme();
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
-        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
 
     const { data: project } = useProject(projectUuid);
 
-    const [sorting, setSorting] = useState<MRT_SortingState>([
+    const [sorting, setSorting] = useState<ContentTableSortingState>([
         { id: 'createdAt', desc: true },
     ]);
 
@@ -135,7 +137,7 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
 
-    const columns: MRT_ColumnDef<ProjectCompileLog>[] = useMemo(
+    const columns: ContentTableColumnDef<ProjectCompileLog>[] = useMemo(
         () => [
             {
                 accessorKey: 'createdAt',

--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
@@ -16,8 +16,8 @@ import { useCallback, useMemo, useState, type FC } from 'react';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
+    type ContentTableColumnDef,
+    type ContentTableSortingState,
 } from '../common/ContentTable';
 import MantineIcon from '../common/MantineIcon';
 import {
@@ -43,7 +43,7 @@ const PreAggregateStatsTable: FC<Props> = ({
 }) => {
     const theme = useMantineTheme();
 
-    const [sorting, setSorting] = useState<MRT_SortingState>([
+    const [sorting, setSorting] = useState<ContentTableSortingState>([
         { id: 'queries', desc: true },
     ]);
     const [selectedQueryType, setSelectedQueryType] =
@@ -124,7 +124,7 @@ const PreAggregateStatsTable: FC<Props> = ({
         selectedMissReason,
     ]);
 
-    const columns = useMemo<MRT_ColumnDef<AggregatedRow>[]>(
+    const columns = useMemo<ContentTableColumnDef<AggregatedRow>[]>(
         () => [
             {
                 accessorKey: 'exploreName',

--- a/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
@@ -56,8 +56,8 @@ import Callout from '../common/Callout';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
+    type ContentTableColumnDef,
+    type ContentTableSortingState,
 } from '../common/ContentTable';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
@@ -223,7 +223,7 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
         [data],
     );
 
-    const [sorting, setSorting] = useState<MRT_SortingState>([]);
+    const [sorting, setSorting] = useState<ContentTableSortingState>([]);
     const [searchQuery, setSearchQuery] = useState('');
     const [selectedStatus, setSelectedStatus] = useState<StatusType | null>(
         null,
@@ -276,7 +276,7 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
     }, [filteredMaterializations]);
 
     const columns = useMemo<
-        MRT_ColumnDef<PreAggregateMaterializationSummary>[]
+        ContentTableColumnDef<PreAggregateMaterializationSummary>[]
     >(
         () => [
             {

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -58,7 +58,7 @@ import {
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../common/ContentTable';
 import MantineIcon from '../common/MantineIcon';
 import CreateProjectAccessModal from './CreateProjectAccessModal';
@@ -350,196 +350,205 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
         rolesData,
     ]);
 
-    const columns: MRT_ColumnDef<EnrichedProjectUser>[] = useMemo(() => {
-        const cols: MRT_ColumnDef<EnrichedProjectUser>[] = [
-            {
-                accessorKey: 'email',
-                header: 'User',
-                enableSorting: false,
-                size: 300,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconUserCircle} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
-                Cell: ({ row }) => {
-                    const u = row.original;
+    const columns: ContentTableColumnDef<EnrichedProjectUser>[] =
+        useMemo(() => {
+            const cols: ContentTableColumnDef<EnrichedProjectUser>[] = [
+                {
+                    accessorKey: 'email',
+                    header: 'User',
+                    enableSorting: false,
+                    size: 300,
+                    Header: ({ column }) => (
+                        <Group gap="two">
+                            <MantineIcon
+                                icon={IconUserCircle}
+                                color="ldGray.6"
+                            />
+                            {column.columnDef.header}
+                        </Group>
+                    ),
+                    Cell: ({ row }) => {
+                        const u = row.original;
 
-                    // Build role summary tooltip
-                    const roleSummary = (
-                        <Stack>
-                            <Text fw={300} fz="xs">
-                                Organization role:{' '}
-                                <Text fw={600} span fz="xs">
-                                    {getRoleName(u.organizationRoleId || '')}
-                                </Text>
-                            </Text>
-                            {u.userGroupAccesses.map((uga) => (
-                                <Text key={uga.group.uuid} fw={300}>
-                                    Group{' '}
-                                    <Text fw={600} span>
-                                        {uga.group.name}
-                                    </Text>
-                                    :{' '}
-                                    <Text fw={600} span>
-                                        {uga.roleName}
+                        // Build role summary tooltip
+                        const roleSummary = (
+                            <Stack>
+                                <Text fw={300} fz="xs">
+                                    Organization role:{' '}
+                                    <Text fw={600} span fz="xs">
+                                        {getRoleName(
+                                            u.organizationRoleId || '',
+                                        )}
                                     </Text>
                                 </Text>
-                            ))}
-                            {u.hasProjectRole && (
-                                <Text fw={300}>
-                                    Project role:{' '}
-                                    <Text fw={600} span>
-                                        {u.projectRole}
+                                {u.userGroupAccesses.map((uga) => (
+                                    <Text key={uga.group.uuid} fw={300}>
+                                        Group{' '}
+                                        <Text fw={600} span>
+                                            {uga.group.name}
+                                        </Text>
+                                        :{' '}
+                                        <Text fw={600} span>
+                                            {uga.roleName}
+                                        </Text>
                                     </Text>
-                                </Text>
-                            )}
-                        </Stack>
-                    );
-
-                    return (
-                        <Tooltip
-                            label={roleSummary}
-                            fz="sm"
-                            position="top-start"
-                        >
-                            <Stack gap="xxs" align="flex-start">
-                                {u.firstName && (
-                                    <Text fw={600} fz="sm">
-                                        {u.firstName} {u.lastName}
+                                ))}
+                                {u.hasProjectRole && (
+                                    <Text fw={300}>
+                                        Project role:{' '}
+                                        <Text fw={600} span>
+                                            {u.projectRole}
+                                        </Text>
                                     </Text>
-                                )}
-                                {u.email && (
-                                    <Badge variant="light" color="gray">
-                                        {u.email}
-                                    </Badge>
                                 )}
                             </Stack>
-                        </Tooltip>
-                    );
-                },
-            },
-            {
-                accessorKey: 'role',
-                header: 'Role',
-                enableSorting: false,
-                size: 300,
-                Cell: ({ row }) => {
-                    const u = row.original;
+                        );
 
-                    return (
-                        <Group gap="xs">
+                        return (
                             <Tooltip
-                                disabled={u.hasProjectRole}
-                                multiline
-                                w={
-                                    u.isMember && !u.hasProjectRole
-                                        ? 280
-                                        : undefined
-                                }
-                                label={
-                                    u.isMember && !u.hasProjectRole ? (
-                                        <Text fz="xs">
-                                            <Text fw={600} fz="xs">
-                                                Members have no access to this
-                                                project.
-                                            </Text>
-                                            <Text fz="xs">
-                                                Assign a project role to grant
-                                                them visibility.
-                                            </Text>
-                                        </Text>
-                                    ) : (
-                                        <Text fz="xs">
-                                            User inherits this role from{' '}
-                                            <Text span fw={600} fz="xs">
-                                                {u.highestRoleType}
-                                            </Text>
-                                        </Text>
-                                    )
-                                }
+                                label={roleSummary}
+                                fz="sm"
+                                position="top-start"
                             >
-                                <Select
-                                    id="user-role"
-                                    w={250}
-                                    size="xs"
-                                    disabled={
-                                        isMutating || !canManageProjectAccess
-                                    }
-                                    data={
+                                <Stack gap="xxs" align="flex-start">
+                                    {u.firstName && (
+                                        <Text fw={600} fz="sm">
+                                            {u.firstName} {u.lastName}
+                                        </Text>
+                                    )}
+                                    {u.email && (
+                                        <Badge variant="light" color="gray">
+                                            {u.email}
+                                        </Badge>
+                                    )}
+                                </Stack>
+                            </Tooltip>
+                        );
+                    },
+                },
+                {
+                    accessorKey: 'role',
+                    header: 'Role',
+                    enableSorting: false,
+                    size: 300,
+                    Cell: ({ row }) => {
+                        const u = row.original;
+
+                        return (
+                            <Group gap="xs">
+                                <Tooltip
+                                    disabled={u.hasProjectRole}
+                                    multiline
+                                    w={
                                         u.isMember && !u.hasProjectRole
-                                            ? [
-                                                  {
-                                                      group: 'Organization role',
-                                                      items: [
-                                                          {
-                                                              value: 'member',
-                                                              label: 'member (no project access)',
-                                                          },
-                                                      ],
-                                                  },
-                                                  ...groupedRolesData,
-                                              ]
-                                            : groupedRolesData
+                                            ? 280
+                                            : undefined
                                     }
-                                    value={u.currentRoleUuid || u.highestRole}
-                                    onChange={(newRoleUuid) =>
-                                        handleRoleChange(
-                                            u.userUuid,
-                                            newRoleUuid,
+                                    label={
+                                        u.isMember && !u.hasProjectRole ? (
+                                            <Text fz="xs">
+                                                <Text fw={600} fz="xs">
+                                                    Members have no access to
+                                                    this project.
+                                                </Text>
+                                                <Text fz="xs">
+                                                    Assign a project role to
+                                                    grant them visibility.
+                                                </Text>
+                                            </Text>
+                                        ) : (
+                                            <Text fz="xs">
+                                                User inherits this role from{' '}
+                                                <Text span fw={600} fz="xs">
+                                                    {u.highestRoleType}
+                                                </Text>
+                                            </Text>
                                         )
                                     }
-                                />
-                            </Tooltip>
-                            {u.accessWarning && (
-                                <Tooltip label={u.accessWarning}>
-                                    <MantineIcon
-                                        icon={IconAlertTriangle}
-                                        color="yellow.9"
+                                >
+                                    <Select
+                                        id="user-role"
+                                        w={250}
+                                        size="xs"
+                                        disabled={
+                                            isMutating ||
+                                            !canManageProjectAccess
+                                        }
+                                        data={
+                                            u.isMember && !u.hasProjectRole
+                                                ? [
+                                                      {
+                                                          group: 'Organization role',
+                                                          items: [
+                                                              {
+                                                                  value: 'member',
+                                                                  label: 'member (no project access)',
+                                                              },
+                                                          ],
+                                                      },
+                                                      ...groupedRolesData,
+                                                  ]
+                                                : groupedRolesData
+                                        }
+                                        value={
+                                            u.currentRoleUuid || u.highestRole
+                                        }
+                                        onChange={(newRoleUuid) =>
+                                            handleRoleChange(
+                                                u.userUuid,
+                                                newRoleUuid,
+                                            )
+                                        }
                                     />
                                 </Tooltip>
-                            )}
-                        </Group>
-                    );
+                                {u.accessWarning && (
+                                    <Tooltip label={u.accessWarning}>
+                                        <MantineIcon
+                                            icon={IconAlertTriangle}
+                                            color="yellow.9"
+                                        />
+                                    </Tooltip>
+                                )}
+                            </Group>
+                        );
+                    },
                 },
-            },
-        ];
+            ];
 
-        if (canManageProjectAccess) {
-            cols.push({
-                id: 'actions',
-                header: '',
-                enableSorting: false,
-                size: 50,
-                Cell: ({ row }) => (
-                    <Box
-                        component="div"
-                        onClick={(e: React.MouseEvent<HTMLDivElement>) => {
-                            e.stopPropagation();
-                            e.preventDefault();
-                        }}
-                    >
-                        <ProjectAccessActionCell
-                            user={row.original}
-                            canManageProjectAccess={canManageProjectAccess}
-                            onDelete={handleDelete}
-                            isLoading={isMutating}
-                        />
-                    </Box>
-                ),
-            });
-        }
+            if (canManageProjectAccess) {
+                cols.push({
+                    id: 'actions',
+                    header: '',
+                    enableSorting: false,
+                    size: 50,
+                    Cell: ({ row }) => (
+                        <Box
+                            component="div"
+                            onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+                                e.stopPropagation();
+                                e.preventDefault();
+                            }}
+                        >
+                            <ProjectAccessActionCell
+                                user={row.original}
+                                canManageProjectAccess={canManageProjectAccess}
+                                onDelete={handleDelete}
+                                isLoading={isMutating}
+                            />
+                        </Box>
+                    ),
+                });
+            }
 
-        return cols;
-    }, [
-        canManageProjectAccess,
-        getRoleName,
-        handleRoleChange,
-        handleDelete,
-        isMutating,
-        groupedRolesData,
-    ]);
+            return cols;
+        }, [
+            canManageProjectAccess,
+            getRoleName,
+            handleRoleChange,
+            handleDelete,
+            isMutating,
+            groupedRolesData,
+        ]);
 
     const table = useContentTable({
         columns,

--- a/packages/frontend/src/components/SchedulersView/LogsTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTable.tsx
@@ -44,8 +44,8 @@ import {
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_Virtualizer,
+    type ContentTableColumnDef,
+    type ContentTableVirtualizer,
 } from '../common/ContentTable';
 import EmptyStateLoader from '../common/EmptyStateLoader';
 import MantineIcon from '../common/MantineIcon';
@@ -95,7 +95,9 @@ const LogsTable: FC<LogsTableProps> = ({
     const isResourceScoped = !!resourceScope;
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
-        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
     const {
         search,
         setSearch,
@@ -302,7 +304,7 @@ const LogsTable: FC<LogsTableProps> = ({
         );
     }, [schedulerRunsData]);
 
-    const allColumns: MRT_ColumnDef<TableRow>[] = useMemo(
+    const allColumns: ContentTableColumnDef<TableRow>[] = useMemo(
         () => [
             {
                 accessorKey: 'scheduler.name',

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -53,9 +53,9 @@ import SlackSvg from '../../svgs/slack.svg?react';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
-    type MRT_Virtualizer,
+    type ContentTableColumnDef,
+    type ContentTableSortingState,
+    type ContentTableVirtualizer,
 } from '../common/ContentTable';
 import MantineIcon from '../common/MantineIcon';
 import ReassignSchedulerOwnerModal from './ReassignSchedulerOwnerModal';
@@ -91,7 +91,9 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
     const theme = useMantineTheme();
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
-        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
     const [, setSearchParams] = useSearchParams();
 
     const {
@@ -217,7 +219,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
 
-    const sorting = useMemo<MRT_SortingState>(
+    const sorting = useMemo<ContentTableSortingState>(
         () => [{ id: sortField, desc: sortDirection === 'desc' }],
         [sortField, sortDirection],
     );
@@ -225,8 +227,8 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
     const handleSortingChange = useCallback(
         (
             updaterOrValue:
-                | MRT_SortingState
-                | ((old: MRT_SortingState) => MRT_SortingState),
+                | ContentTableSortingState
+                | ((old: ContentTableSortingState) => ContentTableSortingState),
         ) => {
             const newSorting =
                 typeof updaterOrValue === 'function'
@@ -241,8 +243,8 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
         [sorting, setSorting],
     );
 
-    const columns: MRT_ColumnDef<SchedulerItem>[] = useMemo(() => {
-        const baseColumns: MRT_ColumnDef<SchedulerItem>[] = [
+    const columns: ContentTableColumnDef<SchedulerItem>[] = useMemo(() => {
+        const baseColumns: ContentTableColumnDef<SchedulerItem>[] = [
             {
                 accessorKey: 'name',
                 header: 'Name',
@@ -817,7 +819,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                   mantineSelectCheckboxProps: { size: 'xs' },
                   mantineSelectAllCheckboxProps: { size: 'xs' },
                   displayColumnDefOptions: {
-                      'mrt-row-select': {
+                      'content-table-row-select': {
                           size: 20,
                           minSize: 20,
                           maxSize: 20,

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -37,8 +37,8 @@ import { useDeleteValidation } from '../../../hooks/validation/useValidation';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_Virtualizer,
+    type ContentTableColumnDef,
+    type ContentTableVirtualizer,
 } from '../../common/ContentTable';
 import MantineIcon from '../../common/MantineIcon';
 import { ChartIcon, IconBox } from '../../common/ResourceIcon';
@@ -141,7 +141,9 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
 }) => {
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
-        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
 
     const { mutate: deleteValidation } = useDeleteValidation(projectUuid);
 
@@ -176,7 +178,7 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
 
-    const columns: MRT_ColumnDef<ValidationResponse>[] = useMemo(
+    const columns: ContentTableColumnDef<ValidationResponse>[] = useMemo(
         () => [
             {
                 accessorKey: 'name',

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -42,7 +42,7 @@ import { useContentAction } from '../../../hooks/useContent';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../common/ContentTable';
 import MantineIcon from '../../common/MantineIcon';
 import AppDeleteModal from '../../common/modal/AppDeleteModal';
@@ -151,7 +151,7 @@ const MyAppsPanel: FC = () => {
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
 
-    const columns: MRT_ColumnDef<ApiAppSummary>[] = useMemo(
+    const columns: ContentTableColumnDef<ApiAppSummary>[] = useMemo(
         () => [
             {
                 accessorKey: 'name',

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -53,7 +53,7 @@ import {
     ContentTableSearchInput,
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../common/ContentTable';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
@@ -274,7 +274,7 @@ const ProjectManagementPanel: FC = () => {
         [lastProjectUuid, navigate, updateActiveProjectMutation],
     );
 
-    const columns: MRT_ColumnDef<OrganizationProject>[] = useMemo(
+    const columns: ContentTableColumnDef<OrganizationProject>[] = useMemo(
         () => [
             {
                 id: 'select',

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -33,7 +33,7 @@ import useApp from '../../../providers/App/useApp';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../common/ContentTable';
 import EmptyStateLoader from '../../common/EmptyStateLoader';
 import MantineIcon from '../../common/MantineIcon';
@@ -64,7 +64,7 @@ const UserAttributesPanel: FC = () => {
     const isGroupManagementEnabled =
         userGroupsFeatureFlagQuery.data?.enabled ?? false;
 
-    const columns: MRT_ColumnDef<UserAttribute>[] = useMemo(
+    const columns: ContentTableColumnDef<UserAttribute>[] = useMemo(
         () => [
             {
                 accessorKey: 'name',

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx
@@ -29,8 +29,8 @@ import useApp from '../../../providers/App/useApp';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_Virtualizer,
+    type ContentTableColumnDef,
+    type ContentTableVirtualizer,
 } from '../../common/ContentTable';
 import MantineIcon from '../../common/MantineIcon';
 import GroupsActionMenu from './GroupsActionMenu';
@@ -49,7 +49,9 @@ const GroupsTable: FC<GroupsTableProps> = ({ onAddClick, onEditGroup }) => {
     const { user: activeUser } = useApp();
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
-        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
 
     const [search, setSearch] = useState('');
 
@@ -113,7 +115,7 @@ const GroupsTable: FC<GroupsTableProps> = ({ onAddClick, onEditGroup }) => {
     const canManageGroups =
         activeUser.data?.ability?.can('manage', 'Group') ?? false;
 
-    const columns: MRT_ColumnDef<GroupWithMembers>[] = useMemo(
+    const columns: ContentTableColumnDef<GroupWithMembers>[] = useMemo(
         () => [
             {
                 accessorKey: 'name',

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -41,8 +41,8 @@ import useApp from '../../../providers/App/useApp';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_Virtualizer,
+    type ContentTableColumnDef,
+    type ContentTableVirtualizer,
 } from '../../common/ContentTable';
 import MantineIcon from '../../common/MantineIcon';
 import InviteSuccess from './InviteSuccess';
@@ -60,7 +60,9 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
     const { user: activeUser } = useApp();
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
-        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
 
     const [search, setSearch] = useState('');
     const inviteLink = useCreateInviteLinkMutation();
@@ -142,10 +144,10 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
     const canInvite =
         activeUser.data?.ability?.can('create', 'InviteLink') ?? false;
 
-    const columns: MRT_ColumnDef<
+    const columns: ContentTableColumnDef<
         OrganizationMemberProfile | OrganizationMemberProfileWithGroups
     >[] = useMemo(() => {
-        const cols: MRT_ColumnDef<
+        const cols: ContentTableColumnDef<
             OrganizationMemberProfile | OrganizationMemberProfileWithGroups
         >[] = [
             {

--- a/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
+++ b/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
@@ -29,7 +29,7 @@ import { useVerifiedContentList } from '../../hooks/useVerifiedContentList';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../common/ContentTable';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
@@ -76,7 +76,7 @@ const VerifiedContentPanel: FC<Props> = ({ projectUuid }) => {
 
     const items = useMemo(() => verifiedContent ?? [], [verifiedContent]);
 
-    const columns: MRT_ColumnDef<VerifiedContentListItem>[] = useMemo(
+    const columns: ContentTableColumnDef<VerifiedContentListItem>[] = useMemo(
         () => [
             {
                 accessorKey: 'name',

--- a/packages/frontend/src/components/common/ContentTable/ContentTable.tsx
+++ b/packages/frontend/src/components/common/ContentTable/ContentTable.tsx
@@ -174,11 +174,11 @@ const useColumnSizeVars = <TData extends RowData>(
 const defaultEstimateSize = () => 44;
 const TALL_SKELETON_ROW_HEIGHT = 64;
 const DISPLAY_COLUMN_IDS = new Set([
-    'mrt-row-actions',
-    'mrt-row-numbers',
-    'mrt-row-select',
+    'content-table-row-actions',
+    'content-table-row-numbers',
+    'content-table-row-select',
 ]);
-const ROW_SELECT_COLUMN_ID = 'mrt-row-select';
+const ROW_SELECT_COLUMN_ID = 'content-table-row-select';
 
 const getRowSelectCellStyle = (columnId: string): CSSProperties | undefined =>
     columnId === ROW_SELECT_COLUMN_ID
@@ -199,9 +199,9 @@ const getSkeletonRowHeight = <TData extends RowData>(
     defaultEstimateSize();
 
 const getSkeletonWidth = (columnId: string, columnIndex: number) => {
-    if (columnId === 'mrt-row-select') return 20;
-    if (columnId === 'mrt-row-actions') return 28;
-    if (columnId === 'mrt-row-numbers') return 24;
+    if (columnId === 'content-table-row-select') return 20;
+    if (columnId === 'content-table-row-actions') return 28;
+    if (columnId === 'content-table-row-numbers') return 24;
 
     const widths = ['72%', '48%', '58%', '42%', '52%'];
     return widths[columnIndex % widths.length];

--- a/packages/frontend/src/components/common/ContentTable/index.ts
+++ b/packages/frontend/src/components/common/ContentTable/index.ts
@@ -6,12 +6,7 @@ export type {
     ContentTableColumnDef,
     ContentTableInstance,
     ContentTableOptions,
+    ContentTableRow,
     ContentTableSortingState,
     ContentTableVirtualizer,
-    MRT_ColumnDef,
-    MRT_Row,
-    MRT_SortingState,
-    MRT_TableInstance,
-    MRT_TableOptions,
-    MRT_Virtualizer,
 } from './types';

--- a/packages/frontend/src/components/common/ContentTable/types.ts
+++ b/packages/frontend/src/components/common/ContentTable/types.ts
@@ -32,6 +32,8 @@ export type ContentTableVirtualizer<
 
 export type ContentTableSortingState = SortingState;
 
+export type ContentTableRow<TData extends RowData> = Row<TData>;
+
 export type ContentTableDensity = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 export type ContentTableHeaderColumn<TData extends RowData> = Omit<
@@ -315,15 +317,3 @@ export type ContentTableInstance<TData extends RowData> = Omit<
 };
 
 export type ContentTableUpdater<TValue> = Updater<TValue>;
-
-export type MRT_ColumnDef<TData extends RowData> = ContentTableColumnDef<TData>;
-export type MRT_Row<TData extends RowData> = Row<TData>;
-export type MRT_SortingState = ContentTableSortingState;
-export type MRT_TableInstance<TData extends RowData> =
-    ContentTableInstance<TData>;
-export type MRT_TableOptions<TData extends RowData> =
-    ContentTableOptions<TData>;
-export type MRT_Virtualizer<
-    TScrollElement extends Element | Window = HTMLDivElement,
-    TItemElement extends Element = HTMLTableRowElement,
-> = ContentTableVirtualizer<TScrollElement, TItemElement>;

--- a/packages/frontend/src/components/common/ContentTable/useContentTable.tsx
+++ b/packages/frontend/src/components/common/ContentTable/useContentTable.tsx
@@ -56,7 +56,7 @@ const DEFAULT_COLUMN_SIZE = 180;
 const DEFAULT_COLUMN_MIN_SIZE = 40;
 const DEFAULT_COLUMN_MAX_SIZE = 1000;
 const DEFAULT_DISPLAY_COLUMN_MIN_SIZE = 40;
-const ROW_SELECT_COLUMN_ID = 'mrt-row-select';
+const ROW_SELECT_COLUMN_ID = 'content-table-row-select';
 const ROW_SELECT_COLUMN_MIN_SIZE = 44;
 
 const getDerivedMinSize = (size: number) =>
@@ -309,24 +309,24 @@ export const useContentTable = <TData extends RowData>(
 
         if (enableRowSelection) {
             leadingDisplayColumns.push({
-                id: 'mrt-row-select',
+                id: 'content-table-row-select',
                 enableResizing: false,
                 enableSorting: false,
                 size: getDisplayColumnSize(
                     displayColumnDefOptions,
                     defaultDisplayColumn,
-                    'mrt-row-select',
+                    'content-table-row-select',
                     60,
                 ),
                 minSize: getDisplayColumnMinSize(
                     displayColumnDefOptions,
                     defaultDisplayColumn,
-                    'mrt-row-select',
+                    'content-table-row-select',
                 ),
                 maxSize: getDisplayColumnMaxSize(
                     displayColumnDefOptions,
                     defaultDisplayColumn,
-                    'mrt-row-select',
+                    'content-table-row-select',
                 ),
                 header: ({ table }) => (
                     <div className={classes.rowSelectContent}>
@@ -357,9 +357,9 @@ export const useContentTable = <TData extends RowData>(
 
         if (enableRowActions) {
             const actionsHeader =
-                displayColumnDefOptions?.['mrt-row-actions']?.header;
+                displayColumnDefOptions?.['content-table-row-actions']?.header;
             const actionsColumn: ColumnDef<TData, unknown> = {
-                id: 'mrt-row-actions',
+                id: 'content-table-row-actions',
                 enableResizing: false,
                 enableSorting: false,
                 header: (headerContext) => {
@@ -383,18 +383,18 @@ export const useContentTable = <TData extends RowData>(
                 size: getDisplayColumnSize(
                     displayColumnDefOptions,
                     defaultDisplayColumn,
-                    'mrt-row-actions',
+                    'content-table-row-actions',
                     72,
                 ),
                 minSize: getDisplayColumnMinSize(
                     displayColumnDefOptions,
                     defaultDisplayColumn,
-                    'mrt-row-actions',
+                    'content-table-row-actions',
                 ),
                 maxSize: getDisplayColumnMaxSize(
                     displayColumnDefOptions,
                     defaultDisplayColumn,
-                    'mrt-row-actions',
+                    'content-table-row-actions',
                 ),
                 cell: ({ row, table }) =>
                     renderRowActions?.({

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -59,10 +59,10 @@ import useApp from '../../../providers/App/useApp';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
-    type MRT_TableOptions,
-    type MRT_Virtualizer,
+    type ContentTableColumnDef,
+    type ContentTableSortingState,
+    type ContentTableOptions,
+    type ContentTableVirtualizer,
 } from '../ContentTable';
 import MantineIcon from '../MantineIcon';
 import TransferItemsModal from '../TransferItemsModal/TransferItemsModal';
@@ -82,7 +82,7 @@ import {
     type ResourceViewItemActionState,
 } from './types';
 
-type ResourceView2Props = Partial<MRT_TableOptions<ResourceViewItem>> & {
+type ResourceView2Props = Partial<ContentTableOptions<ResourceViewItem>> & {
     filters: Pick<ContentArgs, 'spaceUuids' | 'contentTypes'> & {
         projectUuid: string;
     };
@@ -103,7 +103,7 @@ const InfiniteResourceTable = ({
     columnVisibility,
     adminContentView = false,
     initialAdminContentViewValue = 'shared',
-    ...mrtProps
+    ...contentTableProps
 }: ResourceView2Props) => {
     const [selectedAdminContentType, setSelectedAdminContentType] = useState<
         'all' | 'shared'
@@ -144,7 +144,7 @@ const InfiniteResourceTable = ({
         }),
     );
 
-    const ResourceColumns: MRT_ColumnDef<ResourceViewItem>[] = [
+    const ResourceColumns: ContentTableColumnDef<ResourceViewItem>[] = [
         {
             accessorKey: ColumnVisibility.NAME,
             header: capitalize(ColumnVisibility.NAME),
@@ -269,13 +269,14 @@ const InfiniteResourceTable = ({
             },
         },
     ];
-    const initialSorting: MRT_SortingState = [
+    const initialSorting: ContentTableSortingState = [
         {
             id: ContentSortByColumns.LAST_UPDATED_AT,
             desc: true,
         },
     ];
-    const [sorting, setSorting] = useState<MRT_SortingState>(initialSorting);
+    const [sorting, setSorting] =
+        useState<ContentTableSortingState>(initialSorting);
     const [search, setSearch] = useState<string | undefined>(undefined);
     const [selectedContentType, setSelectedContentType] = useState<
         ContentType | undefined
@@ -284,7 +285,9 @@ const InfiniteResourceTable = ({
     const deferredSearch = useDeferredValue(search);
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
-        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
     const sortBy:
         | {
               sortBy: ContentSortByColumns;
@@ -767,10 +770,10 @@ const InfiniteResourceTable = ({
         rowVirtualizerInstanceRef,
         rowVirtualizerProps: { estimateSize: () => 72, overscan: 40 },
         displayColumnDefOptions: {
-            'mrt-row-actions': {
+            'content-table-row-actions': {
                 header: '',
             },
-            'mrt-row-select': {
+            'content-table-row-select': {
                 size: 20,
                 minSize: 20,
                 maxSize: 20,
@@ -780,7 +783,7 @@ const InfiniteResourceTable = ({
         enableFilterMatchHighlighting: true,
         enableEditing: true,
         editDisplayMode: 'cell',
-        ...mrtProps,
+        ...contentTableProps,
         mantineSelectCheckboxProps: {
             size: 'sm',
         },

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -37,7 +37,7 @@ import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../../../../components/common/ContentTable';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
@@ -180,7 +180,7 @@ const AiAgentAdminAgentsTable = () => {
         handleSelectedProjectUuidsChange([]);
     };
 
-    const columns: MRT_ColumnDef<AiAgentSummary>[] = useMemo(
+    const columns: ContentTableColumnDef<AiAgentSummary>[] = useMemo(
         () => [
             {
                 accessorKey: 'name',

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -58,7 +58,7 @@ import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../../../../components/common/ContentTable';
 import FilterFacet, {
     type FilterFacetOption,
@@ -1178,7 +1178,7 @@ const AiAgentAdminReviewItemsTable = ({
         );
     };
 
-    const columns: MRT_ColumnDef<AiAgentReviewItemSummary>[] = useMemo(
+    const columns: ContentTableColumnDef<AiAgentReviewItemSummary>[] = useMemo(
         () => [
             {
                 accessorKey: 'primaryRootCause',
@@ -1357,204 +1357,233 @@ const AiAgentAdminReviewItemsTable = ({
         [agentsMap, onReviewItemSelect, projectsMap],
     );
 
-    const signalColumns: MRT_ColumnDef<AiAgentReviewSignalSummary>[] = useMemo(
-        () => [
-            {
-                accessorKey: 'promotedToFinding',
-                header: 'Result',
-                enableSorting: false,
-                size: 110,
-                Header: ({ column }) => (
-                    <Group gap="two" wrap="nowrap">
-                        <MantineIcon icon={IconTag} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
-                Cell: ({ row }) => {
-                    const signal = row.original;
-                    const ConfidenceIcon = getConfidenceIcon(signal.confidence);
-                    return (
-                        <Group gap={4} wrap="nowrap">
-                            <CategoryBadge
-                                variant="dot"
-                                label={getSignalResultLabel(signal)}
-                                color={
-                                    signal.finding
-                                        ? rootCauseColors[
-                                              signal.finding.primaryRootCause
-                                          ]
-                                        : 'gray'
-                                }
-                            />
-                            <Tooltip
-                                label={`${signal.confidence} confidence`}
-                                withArrow
-                            >
-                                <Box className={styles.confidenceIcon}>
-                                    <MantineIcon
-                                        icon={ConfidenceIcon}
-                                        color="ldGray.6"
-                                        size="xs"
-                                    />
-                                </Box>
-                            </Tooltip>
+    const signalColumns: ContentTableColumnDef<AiAgentReviewSignalSummary>[] =
+        useMemo(
+            () => [
+                {
+                    accessorKey: 'promotedToFinding',
+                    header: 'Result',
+                    enableSorting: false,
+                    size: 110,
+                    Header: ({ column }) => (
+                        <Group gap="two" wrap="nowrap">
+                            <MantineIcon icon={IconTag} color="ldGray.6" />
+                            {column.columnDef.header}
                         </Group>
-                    );
-                },
-            },
-            {
-                accessorKey: 'signal',
-                header: 'Signal',
-                enableSorting: false,
-                size: 300,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconInfoCircle} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
-                Cell: ({ row }) => {
-                    const signal = row.original;
-                    const subcategory = signal.finding?.subcategories[0];
-
-                    return (
-                        <Stack gap={4}>
+                    ),
+                    Cell: ({ row }) => {
+                        const signal = row.original;
+                        const ConfidenceIcon = getConfidenceIcon(
+                            signal.confidence,
+                        );
+                        return (
                             <Group gap={4} wrap="nowrap">
                                 <CategoryBadge
                                     variant="dot"
-                                    label={signalLabels[signal.signal]}
-                                    color="gray"
+                                    label={getSignalResultLabel(signal)}
+                                    color={
+                                        signal.finding
+                                            ? rootCauseColors[
+                                                  signal.finding
+                                                      .primaryRootCause
+                                              ]
+                                            : 'gray'
+                                    }
                                 />
-                                {subcategory && (
+                                <Tooltip
+                                    label={`${signal.confidence} confidence`}
+                                    withArrow
+                                >
+                                    <Box className={styles.confidenceIcon}>
+                                        <MantineIcon
+                                            icon={ConfidenceIcon}
+                                            color="ldGray.6"
+                                            size="xs"
+                                        />
+                                    </Box>
+                                </Tooltip>
+                            </Group>
+                        );
+                    },
+                },
+                {
+                    accessorKey: 'signal',
+                    header: 'Signal',
+                    enableSorting: false,
+                    size: 300,
+                    Header: ({ column }) => (
+                        <Group gap="two">
+                            <MantineIcon
+                                icon={IconInfoCircle}
+                                color="ldGray.6"
+                            />
+                            {column.columnDef.header}
+                        </Group>
+                    ),
+                    Cell: ({ row }) => {
+                        const signal = row.original;
+                        const subcategory = signal.finding?.subcategories[0];
+
+                        return (
+                            <Stack gap={4}>
+                                <Group gap={4} wrap="nowrap">
                                     <CategoryBadge
                                         variant="dot"
-                                        label={subcategory.replaceAll('_', ' ')}
+                                        label={signalLabels[signal.signal]}
                                         color="gray"
                                     />
-                                )}
-                                <SuggestedStep>
-                                    {getSignalActionText(signal)}
-                                </SuggestedStep>
-                            </Group>
-                            <ExpandableText lineClamp={1}>
-                                {getSignalWhyText(signal)}
-                            </ExpandableText>
-                        </Stack>
-                    );
-                },
-            },
-            {
-                accessorKey: 'prompt',
-                header: 'Turn',
-                enableSorting: false,
-                size: 300,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconListCheck} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
-                Cell: ({ row }) => {
-                    const signal = row.original;
-                    return (
-                        <Stack gap={2}>
-                            <Text fw={600} fz="sm" c="ldGray.9" lineClamp={1}>
-                                {signal.prompt}
-                            </Text>
-                            <ExpandableText lineClamp={1}>
-                                {signal.errorMessage ??
-                                    signal.responsePreview ??
-                                    'No response captured'}
-                            </ExpandableText>
-                        </Stack>
-                    );
-                },
-            },
-            {
-                accessorKey: 'agentUuid',
-                header: 'Agent',
-                enableSorting: false,
-                size: 100,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconRobotFace} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
-                Cell: ({ row }) => {
-                    const signal = row.original;
-                    const agent = agentsMap.get(signal.agentUuid);
-                    const project = projectsMap.get(signal.projectUuid);
-
-                    if (agent) {
-                        return (
-                            <AgentNamePill
-                                name={agent.name}
-                                imageUrl={agent.imageUrl}
-                            />
+                                    {subcategory && (
+                                        <CategoryBadge
+                                            variant="dot"
+                                            label={subcategory.replaceAll(
+                                                '_',
+                                                ' ',
+                                            )}
+                                            color="gray"
+                                        />
+                                    )}
+                                    <SuggestedStep>
+                                        {getSignalActionText(signal)}
+                                    </SuggestedStep>
+                                </Group>
+                                <ExpandableText lineClamp={1}>
+                                    {getSignalWhyText(signal)}
+                                </ExpandableText>
+                            </Stack>
                         );
-                    }
-
-                    return (
-                        <Group gap="two" wrap="nowrap">
+                    },
+                },
+                {
+                    accessorKey: 'prompt',
+                    header: 'Turn',
+                    enableSorting: false,
+                    size: 300,
+                    Header: ({ column }) => (
+                        <Group gap="two">
                             <MantineIcon
-                                icon={IconBox}
+                                icon={IconListCheck}
                                 color="ldGray.6"
-                                size="sm"
                             />
-                            <Text fz="sm" c="ldGray.9" lineClamp={1}>
-                                {project?.name ?? 'Unknown agent'}
-                            </Text>
+                            {column.columnDef.header}
                         </Group>
-                    );
-                },
-            },
-            {
-                accessorKey: 'createdAt',
-                header: 'Reviewed',
-                enableSorting: true,
-                size: 150,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconClock} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
-                Cell: ({ row }) => {
-                    const signal = row.original;
-                    return (
-                        <Group gap="xs" wrap="nowrap" justify="space-between">
-                            <Text fz="xs" c="ldGray.7" fw={500}>
-                                {formatLastSeenDate(signal.createdAt)}
-                            </Text>
-                            <Tooltip label="Open AI thread preview" withArrow>
-                                <ActionIcon
-                                    variant="subtle"
-                                    color="gray"
-                                    size="sm"
-                                    aria-label="Open AI thread preview"
-                                    className={styles.threadIcon}
-                                    onClick={(event) => {
-                                        event.stopPropagation();
-                                        onReviewItemSelect?.({
-                                            projectUuid: signal.projectUuid,
-                                            agentUuid: signal.agentUuid,
-                                            threadUuid: signal.threadUuid,
-                                            reviewItemUuid:
-                                                signal.finding?.reviewItemUuid,
-                                        });
-                                    }}
+                    ),
+                    Cell: ({ row }) => {
+                        const signal = row.original;
+                        return (
+                            <Stack gap={2}>
+                                <Text
+                                    fw={600}
+                                    fz="sm"
+                                    c="ldGray.9"
+                                    lineClamp={1}
                                 >
-                                    <MantineIcon icon={IconMessages} />
-                                </ActionIcon>
-                            </Tooltip>
-                        </Group>
-                    );
+                                    {signal.prompt}
+                                </Text>
+                                <ExpandableText lineClamp={1}>
+                                    {signal.errorMessage ??
+                                        signal.responsePreview ??
+                                        'No response captured'}
+                                </ExpandableText>
+                            </Stack>
+                        );
+                    },
                 },
-            },
-        ],
-        [agentsMap, onReviewItemSelect, projectsMap],
-    );
+                {
+                    accessorKey: 'agentUuid',
+                    header: 'Agent',
+                    enableSorting: false,
+                    size: 100,
+                    Header: ({ column }) => (
+                        <Group gap="two">
+                            <MantineIcon
+                                icon={IconRobotFace}
+                                color="ldGray.6"
+                            />
+                            {column.columnDef.header}
+                        </Group>
+                    ),
+                    Cell: ({ row }) => {
+                        const signal = row.original;
+                        const agent = agentsMap.get(signal.agentUuid);
+                        const project = projectsMap.get(signal.projectUuid);
+
+                        if (agent) {
+                            return (
+                                <AgentNamePill
+                                    name={agent.name}
+                                    imageUrl={agent.imageUrl}
+                                />
+                            );
+                        }
+
+                        return (
+                            <Group gap="two" wrap="nowrap">
+                                <MantineIcon
+                                    icon={IconBox}
+                                    color="ldGray.6"
+                                    size="sm"
+                                />
+                                <Text fz="sm" c="ldGray.9" lineClamp={1}>
+                                    {project?.name ?? 'Unknown agent'}
+                                </Text>
+                            </Group>
+                        );
+                    },
+                },
+                {
+                    accessorKey: 'createdAt',
+                    header: 'Reviewed',
+                    enableSorting: true,
+                    size: 150,
+                    Header: ({ column }) => (
+                        <Group gap="two">
+                            <MantineIcon icon={IconClock} color="ldGray.6" />
+                            {column.columnDef.header}
+                        </Group>
+                    ),
+                    Cell: ({ row }) => {
+                        const signal = row.original;
+                        return (
+                            <Group
+                                gap="xs"
+                                wrap="nowrap"
+                                justify="space-between"
+                            >
+                                <Text fz="xs" c="ldGray.7" fw={500}>
+                                    {formatLastSeenDate(signal.createdAt)}
+                                </Text>
+                                <Tooltip
+                                    label="Open AI thread preview"
+                                    withArrow
+                                >
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="gray"
+                                        size="sm"
+                                        aria-label="Open AI thread preview"
+                                        className={styles.threadIcon}
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+                                            onReviewItemSelect?.({
+                                                projectUuid: signal.projectUuid,
+                                                agentUuid: signal.agentUuid,
+                                                threadUuid: signal.threadUuid,
+                                                reviewItemUuid:
+                                                    signal.finding
+                                                        ?.reviewItemUuid,
+                                            });
+                                        }}
+                                    >
+                                        <MantineIcon icon={IconMessages} />
+                                    </ActionIcon>
+                                </Tooltip>
+                            </Group>
+                        );
+                    },
+                },
+            ],
+            [agentsMap, onReviewItemSelect, projectsMap],
+        );
 
     const table = useContentTable({
         columns,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -42,9 +42,9 @@ import { useNavigate } from 'react-router';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
-    type MRT_Virtualizer,
+    type ContentTableColumnDef,
+    type ContentTableSortingState,
+    type ContentTableVirtualizer,
 } from '../../../../../components/common/ContentTable';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useGetSlack } from '../../../../../hooks/slack/useSlack';
@@ -91,7 +91,7 @@ const AiAgentAdminThreadsTable = ({
 
     const deferredSearch = useDeferredValue(search);
 
-    const sorting = useMemo<MRT_SortingState>(
+    const sorting = useMemo<ContentTableSortingState>(
         () => [{ id: sortField, desc: sortDirection === 'desc' }],
         [sortField, sortDirection],
     );
@@ -99,8 +99,8 @@ const AiAgentAdminThreadsTable = ({
     const handleSortingChange = useCallback(
         (
             updaterOrValue:
-                | MRT_SortingState
-                | ((old: MRT_SortingState) => MRT_SortingState),
+                | ContentTableSortingState
+                | ((old: ContentTableSortingState) => ContentTableSortingState),
         ) => {
             const newSorting =
                 typeof updaterOrValue === 'function'
@@ -125,7 +125,9 @@ const AiAgentAdminThreadsTable = ({
 
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
-        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
 
     const { data, isInitialLoading, isFetching, hasNextPage, fetchNextPage } =
         useInfiniteAiAgentAdminThreads(
@@ -184,7 +186,7 @@ const AiAgentAdminThreadsTable = ({
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
 
-    const columns: MRT_ColumnDef<AiAgentAdminThreadSummary>[] = [
+    const columns: ContentTableColumnDef<AiAgentAdminThreadSummary>[] = [
         {
             accessorKey: 'title',
             header: 'Thread',

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
@@ -17,7 +17,7 @@ import { useNavigate, useParams } from 'react-router';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../../../../components/common/ContentTable';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
@@ -104,7 +104,7 @@ export const VerifiedArtifactsTable: FC<Props> = ({
         [navigate, projectUuid, agentUuid],
     );
 
-    const columns: MRT_ColumnDef<AiAgentVerifiedArtifact>[] = useMemo(
+    const columns: ContentTableColumnDef<AiAgentVerifiedArtifact>[] = useMemo(
         () => [
             // {
             //     accessorKey: 'artifactType',

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx
@@ -21,7 +21,7 @@ import { useNavigate } from 'react-router';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../../../../components/common/ContentTable';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
@@ -106,93 +106,94 @@ export const EvalRunDetails: FC<Props> = ({
         };
     }, [runData?.results]);
 
-    const columns: MRT_ColumnDef<AiAgentEvaluationRunResult>[] = useMemo(
-        () => [
-            {
-                accessorKey: 'index',
-                header: '#',
-                enableSorting: false,
-                size: 60,
-                Cell: ({ row }) => (
-                    <Text fz="sm" fw={500} c="dimmed">
-                        {row.index + 1}
-                    </Text>
-                ),
-            },
-            {
-                accessorKey: 'prompt',
-                header: 'Prompt',
-                enableSorting: false,
-                size: 300,
-                Cell: ({ row }) => {
-                    const promptText =
-                        row.original.prompt || `Prompt ${row.index + 1}`;
-                    return (
-                        <Text fz="sm" title={promptText} truncate maw={300}>
-                            {promptText}
+    const columns: ContentTableColumnDef<AiAgentEvaluationRunResult>[] =
+        useMemo(
+            () => [
+                {
+                    accessorKey: 'index',
+                    header: '#',
+                    enableSorting: false,
+                    size: 60,
+                    Cell: ({ row }) => (
+                        <Text fz="sm" fw={500} c="dimmed">
+                            {row.index + 1}
                         </Text>
-                    );
+                    ),
                 },
-            },
-            {
-                accessorKey: 'status',
-                header: 'Eval Status',
-                enableSorting: false,
-                size: 115,
-                Cell: ({ row }) => {
-                    const result = row.original;
-                    const statusStyle = statusConfig[result.status];
-                    const isEvalRunning = isRunning(result.status);
-                    return (
-                        <Tooltip
-                            label={result.errorMessage}
-                            disabled={result.status !== 'failed'}
-                        >
-                            <Text c={statusStyle.color}>
-                                <MantineIcon
-                                    icon={
-                                        isEvalRunning
-                                            ? IconPoint
-                                            : IconPointFilled
-                                    }
-                                />
+                {
+                    accessorKey: 'prompt',
+                    header: 'Prompt',
+                    enableSorting: false,
+                    size: 300,
+                    Cell: ({ row }) => {
+                        const promptText =
+                            row.original.prompt || `Prompt ${row.index + 1}`;
+                        return (
+                            <Text fz="sm" title={promptText} truncate maw={300}>
+                                {promptText}
                             </Text>
-                        </Tooltip>
-                    );
+                        );
+                    },
                 },
-            },
-            {
-                accessorKey: 'assessment',
-                header: 'Assessment',
-                enableSorting: false,
-                size: 120,
-                Cell: ({ row }) => {
-                    const result = row.original;
-                    const isEvalRunning = isRunning(result.status);
-                    const assessmentConfig = getAssessmentConfig(
-                        result.assessment?.passed,
-                    );
-                    return isEvalRunning ? (
-                        <Badge w={68} variant="transparent" color="gray">
-                            {result.status === 'assessing' ? (
-                                <Loader size={12} color="gray" />
-                            ) : (
-                                <>...</>
-                            )}
-                        </Badge>
-                    ) : (
-                        <Badge
-                            color={assessmentConfig.color}
-                            variant="transparent"
-                        >
-                            {assessmentConfig.label}
-                        </Badge>
-                    );
+                {
+                    accessorKey: 'status',
+                    header: 'Eval Status',
+                    enableSorting: false,
+                    size: 115,
+                    Cell: ({ row }) => {
+                        const result = row.original;
+                        const statusStyle = statusConfig[result.status];
+                        const isEvalRunning = isRunning(result.status);
+                        return (
+                            <Tooltip
+                                label={result.errorMessage}
+                                disabled={result.status !== 'failed'}
+                            >
+                                <Text c={statusStyle.color}>
+                                    <MantineIcon
+                                        icon={
+                                            isEvalRunning
+                                                ? IconPoint
+                                                : IconPointFilled
+                                        }
+                                    />
+                                </Text>
+                            </Tooltip>
+                        );
+                    },
                 },
-            },
-        ],
-        [],
-    );
+                {
+                    accessorKey: 'assessment',
+                    header: 'Assessment',
+                    enableSorting: false,
+                    size: 120,
+                    Cell: ({ row }) => {
+                        const result = row.original;
+                        const isEvalRunning = isRunning(result.status);
+                        const assessmentConfig = getAssessmentConfig(
+                            result.assessment?.passed,
+                        );
+                        return isEvalRunning ? (
+                            <Badge w={68} variant="transparent" color="gray">
+                                {result.status === 'assessing' ? (
+                                    <Loader size={12} color="gray" />
+                                ) : (
+                                    <>...</>
+                                )}
+                            </Badge>
+                        ) : (
+                            <Badge
+                                color={assessmentConfig.color}
+                                variant="transparent"
+                            >
+                                {assessmentConfig.label}
+                            </Badge>
+                        );
+                    },
+                },
+            ],
+            [],
+        );
 
     const table = useContentTable({
         columns,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRuns.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRuns.tsx
@@ -23,7 +23,7 @@ import { useNavigate } from 'react-router';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../../../../components/common/ContentTable';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
@@ -66,149 +66,155 @@ export const EvalRuns: FC<Props> = ({ projectUuid, agentUuid, evalUuid }) => {
         );
     };
 
-    const columns: MRT_ColumnDef<AiAgentEvaluationRunSummary>[] = useMemo(
-        () => [
-            {
-                accessorKey: 'runUuid',
-                header: 'Run ID',
-                enableSorting: false,
-                size: 120,
-                Cell: ({ row }) => (
-                    <Text fz="sm" fw={500}>
-                        {row.original.runUuid.slice(-8)}
-                    </Text>
-                ),
-            },
-            {
-                accessorKey: 'status',
-                header: 'Run Status',
-                enableSorting: false,
-                size: 150,
-                Cell: ({ row }) => {
-                    const evalStatus = statusConfig[row.original.status];
-                    return (
-                        <Badge
-                            color={evalStatus.color}
-                            variant="dot"
-                            size="sm"
-                            radius="sm"
-                            c="ldGray.7"
-                            style={{ border: 'none' }}
-                        >
-                            {evalStatus.label}
-                        </Badge>
-                    );
-                },
-            },
-            {
-                accessorKey: 'assessment',
-                header: 'Assessment',
-                enableSorting: false,
-                size: 140,
-                Cell: ({ row }) => {
-                    const run = row.original;
-                    return isRunning(run.status) ? (
-                        <Tooltip label="Running">
-                            <Loader size={12} color="gray" />
-                        </Tooltip>
-                    ) : !run.passedAssessments && !run.failedAssessments ? (
-                        <Tooltip label="No assessments available">
-                            <MantineIcon
-                                icon={IconCircleDotted}
-                                color="ldGray.6"
-                            />
-                        </Tooltip>
-                    ) : (
-                        <Group gap="sm">
-                            {run.passedAssessments > 0 && (
-                                <Group gap={2}>
-                                    <MantineIcon
-                                        icon={IconCheck}
-                                        color="green.8"
-                                    />
-                                    <Text fz="xs" c="green.8" fw={500}>
-                                        {run.passedAssessments}
-                                    </Text>
-                                </Group>
-                            )}
-                            {run.failedAssessments > 0 && (
-                                <Group gap={2}>
-                                    <MantineIcon icon={IconX} color="red.8" />
-                                    <Text fz="xs" c="red.8" fw={500}>
-                                        {run.failedAssessments}
-                                    </Text>
-                                </Group>
-                            )}
-                        </Group>
-                    );
-                },
-            },
-            {
-                accessorKey: 'createdAt',
-                header: 'Created',
-                enableSorting: false,
-                size: 180,
-                Cell: ({ row }) => {
-                    const run = row.original;
-                    const createdAt = run.createdAt
-                        ? dayjs(run.createdAt).format('DD/MM/YYYY HH:mm:ss')
-                        : '-';
-                    const completedAt = run.completedAt
-                        ? dayjs(run.completedAt).format('DD/MM/YYYY HH:mm:ss')
-                        : '-';
-                    return (
-                        <Tooltip
-                            withinPortal
-                            position="left-start"
-                            label={
-                                <Text size="xs">
-                                    Started {createdAt}
-                                    {run.completedAt && (
-                                        <>
-                                            <br />
-                                            Completed {completedAt}
-                                        </>
-                                    )}
-                                </Text>
-                            }
-                        >
-                            <Text fz="sm" c="ldGray.6">
-                                {createdAt}
-                            </Text>
-                        </Tooltip>
-                    );
-                },
-            },
-            {
-                accessorKey: 'duration',
-                header: 'Duration',
-                enableSorting: false,
-                size: 120,
-                Cell: ({ row }) => {
-                    const run = row.original;
-                    const runDuration = run.completedAt
-                        ? dayjs
-                              .utc(
-                                  dayjs
-                                      .duration(
-                                          dayjs(run.completedAt).diff(
-                                              dayjs(run.createdAt),
-                                          ),
-                                      )
-                                      .asMilliseconds(),
-                              )
-                              .format('mm[m]ss[s]')
-                        : '-';
-                    return (
-                        <Text fz="sm" c="ldGray.6">
-                            {runDuration}
+    const columns: ContentTableColumnDef<AiAgentEvaluationRunSummary>[] =
+        useMemo(
+            () => [
+                {
+                    accessorKey: 'runUuid',
+                    header: 'Run ID',
+                    enableSorting: false,
+                    size: 120,
+                    Cell: ({ row }) => (
+                        <Text fz="sm" fw={500}>
+                            {row.original.runUuid.slice(-8)}
                         </Text>
-                    );
+                    ),
                 },
-            },
-        ],
-        [],
-    );
+                {
+                    accessorKey: 'status',
+                    header: 'Run Status',
+                    enableSorting: false,
+                    size: 150,
+                    Cell: ({ row }) => {
+                        const evalStatus = statusConfig[row.original.status];
+                        return (
+                            <Badge
+                                color={evalStatus.color}
+                                variant="dot"
+                                size="sm"
+                                radius="sm"
+                                c="ldGray.7"
+                                style={{ border: 'none' }}
+                            >
+                                {evalStatus.label}
+                            </Badge>
+                        );
+                    },
+                },
+                {
+                    accessorKey: 'assessment',
+                    header: 'Assessment',
+                    enableSorting: false,
+                    size: 140,
+                    Cell: ({ row }) => {
+                        const run = row.original;
+                        return isRunning(run.status) ? (
+                            <Tooltip label="Running">
+                                <Loader size={12} color="gray" />
+                            </Tooltip>
+                        ) : !run.passedAssessments && !run.failedAssessments ? (
+                            <Tooltip label="No assessments available">
+                                <MantineIcon
+                                    icon={IconCircleDotted}
+                                    color="ldGray.6"
+                                />
+                            </Tooltip>
+                        ) : (
+                            <Group gap="sm">
+                                {run.passedAssessments > 0 && (
+                                    <Group gap={2}>
+                                        <MantineIcon
+                                            icon={IconCheck}
+                                            color="green.8"
+                                        />
+                                        <Text fz="xs" c="green.8" fw={500}>
+                                            {run.passedAssessments}
+                                        </Text>
+                                    </Group>
+                                )}
+                                {run.failedAssessments > 0 && (
+                                    <Group gap={2}>
+                                        <MantineIcon
+                                            icon={IconX}
+                                            color="red.8"
+                                        />
+                                        <Text fz="xs" c="red.8" fw={500}>
+                                            {run.failedAssessments}
+                                        </Text>
+                                    </Group>
+                                )}
+                            </Group>
+                        );
+                    },
+                },
+                {
+                    accessorKey: 'createdAt',
+                    header: 'Created',
+                    enableSorting: false,
+                    size: 180,
+                    Cell: ({ row }) => {
+                        const run = row.original;
+                        const createdAt = run.createdAt
+                            ? dayjs(run.createdAt).format('DD/MM/YYYY HH:mm:ss')
+                            : '-';
+                        const completedAt = run.completedAt
+                            ? dayjs(run.completedAt).format(
+                                  'DD/MM/YYYY HH:mm:ss',
+                              )
+                            : '-';
+                        return (
+                            <Tooltip
+                                withinPortal
+                                position="left-start"
+                                label={
+                                    <Text size="xs">
+                                        Started {createdAt}
+                                        {run.completedAt && (
+                                            <>
+                                                <br />
+                                                Completed {completedAt}
+                                            </>
+                                        )}
+                                    </Text>
+                                }
+                            >
+                                <Text fz="sm" c="ldGray.6">
+                                    {createdAt}
+                                </Text>
+                            </Tooltip>
+                        );
+                    },
+                },
+                {
+                    accessorKey: 'duration',
+                    header: 'Duration',
+                    enableSorting: false,
+                    size: 120,
+                    Cell: ({ row }) => {
+                        const run = row.original;
+                        const runDuration = run.completedAt
+                            ? dayjs
+                                  .utc(
+                                      dayjs
+                                          .duration(
+                                              dayjs(run.completedAt).diff(
+                                                  dayjs(run.createdAt),
+                                              ),
+                                          )
+                                          .asMilliseconds(),
+                                  )
+                                  .format('mm[m]ss[s]')
+                            : '-';
+                        return (
+                            <Text fz="sm" c="ldGray.6">
+                                {runDuration}
+                            </Text>
+                        );
+                    },
+                },
+            ],
+            [],
+        );
 
     const table = useContentTable({
         columns,

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -45,7 +45,7 @@ import { Link } from 'react-router';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../../components/common/ContentTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useCustomRoles } from '../customRoles/useCustomRoles';
@@ -120,7 +120,7 @@ const formatCreatedBy = (sa: ServiceAccount): string => {
 
 // Resolve the role label for a row so sort-by-role groups SAs that render
 // the same badge together (rather than sorting on raw scope strings).
-// MRT briefly invokes accessorFn with placeholder rows during auto-sort
+// ContentTable briefly invokes accessorFn with placeholder rows during auto-sort
 // inference, so guard against `scopes` being undefined.
 const formatRoleLabel = (
     sa: ServiceAccount,
@@ -245,7 +245,7 @@ export const ServiceAccountsTable: FC<Props> = ({
         closeRotate();
     }, [closeRotate]);
 
-    const columns: MRT_ColumnDef<ServiceAccountWithProjectAccessCount>[] =
+    const columns: ContentTableColumnDef<ServiceAccountWithProjectAccessCount>[] =
         useMemo(
             () => [
                 {
@@ -469,7 +469,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                     ),
                     // Coerce to a sortable number; null = no-expiration so we
                     // float those rows to the end (Infinity) regardless of
-                    // sort direction. MRT will respect the asc/desc factor.
+                    // sort direction. ContentTable will respect the asc/desc factor.
                     sortingFn: (a, b) => {
                         const av = a.original.expiresAt
                             ? +new Date(a.original.expiresAt)

--- a/packages/frontend/src/ee/features/serviceAccounts/index.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/index.tsx
@@ -25,7 +25,7 @@ export function ServiceAccountsPage() {
 
     const accountsData = listAccounts?.data;
     // First-load vs background refetch: only block UI on the first fetch.
-    // Subsequent refetches keep the existing rows visible (and MRT's own
+    // Subsequent refetches keep the existing rows visible (and ContentTable's
     // loading state will dim them via state.isLoading inside the table) so
     // the page doesn't flash on every revalidation.
     const isInitialLoading = listAccounts.isLoading && !accountsData;

--- a/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
+++ b/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
@@ -40,7 +40,7 @@ import Callout from '../../../components/common/Callout';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../../components/common/ContentTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -323,7 +323,7 @@ export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
         });
     };
 
-    const columns: MRT_ColumnDef<ChangeWithDependencies>[] = useMemo(
+    const columns: ContentTableColumnDef<ChangeWithDependencies>[] = useMemo(
         () => [
             {
                 accessorKey: 'entityName',

--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -2,14 +2,14 @@ import { type CatalogField } from '@lightdash/common';
 import { Button, Tooltip } from '@mantine/core';
 import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router';
-import { type MRT_Row } from '../../../components/common/ContentTable';
+import { type ContentTableRow } from '../../../components/common/ContentTable';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
 import { toggleMetricExploreModal } from '../store/metricsCatalogSlice';
 
 type Props = {
-    row: MRT_Row<CatalogField>;
+    row: ContentTableRow<CatalogField>;
 };
 
 export const ExploreMetricButton = ({ row }: Props) => {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCellOverlay.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCellOverlay.tsx
@@ -10,7 +10,7 @@ import MarkdownPreview, {
     type MarkdownPreviewProps,
 } from '@uiw/react-markdown-preview';
 import { useEffect, useRef, type FC } from 'react';
-import { type MRT_TableInstance } from '../../../components/common/ContentTable';
+import { type ContentTableInstance } from '../../../components/common/ContentTable';
 import { useLockScroll } from '../../../hooks/useLockScroll';
 
 type Props = {
@@ -18,7 +18,7 @@ type Props = {
     setIsOpen: (isOpen: boolean) => void;
     content: string;
     cellRef: React.RefObject<HTMLDivElement | null>;
-    table: MRT_TableInstance<CatalogField>;
+    table: ContentTableInstance<CatalogField>;
     markdownPreviewProps?: Omit<MarkdownPreviewProps, 'source'>;
 };
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageButton.tsx
@@ -1,6 +1,6 @@
 import { type CatalogField } from '@lightdash/common';
 import { Button, Text, Tooltip } from '@mantine-8/core';
-import { type MRT_Row } from '../../../components/common/ContentTable';
+import { type ContentTableRow } from '../../../components/common/ContentTable';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { BarChart } from '../../../svgs/metricsCatalog';
 import { EventName } from '../../../types/Events';
@@ -11,7 +11,7 @@ import styles from './MetricChartUsageButton.module.css';
 export const MetricChartUsageButton = ({
     row,
 }: {
-    row: MRT_Row<CatalogField>;
+    row: ContentTableRow<CatalogField>;
 }) => {
     const hasChartsUsage = row.original.chartUsage ?? 0 > 0;
     const organizationUuid = useAppSelector(

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
@@ -5,8 +5,8 @@ import MarkdownPreview, {
 } from '@uiw/react-markdown-preview';
 import { useRef, useState, type FC } from 'react';
 import {
-    type MRT_Row,
-    type MRT_TableInstance,
+    type ContentTableRow,
+    type ContentTableInstance,
 } from '../../../components/common/ContentTable';
 import { useIsLineClamped } from '../../../hooks/useIsLineClamped';
 import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
@@ -14,8 +14,8 @@ import { setDescriptionPopoverIsClosing } from '../store/metricsCatalogSlice';
 import { MetricCatalogCellOverlay } from './MetricCatalogCellOverlay';
 
 type Props = {
-    row: MRT_Row<CatalogField>;
-    table: MRT_TableInstance<CatalogField>;
+    row: ContentTableRow<CatalogField>;
+    table: ContentTableInstance<CatalogField>;
 };
 
 export const MetricsCatalogColumnDescription: FC<Props> = ({ row, table }) => {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -18,8 +18,8 @@ import EmojiPicker, {
 } from 'emoji-picker-react';
 import { forwardRef, useCallback, useEffect, useState } from 'react';
 import {
-    type MRT_Row,
-    type MRT_TableInstance,
+    type ContentTableRow,
+    type ContentTableInstance,
 } from '../../../components/common/ContentTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -101,8 +101,8 @@ const SharedEmojiPicker = forwardRef(
 );
 
 type Props = {
-    row: MRT_Row<CatalogField>;
-    table: MRT_TableInstance<CatalogField>;
+    row: ContentTableRow<CatalogField>;
+    table: ContentTableInstance<CatalogField>;
 };
 
 export const MetricsCatalogColumnName = forwardRef<HTMLDivElement, Props>(

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnOwner.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnOwner.tsx
@@ -2,10 +2,10 @@ import { type CatalogField } from '@lightdash/common';
 import { Group, Paper, Text, Tooltip } from '@mantine-8/core';
 import { type FC } from 'react';
 import { LightdashUserAvatar } from '../../../components/Avatar';
-import { type MRT_Row } from '../../../components/common/ContentTable';
+import { type ContentTableRow } from '../../../components/common/ContentTable';
 
 type Props = {
-    row: MRT_Row<CatalogField>;
+    row: ContentTableRow<CatalogField>;
 };
 
 export const MetricsCatalogColumnOwner: FC<Props> = ({ row }) => {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Flex, Group, Text } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconPlus, IconUser } from '@tabler/icons-react';
 import { useMemo } from 'react';
-import { type MRT_ColumnDef } from '../../../components/common/ContentTable';
+import { type ContentTableColumnDef } from '../../../components/common/ContentTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import {
     createMetricPreviewUnsavedChartVersion,
@@ -28,7 +28,7 @@ import { MetricsCatalogColumnDescription } from './MetricsCatalogColumnDescripti
 import { MetricsCatalogColumnName } from './MetricsCatalogColumnName';
 import { MetricsCatalogColumnOwner } from './MetricsCatalogColumnOwner';
 
-export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
+export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
     {
         accessorKey: SpotlightTableColumns.METRIC,
         header: 'Metric',

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -33,8 +33,8 @@ import {
 import {
     ContentTable,
     useContentTable,
-    type MRT_SortingState,
-    type MRT_Virtualizer,
+    type ContentTableSortingState,
+    type ContentTableVirtualizer,
 } from '../../../components/common/ContentTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
@@ -106,11 +106,13 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
     const prevView = useRef(metricCatalogView);
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
-        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
 
     // We need internal state to handle non serializable state for the updater function
     const [internalSorting, setInternalSorting] =
-        useState<MRT_SortingState>(stateTableSorting);
+        useState<ContentTableSortingState>(stateTableSorting);
 
     const onCloseMetricExploreModal = () => {
         dispatch(toggleMetricExploreModal(undefined));
@@ -577,7 +579,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
         rowVirtualizerInstanceRef,
         rowVirtualizerProps: { estimateSize: () => 72, overscan: 40 },
         displayColumnDefOptions: {
-            'mrt-row-actions': {
+            'content-table-row-actions': {
                 header: '',
             },
         },

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -49,7 +49,7 @@ import isEqual from 'lodash/isEqual';
 import { memo, useCallback, useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useDebounce } from 'react-use';
-import { type MRT_TableInstance } from '../../../../components/common/ContentTable';
+import { type ContentTableInstance } from '../../../../components/common/ContentTable';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { TotalMetricsDot } from '../../../../svgs/metricsCatalog';
@@ -87,7 +87,7 @@ type MetricsTableTopToolbarProps = GroupProps & {
     totalResults: number;
     showCategoriesFilter?: boolean;
     metricCatalogView: MetricCatalogView;
-    table: MRT_TableInstance<CatalogField>;
+    table: ContentTableInstance<CatalogField>;
 };
 
 const SortableColumn: FC<{

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -7,7 +7,7 @@ import {
     type SpotlightTableConfig,
 } from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import type { MRT_SortingState } from '../../../components/common/ContentTable';
+import type { ContentTableSortingState } from '../../../components/common/ContentTable';
 import type { UserWithAbility } from '../../../hooks/user/useUser';
 import { SavedTreeEditMode } from '../types';
 
@@ -37,7 +37,7 @@ type MetricsCatalogState = {
     tableFilters: string[];
     ownerFilters: string[];
     search: string | undefined;
-    tableSorting: MRT_SortingState;
+    tableSorting: ContentTableSortingState;
     popovers: {
         category: {
             isClosing: boolean;
@@ -186,7 +186,10 @@ export const metricsCatalogSlice = createSlice({
         setSearch: (state, action: PayloadAction<string | undefined>) => {
             state.search = action.payload;
         },
-        setTableSorting: (state, action: PayloadAction<MRT_SortingState>) => {
+        setTableSorting: (
+            state,
+            action: PayloadAction<ContentTableSortingState>,
+        ) => {
             state.tableSorting = action.payload;
         },
         setUser: (

--- a/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
@@ -31,7 +31,7 @@ import { useCallback, useMemo, useState, type FC } from 'react';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../../components/common/ContentTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
@@ -288,8 +288,8 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
             .filter((row): row is EnrichedGroupRow => row !== null);
     }, [projectGroupAccessList, groups, allRoles]);
 
-    const columns: MRT_ColumnDef<EnrichedGroupRow>[] = useMemo(() => {
-        const cols: MRT_ColumnDef<EnrichedGroupRow>[] = [
+    const columns: ContentTableColumnDef<EnrichedGroupRow>[] = useMemo(() => {
+        const cols: ContentTableColumnDef<EnrichedGroupRow>[] = [
             {
                 accessorKey: 'groupUuid',
                 header: 'Group Name',

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -38,7 +38,7 @@ import { CategoryBadge } from '../../../components/common/CategoryBadge/Category
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../../../components/common/ContentTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
@@ -131,7 +131,7 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached, stateFilter]);
 
-    const columns = useMemo<MRT_ColumnDef<PullRequestRow>[]>(
+    const columns = useMemo<ContentTableColumnDef<PullRequestRow>[]>(
         () => [
             {
                 accessorKey: 'title',
@@ -262,7 +262,7 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
         enableRowActions: true,
         positionActionsColumn: 'last',
         displayColumnDefOptions: {
-            'mrt-row-actions': {
+            'content-table-row-actions': {
                 header: '',
                 size: 96,
             },

--- a/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
@@ -42,8 +42,8 @@ import Callout from '../../../components/common/Callout';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
-    type MRT_Virtualizer,
+    type ContentTableColumnDef,
+    type ContentTableVirtualizer,
 } from '../../../components/common/ContentTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { ChartIcon, IconBox } from '../../../components/common/ResourceIcon';
@@ -131,7 +131,9 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
     const theme = useMantineTheme();
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
-        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+        useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
+            null,
+        );
 
     const { health, user } = useApp();
     const retentionDays = health.data?.softDelete.retentionDays;
@@ -227,7 +229,9 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
 
-    const columns = useMemo<MRT_ColumnDef<DeletedContentWithDescendants>[]>(
+    const columns = useMemo<
+        ContentTableColumnDef<DeletedContentWithDescendants>[]
+    >(
         () => [
             {
                 accessorKey: 'name',
@@ -333,7 +337,7 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                       Unknown
                                   </Text>
                               ),
-                      } as MRT_ColumnDef<DeletedContentWithDescendants>,
+                      } as ContentTableColumnDef<DeletedContentWithDescendants>,
                   ]
                 : []),
             {

--- a/packages/frontend/src/pages/DashboardVersionComparison.tsx
+++ b/packages/frontend/src/pages/DashboardVersionComparison.tsx
@@ -38,7 +38,7 @@ import { useMemo, useRef, useState } from 'react';
 import {
     ContentTable,
     useContentTable,
-    type MRT_ColumnDef,
+    type ContentTableColumnDef,
 } from '../components/common/ContentTable';
 import { EmptyState } from '../components/common/EmptyState';
 import { getConditionalRuleLabel } from '../components/common/Filters/FilterInputs/utils';
@@ -281,7 +281,7 @@ const TilesTable = ({ data }: { data: any[] }) => {
         return data.filter((row) => row.tileType !== 'Total');
     }, [data]);
 
-    const columns = useMemo<MRT_ColumnDef<any>[]>(
+    const columns = useMemo<ContentTableColumnDef<any>[]>(
         () => [
             {
                 accessorKey: 'tileType',
@@ -442,7 +442,7 @@ const ChartsTable = ({
     const [search, setSearch] = useState('');
     const tableContainerRef = useRef<HTMLDivElement>(null);
 
-    const columns = useMemo<MRT_ColumnDef<any>[]>(
+    const columns = useMemo<ContentTableColumnDef<any>[]>(
         () => [
             {
                 accessorKey: 'chartName',
@@ -659,7 +659,7 @@ const FiltersTable = ({ data }: { data: any[] }) => {
     const [search, setSearch] = useState('');
     const tableContainerRef = useRef<HTMLDivElement>(null);
 
-    const columns = useMemo<MRT_ColumnDef<any>[]>(
+    const columns = useMemo<ContentTableColumnDef<any>[]>(
         () => [
             {
                 accessorFn: (row) => row.currentFilter?.label || '-',


### PR DESCRIPTION
## Summary
- Rename ContentTable public type exports from `MRT_*` to `ContentTable*`
- Rename internal display column ids from `mrt-row-*` to `content-table-row-*`
- Update ContentTable consumers and related comments

## Validation
- `pnpm dlx oxfmt@0.35.0 ./src --check` from `packages/frontend`
- `rg -n "MRT_|mrtProps|mrt-row|mantine-react-table|\\bMRT\\b" . -g '*.{ts,tsx}' -g '!node_modules' -g '!dist' -g '!build'` found no matches
- `git diff HEAD~1 --check`
- `pnpm -F frontend typecheck` could not run locally: `tsc` missing because `node_modules` is absent in this worktree