### PR TITLE
feat(ai-agents): add auto route from home search

### DIFF
--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -22,8 +22,14 @@ import { Link, useNavigate } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { PolymorphicGroupButton } from '../../../../components/common/PolymorphicGroupButton';
 import { CompactAgentSelector } from '../../../features/aiCopilot/components/AgentSelector';
+import {
+    AI_ROUTING_AUTO_VALUE,
+    AI_ROUTING_SEARCH_PARAM,
+} from '../../../features/aiCopilot/components/AgentSelector/AgentSelectorUtils';
+import { usePendingPrompt } from '../../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { useAiAgentPermission } from '../../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiOrganizationSettings } from '../../../features/aiCopilot/hooks/useAiOrganizationSettings';
+import { useAiRouterConfig } from '../../../features/aiCopilot/hooks/useAiRouter';
 import {
     useCreateAgentThreadMutation,
     useProjectAiAgents,
@@ -37,6 +43,8 @@ import { SearchDropdown } from './SearchDropdown';
 type Props = {
     projectUuid: string;
 };
+
+type SelectedAgent = AiAgentSummary | 'auto';
 
 const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
     const navigate = useNavigate();
@@ -53,7 +61,9 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
         data: userAgentPreferences,
         isLoading: isLoadingUserAgentPreferences,
     } = useGetUserAgentPreferences(projectUuid);
