### PR TITLE
chore(mcp): align with SEP-2640 conventions

### DIFF
--- a/packages/api-tests/tests/mcpServer.test.ts
+++ b/packages/api-tests/tests/mcpServer.test.ts
@@ -128,6 +128,9 @@ describe('MCP server', () => {
         expect(response.status).toBe(200);
         expect(response.body.result.capabilities).toMatchObject({
             resources: { subscribe: false, listChanged: false },
+            experimental: {
+                'io.modelcontextprotocol/skills': {},
+            },
             extensions: {
                 'io.modelcontextprotocol/skills': {},
             },
@@ -157,10 +160,13 @@ describe('MCP server', () => {
         expect(response.status).toBe(200);
         const uris = response.body.result.resources.map((r) => r.uri);
         expect(uris).toContain('skill://index.json');
-        expect(uris).toContain('skill://developing-in-lightdash/SKILL.md');
+        expect(uris).toContain(
+            'skill://lightdash/developing-in-lightdash/SKILL.md',
+        );
 
         const skillMd = response.body.result.resources.find(
-            (r) => r.uri === 'skill://developing-in-lightdash/SKILL.md',
+            (r) =>
+                r.uri === 'skill://lightdash/developing-in-lightdash/SKILL.md',
         );
         expect(skillMd?.name).toBe('developing-in-lightdash');
         expect(skillMd?.mimeType).toBe('text/markdown');
@@ -181,7 +187,9 @@ describe('MCP server', () => {
                 jsonrpc: '2.0',
                 id: 7,
                 method: 'resources/read',
-                params: { uri: 'skill://developing-in-lightdash/SKILL.md' },
+                params: {
+                    uri: 'skill://lightdash/developing-in-lightdash/SKILL.md',
+                },
             },
             { headers: mcpHeaders },
         );
@@ -189,7 +197,7 @@ describe('MCP server', () => {
         expect(response.status).toBe(200);
         expect(response.body.result.contents).toHaveLength(1);
         expect(response.body.result.contents[0].uri).toBe(
-            'skill://developing-in-lightdash/SKILL.md',
+            'skill://lightdash/developing-in-lightdash/SKILL.md',
         );
         expect(response.body.result.contents[0].text).toContain(
             '# Developing in Lightdash',
@@ -221,13 +229,19 @@ describe('MCP server', () => {
         expect(content.mimeType).toBe('application/json');
 
         const index = JSON.parse(content.text) as {
-            skills: Array<{ name: string; type: string; url: string }>;
+            skills: Array<{
+                name: string;
+                type: string;
+                url: string;
+                digest: string;
+            }>;
         };
         expect(index.skills).toContainEqual(
             expect.objectContaining({
                 name: 'developing-in-lightdash',
                 type: 'skill-md',
-                url: 'skill://developing-in-lightdash/SKILL.md',
+                url: 'skill://lightdash/developing-in-lightdash/SKILL.md',
+                digest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
             }),
         );
     });
@@ -282,7 +296,9 @@ describe('MCP server', () => {
         const skill = parsed.skills.find(
             (s) => s.name === 'developing-in-lightdash',
         );
-        expect(skill?.uri).toBe('skill://developing-in-lightdash/SKILL.md');
+        expect(skill?.uri).toBe(
+            'skill://lightdash/developing-in-lightdash/SKILL.md',
+        );
         expect(skill?.resources.length).toBeGreaterThan(0);
         expect(
             skill?.resources.every((r) => r.path.startsWith('resources/')),

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -2789,6 +2789,7 @@ export class McpService extends BaseService {
                             description: skill.description,
                             mimeType: skill.mimeType,
                             size: skill.size,
+                            digest: skill.digest,
                         },
                     },
                 };
@@ -2874,6 +2875,11 @@ export class McpService extends BaseService {
         // detect built-in skill support.
         mcpServer.server.registerCapabilities({
             resources: { subscribe: false, listChanged: false },
+            // Advertise under both: `extensions` per the final SEP, and
+            // `experimental` for draft-era clients (the de-facto wild form).
+            experimental: {
+                [MCP_SKILLS_EXTENSION_NAME]: {},
+            },
             extensions: {
                 [MCP_SKILLS_EXTENSION_NAME]: {},
             },

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
@@ -1,4 +1,5 @@
 import { ParameterError } from '@lightdash/common';
+import crypto from 'crypto';
 import * as fs from 'fs/promises';
 import matter from 'gray-matter';
 import * as path from 'path';
@@ -57,6 +58,7 @@ export type BuiltInSkillToolResource = {
     description: string;
     mimeType: string;
     size: number;
+    digest: string;
 };
 
 /** A built-in skill, as returned by the list/read skill tools. */
@@ -67,6 +69,7 @@ export type BuiltInSkillToolReference = {
     description: string;
     mimeType: string;
     size: number;
+    digest: string;
     resources: BuiltInSkillToolResource[];
 };
 
@@ -77,6 +80,17 @@ export class BuiltInSkills {
 
     private static readonly SKILLS_DISCOVERY_SCHEMA =
         'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
+
+    // Vendor prefix (authority segment) for skill:// URIs, so our skills never
+    // collide when a host mounts several servers' skills into one namespace.
+    private static readonly SKILL_NAMESPACE = 'lightdash';
+
+    private static getContentDigest(content: string): string {
+        return `sha256:${crypto
+            .createHash('sha256')
+            .update(content)
+            .digest('hex')}`;
+    }
 
     private static loaded: LoadedBuiltInSkill[] | undefined;
 
@@ -250,14 +264,14 @@ export class BuiltInSkills {
     }
 
     private static getSkillUri(skillName: string): string {
-        return `skill://${skillName}/SKILL.md`;
+        return `skill://${this.SKILL_NAMESPACE}/${skillName}/SKILL.md`;
     }
 
     private static getSkillResourceUri(
         skillName: string,
         fileName: string,
     ): string {
-        return `skill://${skillName}/resources/${fileName}`;
+        return `skill://${this.SKILL_NAMESPACE}/${skillName}/resources/${fileName}`;
     }
 
     private static buildSkillIndex(
@@ -270,6 +284,7 @@ export class BuiltInSkills {
                 type: 'skill-md',
                 description: item.resource.description,
                 url: item.resource.uri,
+                digest: this.getContentDigest(item.body),
             }));
         const body = JSON.stringify(
             { $schema: this.SKILLS_DISCOVERY_SCHEMA, skills },
@@ -362,6 +377,7 @@ export class BuiltInSkills {
                 description: skill.skill.description,
                 mimeType: 'text/markdown',
                 size: Buffer.byteLength(skill.skill.raw, 'utf8'),
+                digest: this.getContentDigest(skill.skill.raw),
                 resources: skill.resources.map((file) => ({
                     path: `resources/${file.fileName}`,
                     uri: this.getSkillResourceUri(skill.name, file.fileName),
@@ -375,6 +391,7 @@ export class BuiltInSkills {
                     description: file.description,
                     mimeType: 'text/markdown',
                     size: Buffer.byteLength(file.raw, 'utf8'),
+                    digest: this.getContentDigest(file.raw),
                 })),
             };
         });


### PR DESCRIPTION
Closes: ZAP-421

Namespace skill:// URIs under a lightdash authority segment (skill://lightdash/<name>/...), advertise the skills extension under both experimental and extensions, and include a sha256 digest on index entries and skill tool references.