### PR TITLE
feat(mcp): skill fallback tools

### DIFF
--- a/packages/api-tests/tests/mcpServer.test.ts
+++ b/packages/api-tests/tests/mcpServer.test.ts
@@ -231,4 +231,110 @@ describe('MCP server', () => {
             }),
         );
     });
+
+    it('should expose the skill fallback tools', async () => {
+        const response = await admin.post<
+            McpResponse<{ tools: Array<{ name: string }> }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 9,
+                method: 'tools/list',
+                params: {},
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        const names = response.body.result.tools.map((tool) => tool.name);
+        expect(names).toEqual(
+            expect.arrayContaining([
+                'list_skills',
+                'read_skill',
+                'read_skill_resource',
+            ]),
+        );
+    });
+
+    it('should call the list_skills tool', async () => {
+        const response = await admin.post<
+            McpResponse<{ content: Array<{ type: string; text: string }> }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 10,
+                method: 'tools/call',
+                params: { name: 'list_skills', arguments: {} },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        const parsed = JSON.parse(response.body.result.content[0].text) as {
+            skills: Array<{
+                name: string;
+                uri: string;
+                resources: Array<{ path: string }>;
+            }>;
+        };
+        const skill = parsed.skills.find(
+            (s) => s.name === 'developing-in-lightdash',
+        );
+        expect(skill?.uri).toBe('skill://developing-in-lightdash/SKILL.md');
+        expect(skill?.resources.length).toBeGreaterThan(0);
+        expect(
+            skill?.resources.every((r) => r.path.startsWith('resources/')),
+        ).toBe(true);
+    });
+
+    it('should call the read_skill tool', async () => {
+        const response = await admin.post<
+            McpResponse<{ content: Array<{ type: string; text: string }> }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 11,
+                method: 'tools/call',
+                params: {
+                    name: 'read_skill',
+                    arguments: { name: 'developing-in-lightdash' },
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.result.content[0].text).toContain(
+            '# Developing in Lightdash',
+        );
+    });
+
+    it('should call the read_skill_resource tool', async () => {
+        const response = await admin.post<
+            McpResponse<{ content: Array<{ type: string; text: string }> }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 12,
+                method: 'tools/call',
+                params: {
+                    name: 'read_skill_resource',
+                    arguments: {
+                        name: 'developing-in-lightdash',
+                        path: 'resources/dashboard-reference.md',
+                    },
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.result.content[0].text).toContain(
+            '# Dashboard Reference',
+        );
+    });
 });

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -148,10 +148,34 @@ export enum McpToolName {
     SEARCH_FIELD_VALUES = 'search_field_values',
     LIST_VERIFIED_CONTENT = 'list_verified_content',
     RUN_AI_WRITEBACK = 'run_ai_writeback',
+    LIST_SKILLS = 'list_skills',
+    READ_SKILL = 'read_skill',
+    READ_SKILL_RESOURCE = 'read_skill_resource',
 }
 
 // Skills-over-MCP extension identifier (SEP-2640).
 const MCP_SKILLS_EXTENSION_NAME = 'io.modelcontextprotocol/skills';
+
+const listSkillsToolSchema = z.object({});
+const readSkillToolSchema = z.object({
+    name: z
+        .string()
+        .describe(
+            'Skill name from list_skills, for example developing-in-lightdash',
+        ),
+});
+const readSkillResourceToolSchema = z.object({
+    name: z
+        .string()
+        .describe(
+            'Skill name from list_skills, for example developing-in-lightdash',
+        ),
+    path: z
+        .string()
+        .describe(
+            'Resource path from list_skills, for example resources/dashboard-reference.md',
+        ),
+});
 
 const mcpRunAiWritebackTool = runAiWritebackToolDefinition.for('mcp');
 const mcpGetLightdashVersionTool = getLightdashVersionToolDefinition.for('mcp');
@@ -2327,6 +2351,8 @@ export class McpService extends BaseService {
             },
         );
 
+        this.registerSkillToolHandlers();
+
         // Dark-launched: this tool is only registered — and therefore only
         // advertised in tools/list and invocable — when the AiWriteback
         // feature flag is enabled for the caller. Clients without the flag
