### PR TITLE
fix(pivot): order hidden sort-only dims at their declared position (PROD-8159)

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -22710,6 +22710,10 @@ const models: TsoaRoute.Models = {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'GroupByColumn' },
                 },
+                pivotColumnsOrder: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'GroupByColumn' },
+                },
                 sortOnlyColumns: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'ValuesColumn' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -23257,6 +23257,13 @@
                         "type": "array",
                         "description": "Dimensions referenced by ORDER BY but NOT spread into pivot columns.\nUsed when a user hides a dim that's part of `pivotConfig.columns` and has\na sort entry on it: the dim still ranks column order via the GROUP BY /\nORDER BY pipeline, but it doesn't become a pivot column header level.\nMirrors `sortOnlyColumns` (which serves the same purpose for metrics)."
                     },
+                    "pivotColumnsOrder": {
+                        "items": {
+                            "$ref": "#/components/schemas/GroupByColumn"
+                        },
+                        "type": "array",
+                        "description": "Declared order of the pivot-column dimensions (visible `groupByColumns`\nplus hidden `sortOnlyDimensions`) as they appear in the chart's\n`pivotConfig.columns`. `column_ranking` orders columns by this sequence so\na hidden sort-only dim sorts at its DECLARED position — hiding a dim then\nleaves column order identical to when it was visible, instead of hoisting\nthe hidden dim to the front of the ORDER BY. Passthrough (hidden, non-sort)\ndims are excluded since they don't drive sort. When omitted, ordering falls\nback to hoisting sort-only sort targets to the front (legacy behavior)."
+                    },
                     "sortOnlyColumns": {
                         "items": {
                             "$ref": "#/components/schemas/ValuesColumn"

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -5668,6 +5668,147 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).toContain('"revenue_ca" AS (');
             expect(result).toContain('column_ranking AS (');
         });
