### PR TITLE
feat(mcp): expose built-in skills as resources

### DIFF
--- a/packages/api-tests/tests/mcpServer.test.ts
+++ b/packages/api-tests/tests/mcpServer.test.ts
@@ -101,4 +101,134 @@ describe('MCP server', () => {
         expect(response.body.id).toBe(4);
         expect(response.body.result).toEqual({});
     });
+
+    it('should advertise the skills extension capability', async () => {
+        const response = await admin.post<
+            McpResponse<{
+                capabilities: {
+                    resources?: { subscribe?: boolean; listChanged?: boolean };
+                    extensions?: Record<string, unknown>;
+                };
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 5,
+                method: 'initialize',
+                params: {
+                    protocolVersion: '2025-03-26',
+                    capabilities: {},
+                    clientInfo: { name: 'test-client', version: '1.0.0' },
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.result.capabilities).toMatchObject({
+            resources: { subscribe: false, listChanged: false },
+            extensions: {
+                'io.modelcontextprotocol/skills': {},
+            },
+        });
+    });
+
+    it('should list built-in skill resources', async () => {
+        const response = await admin.post<
+            McpResponse<{
+                resources: Array<{
+                    uri: string;
+                    name: string;
+                    mimeType?: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 6,
+                method: 'resources/list',
+                params: {},
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        const uris = response.body.result.resources.map((r) => r.uri);
+        expect(uris).toContain('skill://index.json');
+        expect(uris).toContain('skill://developing-in-lightdash/SKILL.md');
+
+        const skillMd = response.body.result.resources.find(
+            (r) => r.uri === 'skill://developing-in-lightdash/SKILL.md',
+        );
+        expect(skillMd?.name).toBe('developing-in-lightdash');
+        expect(skillMd?.mimeType).toBe('text/markdown');
+    });
+
+    it('should read a built-in skill resource', async () => {
+        const response = await admin.post<
+            McpResponse<{
+                contents: Array<{
+                    uri: string;
+                    mimeType?: string;
+                    text: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 7,
+                method: 'resources/read',
+                params: { uri: 'skill://developing-in-lightdash/SKILL.md' },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.result.contents).toHaveLength(1);
+        expect(response.body.result.contents[0].uri).toBe(
+            'skill://developing-in-lightdash/SKILL.md',
+        );
+        expect(response.body.result.contents[0].text).toContain(
+            '# Developing in Lightdash',
+        );
+    });
+
+    it('should read the skills index resource', async () => {
+        const response = await admin.post<
+            McpResponse<{
+                contents: Array<{
+                    uri: string;
+                    mimeType?: string;
+                    text: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 8,
+                method: 'resources/read',
+                params: { uri: 'skill://index.json' },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        const content = response.body.result.contents[0];
+        expect(content.mimeType).toBe('application/json');
+
+        const index = JSON.parse(content.text) as {
+            skills: Array<{ name: string; type: string; url: string }>;
+        };
+        expect(index.skills).toContainEqual(
+            expect.objectContaining({
+                name: 'developing-in-lightdash',
+                type: 'skill-md',
+                url: 'skill://developing-in-lightdash/SKILL.md',
+            }),
+        );
+    });
 });

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -101,6 +101,7 @@ import {
     getMcpAnalystPromptWithContext,
     MCP_ANALYST_PROMPT,
 } from '../ai/prompts/mcpAnalyst';
+import { BuiltInSkills } from '../ai/skills/builtInSkills';
 import { getFindContent } from '../ai/tools/findContent';
 import { getFindExplores } from '../ai/tools/findExplores';
 import { getFindFields } from '../ai/tools/findFields';
@@ -148,6 +149,9 @@ export enum McpToolName {
     LIST_VERIFIED_CONTENT = 'list_verified_content',
     RUN_AI_WRITEBACK = 'run_ai_writeback',
 }
+
+// Skills-over-MCP extension identifier (SEP-2640).
+const MCP_SKILLS_EXTENSION_NAME = 'io.modelcontextprotocol/skills';
 
 const mcpRunAiWritebackTool = runAiWritebackToolDefinition.for('mcp');
 const mcpGetLightdashVersionTool = getLightdashVersionToolDefinition.for('mcp');
@@ -2655,10 +2659,10 @@ export class McpService extends BaseService {
      * Required for SDK 1.26.0+ stateful mode where each session needs its own server.
      * See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
      */
-    public createServer(options?: {
+    public async createServer(options?: {
         projectPinned?: boolean;
         aiWritebackEnabled?: boolean;
-    }): McpServer {
+    }): Promise<McpServer> {
         const newServer = Sentry.wrapMcpServerWithSentry(
             new McpServer({
                 name: 'Lightdash MCP Server',
@@ -2683,7 +2687,9 @@ export class McpService extends BaseService {
             }),
         );
 
-        // Temporarily swap the server to register handlers on the new instance
+        // Temporarily swap the server to register handlers on the new instance.
+        // Kept synchronous so concurrent createServer calls can't observe each
+        // other's swapped this.mcpServer across an await.
         const originalServer = this.mcpServer;
         this.mcpServer = newServer;
         this.setupHandlers({
@@ -2692,7 +2698,60 @@ export class McpService extends BaseService {
         });
         this.mcpServer = originalServer;
 
+        // Skill resources load asynchronously; register them directly on the
+        // new server so no server swap spans the await.
+        await McpService.setupSkillResourceHandlers(newServer);
+
         return newServer;
+    }
+
+    private static async setupSkillResourceHandlers(
+        mcpServer: McpServer,
+    ): Promise<void> {
+        const resources = await BuiltInSkills.listMcpResources();
+
+        resources.forEach((resource) => {
+            mcpServer.registerResource(
+                resource.name,
+                resource.uri,
+                {
+                    title: resource.title,
+                    description: resource.description,
+                    mimeType: resource.mimeType,
+                    size: resource.size,
+                },
+                async () => {
+                    const text = await BuiltInSkills.getMcpResourceBody(
+                        resource.uri,
+                    );
+                    if (text === undefined) {
+                        throw new NotFoundError(
+                            `Resource "${resource.uri}" was not found`,
+                        );
+                    }
+                    return {
+                        contents: [
+                            {
+                                uri: resource.uri,
+                                mimeType: resource.mimeType,
+                                text,
+                            },
+                        ],
+                    };
+                },
+            );
+        });
+
+        // The SDK auto-advertises `resources.listChanged: true` when
+        // registerResource is called, but we never emit list_changed
+        // notifications. We also declare the skills extension so clients can
+        // detect built-in skill support.
+        mcpServer.server.registerCapabilities({
+            resources: { subscribe: false, listChanged: false },
+            extensions: {
+                [MCP_SKILLS_EXTENSION_NAME]: {},
+            },
+        });
     }
 
     static getAccount(context: McpProtocolContext) {

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -36,6 +36,9 @@ jest.mock('@sentry/node', () => ({
 
 jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
     McpServer: jest.fn().mockImplementation(() => ({
+        server: {
+            registerCapabilities: jest.fn(),
+        },
         registerResource: jest.fn(),
         registerPrompt: jest.fn(
             (
@@ -115,12 +118,12 @@ describe('MCP tool contracts', () => {
         expect(sharedMcpToolDefinitionNames).toMatchSnapshot();
     });
 
-    it('matches the current MCP tool and prompt contract snapshot', () => {
+    it('matches the current MCP tool and prompt contract snapshot', async () => {
         const mcpService = makeMcpService();
 
         mockRegisteredMcpTools.length = 0;
         mockRegisteredMcpPrompts.length = 0;
-        mcpService.createServer({ aiWritebackEnabled: true });
+        await mcpService.createServer({ aiWritebackEnabled: true });
 
         expect({
             prompts: mockRegisteredMcpPrompts.map(({ name, config }) => ({

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
@@ -17,11 +17,12 @@ type SkillFrontmatter = {
  * A single parsed markdown file within a skill directory — the skill's SKILL.md
  * or one of its supporting resource files. This is the shared, parse-once
  * representation that every consumer projects its own view from (the AI-agent
- * skill API today; the MCP resource API in later slices).
+ * skill API and the MCP resource API).
  */
 export type ParsedSkillFile = SkillFrontmatter & {
     fileName: string;
     content: string;
+    raw: string;
 };
 
 /** A fully-loaded built-in skill: its SKILL.md plus supporting resource files. */
@@ -32,12 +33,34 @@ export type LoadedBuiltInSkill = {
     resources: ParsedSkillFile[];
 };
 
+/** A built-in skill file exposed as an MCP resource. */
+export type BuiltInSkillMcpResource = {
+    uri: string;
+    name: string;
+    title: string;
+    description: string;
+    mimeType: string;
+    size: number;
+};
+
+type McpResourceWithBody = {
+    resource: BuiltInSkillMcpResource;
+    body: string;
+};
+
 export class BuiltInSkills {
     private static readonly SKILLS_DIR = path.join(__dirname, 'builtInSkills');
+
+    private static readonly SKILL_INDEX_URI = 'skill://index.json';
+
+    private static readonly SKILLS_DISCOVERY_SCHEMA =
+        'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
 
     private static loaded: LoadedBuiltInSkill[] | undefined;
 
     private static loadedPromise: Promise<LoadedBuiltInSkill[]> | undefined;
+
+    private static mcpResources: McpResourceWithBody[] | undefined;
 
     private static parseSkillFile(
         filePath: string,
@@ -57,6 +80,7 @@ export class BuiltInSkills {
             name,
             description,
             content,
+            raw: fileContents,
         };
     }
 
@@ -193,5 +217,114 @@ export class BuiltInSkills {
             (loaded) => loaded.name.toLowerCase() === name.trim().toLowerCase(),
         );
         return skill ? this.toAiAgentSkill(skill) : undefined;
+    }
+
+    private static deriveTitleFromName(name: string): string {
+        return name
+            .split(/[-_/]/)
+            .filter((part) => part.length > 0)
+            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .join(' ');
+    }
+
+    private static getSkillUri(skillName: string): string {
+        return `skill://${skillName}/SKILL.md`;
+    }
+
+    private static getSkillResourceUri(
+        skillName: string,
+        fileName: string,
+    ): string {
+        return `skill://${skillName}/resources/${fileName}`;
+    }
+
+    private static buildSkillIndex(
+        skillResources: McpResourceWithBody[],
+    ): McpResourceWithBody {
+        const skills = skillResources
+            .filter((item) => item.resource.uri.endsWith('/SKILL.md'))
+            .map((item) => ({
+                name: item.resource.name,
+                type: 'skill-md',
+                description: item.resource.description,
+                url: item.resource.uri,
+            }));
+        const body = JSON.stringify(
+            { $schema: this.SKILLS_DISCOVERY_SCHEMA, skills },
+            null,
+            2,
+        );
+
+        return {
+            resource: {
+                uri: this.SKILL_INDEX_URI,
+                name: 'skills-index',
+                title: 'Lightdash Skills Index',
+                description:
+                    'Index of Lightdash built-in skills exposed as MCP resources.',
+                mimeType: 'application/json',
+                size: Buffer.byteLength(body, 'utf8'),
+            },
+            body,
+        };
+    }
+
+    /**
+     * Projects the loaded skills into MCP resources (the SKILL.md, each
+     * supporting file, and a discovery index), keyed by skill:// URI.
+     */
+    private static async loadMcpResources(): Promise<McpResourceWithBody[]> {
+        if (this.mcpResources) {
+            return this.mcpResources;
+        }
+
+        const skillResources = (await this.load()).flatMap((skill) => {
+            const skillTitle = this.deriveTitleFromName(skill.name);
+            const skillMd: McpResourceWithBody = {
+                resource: {
+                    uri: this.getSkillUri(skill.name),
+                    name: skill.skill.name,
+                    title: skillTitle,
+                    description: skill.skill.description,
+                    mimeType: 'text/markdown',
+                    size: Buffer.byteLength(skill.skill.raw, 'utf8'),
+                },
+                body: skill.skill.raw,
+            };
+            const supporting = skill.resources.map((file) => ({
+                resource: {
+                    uri: this.getSkillResourceUri(skill.name, file.fileName),
+                    name: `${skill.name}/resources/${path.basename(
+                        file.fileName,
+                        '.md',
+                    )}`,
+                    title: `${skillTitle} / ${this.deriveTitleFromName(
+                        file.name,
+                    )}`,
+                    description: file.description,
+                    mimeType: 'text/markdown',
+                    size: Buffer.byteLength(file.raw, 'utf8'),
+                },
+                body: file.raw,
+            }));
+            return [skillMd, ...supporting];
+        });
+
+        const resources = [
+            this.buildSkillIndex(skillResources),
+            ...skillResources,
+        ];
+        this.mcpResources = resources;
+        return resources;
+    }
+
+    static async listMcpResources(): Promise<BuiltInSkillMcpResource[]> {
+        return (await this.loadMcpResources()).map((item) => item.resource);
+    }
+
+    static async getMcpResourceBody(uri: string): Promise<string | undefined> {
+        return (await this.loadMcpResources()).find(
+            (item) => item.resource.uri === uri,
+        )?.body;
     }
 }

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -176,7 +176,7 @@ mcpRouter.all(
                 // registration in createServer/setupHandlers is synchronous.
                 const aiWritebackEnabled =
                     await mcpService.isAiWritebackEnabled(req.user!);
-                const mcpServer = mcpService.createServer({
+                const mcpServer = await mcpService.createServer({
                     projectPinned: headerProjectUuid !== undefined,
                     aiWritebackEnabled,
                 });


### PR DESCRIPTION
Relates: ZAP-421

Register each built-in skill SKILL.md and supporting file as an MCP resource under skill:// URIs, add a skill://index.json discovery index, and advertise the io.modelcontextprotocol/skills extension capability. Resource loading reuses the shared skill loader; createServer becomes async so resources register per request.