### PR TITLE
fix(pivot): duplicate distinct metric projection in pivot queries

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -3728,6 +3728,46 @@ export const EXPLORE_WITH_FANOUT_AND_DD_REFERENCE: Explore = {
                     tablesReferences: ['customers'],
                     hidden: false,
                 },
+                total_customer_value: {
+                    type: MetricType.SUM,
+                    name: 'total_customer_value',
+                    label: 'Total Customer Value',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.METRIC,
+                    sql: '${TABLE}.lifetime_value',
+                    compiledSql: 'SUM("customers".lifetime_value)',
+                    tablesReferences: ['customers'],
+                    hidden: false,
+                },
+                total_customer_value_deduped: {
+                    type: MetricType.SUM_DISTINCT,
+                    name: 'total_customer_value_deduped',
+                    label: 'Total Customer Value (Deduped)',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.METRIC,
+                    sql: '${TABLE}.lifetime_value',
+                    distinctKeys: ['customers.customer_id'],
+                    compiledSql: 'SUM("customers".lifetime_value)',
+                    compiledValueSql: '("customers".lifetime_value)',
+                    compiledDistinctKeys: ['("customers".customer_id)'],
+                    tablesReferences: ['customers'],
+                    hidden: false,
+                },
+                average_customer_value_deduped: {
+                    type: MetricType.NUMBER,
+                    name: 'average_customer_value_deduped',
+                    label: 'Average Customer Value (Deduped)',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.METRIC,
+                    sql: '${total_customer_value} / NULLIF(${total_customer_value_deduped}, 0)',
+                    compiledSql:
+                        '(SUM("customers".lifetime_value)) / NULLIF((SUM("customers".lifetime_value)), 0)',
+                    tablesReferences: ['customers'],
+                    hidden: false,
+                },
                 total_order_amount_deduped: {
                     type: MetricType.SUM_DISTINCT,
                     name: 'total_order_amount_deduped',
@@ -3890,3 +3930,26 @@ export const METRIC_QUERY_FANOUT_AND_DD_REFERENCE: CompiledMetricQuery = {
     compiledAdditionalMetrics: [],
     compiledCustomDimensions: [],
 };
+
+export const METRIC_QUERY_FANOUT_AND_SAME_TABLE_DD_REFERENCE: CompiledMetricQuery =
+    {
+        exploreName: 'customers',
+        dimensions: [],
+        metrics: [
+            'customers_average_customer_value_deduped',
+            'customers_total_customer_value',
+            'orders_total_order_amount',
+        ],
+        filters: {},
+        sorts: [
+            {
+                fieldId: 'customers_average_customer_value_deduped',
+                descending: true,
+            },
+        ],
+        limit: 500,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -3755,6 +3755,21 @@ export const EXPLORE_WITH_FANOUT_AND_DD_REFERENCE: Explore = {
                     tablesReferences: ['customers'],
                     hidden: false,
                 },
+                average_customer_value_distinct: {
+                    type: MetricType.AVERAGE_DISTINCT,
+                    name: 'average_customer_value_distinct',
+                    label: 'Average Customer Value (Distinct)',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.METRIC,
+                    sql: '${TABLE}.lifetime_value',
+                    distinctKeys: ['customers.customer_id'],
+                    compiledSql: 'AVG("customers".lifetime_value)',
+                    compiledValueSql: '("customers".lifetime_value)',
+                    compiledDistinctKeys: ['("customers".customer_id)'],
+                    tablesReferences: ['customers'],
+                    hidden: false,
+                },
                 average_customer_value_deduped: {
                     type: MetricType.NUMBER,
                     name: 'average_customer_value_deduped',
@@ -3765,6 +3780,19 @@ export const EXPLORE_WITH_FANOUT_AND_DD_REFERENCE: Explore = {
                     sql: '${total_customer_value} / NULLIF(${total_customer_value_deduped}, 0)',
                     compiledSql:
                         '(SUM("customers".lifetime_value)) / NULLIF((SUM("customers".lifetime_value)), 0)',
+                    tablesReferences: ['customers'],
+                    hidden: false,
+                },
+                customer_value_vs_distinct_average: {
+                    type: MetricType.NUMBER,
+                    name: 'customer_value_vs_distinct_average',
+                    label: 'Customer Value vs Distinct Average',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.METRIC,
+                    sql: '${total_customer_value} / NULLIF(${average_customer_value_distinct}, 0)',
+                    compiledSql:
+                        '(SUM("customers".lifetime_value)) / NULLIF((AVG("customers".lifetime_value)), 0)',
                     tablesReferences: ['customers'],
                     hidden: false,
                 },
@@ -3944,6 +3972,29 @@ export const METRIC_QUERY_FANOUT_AND_SAME_TABLE_DD_REFERENCE: CompiledMetricQuer
         sorts: [
             {
                 fieldId: 'customers_average_customer_value_deduped',
+                descending: true,
+            },
+        ],
+        limit: 500,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+export const METRIC_QUERY_FANOUT_AND_SAME_TABLE_AVERAGE_DD_REFERENCE: CompiledMetricQuery =
+    {
+        exploreName: 'customers',
+        dimensions: [],
+        metrics: [
+            'customers_customer_value_vs_distinct_average',
+            'customers_total_customer_value',
+            'orders_total_order_amount',
+        ],
+        filters: {},
+        sorts: [
+            {
+                fieldId: 'customers_customer_value_vs_distinct_average',
                 descending: true,
             },
         ],

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -2231,6 +2231,14 @@ export class MetricQueryBuilder {
                 if (nestedAggOuterIds.has(getItemId(metric))) {
                     return;
                 }
+                // Non-aggregate metrics referencing sum_distinct/average_distinct
+                // must be emitted from the outer dd SELECT where dd_* aliases
+                // are available. Emitting compiledSql here expands the distinct
+                // metric to its raw fallback aggregate and can duplicate the
+                // outer alias.
+                if (nonAggReferencingDd.has(getItemId(metric))) {
+                    return;
+                }
                 // Inflation proof metrics don't need CTE
                 if (isInflationProofMetric(metric.type)) {
                     return;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/fanoutQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/fanoutQueries.test.ts.snap
@@ -130,6 +130,76 @@ LIMIT
   10"
 `;
 
+exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a fanout-protected metric that references sum_distinct on the same table 1`] = `
+"WITH
+  cte_keys_customers AS (
+    SELECT DISTINCT
+      "customers".customer_id AS "pk_customer_id"
+    FROM
+      customers AS "customers"
+      LEFT OUTER JOIN orders AS "orders" ON ("customers".customer_id) = ("orders".customer_id)
+  ),
+  cte_metrics_customers AS (
+    SELECT
+      SUM("customers".lifetime_value) AS "customers_total_customer_value"
+    FROM
+      cte_keys_customers
+      LEFT JOIN customers AS "customers" ON cte_keys_customers."pk_customer_id" = "customers".customer_id
+  ),
+  cte_unaffected AS (
+    SELECT
+      SUM("orders".amount) AS "orders_total_order_amount"
+    FROM
+      customers AS "customers"
+      LEFT OUTER JOIN orders AS "orders" ON ("customers".customer_id) = ("orders".customer_id)
+  ),
+  dd_customers_total_customer_value_deduped AS (
+    SELECT
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "customers_total_customer_value_deduped"
+    FROM
+      (
+        SELECT
+          ("customers".lifetime_value) AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              ("customers".customer_id)
+            ORDER BY
+              ("customers".lifetime_value)
+          ) AS __dd_rn
+        FROM
+          customers AS "customers"
+          LEFT OUTER JOIN orders AS "orders" ON ("customers".customer_id) = ("orders".customer_id)
+      ) __dd_sub
+  ),
+  dd_base AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_customers."customers_total_customer_value" AS "customers_total_customer_value"
+    FROM
+      cte_unaffected
+      CROSS JOIN cte_metrics_customers
+  )
+SELECT
+  dd_base.*,
+  dd_customers_total_customer_value_deduped."customers_total_customer_value_deduped" AS "customers_total_customer_value_deduped",
+  dd_base."customers_total_customer_value" / NULLIF(
+    dd_customers_total_customer_value_deduped."customers_total_customer_value_deduped",
+    0
+  ) AS "customers_average_customer_value_deduped"
+FROM
+  dd_base
+  CROSS JOIN dd_customers_total_customer_value_deduped
+ORDER BY
+  "customers_average_customer_value_deduped" DESC
+LIMIT
+  500"
+`;
+
 exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a filter-only fanout metric query 1`] = `
 "WITH
   cte_keys_table2 AS (

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/fanoutQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/fanoutQueries.test.ts.snap
@@ -130,6 +130,87 @@ LIMIT
   10"
 `;
 
+exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a fanout-protected metric that references average_distinct on the same table 1`] = `
+"WITH
+  cte_keys_customers AS (
+    SELECT DISTINCT
+      "customers".customer_id AS "pk_customer_id"
+    FROM
+      customers AS "customers"
+      LEFT OUTER JOIN orders AS "orders" ON ("customers".customer_id) = ("orders".customer_id)
+  ),
+  cte_metrics_customers AS (
+    SELECT
+      SUM("customers".lifetime_value) AS "customers_total_customer_value"
+    FROM
+      cte_keys_customers
+      LEFT JOIN customers AS "customers" ON cte_keys_customers."pk_customer_id" = "customers".customer_id
+  ),
+  cte_unaffected AS (
+    SELECT
+      SUM("orders".amount) AS "orders_total_order_amount"
+    FROM
+      customers AS "customers"
+      LEFT OUTER JOIN orders AS "orders" ON ("customers".customer_id) = ("orders".customer_id)
+  ),
+  dd_customers_average_customer_value_distinct AS (
+    SELECT
+      CAST(
+        SUM(
+          CASE
+            WHEN __dd_rn = 1 THEN __dd_val
+            ELSE NULL
+          END
+        ) AS FLOAT
+      ) / CAST(
+        NULLIF(
+          COUNT(
+            CASE
+              WHEN __dd_rn = 1 THEN __dd_val
+            END
+          ),
+          0
+        ) AS FLOAT
+      ) AS "customers_average_customer_value_distinct"
+    FROM
+      (
+        SELECT
+          ("customers".lifetime_value) AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              ("customers".customer_id)
+            ORDER BY
+              ("customers".lifetime_value)
+          ) AS __dd_rn
+        FROM
+          customers AS "customers"
+          LEFT OUTER JOIN orders AS "orders" ON ("customers".customer_id) = ("orders".customer_id)
+      ) __dd_sub
+  ),
+  dd_base AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_customers."customers_total_customer_value" AS "customers_total_customer_value"
+    FROM
+      cte_unaffected
+      CROSS JOIN cte_metrics_customers
+  )
+SELECT
+  dd_base.*,
+  dd_customers_average_customer_value_distinct."customers_average_customer_value_distinct" AS "customers_average_customer_value_distinct",
+  dd_base."customers_total_customer_value" / NULLIF(
+    dd_customers_average_customer_value_distinct."customers_average_customer_value_distinct",
+    0
+  ) AS "customers_customer_value_vs_distinct_average"
+FROM
+  dd_base
+  CROSS JOIN dd_customers_average_customer_value_distinct
+ORDER BY
+  "customers_customer_value_vs_distinct_average" DESC
+LIMIT
+  500"
+`;
+
 exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a fanout-protected metric that references sum_distinct on the same table 1`] = `
 "WITH
   cte_keys_customers AS (

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/fanoutQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/fanoutQueries.test.ts
@@ -2,7 +2,9 @@ import { FilterOperator } from '@lightdash/common';
 import {
     EXPLORE,
     EXPLORE_WITH_CROSS_TABLE_METRICS,
+    EXPLORE_WITH_FANOUT_AND_DD_REFERENCE,
     METRIC_QUERY_CROSS_TABLE,
+    METRIC_QUERY_FANOUT_AND_SAME_TABLE_DD_REFERENCE,
     METRIC_QUERY_TWO_TABLES,
 } from '../MetricQueryBuilder.mock';
 import { buildQuery } from './helpers';
@@ -114,5 +116,22 @@ describe('MetricQueryBuilder snapshot: fanout queries', () => {
                 },
             }),
         ).toMatchSnapshot();
+    });
+
+    test('matches snapshot for a fanout-protected metric that references sum_distinct on the same table', () => {
+        const query = buildQuery({
+            explore: EXPLORE_WITH_FANOUT_AND_DD_REFERENCE,
+            compiledMetricQuery:
+                METRIC_QUERY_FANOUT_AND_SAME_TABLE_DD_REFERENCE,
+        });
+
+        expect(query).toContain('cte_metrics_customers');
+        expect(query).not.toContain(
+            '(SUM("customers".lifetime_value)) / NULLIF((SUM("customers".lifetime_value)), 0) AS "customers_average_customer_value_deduped"',
+        );
+        expect(
+            query.match(/AS "customers_average_customer_value_deduped"/g),
+        ).toHaveLength(1);
+        expect(query).toMatchSnapshot();
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/fanoutQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/fanoutQueries.test.ts
@@ -4,6 +4,7 @@ import {
     EXPLORE_WITH_CROSS_TABLE_METRICS,
     EXPLORE_WITH_FANOUT_AND_DD_REFERENCE,
     METRIC_QUERY_CROSS_TABLE,
+    METRIC_QUERY_FANOUT_AND_SAME_TABLE_AVERAGE_DD_REFERENCE,
     METRIC_QUERY_FANOUT_AND_SAME_TABLE_DD_REFERENCE,
     METRIC_QUERY_TWO_TABLES,
 } from '../MetricQueryBuilder.mock';
@@ -131,6 +132,23 @@ describe('MetricQueryBuilder snapshot: fanout queries', () => {
         );
         expect(
             query.match(/AS "customers_average_customer_value_deduped"/g),
+        ).toHaveLength(1);
+        expect(query).toMatchSnapshot();
+    });
+
+    test('matches snapshot for a fanout-protected metric that references average_distinct on the same table', () => {
+        const query = buildQuery({
+            explore: EXPLORE_WITH_FANOUT_AND_DD_REFERENCE,
+            compiledMetricQuery:
+                METRIC_QUERY_FANOUT_AND_SAME_TABLE_AVERAGE_DD_REFERENCE,
+        });
+
+        expect(query).toContain('cte_metrics_customers');
+        expect(query).not.toContain(
+            '(SUM("customers".lifetime_value)) / NULLIF((AVG("customers".lifetime_value)), 0) AS "customers_customer_value_vs_distinct_average"',
+        );
+        expect(
+            query.match(/AS "customers_customer_value_vs_distinct_average"/g),
         ).toHaveLength(1);
         expect(query).toMatchSnapshot();
     });


### PR DESCRIPTION
Closes #23861

## Summary
- Skip non-aggregate metrics that reference `sum_distinct`/`average_distinct` from the fanout metrics CTE so they are only emitted from the outer `dd` select.
- Add regression coverage for the same-table fanout path that reproduces PROD-8117.
- Update the jaffle example models to make the repro easier to exercise.

## Testing
- `MetricQueryBuilder.test.ts` passed with the new fanout regression.
- `distinctQueries.test.ts` passed and snapshots were updated for the distinct wrapper case.
