### PR TITLE
feat(ai-agents): model review remediations

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -378,6 +378,8 @@ import {
     AiAgentReviewClassifierRunTableName,
     AiAgentReviewItemTable,
     AiAgentReviewItemTableName,
+    AiAgentReviewRemediationTable,
+    AiAgentReviewRemediationTableName,
     AiAgentTurnSignalTable,
     AiAgentTurnSignalTableName,
 } from '../ee/database/entities/aiAgentReviewClassifier';
@@ -548,6 +550,7 @@ declare module 'knex/types/tables' {
         [AiAgentReviewClassifierRunTableName]: AiAgentReviewClassifierRunTable;
         [AiAgentTurnSignalTableName]: AiAgentTurnSignalTable;
         [AiAgentReviewItemTableName]: AiAgentReviewItemTable;
+        [AiAgentReviewRemediationTableName]: AiAgentReviewRemediationTable;
         [AiAgentGroupAccessTableName]: AiAgentGroupAccessTable;
         [AiAgentIntegrationTableName]: AiAgentIntegrationTable;
         [AiAgentSlackIntegrationTableName]: AiAgentSlackIntegrationTable;

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -15,6 +15,7 @@ import type {
     AiAgentReviewItemPrState,
     AiAgentReviewItemStatus,
     AiAgentReviewItemWritebackStatus,
+    AiAgentReviewRemediationStatus,
     AiAgentRootCause,
     AiAgentRuntimeContextSnapshot,
     AiAgentTargetRef,
@@ -169,6 +170,7 @@ export type AiAgentTurnSignalTable = Knex.CompositeTableType<
 >;
 
 export const AiAgentReviewItemTableName = 'ai_agent_review_item';
+export const AiAgentReviewRemediationTableName = 'ai_agent_review_remediation';
 
 export type DbAiAgentReviewItem = {
     ai_agent_review_item_uuid: string;
@@ -213,6 +215,64 @@ export type AiAgentReviewItemTable = Knex.CompositeTableType<
         Omit<
             DbAiAgentReviewItem,
             'ai_agent_review_item_uuid' | 'fingerprint' | 'created_at'
+        >
+    >
+>;
+
+export type DbAiAgentReviewRemediation = {
+    ai_agent_review_remediation_uuid: string;
+    fingerprint: string;
+    organization_uuid: string;
+    source_ai_agent_review_turn_signal_uuid: string;
+    source_prompt_uuid: string;
+    source_thread_uuid: string;
+    source_project_uuid: string;
+    source_agent_uuid: string;
+    pull_request_uuid: string | null;
+    preview_project_uuid: string | null;
+    preview_agent_uuid: string | null;
+    preview_thread_uuid: string | null;
+    status: AiAgentReviewRemediationStatus;
+    error_message: string | null;
+    retry_prompt: string | null;
+    created_by_user_uuid: string | null;
+    resolved_by_user_uuid: string | null;
+    resolved_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiAgentReviewRemediationTable = Knex.CompositeTableType<
+    DbAiAgentReviewRemediation,
+    Pick<
+        DbAiAgentReviewRemediation,
+        | 'fingerprint'
+        | 'organization_uuid'
+        | 'source_ai_agent_review_turn_signal_uuid'
+        | 'source_prompt_uuid'
+        | 'source_thread_uuid'
+        | 'source_project_uuid'
+        | 'source_agent_uuid'
+    > &
+        Partial<
+            Omit<
+                DbAiAgentReviewRemediation,
+                | 'ai_agent_review_remediation_uuid'
+                | 'created_at'
+                | 'updated_at'
+                | 'fingerprint'
+                | 'organization_uuid'
+                | 'source_ai_agent_review_turn_signal_uuid'
+                | 'source_prompt_uuid'
+                | 'source_thread_uuid'
+                | 'source_project_uuid'
+                | 'source_agent_uuid'
+            >
+        >,
+    Partial<
+        Omit<
+            DbAiAgentReviewRemediation,
+            'ai_agent_review_remediation_uuid' | 'fingerprint' | 'created_at'
         >
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260608140000_add_ai_agent_review_remediation.ts
+++ b/packages/backend/src/ee/database/migrations/20260608140000_add_ai_agent_review_remediation.ts
@@ -1,0 +1,141 @@
+import { Knex } from 'knex';
+
+const remediationTable = 'ai_agent_review_remediation';
+const reviewItemTable = 'ai_agent_review_item';
+const turnSignalTable = 'ai_agent_review_turn_signal';
+const organizationsTable = 'organizations';
+const projectsTable = 'projects';
+const aiAgentTable = 'ai_agent';
+const aiThreadTable = 'ai_thread';
+const aiPromptTable = 'ai_prompt';
+const pullRequestsTable = 'pull_requests';
+const usersTable = 'users';
+const activeRemediationIndex =
+    'ai_agent_review_remediation_active_fingerprint_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(remediationTable, (table) => {
+        table
+            .uuid('ai_agent_review_remediation_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .text('fingerprint')
+            .notNullable()
+            .references('fingerprint')
+            .inTable(reviewItemTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable(organizationsTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('source_ai_agent_review_turn_signal_uuid')
+            .notNullable()
+            .references('ai_agent_review_turn_signal_uuid')
+            .inTable(turnSignalTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('source_prompt_uuid')
+            .notNullable()
+            .references('ai_prompt_uuid')
+            .inTable(aiPromptTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('source_thread_uuid')
+            .notNullable()
+            .references('ai_thread_uuid')
+            .inTable(aiThreadTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('source_project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable(projectsTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('source_agent_uuid')
+            .notNullable()
+            .references('ai_agent_uuid')
+            .inTable(aiAgentTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('pull_request_uuid')
+            .nullable()
+            .references('pull_request_uuid')
+            .inTable(pullRequestsTable)
+            .onDelete('SET NULL');
+        table
+            .uuid('preview_project_uuid')
+            .nullable()
+            .references('project_uuid')
+            .inTable(projectsTable)
+            .onDelete('SET NULL');
+        table
+            .uuid('preview_agent_uuid')
+            .nullable()
+            .references('ai_agent_uuid')
+            .inTable(aiAgentTable)
+            .onDelete('SET NULL');
+        table
+            .uuid('preview_thread_uuid')
+            .nullable()
+            .references('ai_thread_uuid')
+            .inTable(aiThreadTable)
+            .onDelete('SET NULL');
+        table
+            .text('status')
+            .notNullable()
+            .defaultTo('queued')
+            .checkIn([
+                'queued',
+                'running',
+                'pr_open',
+                'preview_ready',
+                'resolved',
+                'failed',
+            ]);
+        table.text('error_message').nullable();
+        table.text('retry_prompt').nullable();
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(usersTable)
+            .onDelete('SET NULL');
+        table
+            .uuid('resolved_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(usersTable)
+            .onDelete('SET NULL');
+        table.timestamp('resolved_at', { useTz: false }).nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['organization_uuid', 'status']);
+        table.index(['fingerprint']);
+        table.index(['pull_request_uuid']);
+        table.index(['preview_project_uuid']);
+        table.index(['preview_thread_uuid']);
+    });
+
+    await knex.raw(
+        `CREATE UNIQUE INDEX ${activeRemediationIndex}
+            ON ${remediationTable} (fingerprint)
+            WHERE status IN ('queued', 'running', 'pr_open', 'preview_ready')`,
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP INDEX IF EXISTS ${activeRemediationIndex}`);
+    await knex.schema.dropTableIfExists(remediationTable);
+}

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -3,6 +3,7 @@ import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import {
     AiAgentReviewClassifierRunTableName,
     AiAgentReviewItemTableName,
+    AiAgentReviewRemediationTableName,
     AiAgentTurnSignalTableName,
 } from '../database/entities/aiAgentReviewClassifier';
 import { AiAgentReviewClassifierModel } from './AiAgentReviewClassifierModel';
@@ -14,6 +15,11 @@ const RUN_UUID = '00000000-0000-0000-0000-000000000006';
 const THREAD_UUID = '00000000-0000-0000-0000-000000000007';
 const PROMPT_UUID = '00000000-0000-0000-0000-000000000008';
 const TURN_SIGNAL_UUID = '00000000-0000-0000-0000-000000000009';
+const REMEDIATION_UUID = '00000000-0000-0000-0000-000000000010';
+const PULL_REQUEST_UUID = '00000000-0000-0000-0000-000000000011';
+const PREVIEW_PROJECT_UUID = '00000000-0000-0000-0000-000000000012';
+const PREVIEW_AGENT_UUID = '00000000-0000-0000-0000-000000000013';
+const PREVIEW_THREAD_UUID = '00000000-0000-0000-0000-000000000014';
 const SEEN_AT = new Date('2026-05-26T10:00:00.000Z');
 const FINGERPRINT = 'ai_agent_review_item:fingerprint';
 
@@ -114,6 +120,33 @@ const makeTurnSignalRow = (
         model: 'gpt-5',
     },
     created_at: SEEN_AT,
+    ...overrides,
+});
+
+const makeRemediationRow = (
+    overrides: Partial<Record<string, unknown>> = {},
+) => ({
+    ai_agent_review_remediation_uuid: REMEDIATION_UUID,
+    fingerprint: FINGERPRINT,
+    organization_uuid: ORGANIZATION_UUID,
+    source_ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID,
+    source_prompt_uuid: PROMPT_UUID,
+    source_thread_uuid: THREAD_UUID,
+    source_project_uuid: PROJECT_UUID,
+    source_agent_uuid: AGENT_UUID,
+    pull_request_uuid: PULL_REQUEST_UUID,
+    linked_pr_url: 'https://github.com/acme/dbt/pull/42',
+    preview_project_uuid: PREVIEW_PROJECT_UUID,
+    preview_agent_uuid: PREVIEW_AGENT_UUID,
+    preview_thread_uuid: PREVIEW_THREAD_UUID,
+    status: 'preview_ready',
+    error_message: null,
+    retry_prompt: 'Show revenue',
+    created_by_user_uuid: null,
+    resolved_by_user_uuid: null,
+    resolved_at: null,
+    created_at: SEEN_AT,
+    updated_at: SEEN_AT,
     ...overrides,
 });
 
@@ -292,6 +325,9 @@ describe('AiAgentReviewClassifierModel', () => {
                 .select(AiAgentTurnSignalTableName)
                 .responseOnce([makeTurnSignalRow()]);
             tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on
+                .select(AiAgentReviewRemediationTableName)
+                .responseOnce([]);
 
             const result = await model.listReviewItems({
                 organizationUuid: ORGANIZATION_UUID,
@@ -306,6 +342,7 @@ describe('AiAgentReviewClassifierModel', () => {
                     status: 'open',
                     linkedPrUrl: null,
                     prState: null,
+                    remediation: null,
                     findingCount: 2,
                 }),
             );
@@ -357,6 +394,9 @@ describe('AiAgentReviewClassifierModel', () => {
                     updated_at: SEEN_AT,
                 },
             ]);
+            tracker.on
+                .select(AiAgentReviewRemediationTableName)
+                .responseOnce([]);
 
             const result = await model.listReviewItems({
                 organizationUuid: ORGANIZATION_UUID,
@@ -367,6 +407,43 @@ describe('AiAgentReviewClassifierModel', () => {
                     status: 'resolved',
                     linkedPrUrl: 'https://github.com/acme/dbt/pull/42',
                     prState: 'merged',
+                    remediation: null,
+                }),
+            );
+        });
+
+        it('overlays the latest remediation onto the projection', async () => {
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
+                {
+                    fingerprint: FINGERPRINT,
+                    first_seen_at: SEEN_AT,
+                    last_seen_at: SEEN_AT,
+                    finding_count: '1',
+                },
+            ]);
+            tracker.on
+                .select(AiAgentTurnSignalTableName)
+                .responseOnce([makeTurnSignalRow()]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on
+                .select(AiAgentReviewRemediationTableName)
+                .responseOnce([makeRemediationRow()]);
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result[0].remediation).toEqual(
+                expect.objectContaining({
+                    uuid: REMEDIATION_UUID,
+                    fingerprint: FINGERPRINT,
+                    status: 'preview_ready',
+                    pullRequestUuid: PULL_REQUEST_UUID,
+                    linkedPrUrl: 'https://github.com/acme/dbt/pull/42',
+                    previewProjectUuid: PREVIEW_PROJECT_UUID,
+                    previewAgentUuid: PREVIEW_AGENT_UUID,
+                    previewThreadUuid: PREVIEW_THREAD_UUID,
+                    retryPrompt: 'Show revenue',
                 }),
             );
         });
@@ -380,6 +457,77 @@ describe('AiAgentReviewClassifierModel', () => {
             });
 
             expect(result).toHaveLength(0);
+        });
+    });
+
+    describe('review remediations', () => {
+        it('creates a remediation for a review item finding', async () => {
+            tracker.on.insert(AiAgentReviewRemediationTableName).responseOnce([
+                makeRemediationRow({
+                    pull_request_uuid: null,
+                    linked_pr_url: undefined,
+                }),
+            ]);
+
+            const result = await model.createReviewRemediation({
+                fingerprint: FINGERPRINT,
+                organizationUuid: ORGANIZATION_UUID,
+                sourceFindingUuid: TURN_SIGNAL_UUID,
+                sourcePromptUuid: PROMPT_UUID,
+                sourceThreadUuid: THREAD_UUID,
+                sourceProjectUuid: PROJECT_UUID,
+                sourceAgentUuid: AGENT_UUID,
+                retryPrompt: 'Show revenue',
+                createdByUserUuid: null,
+            });
+
+            expect(result).toEqual(
+                expect.objectContaining({
+                    uuid: REMEDIATION_UUID,
+                    fingerprint: FINGERPRINT,
+                    sourceFindingUuid: TURN_SIGNAL_UUID,
+                    sourcePromptUuid: PROMPT_UUID,
+                    sourceThreadUuid: THREAD_UUID,
+                    sourceProjectUuid: PROJECT_UUID,
+                    sourceAgentUuid: AGENT_UUID,
+                    linkedPrUrl: null,
+                    retryPrompt: 'Show revenue',
+                }),
+            );
+        });
+
+        it('links PR and preview thread state onto a remediation', async () => {
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce([]);
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce([]);
+
+            await model.setReviewRemediationPullRequest({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+                pullRequestUuid: PULL_REQUEST_UUID,
+            });
+            await model.setReviewRemediationPreviewThread({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+                previewProjectUuid: PREVIEW_PROJECT_UUID,
+                previewAgentUuid: PREVIEW_AGENT_UUID,
+                previewThreadUuid: PREVIEW_THREAD_UUID,
+            });
+
+            expect(tracker.history.update).toHaveLength(2);
+            expect(tracker.history.update[0].bindings).toContain(
+                PULL_REQUEST_UUID,
+            );
+            expect(tracker.history.update[1].bindings).toEqual(
+                expect.arrayContaining([
+                    PREVIEW_PROJECT_UUID,
+                    PREVIEW_AGENT_UUID,
+                    PREVIEW_THREAD_UUID,
+                ]),
+            );
         });
     });
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -21,12 +21,15 @@ import type {
     AiAgentReviewItemSummary,
     AiAgentReviewItemWritebackEligibility,
     AiAgentReviewItemWritebackStatus,
+    AiAgentReviewRemediation,
+    AiAgentReviewRemediationStatus,
     AiAgentReviewSignalSummary,
     AiAgentRootCause,
     AiAgentTargetRef,
     AiAgentTurnSignal,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
+import { PullRequestsTableName } from '../../database/entities/pullRequests';
 import { QueryHistoryTableName } from '../../database/entities/queryHistory';
 import {
     AiAgentToolCallTableName,
@@ -39,12 +42,15 @@ import {
 import {
     AiAgentReviewClassifierRunTableName,
     AiAgentReviewItemTableName,
+    AiAgentReviewRemediationTableName,
     AiAgentTurnSignalTableName,
     type AiAgentReviewClassifierRunTable,
     type AiAgentReviewItemTable,
+    type AiAgentReviewRemediationTable,
     type AiAgentTurnSignalTable,
     type DbAiAgentReviewClassifierRun,
     type DbAiAgentReviewItem,
+    type DbAiAgentReviewRemediation,
     type DbAiAgentTurnSignal,
 } from '../database/entities/aiAgentReviewClassifier';
 
@@ -59,12 +65,49 @@ type ReviewItemAggregateRow = {
     finding_count: string | number;
 };
 
+type ReviewRemediationRow = DbAiAgentReviewRemediation & {
+    linked_pr_url: string | null;
+};
+
 const defaultWritebackEligibility: AiAgentReviewItemWritebackEligibility = {
     eligible: false,
     reason: 'reviews_disabled',
     provider: null,
     strategy: null,
 };
+
+const ACTIVE_REMEDIATION_STATUSES: AiAgentReviewRemediationStatus[] = [
+    'queued',
+    'running',
+    'pr_open',
+    'preview_ready',
+];
+
+const mapReviewRemediation = (
+    row: ReviewRemediationRow,
+): AiAgentReviewRemediation => ({
+    uuid: row.ai_agent_review_remediation_uuid,
+    fingerprint: row.fingerprint,
+    organizationUuid: row.organization_uuid,
+    sourceFindingUuid: row.source_ai_agent_review_turn_signal_uuid,
+    sourcePromptUuid: row.source_prompt_uuid,
+    sourceThreadUuid: row.source_thread_uuid,
+    sourceProjectUuid: row.source_project_uuid,
+    sourceAgentUuid: row.source_agent_uuid,
+    pullRequestUuid: row.pull_request_uuid,
+    linkedPrUrl: row.linked_pr_url,
+    previewProjectUuid: row.preview_project_uuid,
+    previewAgentUuid: row.preview_agent_uuid,
+    previewThreadUuid: row.preview_thread_uuid,
+    status: row.status,
+    errorMessage: row.error_message,
+    retryPrompt: row.retry_prompt,
+    createdByUserUuid: row.created_by_user_uuid,
+    resolvedByUserUuid: row.resolved_by_user_uuid,
+    resolvedAt: row.resolved_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+});
 
 type CreateRunArgs = {
     organizationUuid: string;
@@ -118,6 +161,40 @@ type UpsertReviewItemStateArgs = {
     status: AiAgentReviewItemStatus;
     dismissedReason: AiAgentReviewItemDismissedReason | null;
     statusUpdatedByUserUuid: string | null;
+};
+
+type CreateReviewRemediationArgs = {
+    fingerprint: string;
+    organizationUuid: string;
+    sourceFindingUuid: string;
+    sourcePromptUuid: string;
+    sourceThreadUuid: string;
+    sourceProjectUuid: string;
+    sourceAgentUuid: string;
+    retryPrompt: string | null;
+    createdByUserUuid: string | null;
+};
+
+type UpdateReviewRemediationStatusArgs = {
+    remediationUuid: string;
+    organizationUuid: string;
+    status: AiAgentReviewRemediationStatus;
+    errorMessage?: string | null;
+    resolvedByUserUuid?: string | null;
+};
+
+type SetReviewRemediationPullRequestArgs = {
+    remediationUuid: string;
+    organizationUuid: string;
+    pullRequestUuid: string;
+};
+
+type SetReviewRemediationPreviewThreadArgs = {
+    remediationUuid: string;
+    organizationUuid: string;
+    previewProjectUuid: string;
+    previewAgentUuid: string;
+    previewThreadUuid: string;
 };
 
 type ListReviewSignalsArgs = {
@@ -920,7 +997,13 @@ export class AiAgentReviewClassifierModel {
         const aggregateByFingerprint = new Map(
             aggregateRows.map((row) => [row.fingerprint, row]),
         );
-        const persisted = await this.getReviewItemsByFingerprint(fingerprints);
+        const [persisted, remediationByFingerprint] = await Promise.all([
+            this.getReviewItemsByFingerprint(fingerprints),
+            this.getLatestReviewRemediationsByFingerprint({
+                organizationUuid: args.organizationUuid,
+                fingerprints,
+            }),
+        ]);
 
         const reviewItems = fingerprints
             .map((fingerprint): AiAgentReviewItemSummary | null => {
@@ -932,6 +1015,8 @@ export class AiAgentReviewClassifierModel {
                 const firstSeenAt = new Date(aggregate.first_seen_at);
                 const lastSeenAt = new Date(aggregate.last_seen_at);
                 const item = persisted.get(fingerprint) ?? null;
+                const remediation =
+                    remediationByFingerprint.get(fingerprint) ?? null;
                 return {
                     uuid: fingerprint,
                     fingerprint,
@@ -958,6 +1043,7 @@ export class AiAgentReviewClassifierModel {
                     prWritebackMessage: item?.pr_writeback_message ?? null,
                     writebackEligible: false,
                     writebackEligibility: defaultWritebackEligibility,
+                    remediation,
                     createdAt: item?.created_at ?? firstSeenAt,
                     updatedAt: item?.updated_at ?? lastSeenAt,
                     latestFinding: {
@@ -995,6 +1081,127 @@ export class AiAgentReviewClassifierModel {
             AiAgentReviewItemTableName,
         ).whereIn('fingerprint', fingerprints);
         return new Map(items.map((item) => [item.fingerprint, item]));
+    }
+
+    async getLatestReviewRemediationsByFingerprint(args: {
+        organizationUuid: string;
+        fingerprints: string[];
+    }): Promise<Map<string, AiAgentReviewRemediation>> {
+        if (args.fingerprints.length === 0) {
+            return new Map();
+        }
+
+        const rows = (await this.database<AiAgentReviewRemediationTable>(
+            `${AiAgentReviewRemediationTableName} as remediation`,
+        )
+            .leftJoin(
+                `${PullRequestsTableName} as pull_request`,
+                'pull_request.pull_request_uuid',
+                'remediation.pull_request_uuid',
+            )
+            .where('remediation.organization_uuid', args.organizationUuid)
+            .whereIn('remediation.fingerprint', args.fingerprints)
+            .select<ReviewRemediationRow[]>('remediation.*', {
+                linked_pr_url: 'pull_request.pr_url',
+            })
+            .orderBy('remediation.fingerprint')
+            .orderByRaw(
+                `CASE WHEN remediation.status IN (${ACTIVE_REMEDIATION_STATUSES.map(
+                    () => '?',
+                ).join(', ')}) THEN 0 ELSE 1 END`,
+                ACTIVE_REMEDIATION_STATUSES,
+            )
+            .orderBy(
+                'remediation.updated_at',
+                'desc',
+            )) as ReviewRemediationRow[];
+
+        const remediations = new Map<string, AiAgentReviewRemediation>();
+        rows.forEach((row) => {
+            if (!remediations.has(row.fingerprint)) {
+                remediations.set(row.fingerprint, mapReviewRemediation(row));
+            }
+        });
+        return remediations;
+    }
+
+    async createReviewRemediation(
+        args: CreateReviewRemediationArgs,
+    ): Promise<AiAgentReviewRemediation> {
+        const [row] = await this.database<AiAgentReviewRemediationTable>(
+            AiAgentReviewRemediationTableName,
+        )
+            .insert({
+                fingerprint: args.fingerprint,
+                organization_uuid: args.organizationUuid,
+                source_ai_agent_review_turn_signal_uuid: args.sourceFindingUuid,
+                source_prompt_uuid: args.sourcePromptUuid,
+                source_thread_uuid: args.sourceThreadUuid,
+                source_project_uuid: args.sourceProjectUuid,
+                source_agent_uuid: args.sourceAgentUuid,
+                retry_prompt: args.retryPrompt,
+                created_by_user_uuid: args.createdByUserUuid,
+            })
+            .returning('*');
+
+        return mapReviewRemediation({ ...row, linked_pr_url: null });
+    }
+
+    async updateReviewRemediationStatus(
+        args: UpdateReviewRemediationStatusArgs,
+    ): Promise<void> {
+        await this.database<AiAgentReviewRemediationTable>(
+            AiAgentReviewRemediationTableName,
+        )
+            .where('ai_agent_review_remediation_uuid', args.remediationUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .update({
+                status: args.status,
+                error_message: args.errorMessage ?? null,
+                resolved_by_user_uuid:
+                    args.status === 'resolved'
+                        ? (args.resolvedByUserUuid ?? null)
+                        : null,
+                resolved_at:
+                    args.status === 'resolved'
+                        ? (this.database.fn.now() as never)
+                        : null,
+                updated_at: this.database.fn.now() as never,
+            });
+    }
+
+    async setReviewRemediationPullRequest(
+        args: SetReviewRemediationPullRequestArgs,
+    ): Promise<void> {
+        await this.database<AiAgentReviewRemediationTable>(
+            AiAgentReviewRemediationTableName,
+        )
+            .where('ai_agent_review_remediation_uuid', args.remediationUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .update({
+                pull_request_uuid: args.pullRequestUuid,
+                status: 'pr_open',
+                error_message: null,
+                updated_at: this.database.fn.now() as never,
+            });
+    }
+
+    async setReviewRemediationPreviewThread(
+        args: SetReviewRemediationPreviewThreadArgs,
+    ): Promise<void> {
+        await this.database<AiAgentReviewRemediationTable>(
+            AiAgentReviewRemediationTableName,
+        )
+            .where('ai_agent_review_remediation_uuid', args.remediationUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .update({
+                preview_project_uuid: args.previewProjectUuid,
+                preview_agent_uuid: args.previewAgentUuid,
+                preview_thread_uuid: args.previewThreadUuid,
+                status: 'preview_ready',
+                error_message: null,
+                updated_at: this.database.fn.now() as never,
+            });
     }
 
     async getReviewItem(

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -40,6 +40,7 @@ const makeReviewItem = (
         provider: null,
         strategy: null,
     },
+    remediation: null,
     latestFinding: null,
     ...overrides,
 });

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -36,6 +36,7 @@ const baseItem = (
         strategy: 'semantic_layer',
         reason: null,
     },
+    remediation: null,
     createdAt: new Date('2026-05-26T00:00:00.000Z'),
     updatedAt: new Date('2026-05-26T00:00:00.000Z'),
     latestFinding: {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12688,17 +12688,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -12727,7 +12727,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12735,7 +12735,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12750,7 +12754,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12758,11 +12762,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12969,17 +12969,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -13158,40 +13158,6 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
-                                                                explore: {
-                                                                    dataType:
-                                                                        'nestedObjectLiteral',
-                                                                    nestedProperties:
-                                                                        {
-                                                                            joinedTables:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                    },
-                                                                                    required: true,
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                        },
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13248,6 +13214,29 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -13268,30 +13257,7 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -13302,18 +13268,52 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                name: {
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                explore: {
+                                                                    dataType:
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                        },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -13344,17 +13344,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -13468,6 +13468,10 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
+                                                href: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 warnings: {
                                                     dataType: 'array',
                                                     array: {
@@ -13475,17 +13479,13 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                href: {
-                                                    dataType: 'string',
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                                 slug: {
                                                     dataType: 'string',
-                                                    required: true,
-                                                },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                                 uuid: {
@@ -13587,16 +13587,18 @@ const models: TsoaRoute.Models = {
                                                                     'nestedObjectLiteral',
                                                                 nestedProperties:
                                                                     {
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
                                                                         kind: {
                                                                             dataType:
                                                                                 'union',
                                                                             subSchemas:
                                                                                 [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
                                                                                     {
                                                                                         dataType:
                                                                                             'enum',
@@ -13615,13 +13617,6 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
                                                                                             'compile',
                                                                                         ],
                                                                                     },
@@ -13633,6 +13628,11 @@ const models: TsoaRoute.Models = {
                                                                                         ],
                                                                                     },
                                                                                 ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
                                                                             required: true,
                                                                         },
                                                                     },
@@ -13749,13 +13749,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                slug: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -13837,11 +13837,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13912,6 +13912,12 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
+                                                                                tableName:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -13923,12 +13929,6 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                tableName:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -14018,11 +14018,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -19874,6 +19874,126 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewRemediationStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['queued'] },
+                { dataType: 'enum', enums: ['running'] },
+                { dataType: 'enum', enums: ['pr_open'] },
+                { dataType: 'enum', enums: ['preview_ready'] },
+                { dataType: 'enum', enums: ['resolved'] },
+                { dataType: 'enum', enums: ['failed'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewRemediation: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                resolvedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                resolvedByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                retryPrompt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                errorMessage: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: {
+                    ref: 'AiAgentReviewRemediationStatus',
+                    required: true,
+                },
+                previewThreadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                previewAgentUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                previewProjectUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                linkedPrUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                pullRequestUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                sourceAgentUuid: { dataType: 'string', required: true },
+                sourceProjectUuid: { dataType: 'string', required: true },
+                sourceThreadUuid: { dataType: 'string', required: true },
+                sourcePromptUuid: { dataType: 'string', required: true },
+                sourceFindingUuid: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+                fingerprint: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentFixTarget: {
         dataType: 'refAlias',
         type: {
@@ -20301,6 +20421,14 @@ const models: TsoaRoute.Models = {
                                         },
                                     },
                                 },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        remediation: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'AiAgentReviewRemediation' },
                                 { dataType: 'enum', enums: [null] },
                             ],
                             required: true,
@@ -28662,7 +28790,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28672,7 +28800,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28682,7 +28810,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28695,7 +28823,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14126,10 +14126,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -14138,8 +14138,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -14149,16 +14149,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -14251,10 +14251,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -14263,8 +14263,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -14359,32 +14359,6 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
-                                                                    "explore": {
-                                                                        "properties": {
-                                                                            "joinedTables": {
-                                                                                "items": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "type": "array"
-                                                                            },
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "label": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "name": {
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "joinedTables",
-                                                                            "baseTable",
-                                                                            "label",
-                                                                            "name"
-                                                                        ],
-                                                                        "type": "object"
-                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -14405,27 +14379,27 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "label": {
+                                                                                "name": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "name": {
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
@@ -14434,16 +14408,42 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "description",
                                                                                 "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
+                                                                                "description",
                                                                                 "label",
-                                                                                "name"
+                                                                                "fieldId",
+                                                                                "name",
+                                                                                "table"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
+                                                                    },
+                                                                    "explore": {
+                                                                        "properties": {
+                                                                            "baseTable": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "joinedTables": {
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "label": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "baseTable",
+                                                                            "joinedTables",
+                                                                            "label",
+                                                                            "name"
+                                                                        ],
+                                                                        "type": "object"
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -14455,8 +14455,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "explore",
                                                                     "fields",
+                                                                    "explore",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14469,10 +14469,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -14480,8 +14480,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "exploreLabel",
                                                                                 "reason",
+                                                                                "exploreLabel",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -14555,22 +14555,22 @@
                                                         ],
                                                         "type": "object"
                                                     },
+                                                    "href": {
+                                                        "type": "string"
+                                                    },
                                                     "warnings": {
                                                         "items": {
                                                             "type": "string"
                                                         },
                                                         "type": "array"
                                                     },
-                                                    "href": {
-                                                        "type": "string"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
                                                     },
                                                     "uuid": {
                                                         "type": "string"
@@ -14581,10 +14581,10 @@
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "warnings",
                                                     "href",
-                                                    "slug",
+                                                    "warnings",
                                                     "status",
+                                                    "slug",
                                                     "uuid",
                                                     "name"
                                                 ],
@@ -14595,23 +14595,23 @@
                                                     "steps": {
                                                         "items": {
                                                             "properties": {
-                                                                "label": {
-                                                                    "type": "string"
-                                                                },
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
+                                                                        "search",
                                                                         "read",
                                                                         "edit",
-                                                                        "search",
                                                                         "compile",
                                                                         "stage"
                                                                     ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
                                                                 }
                                                             },
                                                             "required": [
-                                                                "label",
-                                                                "kind"
+                                                                "kind",
+                                                                "label"
                                                             ],
                                                             "type": "object"
                                                         },
@@ -14667,13 +14667,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -14681,8 +14681,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "slug",
                                                     "status",
+                                                    "slug",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -14719,13 +14719,13 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
+                                                                        "tableName": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -14733,9 +14733,9 @@
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "tableName",
                                                                         "fieldType",
                                                                         "label",
-                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -20376,6 +20376,121 @@
                     }
                 ]
             },
+            "AiAgentReviewRemediationStatus": {
+                "type": "string",
+                "enum": [
+                    "queued",
+                    "running",
+                    "pr_open",
+                    "preview_ready",
+                    "resolved",
+                    "failed"
+                ]
+            },
+            "AiAgentReviewRemediation": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "resolvedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "resolvedByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "retryPrompt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "errorMessage": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/AiAgentReviewRemediationStatus"
+                    },
+                    "previewThreadUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "previewAgentUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "previewProjectUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "linkedPrUrl": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pullRequestUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "sourceAgentUuid": {
+                        "type": "string"
+                    },
+                    "sourceProjectUuid": {
+                        "type": "string"
+                    },
+                    "sourceThreadUuid": {
+                        "type": "string"
+                    },
+                    "sourcePromptUuid": {
+                        "type": "string"
+                    },
+                    "sourceFindingUuid": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "fingerprint": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "createdAt",
+                    "resolvedAt",
+                    "resolvedByUserUuid",
+                    "createdByUserUuid",
+                    "retryPrompt",
+                    "errorMessage",
+                    "status",
+                    "previewThreadUuid",
+                    "previewAgentUuid",
+                    "previewProjectUuid",
+                    "linkedPrUrl",
+                    "pullRequestUuid",
+                    "sourceAgentUuid",
+                    "sourceProjectUuid",
+                    "sourceThreadUuid",
+                    "sourcePromptUuid",
+                    "sourceFindingUuid",
+                    "organizationUuid",
+                    "fingerprint",
+                    "uuid"
+                ],
+                "type": "object"
+            },
             "AiAgentFixTarget": {
                 "type": "string",
                 "enum": [
@@ -20817,6 +20932,14 @@
                                 "type": "object",
                                 "nullable": true
                             },
+                            "remediation": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/AiAgentReviewRemediation"
+                                    }
+                                ],
+                                "nullable": true
+                            },
                             "writebackEligibility": {
                                 "$ref": "#/components/schemas/AiAgentReviewItemWritebackEligibility"
                             },
@@ -20827,6 +20950,7 @@
                         },
                         "required": [
                             "latestFinding",
+                            "remediation",
                             "writebackEligibility",
                             "writebackEligible"
                         ],
@@ -29359,22 +29483,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -38272,7 +38396,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3124.2",
+        "version": "0.3125.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -352,6 +352,38 @@ export type AiAgentReviewItemWritebackEligibility =
           reason: AiAgentReviewItemWritebackBlockedReason;
       };
 
+export type AiAgentReviewRemediationStatus =
+    | 'queued'
+    | 'running'
+    | 'pr_open'
+    | 'preview_ready'
+    | 'resolved'
+    | 'failed';
+
+export type AiAgentReviewRemediation = {
+    uuid: string;
+    fingerprint: string;
+    organizationUuid: string;
+    sourceFindingUuid: string;
+    sourcePromptUuid: string;
+    sourceThreadUuid: string;
+    sourceProjectUuid: string;
+    sourceAgentUuid: string;
+    pullRequestUuid: string | null;
+    linkedPrUrl: string | null;
+    previewProjectUuid: string | null;
+    previewAgentUuid: string | null;
+    previewThreadUuid: string | null;
+    status: AiAgentReviewRemediationStatus;
+    errorMessage: string | null;
+    retryPrompt: string | null;
+    createdByUserUuid: string | null;
+    resolvedByUserUuid: string | null;
+    resolvedAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
 const aiAgentConfigurationSettingSchema = z.enum([
     'instructions',
     'knowledge_documents',
@@ -577,6 +609,7 @@ export type AiAgentReviewItemSummary = AiAgentReviewItem & {
      */
     writebackEligible: boolean;
     writebackEligibility: AiAgentReviewItemWritebackEligibility;
+    remediation: AiAgentReviewRemediation | null;
     latestFinding: {
         uuid: string;
         promptUuid: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
@@ -40,6 +40,7 @@ const makeExampleReviewItem = (
         provider: null,
         strategy: null,
     },
+    remediation: null,
     createdAt: EXAMPLE_SEEN_AT,
     updatedAt: EXAMPLE_SEEN_AT,
     latestFinding: null,


### PR DESCRIPTION
## Summary
- add `ai_agent_review_remediation` to track review item remediation lifecycle
- expose latest remediation metadata on review item summaries
- add model helpers for create/link/update flows across PRs, previews, and work threads
- cover remediation projection and lifecycle helpers in model tests

## Validation
- `git diff --check`
- `pnpm -F backend test -- AiAgentReviewClassifierModel.test.ts AiAgentAdminService.test.ts buildReviewWritebackPrompt.test.ts --runInBand`
- `pnpm -F @lightdash/common build`
- `pnpm -F backend typecheck`
- `pnpm -F @lightdash/frontend typecheck`