-    const [selectedAgent, setSelectedAgent] = useState<AiAgentSummary>();
+    const aiRouterConfigQuery = useAiRouterConfig();
+    const [selectedAgent, setSelectedAgent] = useState<SelectedAgent>();
+    const { setPendingPrompt } = usePendingPrompt();
     const canManageAgents = useAiAgentPermission({
         action: 'manage',
         projectUuid,
@@ -62,16 +72,42 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
     const noAgentsAvailable =
         !isLoadingAgents && (!agents || agents.length === 0);
 
+    const showAutoOption =
+        (agents?.length ?? 0) > 1 && aiRouterConfigQuery.data?.enabled === true;
+
+    const validDefaultAgent = agents?.find(
+        (agent) => agent.uuid === userAgentPreferences?.defaultAgentUuid,
+    );
+    const preferredSelection: SelectedAgent | undefined =
+        validDefaultAgent ?? (showAutoOption ? 'auto' : agents?.[0]);
+    const activeSelection = selectedAgent ?? preferredSelection;
+
     useEffect(() => {
         if (!agents || agents.length === 0) return;
+        if (isLoadingUserAgentPreferences) return;
+        if (aiRouterConfigQuery.isLoading) return;
 
-        const preferredAgent =
-            agents.find(
-                (agent) =>
-                    agent.uuid === userAgentPreferences?.defaultAgentUuid,
-            ) ?? agents[0];
-        setSelectedAgent(preferredAgent);
-    }, [agents, userAgentPreferences?.defaultAgentUuid]);
+        setSelectedAgent((currentSelection) => {
+            if (currentSelection === 'auto') {
+                return showAutoOption ? currentSelection : preferredSelection;
+            }
+
+            if (
+                currentSelection &&
+                agents.some((agent) => agent.uuid === currentSelection.uuid)
+            ) {
+                return currentSelection;
+            }
+
+            return preferredSelection;
+        });
+    }, [
+        agents,
+        aiRouterConfigQuery.isLoading,
+        isLoadingUserAgentPreferences,
+        preferredSelection,
+        showAutoOption,
+    ]);
 
     const form = useForm({
         initialValues: {
@@ -83,12 +119,28 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
         useCreateAgentThreadMutation(projectUuid);
 
     const handleSubmit = form.onSubmit(async (values) => {
-        if (!selectedAgent) {
+        const prompt = values.prompt.trim();
+
+        if (activeSelection === 'auto') {
+            setPendingPrompt(prompt);
+            void navigate(
+                {
+                    pathname: `/projects/${projectUuid}/ai-agents`,
+                    search: new URLSearchParams({
+                        [AI_ROUTING_SEARCH_PARAM]: AI_ROUTING_AUTO_VALUE,
+                    }).toString(),
+                },
+                {
+                    state: { autoSubmitPrompt: prompt },
+                    viewTransition: true,
+                },
+            );
+        } else if (!activeSelection) {
             void navigate(`/projects/${projectUuid}/ai-agents`);
         } else {
             await createAgentThread({
-                agentUuid: selectedAgent.uuid,
-                prompt: values.prompt.trim(),
+                agentUuid: activeSelection.uuid,
+                prompt,
             });
         }
     });
@@ -99,13 +151,22 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
 
     const onSelect = (agentUuid: string) => {
         if (!agents) return;
+        if (agentUuid === AI_ROUTING_AUTO_VALUE && showAutoOption) {
+            setSelectedAgent('auto');
+            return;
+        }
+
         setSelectedAgent(
             (currentSelection) =>
                 agents.find((a) => a.uuid === agentUuid) ?? currentSelection,
         );
     };
 
-    if (isLoadingAgents || isLoadingUserAgentPreferences) {
+    if (
+        isLoadingAgents ||
+        isLoadingUserAgentPreferences ||
+        aiRouterConfigQuery.isLoading
+    ) {
         return (
             <Paper style={{ overflow: 'hidden' }} p="md">
                 <Group wrap="nowrap" align="center">
@@ -132,8 +193,9 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                     <Group>
                         <CompactAgentSelector
                             agents={agents}
-                            selectedAgent={selectedAgent ?? agents[0]}
+                            selectedAgent={activeSelection ?? agents[0]}
                             onSelect={onSelect}
+                            showAutoOption={showAutoOption}
                         />
                         <Group gap="xs" flex={1}>
                             <SearchDropdown
@@ -144,9 +206,11 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                                 }
                                 onSearchItemSelect={handleSearchItemSelect}
                                 placeholder={
-                                    selectedAgent
-                                        ? `Ask ${selectedAgent.name} or search your data`
-                                        : 'Search your data'
+                                    activeSelection === 'auto'
+                                        ? 'Ask AI or search your data'
+                                        : activeSelection
+                                          ? `Ask ${activeSelection.name} or search your data`
+                                          : 'Search your data'
                                 }
                                 onHeaderClick={handleSubmit}
                                 header={
@@ -175,9 +239,11 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                                             mt={2}
                                         >
                                             Ask{' '}
-                                            {selectedAgent
-                                                ? selectedAgent.name
-                                                : 'AI'}
+                                            {activeSelection === 'auto'
+                                                ? 'AI'
+                                                : activeSelection
+                                                  ? activeSelection.name
+                                                  : 'AI'}
                                             :{' '}
                                             <Text
                                                 component="span"

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -1,4 +1,3 @@
-import { type AiAgentSummary } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -16,7 +15,7 @@ import {
     IconSettings,
     IconSparkles,
 } from '@tabler/icons-react';
-import { useEffect, useState, type FC } from 'react';
+import { useState, type FC } from 'react';
 import { Provider } from 'react-redux';
 import { Link, useNavigate } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -44,8 +43,6 @@ type Props = {
     projectUuid: string;
 };
 
-type SelectedAgent = AiAgentSummary | 'auto';
-
 const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
     const navigate = useNavigate();
 
@@ -62,7 +59,7 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
         isLoading: isLoadingUserAgentPreferences,
     } = useGetUserAgentPreferences(projectUuid);
     const aiRouterConfigQuery = useAiRouterConfig();
-    const [selectedAgent, setSelectedAgent] = useState<SelectedAgent>();
+    const [selectedAgentUuid, setSelectedAgentUuid] = useState<string>();
     const { setPendingPrompt } = usePendingPrompt();
     const canManageAgents = useAiAgentPermission({
         action: 'manage',
@@ -78,36 +75,14 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
     const validDefaultAgent = agents?.find(
         (agent) => agent.uuid === userAgentPreferences?.defaultAgentUuid,
     );
-    const preferredSelection: SelectedAgent | undefined =
+    const preferredSelection =
         validDefaultAgent ?? (showAutoOption ? 'auto' : agents?.[0]);
+
+    const selectedAgent =
+        selectedAgentUuid === AI_ROUTING_AUTO_VALUE && showAutoOption
+            ? 'auto'
+            : agents?.find((agent) => agent.uuid === selectedAgentUuid);
     const activeSelection = selectedAgent ?? preferredSelection;
-
-    useEffect(() => {
-        if (!agents || agents.length === 0) return;
-        if (isLoadingUserAgentPreferences) return;
-        if (aiRouterConfigQuery.isLoading) return;
-
-        setSelectedAgent((currentSelection) => {
-            if (currentSelection === 'auto') {
-                return showAutoOption ? currentSelection : preferredSelection;
-            }
-
-            if (
-                currentSelection &&
-                agents.some((agent) => agent.uuid === currentSelection.uuid)
-            ) {
-                return currentSelection;
-            }
-
-            return preferredSelection;
-        });
-    }, [
-        agents,
-        aiRouterConfigQuery.isLoading,
-        isLoadingUserAgentPreferences,
-        preferredSelection,
-        showAutoOption,
-    ]);
 
     const form = useForm({
         initialValues: {
@@ -120,6 +95,8 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
 
     const handleSubmit = form.onSubmit(async (values) => {
         const prompt = values.prompt.trim();
+
+        if (!prompt) return;
 
         if (activeSelection === 'auto') {
             setPendingPrompt(prompt);
@@ -152,14 +129,13 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
     const onSelect = (agentUuid: string) => {
         if (!agents) return;
         if (agentUuid === AI_ROUTING_AUTO_VALUE && showAutoOption) {
-            setSelectedAgent('auto');
+            setSelectedAgentUuid(AI_ROUTING_AUTO_VALUE);
             return;
         }
 
-        setSelectedAgent(
-            (currentSelection) =>
-                agents.find((a) => a.uuid === agentUuid) ?? currentSelection,
-        );
+        if (agents.some((agent) => agent.uuid === agentUuid)) {
+            setSelectedAgentUuid(agentUuid);
+        }
     };
 
     if (

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
@@ -2,16 +2,18 @@ import {
     Avatar,
     Combobox,
     Group,
+    Text,
     Tooltip,
     UnstyledButton,
     useCombobox,
     type ComboboxProps,
 } from '@mantine-8/core';
-import { IconChevronDown } from '@tabler/icons-react';
+import { IconCheck, IconChevronDown } from '@tabler/icons-react';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import Logo from '../../../../../svgs/logo-icon-round.svg?react';
 import {
+    AI_ROUTING_AUTO_VALUE,
     getAgentOptions,
     renderSelectOption,
     type Agent,
@@ -19,22 +21,26 @@ import {
 
 type Props = ComboboxProps & {
     agents: Agent[];
-    selectedAgent: Agent;
+    selectedAgent: Agent | 'auto';
     onSelect: (val: string) => void;
+    showAutoOption?: boolean;
 };
 
 export const CompactAgentSelector = ({
     agents,
     selectedAgent,
     onSelect,
+    showAutoOption = false,
     ...props
 }: Props) => {
     const combobox = useCombobox({
         onDropdownClose: () => combobox.resetSelectedOption(),
     });
     const agentOptions = getAgentOptions(agents);
-    const hasOneAgent = agentOptions.length === 1;
+    const isAuto = selectedAgent === 'auto';
+    const hasOneOption = agentOptions.length + (showAutoOption ? 1 : 0) === 1;
     const hasAgents = agentOptions.length > 0;
+    const tooltipLabel = isAuto ? 'Auto' : selectedAgent?.name;
 
     return (
         <Combobox
@@ -49,7 +55,7 @@ export const CompactAgentSelector = ({
         >
             <Combobox.Target>
                 <Tooltip
-                    label={selectedAgent?.name}
+                    label={tooltipLabel}
                     withArrow
                     withinPortal
                     fz="xs"
@@ -61,10 +67,16 @@ export const CompactAgentSelector = ({
                         variant="light"
                         color="gray"
                         p={0}
-                        disabled={hasOneAgent || !hasAgents}
+                        disabled={hasOneOption || !hasAgents}
                     >
                         <Group gap="two">
-                            {hasAgents ? (
+                            {isAuto ? (
+                                <Avatar size="md" color="ldGray" radius="xl">
+                                    <Text size="xs" fw={700} c="ldGray.6">
+                                        AI
+                                    </Text>
+                                </Avatar>
+                            ) : hasAgents ? (
                                 <LightdashUserAvatar
                                     size="md"
                                     name={selectedAgent.name}
@@ -76,7 +88,7 @@ export const CompactAgentSelector = ({
                                 </Avatar>
                             )}
 
-                            {!hasOneAgent && hasAgents && (
+                            {!hasOneOption && hasAgents && (
                                 <MantineIcon
                                     icon={IconChevronDown}
                                     color="ldGray.6"
@@ -89,11 +101,33 @@ export const CompactAgentSelector = ({
             </Combobox.Target>
 
             <Combobox.Dropdown>
+                {showAutoOption && (
+                    <Combobox.Option value={AI_ROUTING_AUTO_VALUE}>
+                        <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
+                            <Avatar size={22} color="ldGray" radius="xl">
+                                <Text size="10px" fw={700} c="ldGray.6">
+                                    AI
+                                </Text>
+                            </Avatar>
+                            <Text size="xs" truncate="end" flex={1}>
+                                Auto
+                            </Text>
+                            {isAuto && (
+                                <MantineIcon
+                                    icon={IconCheck}
+                                    size="sm"
+                                    color="violet"
+                                />
+                            )}
+                        </Group>
+                    </Combobox.Option>
+                )}
                 {agentOptions.map((agent) => (
                     <Combobox.Option key={agent.value} value={agent.value}>
                         {renderSelectOption({
                             option: agent,
-                            checked: agent.value === selectedAgent.uuid,
+                            checked:
+                                !isAuto && agent.value === selectedAgent.uuid,
                         })}
                     </Combobox.Option>
                 ))}

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -23,7 +23,7 @@ import {
     IconSettings,
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router';
+import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { getModelKey } from '../../../components/common/ModelSelector/utils';
@@ -64,6 +64,7 @@ type Phase =
 const AgentsRouterPage = () => {
     const { projectUuid } = useParams();
     const navigate = useNavigate();
+    const location = useLocation();
     const dispatch = useAiAgentStoreDispatch();
 
     const { data: agents } = useProjectAiAgents({
@@ -251,6 +252,31 @@ const AgentsRouterPage = () => {
             startThreadForDecision,
         ],
     );
+
+    useEffect(() => {
+        const autoSubmitPrompt =
+            typeof location.state?.autoSubmitPrompt === 'string'
+                ? location.state.autoSubmitPrompt.trim()
+                : '';
+
+        if (!autoSubmitPrompt || phase.kind !== 'idle') return;
+
+        void navigate(
+            { pathname: location.pathname, search: location.search },
+            { replace: true, state: undefined },
+        );
+        void handleSubmit({
+            message: autoSubmitPrompt,
+            toolHints: [],
+        });
+    }, [
+        handleSubmit,
+        location.pathname,
+        location.search,
+        location.state,
+        navigate,
+        phase.kind,
+    ]);
 
     const confirmPick = useCallback(
         async (agentUuid: string) => {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -22,7 +22,7 @@ import {
     IconInfoCircle,
     IconSettings,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -123,6 +123,7 @@ const AgentsRouterPage = () => {
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
 
     const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+    const consumedAutoSubmitKeyRef = useRef<string | undefined>(undefined);
 
     const agentsByUuid = useMemo(() => {
         const m = new Map<string, AiAgentSummary>();
@@ -253,13 +254,16 @@ const AgentsRouterPage = () => {
         ],
     );
 
-    useEffect(() => {
-        const autoSubmitPrompt =
-            typeof location.state?.autoSubmitPrompt === 'string'
-                ? location.state.autoSubmitPrompt.trim()
-                : '';
+    const autoSubmitPrompt =
+        typeof location.state?.autoSubmitPrompt === 'string'
+            ? location.state.autoSubmitPrompt.trim()
+            : '';
 
+    useEffect(() => {
         if (!autoSubmitPrompt || phase.kind !== 'idle') return;
+        if (consumedAutoSubmitKeyRef.current === location.key) return;
+
+        consumedAutoSubmitKeyRef.current = location.key;
 
         void navigate(
             { pathname: location.pathname, search: location.search },
@@ -270,10 +274,11 @@ const AgentsRouterPage = () => {
             toolHints: [],
         });
     }, [
+        autoSubmitPrompt,
         handleSubmit,
+        location.key,
         location.pathname,
         location.search,
-        location.state,
         navigate,
         phase.kind,
     ]);
@@ -461,9 +466,7 @@ const AgentsRouterPage = () => {
                                                 onClick={() =>
                                                     confirmPick(c.agentUuid)
                                                 }
-                                                className={`${
-                                                    classes.candidateButton
-                                                } ${
+                                                className={`${classes.candidateButton} ${
                                                     isRecommended
                                                         ? classes.recommended
                                                         : ''


### PR DESCRIPTION
Closes: PROD-8173

## Summary
- Add an Auto option to the home AI search agent selector when the AI router is enabled.
- Submit home prompts through the existing `/ai-agents?routing=auto` router flow.
- Keep default agent preferences taking precedence, matching the existing agents landing behavior.

## Validation
- `pnpm common-build:fast`
- `pnpm formula:build:fast`
- `pnpm frontend-typecheck`
- `pnpm frontend-format`
- `pnpm frontend-lint` (passes with 4 existing warnings outside touched files)