+
+        test('pivotColumnsOrder makes a hidden sort dim sort at its declared position, not leading, preserving outer column grouping (PROD-8159)', () => {
+            // Repro of the prod bug: two visible groupByColumns (case = outer,
+            // metric_type = inner) plus a hidden sort helper (item_order) that is
+            // declared BETWEEN them and orders the inner level. Hiding item_order
+            // must leave column order identical to when it was visible:
+            // case (outer) first, then item_order ordering metric_type within it.
+            // The old "hoist sort-only to the front" behavior produced
+            // ORDER BY item_order, case, metric_type — which groups columns by
+            // item_order ACROSS cases, breaking the case grouping and scrambling
+            // the rendered headers.
+            const pivotConfiguration = {
+                indexColumn: [
+                    { reference: 'item', type: VizIndexType.CATEGORY },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'value',
+                        aggregation: VizAggregationOptions.ANY,
+                    },
+                ],
+                groupByColumns: [
+                    { reference: 'case' },
+                    { reference: 'metric_type' },
+                ],
+                sortOnlyDimensions: [{ reference: 'item_order' }],
+                pivotColumnsOrder: [
+                    { reference: 'case' },
+                    { reference: 'item_order' },
+                    { reference: 'metric_type' },
+                ],
+                sortBy: [
+                    { reference: 'item_order', direction: SortByDirection.ASC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const collapsed = replaceWhitespace(builder.toSql());
+
+            // ORDER BY follows declared position: case (outer) leads, item_order
+            // orders the inner metric_type, metric_type trails as tiebreaker.
+            expect(collapsed).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."case" ASC, g."item_order" ASC, g."metric_type" ASC) AS "col_idx"',
+            );
+            // Column identity (DISTINCT) is visible dims only — item_order is
+            // never spread as a pivot column header.
+            expect(collapsed).toContain(
+                'column_ranking AS (SELECT DISTINCT g."case" AS "case", g."metric_type" AS "metric_type",',
+            );
+        });
+
+        test('pivotColumnsOrder holds declared position when the OUTER dim is also a sort target (prod sortBy [outer, helper]) (PROD-8159)', () => {
+            // Mirrors the exact prod payload: the user sorts the visible OUTER
+            // dim AND the hidden helper — sortBy [case ASC, item_order ASC].
+            // The helper must still sort at its declared position (not lead), and
+            // the visible groupByColumns keep their declared order regardless of
+            // sortBy order (issue #16871 invariant).
+            const pivotConfiguration = {
+                indexColumn: [
+                    { reference: 'item', type: VizIndexType.CATEGORY },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'value',
+                        aggregation: VizAggregationOptions.ANY,
+                    },
+                ],
+                groupByColumns: [
+                    { reference: 'case' },
+                    { reference: 'metric_type' },
+                ],
+                sortOnlyDimensions: [{ reference: 'item_order' }],
+                pivotColumnsOrder: [
+                    { reference: 'case' },
+                    { reference: 'item_order' },
+                    { reference: 'metric_type' },
+                ],
+                sortBy: [
+                    { reference: 'case', direction: SortByDirection.ASC },
+                    { reference: 'item_order', direction: SortByDirection.ASC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const collapsed = replaceWhitespace(builder.toSql());
+
+            // Same declared-position ORDER BY as when only the helper is sorted:
+            // the explicit outer sort does not hoist the helper, and does not
+            // reorder the visible groupByColumns.
+            expect(collapsed).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."case" ASC, g."item_order" ASC, g."metric_type" ASC) AS "col_idx"',
+            );
+        });
+
+        test('pivotColumnsOrder with the hidden sort dim declared first still leads the column ORDER BY (PROD-5789 stays fixed)', () => {
+            // Declared-position rule subsumes the original "lead" behavior: when
+            // the hidden helper is declared outermost (the single-visible-dim
+            // PROD-5789 shape), it naturally leads.
+            const pivotConfiguration = {
+                indexColumn: [
+                    { reference: 'customer_id', type: VizIndexType.CATEGORY },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'orders_status' }],
+                sortOnlyDimensions: [{ reference: 'orders_status_priority' }],
+                pivotColumnsOrder: [
+                    { reference: 'orders_status_priority' },
+                    { reference: 'orders_status' },
+                ],
+                sortBy: [
+                    {
+                        reference: 'orders_status_priority',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const collapsed = replaceWhitespace(builder.toSql());
+
+            expect(collapsed).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."orders_status_priority" ASC, g."orders_status" ASC) AS "col_idx"',
+            );
+        });
     });
 
     describe('passthroughDimensions — hidden non-sort pivot dims carried for cross-field templating (PROD-7873)', () => {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -541,6 +541,35 @@ export class PivotQueryBuilder {
             ...(sortOnlyDimensions || []),
         ];
 
+        // When the declared pivot-column order is known, order the dimension
+        // part of the ORDER BY by it so a hidden sort-only dim sorts at its
+        // DECLARED position — i.e. hiding a dim leaves column order identical to
+        // when it was visible. Returns undefined when not provided, so callers
+        // fall back to the legacy "hoist sort-only to the front" behavior.
+        const { pivotColumnsOrder } = this.pivotConfiguration;
+        const orderDimsByDeclaredPosition = ():
+            | typeof allOrderableDims
+            | undefined => {
+            if (!pivotColumnsOrder || pivotColumnsOrder.length === 0) {
+                return undefined;
+            }
+            const byRef = new Map(
+                allOrderableDims.map((d) => [d.reference, d]),
+            );
+            const declared = pivotColumnsOrder
+                .map((d) => byRef.get(d.reference))
+                .filter(
+                    (d): d is (typeof allOrderableDims)[number] =>
+                        d !== undefined,
+                );
+            const seen = new Set(declared.map((d) => d.reference));
+            // Append any orderable dims missing from pivotColumnsOrder (safety).
+            return [
+                ...declared,
+                ...allOrderableDims.filter((d) => !seen.has(d.reference)),
+            ];
+        };
+
         if (sortBy) {
             const isValueColumn = (sort: VizSortBy | undefined) =>
                 valuesColumns?.some(
@@ -572,7 +601,8 @@ export class PivotQueryBuilder {
                     return acc;
                 }, []);
 
-            // Build groups order parts:
+            // Build groups order parts. Prefer declared-position ordering; when
+            // pivotColumnsOrder is absent, fall back to the legacy behavior:
             //   1. sortOnlyDimensions that appear in sortBy lead (in sortBy order) —
             //      otherwise the visible groupBy (typically 1-to-1 with the
             //      sort helper) would dominate alphabetically and the helper
@@ -581,23 +611,31 @@ export class PivotQueryBuilder {
             //      issue #16871's invariant: sortBy order does NOT leak into
             //      groupByColumns ordering).
             //   3. remaining sortOnlyDimensions (without sortBy entries) trail.
-            const sortOnlyRefs = new Set(
-                (sortOnlyDimensions || []).map((d) => d.reference),
-            );
-            const leadingDims = sortBy
-                .filter((s) => sortOnlyRefs.has(s.reference))
-                .map((s) =>
-                    allOrderableDims.find((d) => d.reference === s.reference),
-                )
-                .filter(
-                    (d): d is (typeof allOrderableDims)[number] =>
-                        d !== undefined,
-                );
-            const leadingRefs = new Set(leadingDims.map((d) => d.reference));
-            const trailingDims = allOrderableDims.filter(
-                (d) => !leadingRefs.has(d.reference),
-            );
-            const orderedDims = [...leadingDims, ...trailingDims];
+            const orderedDims =
+                orderDimsByDeclaredPosition() ??
+                (() => {
+                    const sortOnlyRefs = new Set(
+                        (sortOnlyDimensions || []).map((d) => d.reference),
+                    );
+                    const leadingDims = sortBy
+                        .filter((s) => sortOnlyRefs.has(s.reference))
+                        .map((s) =>
+                            allOrderableDims.find(
+                                (d) => d.reference === s.reference,
+                            ),
+                        )
+                        .filter(
+                            (d): d is (typeof allOrderableDims)[number] =>
+                                d !== undefined,
+                        );
+                    const leadingRefs = new Set(
+                        leadingDims.map((d) => d.reference),
+                    );
+                    const trailingDims = allOrderableDims.filter(
+                        (d) => !leadingRefs.has(d.reference),
+                    );
+                    return [...leadingDims, ...trailingDims];
+                })();
 
             const groupsOrderByParts = orderedDims.map((col) => {
                 const sort = sortBy.find((s) => s.reference === col.reference);
@@ -623,8 +661,10 @@ export class PivotQueryBuilder {
                 orderByParts.push(...groupsOrderByParts, ...valuesOrderByParts);
             }
         } else {
-            // Default to all orderable dim columns with ASC direction
-            allOrderableDims.forEach((col) => {
+            // Default to all orderable dim columns with ASC direction, in
+            // declared position when known (else original groupBy order).
+            const dims = orderDimsByDeclaredPosition() ?? allOrderableDims;
+            dims.forEach((col) => {
                 orderByParts.push(`g.${q}${col.reference}${q} ASC`);
             });
         }

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -1398,6 +1398,65 @@ describe('derivePivotConfigurationFromChart', () => {
             ).toBe(true);
         });
 
+        it('sets pivotColumnsOrder to the declared pivot-column order (visible + sort-only) so a hidden sort dim keeps its position (PROD-8159)', () => {
+            // Declared order: payment_method (outer, visible), status_priority
+            // (hidden sort helper), status (inner, visible). Hiding the helper
+            // must not change column order, so pivotColumnsOrder preserves the
+            // full declared sequence — the SQL builder then sorts the helper at
+            // its declared (middle) position instead of hoisting it to the front.
+            const chartConfig = {
+                type: ChartType.TABLE,
+                config: {
+                    columns: { orders_status_priority: { visible: false } },
+                    pivotDimensions: [
+                        'payments_payment_method',
+                        'orders_status_priority',
+                        'orders_status',
+                    ],
+                    showSubtotals: false,
+                },
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig,
+                pivotConfig: {
+                    columns: [
+                        'payments_payment_method',
+                        'orders_status_priority',
+                        'orders_status',
+                    ],
+                },
+            };
+
+            const mq: MetricQuery = {
+                ...mockMetricQuery,
+                dimensions: [
+                    'payments_payment_method',
+                    'orders_status',
+                    'orders_status_priority',
+                ],
+                metrics: ['payments_total_revenue'],
+                sorts: [
+                    { fieldId: 'orders_status_priority', descending: false },
+                ],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                mq,
+                itemsWithPriority,
+            );
+
+            expect(result?.pivotColumnsOrder).toEqual([
+                { reference: 'payments_payment_method' },
+                { reference: 'orders_status_priority' },
+                { reference: 'orders_status' },
+            ]);
+        });
+
         it('routes a hidden pivot-column dim with no sort entry to passthroughDimensions (PROD-7873)', () => {
             // Hidden + not sorted used to drop the dim from the query entirely,
             // which broke richText / image templates on visible fields that

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -262,6 +262,18 @@ function getTablePivotConfiguration(
         )
         .map((col) => ({ reference: col.reference }));
 
+    // Declared order of pivot-column dims that drive column ORDER BY: visible
+    // groupByColumns + hidden sortOnlyDimensions, in their declared
+    // (pivotConfig.columns) order. Passthrough dims are excluded (they don't
+    // sort). PivotQueryBuilder orders columns by this so a hidden sort dim sorts
+    // at its declared position — hiding it preserves the visible column order.
+    const passthroughPivotRefs = new Set(
+        passthroughPivotDimensions.map((c) => c.reference),
+    );
+    const pivotColumnsOrder = allPivotGroupByColumns.filter(
+        (col) => !passthroughPivotRefs.has(col.reference),
+    );
+
     const groupByRefs = new Set([
         ...groupByColumns.map((c) => c.reference),
         ...sortOnlyPivotDimensions.map((c) => c.reference),
@@ -339,6 +351,7 @@ function getTablePivotConfiguration(
         }),
         ...(sortOnlyPivotDimensions.length > 0 && {
             sortOnlyDimensions: sortOnlyPivotDimensions,
+            pivotColumnsOrder,
         }),
         ...((passthroughPivotDimensions.length > 0 ||
             passthroughRowDimensions.length > 0) && {

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -59,6 +59,17 @@ export type PivotConfiguration = {
      * references would silently resolve to undefined.
      */
     passthroughDimensions?: GroupByColumn[];
+    /**
+     * Declared order of the pivot-column dimensions (visible `groupByColumns`
+     * plus hidden `sortOnlyDimensions`) as they appear in the chart's
+     * `pivotConfig.columns`. `column_ranking` orders columns by this sequence so
+     * a hidden sort-only dim sorts at its DECLARED position — hiding a dim then
+     * leaves column order identical to when it was visible, instead of hoisting
+     * the hidden dim to the front of the ORDER BY. Passthrough (hidden, non-sort)
+     * dims are excluded since they don't drive sort. When omitted, ordering falls
+     * back to hoisting sort-only sort targets to the front (legacy behavior).
+     */
+    pivotColumnsOrder?: GroupByColumn[];
 };
 
 type Field =


### PR DESCRIPTION
Closes: PROD-8159

### Description:

Introduces a `pivotColumnsOrder` field to `PivotConfiguration` that records the declared order of pivot-column dimensions (visible `groupByColumns` plus hidden `sortOnlyDimensions`) as they appear in `pivotConfig.columns`.

Previously, when a sort-only dimension was hidden, the `PivotQueryBuilder` would hoist it to the front of the `column_ranking` ORDER BY. This caused the hidden sort helper to group columns by its own values *across* outer visible dimensions, breaking the expected column grouping and scrambling rendered pivot headers.

With `pivotColumnsOrder` provided, the builder now sorts each dimension at its **declared position** rather than hoisting hidden sort-only dims to the front. Hiding a dimension therefore leaves the visible column order identical to when it was visible.

`derivePivotConfigurationFromChart` now computes and emits `pivotColumnsOrder` whenever `sortOnlyDimensions` are present, filtering out passthrough dims (which don't drive sort). When `pivotColumnsOrder` is absent, the builder falls back to the previous legacy hoisting behavior, preserving backwards compatibility.