### PR TITLE
feat(ai-agents): create remediation from review writeback

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -1,5 +1,6 @@
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { AiPromptTableName } from '../database/entities/ai';
 import {
     AiAgentReviewClassifierRunTableName,
     AiAgentReviewItemTableName,
@@ -503,11 +504,20 @@ describe('AiAgentReviewClassifierModel', () => {
             tracker.on
                 .update(AiAgentReviewRemediationTableName)
                 .responseOnce([]);
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce([]);
 
             await model.setReviewRemediationPullRequest({
                 remediationUuid: REMEDIATION_UUID,
                 organizationUuid: ORGANIZATION_UUID,
                 pullRequestUuid: PULL_REQUEST_UUID,
+            });
+            await model.setReviewRemediationPreview({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+                previewProjectUuid: PREVIEW_PROJECT_UUID,
+                previewAgentUuid: PREVIEW_AGENT_UUID,
             });
             await model.setReviewRemediationPreviewThread({
                 remediationUuid: REMEDIATION_UUID,
@@ -517,7 +527,7 @@ describe('AiAgentReviewClassifierModel', () => {
                 previewThreadUuid: PREVIEW_THREAD_UUID,
             });
 
-            expect(tracker.history.update).toHaveLength(2);
+            expect(tracker.history.update).toHaveLength(3);
             expect(tracker.history.update[0].bindings).toContain(
                 PULL_REQUEST_UUID,
             );
@@ -525,9 +535,47 @@ describe('AiAgentReviewClassifierModel', () => {
                 expect.arrayContaining([
                     PREVIEW_PROJECT_UUID,
                     PREVIEW_AGENT_UUID,
+                ]),
+            );
+            expect(tracker.history.update[2].bindings).toEqual(
+                expect.arrayContaining([
+                    PREVIEW_PROJECT_UUID,
+                    PREVIEW_AGENT_UUID,
                     PREVIEW_THREAD_UUID,
                 ]),
             );
+        });
+
+        it('gets a single remediation with linked PR URL', async () => {
+            tracker.on
+                .select(AiAgentReviewRemediationTableName)
+                .responseOnce([makeRemediationRow()]);
+
+            const result = await model.getReviewRemediation({
+                organizationUuid: ORGANIZATION_UUID,
+                remediationUuid: REMEDIATION_UUID,
+            });
+
+            expect(result).toEqual(
+                expect.objectContaining({
+                    uuid: REMEDIATION_UUID,
+                    linkedPrUrl: 'https://github.com/acme/dbt/pull/42',
+                    previewProjectUuid: PREVIEW_PROJECT_UUID,
+                }),
+            );
+        });
+
+        it('gets prompt text for a retry prompt', async () => {
+            tracker.on
+                .select(AiPromptTableName)
+                .responseOnce([{ prompt: 'Show revenue' }]);
+
+            await expect(
+                model.getPromptText({
+                    organizationUuid: ORGANIZATION_UUID,
+                    promptUuid: PROMPT_UUID,
+                }),
+            ).resolves.toEqual('Show revenue');
         });
     });
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -189,6 +189,13 @@ type SetReviewRemediationPullRequestArgs = {
     pullRequestUuid: string;
 };
 
+type SetReviewRemediationPreviewArgs = {
+    remediationUuid: string;
+    organizationUuid: string;
+    previewProjectUuid: string;
+    previewAgentUuid: string;
+};
+
 type SetReviewRemediationPreviewThreadArgs = {
     remediationUuid: string;
     organizationUuid: string;
@@ -202,6 +209,11 @@ type ListReviewSignalsArgs = {
     projectUuid?: string;
     agentUuid?: string;
     limit?: number;
+};
+
+type GetPromptTextArgs = {
+    organizationUuid: string;
+    promptUuid: string;
 };
 
 type BaseCandidateRow = {
@@ -1125,6 +1137,31 @@ export class AiAgentReviewClassifierModel {
         return remediations;
     }
 
+    async getReviewRemediation(args: {
+        organizationUuid: string;
+        remediationUuid: string;
+    }): Promise<AiAgentReviewRemediation | null> {
+        const row = (await this.database<AiAgentReviewRemediationTable>(
+            `${AiAgentReviewRemediationTableName} as remediation`,
+        )
+            .leftJoin(
+                `${PullRequestsTableName} as pull_request`,
+                'pull_request.pull_request_uuid',
+                'remediation.pull_request_uuid',
+            )
+            .where('remediation.organization_uuid', args.organizationUuid)
+            .where(
+                'remediation.ai_agent_review_remediation_uuid',
+                args.remediationUuid,
+            )
+            .select<ReviewRemediationRow>('remediation.*', {
+                linked_pr_url: 'pull_request.pr_url',
+            })
+            .first()) as ReviewRemediationRow | undefined;
+
+        return row ? mapReviewRemediation(row) : null;
+    }
+
     async createReviewRemediation(
         args: CreateReviewRemediationArgs,
     ): Promise<AiAgentReviewRemediation> {
@@ -1186,6 +1223,23 @@ export class AiAgentReviewClassifierModel {
             });
     }
 
+    async setReviewRemediationPreview(
+        args: SetReviewRemediationPreviewArgs,
+    ): Promise<void> {
+        await this.database<AiAgentReviewRemediationTable>(
+            AiAgentReviewRemediationTableName,
+        )
+            .where('ai_agent_review_remediation_uuid', args.remediationUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .update({
+                preview_project_uuid: args.previewProjectUuid,
+                preview_agent_uuid: args.previewAgentUuid,
+                status: 'preview_ready',
+                error_message: null,
+                updated_at: this.database.fn.now() as never,
+            });
+    }
+
     async setReviewRemediationPreviewThread(
         args: SetReviewRemediationPreviewThreadArgs,
     ): Promise<void> {
@@ -1213,6 +1267,20 @@ export class AiAgentReviewClassifierModel {
             fingerprint,
         });
         return items[0] ?? null;
+    }
+
+    async getPromptText(args: GetPromptTextArgs): Promise<string | null> {
+        const row = await this.database(`${AiPromptTableName} as prompt`)
+            .join(
+                `${AiThreadTableName} as thread`,
+                'thread.ai_thread_uuid',
+                'prompt.ai_thread_uuid',
+            )
+            .where('thread.organization_uuid', args.organizationUuid)
+            .where('prompt.ai_prompt_uuid', args.promptUuid)
+            .first<{ prompt: string }>('prompt.prompt');
+
+        return row?.prompt ?? null;
     }
 
     async getPromotedFingerprintScope(

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -1,6 +1,7 @@
 import {
     AiAgentEvalRunJobPayload,
     AiAgentReviewClassifierJobPayload,
+    AiAgentReviewRemediationPreviewJobPayload,
     AiAgentReviewWritebackJobPayload,
     AppGeneratePipelineJobPayload,
     EE_SCHEDULER_TASKS,
@@ -106,6 +107,23 @@ export class CommercialSchedulerClient extends SchedulerClient {
                 runAt: new Date(),
                 maxAttempts: 1,
                 jobKey: `ai-agent-review-writeback:${payload.fingerprint}`,
+            },
+        );
+        return { jobId };
+    }
+
+    async aiAgentReviewRemediationPreview(
+        payload: AiAgentReviewRemediationPreviewJobPayload,
+        runAt: Date = new Date(),
+    ) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW,
+            payload,
+            {
+                runAt,
+                maxAttempts: 1,
+                jobKey: `ai-agent-review-remediation-preview:${payload.remediationUuid}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -102,6 +102,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             ) => {
                 await this.aiAgentService.pollSlackWritebackPreview(payload);
             },
+            [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: async (
+                payload,
+                _helpers,
+            ) => {
+                await this.aiAgentAdminService.pollReviewRemediationPreview(
+                    payload,
+                );
+            },
             [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: async (
                 payload,
                 _helpers,

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -148,4 +148,48 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
             reason: 'missing_writeback_config',
         });
     });
+
+    it('blocks writeback when an active remediation exists', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem({
+                    remediation: {
+                        uuid: 'remediation-1',
+                        fingerprint: 'fingerprint-1',
+                        organizationUuid: 'org-1',
+                        sourceFindingUuid: 'finding-1',
+                        sourcePromptUuid: 'prompt-1',
+                        sourceThreadUuid: 'thread-1',
+                        sourceProjectUuid: 'project-1',
+                        sourceAgentUuid: 'agent-1',
+                        pullRequestUuid: null,
+                        linkedPrUrl: null,
+                        previewProjectUuid: null,
+                        previewAgentUuid: null,
+                        previewThreadUuid: null,
+                        status: 'pr_open',
+                        errorMessage: null,
+                        retryPrompt: 'Show revenue',
+                        createdByUserUuid: null,
+                        resolvedByUserUuid: null,
+                        resolvedAt: null,
+                        createdAt: NOW,
+                        updatedAt: NOW,
+                    },
+                }),
+                reviewsEnabled: true,
+                projectContextEnabled: false,
+                projectAccess: {
+                    provider: PullRequestProvider.GITHUB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: true,
+            }),
+        ).toEqual({
+            eligible: false,
+            provider: null,
+            strategy: null,
+            reason: 'writeback_in_progress',
+        });
+    });
 });

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -5,10 +5,13 @@ import {
     AiAgentAdminSort,
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
+    AiAgentReviewRemediationPreviewJobPayload,
     AiAgentReviewSignalSummary,
     AiAgentReviewWritebackJobPayload,
     AiAgentSummary,
     DbtProjectType,
+    extractPreviewProjectUuidFromUrl,
+    extractPreviewUrlFromComments,
     FeatureFlags,
     ForbiddenError,
     getErrorMessage,
@@ -24,6 +27,7 @@ import {
     type AiAgentReviewItemWritebackEligibility,
     type AiAgentReviewItemWritebackPreview,
     type AiAgentReviewItemWritebackStrategy,
+    type PullRequest,
     type SessionUser,
 } from '@lightdash/common';
 import jwt from 'jsonwebtoken';
@@ -31,6 +35,7 @@ import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import {
     getInstallationToken,
     getPullRequest,
+    getPullRequestComments,
 } from '../../clients/github/Github';
 import { type LightdashConfig } from '../../config/parseConfig';
 import { type GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
@@ -98,6 +103,16 @@ const terminalReviewStatuses = new Set<AiAgentReviewItemStatus>([
     'dismissed',
     'duplicate',
 ]);
+
+const activeRemediationStatuses = new Set([
+    'queued',
+    'running',
+    'pr_open',
+    'preview_ready',
+]);
+
+const REVIEW_PREVIEW_POLL_INTERVAL_MS = 25_000;
+const REVIEW_PREVIEW_WAIT_TIMEOUT_MS = 10 * 60_000;
 
 const unavailableWritebackEligibility = (
     reason: AiAgentReviewItemWritebackBlockedReason,
@@ -173,6 +188,12 @@ export const getAiAgentReviewItemWritebackEligibility = (args: {
     }
     if (item.linkedPrUrl && item.prState === 'open') {
         return unavailableWritebackEligibility('pull_request_open');
+    }
+    if (
+        item.remediation &&
+        activeRemediationStatuses.has(item.remediation.status)
+    ) {
+        return unavailableWritebackEligibility('writeback_in_progress');
     }
     if (
         item.prWritebackStatus === 'queued' ||
@@ -816,6 +837,12 @@ export class AiAgentAdminService extends BaseService {
         if (!reviewItem) {
             throw new NotFoundError('Review item not found');
         }
+        const finding = reviewItem.latestFinding;
+        if (!finding) {
+            throw new ParameterError(
+                'Writeback requires a promoted review finding',
+            );
+        }
         const [reviewsEnabled, projectContextEnabled] = await Promise.all([
             this.areReviewsEnabled(user),
             reviewItem.primaryRootCause === 'project_context'
@@ -852,6 +879,24 @@ export class AiAgentAdminService extends BaseService {
             throw new NotFoundError('Review item not found');
         }
 
+        const retryPrompt =
+            await this.aiAgentReviewClassifierModel.getPromptText({
+                organizationUuid,
+                promptUuid: finding.promptUuid,
+            });
+        const remediation =
+            await this.aiAgentReviewClassifierModel.createReviewRemediation({
+                fingerprint,
+                organizationUuid,
+                sourceFindingUuid: finding.uuid,
+                sourcePromptUuid: finding.promptUuid,
+                sourceThreadUuid: finding.threadUuid,
+                sourceProjectUuid: finding.projectUuid,
+                sourceAgentUuid: finding.agentUuid,
+                retryPrompt,
+                createdByUserUuid: user.userUuid,
+            });
+
         await this.aiAgentReviewClassifierModel.setReviewItemWritebackStatus({
             fingerprint,
             organizationUuid,
@@ -866,6 +911,7 @@ export class AiAgentAdminService extends BaseService {
             organizationUuid,
             projectUuid: scope.projectUuid,
             userUuid: user.userUuid,
+            remediationUuid: remediation.uuid,
         });
 
         this.analytics.track({
@@ -892,8 +938,13 @@ export class AiAgentAdminService extends BaseService {
     async runReviewItemWritebackJob(
         payload: AiAgentReviewWritebackJobPayload,
     ): Promise<void> {
-        const { fingerprint, organizationUuid, projectUuid, userUuid } =
-            payload;
+        const {
+            fingerprint,
+            organizationUuid,
+            projectUuid,
+            userUuid,
+            remediationUuid,
+        } = payload;
 
         const setProgress = (message: string) =>
             this.aiAgentReviewClassifierModel.updateReviewItemWritebackProgress(
@@ -918,6 +969,15 @@ export class AiAgentAdminService extends BaseService {
             return;
         }
         const { agentUuid } = scope;
+        if (remediationUuid) {
+            await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                {
+                    remediationUuid,
+                    organizationUuid,
+                    status: 'running',
+                },
+            );
+        }
 
         const setTerminal = (
             status: 'completed' | 'failed',
@@ -949,6 +1009,7 @@ export class AiAgentAdminService extends BaseService {
             strategy = planStrategy;
 
             let prUrl: string | null;
+            let pullRequest: PullRequest | null = null;
             if (plan.strategy === 'project_context') {
                 await setProgress('Updating project context…');
                 const finding = reviewItem.latestFinding;
@@ -969,7 +1030,7 @@ export class AiAgentAdminService extends BaseService {
                 prUrl = writeback.prUrl;
                 // Surface the PR in the project's Pull Requests list with
                 // AI_AGENT provenance, same as the semantic_layer writeback.
-                await this.pullRequestsModel.findOrCreate({
+                pullRequest = await this.pullRequestsModel.findOrCreate({
                     organizationUuid,
                     projectUuid,
                     createdByUserUuid: userUuid,
@@ -991,6 +1052,12 @@ export class AiAgentAdminService extends BaseService {
                     },
                 });
                 prUrl = result.prUrl;
+                pullRequest = prUrl
+                    ? await this.pullRequestsModel.findByProjectAndUrl(
+                          projectUuid,
+                          prUrl,
+                      )
+                    : null;
             }
 
             if (prUrl) {
@@ -1002,8 +1069,46 @@ export class AiAgentAdminService extends BaseService {
                     linkedPrUrl: prUrl,
                     prState: 'open',
                 });
+                if (remediationUuid && pullRequest) {
+                    await this.aiAgentReviewClassifierModel.setReviewRemediationPullRequest(
+                        {
+                            remediationUuid,
+                            organizationUuid,
+                            pullRequestUuid: pullRequest.pullRequestUuid,
+                        },
+                    );
+                    await this.scheduleReviewRemediationPreviewPoll({
+                        remediationUuid,
+                        fingerprint,
+                        organizationUuid,
+                        projectUuid,
+                        userUuid,
+                        prUrl,
+                    });
+                } else if (remediationUuid) {
+                    await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                        {
+                            remediationUuid,
+                            organizationUuid,
+                            status: 'failed',
+                            errorMessage:
+                                'Opened pull request but could not record it',
+                        },
+                    );
+                }
                 await setTerminal('completed', 'Opened pull request');
             } else {
+                if (remediationUuid) {
+                    await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                        {
+                            remediationUuid,
+                            organizationUuid,
+                            status: 'failed',
+                            errorMessage:
+                                'Writeback ran without opening a pull request',
+                        },
+                    );
+                }
                 await setTerminal(
                     'completed',
                     'Writeback ran — no changes were needed',
@@ -1022,6 +1127,16 @@ export class AiAgentAdminService extends BaseService {
                 },
             });
         } catch (error) {
+            if (remediationUuid) {
+                await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                    {
+                        remediationUuid,
+                        organizationUuid,
+                        status: 'failed',
+                        errorMessage: getErrorMessage(error),
+                    },
+                );
+            }
             await setTerminal('failed', getErrorMessage(error));
             this.analytics.track({
                 event: 'ai_agent_review_item.writeback_failed',
@@ -1037,6 +1152,151 @@ export class AiAgentAdminService extends BaseService {
             });
             throw error;
         }
+    }
+
+    private async scheduleReviewRemediationPreviewPoll(args: {
+        remediationUuid: string;
+        fingerprint: string;
+        organizationUuid: string;
+        projectUuid: string;
+        userUuid: string;
+        prUrl: string;
+    }): Promise<void> {
+        if (!parsePullRequestUrl(args.prUrl)) {
+            return;
+        }
+
+        try {
+            await this.schedulerClient.aiAgentReviewRemediationPreview({
+                organizationUuid: args.organizationUuid,
+                projectUuid: args.projectUuid,
+                userUuid: args.userUuid,
+                fingerprint: args.fingerprint,
+                remediationUuid: args.remediationUuid,
+                prUrl: args.prUrl,
+                startedAt: Date.now(),
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Failed to schedule review remediation preview poll: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+        }
+    }
+
+    private async resolveReviewWritebackPreviewUrl(
+        organizationUuid: string,
+        prUrl: string,
+    ): Promise<string | null> {
+        const parsed = parsePullRequestUrl(prUrl);
+        if (!parsed) {
+            return null;
+        }
+
+        try {
+            const installationId =
+                await this.githubAppInstallationsModel.getInstallationId(
+                    organizationUuid,
+                );
+            const comments = await getPullRequestComments({
+                owner: parsed.owner,
+                repo: parsed.repo,
+                pullNumber: parsed.pullNumber,
+                installationId,
+            });
+            return extractPreviewUrlFromComments(
+                comments,
+                this.lightdashConfig.siteUrl,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `Failed to resolve review remediation preview URL: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            return null;
+        }
+    }
+
+    async pollReviewRemediationPreview(
+        payload: AiAgentReviewRemediationPreviewJobPayload,
+    ): Promise<void> {
+        const { organizationUuid, remediationUuid, prUrl, startedAt } = payload;
+
+        if (Date.now() - startedAt > REVIEW_PREVIEW_WAIT_TIMEOUT_MS) {
+            await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                {
+                    remediationUuid,
+                    organizationUuid,
+                    status: 'pr_open',
+                    errorMessage: 'Preview URL was not published in time',
+                },
+            );
+            return;
+        }
+
+        const remediation =
+            await this.aiAgentReviewClassifierModel.getReviewRemediation({
+                organizationUuid,
+                remediationUuid,
+            });
+        if (!remediation || remediation.status !== 'pr_open') {
+            return;
+        }
+
+        const previewUrl = await this.resolveReviewWritebackPreviewUrl(
+            organizationUuid,
+            prUrl,
+        );
+        if (!previewUrl) {
+            await this.schedulerClient.aiAgentReviewRemediationPreview(
+                payload,
+                new Date(Date.now() + REVIEW_PREVIEW_POLL_INTERVAL_MS),
+            );
+            return;
+        }
+
+        const previewProjectUuid = extractPreviewProjectUuidFromUrl(
+            previewUrl,
+            this.lightdashConfig.siteUrl,
+        );
+        if (!previewProjectUuid) {
+            await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                {
+                    remediationUuid,
+                    organizationUuid,
+                    status: 'failed',
+                    errorMessage:
+                        'Preview URL did not contain a Lightdash project',
+                },
+            );
+            return;
+        }
+
+        const previewAgentUuid = await this.projectModel.getPreviewAiAgentUuid({
+            projectUuid: remediation.sourceProjectUuid,
+            previewProjectUuid,
+            aiAgentUuid: remediation.sourceAgentUuid,
+        });
+        if (!previewAgentUuid) {
+            await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                {
+                    remediationUuid,
+                    organizationUuid,
+                    status: 'failed',
+                    errorMessage: 'Preview did not copy the source AI agent',
+                },
+            );
+            return;
+        }
+
+        await this.aiAgentReviewClassifierModel.setReviewRemediationPreview({
+            remediationUuid,
+            organizationUuid,
+            previewProjectUuid,
+            previewAgentUuid,
+        });
     }
 
     async failReviewItemWritebackJob(args: {

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -258,17 +258,47 @@ const isWritebackStale = (
         item.prWritebackStatus === 'running') &&
     now - new Date(item.updatedAt).getTime() > WRITEBACK_STALE_MS;
 
+// queued/running are worker-bound states; jobs run with maxAttempts: 1, so a
+// crashed worker would otherwise leave the remediation active forever and the
+// eligibility gate (plus the one-active-per-fingerprint index) would block any
+// retry. pr_open/preview_ready are deliberately excluded — a PR can stay open
+// for a long time legitimately.
+const isRemediationStale = (
+    remediation: NonNullable<AiAgentReviewItemSummary['remediation']>,
+    now: number,
+): boolean =>
+    (remediation.status === 'queued' || remediation.status === 'running') &&
+    now - new Date(remediation.updatedAt).getTime() > WRITEBACK_STALE_MS;
+
 const withStaleWritebackOverride = (
     item: AiAgentReviewItemSummary,
     now: number,
-): AiAgentReviewItemSummary =>
-    isWritebackStale(item, now)
-        ? {
-              ...item,
-              prWritebackStatus: 'failed',
-              prWritebackMessage: 'Writeback timed out',
-          }
-        : item;
+): AiAgentReviewItemSummary => {
+    const writebackStale = isWritebackStale(item, now);
+    const remediationStale =
+        item.remediation !== null && isRemediationStale(item.remediation, now);
+    if (!writebackStale && !remediationStale) {
+        return item;
+    }
+    return {
+        ...item,
+        ...(writebackStale
+            ? {
+                  prWritebackStatus: 'failed',
+                  prWritebackMessage: 'Writeback timed out',
+              }
+            : {}),
+        ...(remediationStale && item.remediation
+            ? {
+                  remediation: {
+                      ...item.remediation,
+                      status: 'failed',
+                      errorMessage: 'Writeback timed out',
+                  },
+              }
+            : {}),
+    };
+};
 
 export class AiAgentAdminService extends BaseService {
     private readonly analytics: LightdashAnalytics;
@@ -879,6 +909,23 @@ export class AiAgentAdminService extends BaseService {
             throw new NotFoundError('Review item not found');
         }
 
+        // The stale override above only relaxes the eligibility check; the
+        // partial unique index still sees the old remediation as active, so it
+        // must be persisted as failed before a new one can be inserted.
+        if (
+            reviewItem.remediation &&
+            isRemediationStale(reviewItem.remediation, Date.now())
+        ) {
+            await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                {
+                    remediationUuid: reviewItem.remediation.uuid,
+                    organizationUuid,
+                    status: 'failed',
+                    errorMessage: 'Writeback timed out',
+                },
+            );
+        }
+
         const retryPrompt =
             await this.aiAgentReviewClassifierModel.getPromptText({
                 organizationUuid,
@@ -966,6 +1013,16 @@ export class AiAgentAdminService extends BaseService {
                 fingerprint,
             );
         if (!scope || !reviewItem) {
+            if (remediationUuid) {
+                await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                    {
+                        remediationUuid,
+                        organizationUuid,
+                        status: 'failed',
+                        errorMessage: 'Review item no longer exists',
+                    },
+                );
+            }
             return;
         }
         const { agentUuid } = scope;
@@ -1058,6 +1115,24 @@ export class AiAgentAdminService extends BaseService {
                           prUrl,
                       )
                     : null;
+                if (prUrl && !pullRequest) {
+                    const parsed = parsePullRequestUrl(prUrl);
+                    if (parsed) {
+                        pullRequest = await this.pullRequestsModel.findOrCreate(
+                            {
+                                organizationUuid,
+                                projectUuid,
+                                createdByUserUuid: userUuid,
+                                provider: PullRequestProvider.GITHUB,
+                                source: PullRequestSource.AI_AGENT,
+                                owner: parsed.owner,
+                                repo: parsed.repo,
+                                prNumber: parsed.pullNumber,
+                                prUrl,
+                            },
+                        );
+                    }
+                }
             }
 
             if (prUrl) {
@@ -1086,26 +1161,29 @@ export class AiAgentAdminService extends BaseService {
                         prUrl,
                     });
                 } else if (remediationUuid) {
+                    // The PR exists (e.g. a non-GitHub URL we cannot record in
+                    // pull_requests) — keep the lifecycle truthful instead of
+                    // failing a successful writeback. Preview polling is
+                    // skipped without a recorded pull request.
                     await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
                         {
                             remediationUuid,
                             organizationUuid,
-                            status: 'failed',
-                            errorMessage:
-                                'Opened pull request but could not record it',
+                            status: 'pr_open',
                         },
                     );
                 }
                 await setTerminal('completed', 'Opened pull request');
             } else {
                 if (remediationUuid) {
+                    // No PR means nothing was wrong to fix — a legitimate
+                    // no-op, not a failure; close the remediation to match the
+                    // item's completed status.
                     await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
                         {
                             remediationUuid,
                             organizationUuid,
-                            status: 'failed',
-                            errorMessage:
-                                'Writeback ran without opening a pull request',
+                            status: 'resolved',
                         },
                     );
                 }