@@ -2703,6 +2729,106 @@ export class McpService extends BaseService {
         await McpService.setupSkillResourceHandlers(newServer);
 
         return newServer;
+    }
+
+    private registerSkillToolHandlers(): void {
+        this.mcpServer.registerTool(
+            McpToolName.LIST_SKILLS,
+            {
+                title: 'List Skills',
+                description:
+                    'List Lightdash built-in skills available to this MCP server. Use this when the client does not expose MCP resources directly.',
+                inputSchema: this.getMcpCompatibleSchema(listSkillsToolSchema),
+                annotations: { readOnlyHint: true },
+            },
+            async (_args, extra) => {
+                const ctx = getMcpContext(extra);
+                this.trackToolCall(ctx, McpToolName.LIST_SKILLS);
+
+                const skills = await BuiltInSkills.listSkillToolReferences();
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify({ skills }, null, 2),
+                        },
+                    ],
+                    structuredContent: { skills },
+                };
+            },
+        );
+
+        this.mcpServer.registerTool(
+            McpToolName.READ_SKILL,
+            {
+                title: 'Read Skill',
+                description:
+                    'Read the main SKILL.md instructions for a Lightdash built-in skill. Call list_skills first to discover available skill names.',
+                inputSchema: this.getMcpCompatibleSchema(readSkillToolSchema),
+                annotations: { readOnlyHint: true },
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+                this.trackToolCall(ctx, McpToolName.READ_SKILL);
+
+                const result = await BuiltInSkills.readSkillTool(args.name);
+                if (!result) {
+                    throw new NotFoundError(
+                        `Skill "${args.name}" was not found`,
+                    );
+                }
+                const { skill, body } = result;
+
+                return {
+                    content: [{ type: 'text' as const, text: body }],
+                    structuredContent: {
+                        skill: {
+                            name: skill.name,
+                            uri: skill.uri,
+                            title: skill.title,
+                            description: skill.description,
+                            mimeType: skill.mimeType,
+                            size: skill.size,
+                        },
+                    },
+                };
+            },
+        );
+
+        this.mcpServer.registerTool(
+            McpToolName.READ_SKILL_RESOURCE,
+            {
+                title: 'Read Skill Resource',
+                description:
+                    'Read a supporting resource file for a Lightdash built-in skill. Use the resource path returned by list_skills.',
+                inputSchema: this.getMcpCompatibleSchema(
+                    readSkillResourceToolSchema,
+                ),
+                annotations: { readOnlyHint: true },
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+                this.trackToolCall(ctx, McpToolName.READ_SKILL_RESOURCE);
+
+                const result = await BuiltInSkills.readSkillToolResource({
+                    name: args.name,
+                    resourcePath: args.path,
+                });
+                if (!result) {
+                    throw new NotFoundError(
+                        `Skill resource "${args.path}" was not found for skill "${args.name}"`,
+                    );
+                }
+
+                return {
+                    content: [{ type: 'text' as const, text: result.body }],
+                    structuredContent: {
+                        skill: { name: result.skillName },
+                        resource: result.resource,
+                    },
+                };
+            },
+        );
     }
 
     private static async setupSkillResourceHandlers(

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -7367,6 +7367,63 @@ Notes:
     },
     {
       "agentName": null,
+      "description": "List Lightdash built-in skills available to this MCP server. Use this when the client does not expose MCP resources directly.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object",
+      },
+      "name": "list_skills",
+      "title": "List Skills",
+    },
+    {
+      "agentName": null,
+      "description": "Read the main SKILL.md instructions for a Lightdash built-in skill. Call list_skills first to discover available skill names.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "Skill name from list_skills, for example developing-in-lightdash",
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+        ],
+        "type": "object",
+      },
+      "name": "read_skill",
+      "title": "Read Skill",
+    },
+    {
+      "agentName": null,
+      "description": "Read a supporting resource file for a Lightdash built-in skill. Use the resource path returned by list_skills.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "Skill name from list_skills, for example developing-in-lightdash",
+            "type": "string",
+          },
+          "path": {
+            "description": "Resource path from list_skills, for example resources/dashboard-reference.md",
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+          "path",
+        ],
+        "type": "object",
+      },
+      "name": "read_skill_resource",
+      "title": "Read Skill Resource",
+    },
+    {
+      "agentName": null,
       "description": "Tool: run_ai_writeback
 
 Purpose:

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
@@ -48,6 +48,28 @@ type McpResourceWithBody = {
     body: string;
 };
 
+/** A built-in skill's supporting file, as returned by the skill read tools. */
+export type BuiltInSkillToolResource = {
+    path: string;
+    uri: string;
+    name: string;
+    title: string;
+    description: string;
+    mimeType: string;
+    size: number;
+};
+
+/** A built-in skill, as returned by the list/read skill tools. */
+export type BuiltInSkillToolReference = {
+    name: string;
+    uri: string;
+    title: string;
+    description: string;
+    mimeType: string;
+    size: number;
+    resources: BuiltInSkillToolResource[];
+};
+
 export class BuiltInSkills {
     private static readonly SKILLS_DIR = path.join(__dirname, 'builtInSkills');
 
@@ -326,5 +348,91 @@ export class BuiltInSkills {
         return (await this.loadMcpResources()).find(
             (item) => item.resource.uri === uri,
         )?.body;
+    }
+
+    static async listSkillToolReferences(): Promise<
+        BuiltInSkillToolReference[]
+    > {
+        return (await this.load()).map((skill) => {
+            const skillTitle = this.deriveTitleFromName(skill.name);
+            return {
+                name: skill.name,
+                uri: this.getSkillUri(skill.name),
+                title: skillTitle,
+                description: skill.skill.description,
+                mimeType: 'text/markdown',
+                size: Buffer.byteLength(skill.skill.raw, 'utf8'),
+                resources: skill.resources.map((file) => ({
+                    path: `resources/${file.fileName}`,
+                    uri: this.getSkillResourceUri(skill.name, file.fileName),
+                    name: `${skill.name}/resources/${path.basename(
+                        file.fileName,
+                        '.md',
+                    )}`,
+                    title: `${skillTitle} / ${this.deriveTitleFromName(
+                        file.name,
+                    )}`,
+                    description: file.description,
+                    mimeType: 'text/markdown',
+                    size: Buffer.byteLength(file.raw, 'utf8'),
+                })),
+            };
+        });
+    }
+
+    private static async getSkillToolReference(
+        name: string,
+    ): Promise<BuiltInSkillToolReference | undefined> {
+        return (await this.listSkillToolReferences()).find(
+            (skill) => skill.name.toLowerCase() === name.trim().toLowerCase(),
+        );
+    }
+
+    static async readSkillTool(
+        name: string,
+    ): Promise<{ skill: BuiltInSkillToolReference; body: string } | undefined> {
+        const skill = await this.getSkillToolReference(name);
+        if (!skill) {
+            return undefined;
+        }
+        const body = await this.getMcpResourceBody(skill.uri);
+        if (body === undefined) {
+            return undefined;
+        }
+        return { skill, body };
+    }
+
+    static async readSkillToolResource({
+        name,
+        resourcePath,
+    }: {
+        name: string;
+        resourcePath: string;
+    }): Promise<
+        | {
+              skillName: string;
+              resource: BuiltInSkillToolResource;
+              body: string;
+          }
+        | undefined
+    > {
+        const skill = await this.getSkillToolReference(name);
+        if (!skill) {
+            return undefined;
+        }
+        const normalizedPath = resourcePath.startsWith('resources/')
+            ? resourcePath
+            : `resources/${resourcePath}`;
+        const resource = skill.resources.find(
+            (item) => item.path === normalizedPath,
+        );
+        if (!resource) {
+            return undefined;
+        }
+        const body = await this.getMcpResourceBody(resource.uri);
+        if (body === undefined) {
+            return undefined;
+        }
+        return { skillName: skill.name, resource, body };
     }
 }


### PR DESCRIPTION
Relates: ZAP-421

Add list_skills, read_skill, and read_skill_resource tools so MCP clients that do not consume resources directly (e.g. Claude Code) can still discover and read built-in skills. The tools project from the same shared skill loader as the resource view.