@@ -1224,6 +1302,18 @@ export class AiAgentAdminService extends BaseService {
     ): Promise<void> {
         const { organizationUuid, remediationUuid, prUrl, startedAt } = payload;
 
+        // Status guard must run before the timeout: a poll firing after the
+        // remediation reached a terminal state (e.g. an admin marked it fixed)
+        // must not overwrite that state.
+        const remediation =
+            await this.aiAgentReviewClassifierModel.getReviewRemediation({
+                organizationUuid,
+                remediationUuid,
+            });
+        if (!remediation || remediation.status !== 'pr_open') {
+            return;
+        }
+
         if (Date.now() - startedAt > REVIEW_PREVIEW_WAIT_TIMEOUT_MS) {
             await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
                 {
@@ -1233,15 +1323,6 @@ export class AiAgentAdminService extends BaseService {
                     errorMessage: 'Preview URL was not published in time',
                 },
             );
-            return;
-        }
-
-        const remediation =
-            await this.aiAgentReviewClassifierModel.getReviewRemediation({
-                organizationUuid,
-                remediationUuid,
-            });
-        if (!remediation || remediation.status !== 'pr_open') {
             return;
         }
 

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -3583,6 +3583,30 @@ export class ProjectModel {
         });
     }
 
+    async getPreviewAiAgentUuid({
+        projectUuid,
+        previewProjectUuid,
+        aiAgentUuid,
+    }: {
+        projectUuid: string;
+        previewProjectUuid: string;
+        aiAgentUuid: string;
+    }): Promise<string | null> {
+        const row = await this.database('preview_content')
+            .select<{ content_mapping: PreviewContentMapping }[]>(
+                'content_mapping',
+            )
+            .where('project_uuid', projectUuid)
+            .where('preview_project_uuid', previewProjectUuid)
+            .orderBy('created_at', 'desc')
+            .first();
+
+        const match = row?.content_mapping.aiAgents.find(
+            (mapping) => String(mapping.id) === aiAgentUuid,
+        );
+        return typeof match?.newId === 'string' ? match.newId : null;
+    }
+
     // Easier to mock in ProjectService
     // eslint-disable-next-line class-methods-use-this
     getWarehouseClientFromCredentials(credentials: CreateWarehouseCredentials) {

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -171,6 +171,14 @@ const getTagsForTask: {
         'user.uuid': payload.userUuid,
     }),
 
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid,
+        'ai_agent_review.fingerprint': payload.fingerprint,
+        'ai_agent_review.remediation_uuid': payload.remediationUuid,
+    }),
+
     [SCHEDULER_TASKS.POLL_WRITEBACK_PREVIEW]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'project.uuid': payload.projectUuid,

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -194,6 +194,14 @@ export type AiAgentReviewWritebackJobPayload = TraceTaskBase & {
     fingerprint: string;
     organizationUuid: string;
     projectUuid: string;
+    remediationUuid?: string;
+};
+
+export type AiAgentReviewRemediationPreviewJobPayload = TraceTaskBase & {
+    fingerprint: string;
+    remediationUuid: string;
+    prUrl: string;
+    startedAt: number;
 };
 
 export type EmbedArtifactVersionJobPayload = TraceTaskBase & {

--- a/packages/common/src/types/gitIntegration.test.ts
+++ b/packages/common/src/types/gitIntegration.test.ts
@@ -1,4 +1,7 @@
-import { extractPreviewUrlFromComments } from './gitIntegration';
+import {
+    extractPreviewProjectUuidFromUrl,
+    extractPreviewUrlFromComments,
+} from './gitIntegration';
 
 const SITE_URL = 'https://app.lightdash.cloud';
 const PREVIEW_UUID = '3c9a1b2d-4e5f-6071-8293-a4b5c6d7e8f9';
@@ -74,6 +77,32 @@ describe('extractPreviewUrlFromComments', () => {
             extractPreviewUrlFromComments(
                 [`Preview: ${PREVIEW_URL}`],
                 'not a url',
+            ),
+        ).toBeNull();
+    });
+});
+
+describe('extractPreviewProjectUuidFromUrl', () => {
+    it('extracts the preview project UUID from a Lightdash project URL', () => {
+        expect(extractPreviewProjectUuidFromUrl(PREVIEW_URL, SITE_URL)).toEqual(
+            PREVIEW_UUID,
+        );
+    });
+
+    it('matches the project root URL', () => {
+        expect(
+            extractPreviewProjectUuidFromUrl(
+                `${SITE_URL}/projects/${PREVIEW_UUID}`,
+                SITE_URL,
+            ),
+        ).toEqual(PREVIEW_UUID);
+    });
+
+    it('rejects URLs from another host', () => {
+        expect(
+            extractPreviewProjectUuidFromUrl(
+                `https://evil.example.com/projects/${PREVIEW_UUID}/tables`,
+                SITE_URL,
             ),
         ).toBeNull();
     });

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -197,3 +197,22 @@ export const extractPreviewUrlFromComments = (
     }
     return null;
 };
+
+export const extractPreviewProjectUuidFromUrl = (
+    previewUrl: string,
+    siteUrl: string,
+): string | null => {
+    try {
+        const preview = new URL(previewUrl);
+        const site = new URL(siteUrl);
+        if (preview.host !== site.host) {
+            return null;
+        }
+        const match = preview.pathname.match(
+            new RegExp(`^/projects/(${PREVIEW_PROJECT_UUID})(?:/|$)`, 'i'),
+        );
+        return match?.[1] ?? null;
+    } catch {
+        return null;
+    }
+};

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -2,6 +2,7 @@ import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
     type AiAgentReviewClassifierJobPayload,
+    type AiAgentReviewRemediationPreviewJobPayload,
     type AiAgentReviewWritebackJobPayload,
     type ChartReference,
     type DataAppClaudeModel,
@@ -65,6 +66,7 @@ export const EE_SCHEDULER_TASKS = {
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
     AI_AGENT_REVIEW_CLASSIFIER: 'aiAgentReviewClassifier',
     AI_AGENT_REVIEW_WRITEBACK: 'aiAgentReviewWriteback',
+    AI_AGENT_REVIEW_REMEDIATION_PREVIEW: 'aiAgentReviewRemediationPreview',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
@@ -153,6 +155,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: AiAgentReviewRemediationPreviewJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
@@ -165,6 +168,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;
+    [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: AiAgentReviewRemediationPreviewJobPayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;


### PR DESCRIPTION
## Summary
- create review remediation rows when admin review writeback is queued
- link opened review writeback PRs back to remediation state
- add a review-specific scheduler poll that reads PR comments for Lightdash preview URLs
- resolve preview project UUIDs and source-to-preview AI agent mappings
- block duplicate writebacks while active remediation exists

## Validation
- `pnpm -F @lightdash/common test -- gitIntegration.test.ts --runInBand`
- `pnpm -F backend test -- AiAgentReviewClassifierModel.test.ts AiAgentAdminService.test.ts --runInBand`
- `pnpm -F @lightdash/common build`
- `pnpm -F backend typecheck`
- `pnpm -F @lightdash/frontend typecheck`