### PR TITLE
fix(ai-agents): polish chat input controls

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css
@@ -53,13 +53,12 @@
     }
 }
 
-/* Compact: icon-only at rest, no border. On hover / focus / open, the chip
- * grows a border + light background to match the adjacent model+thinking
- * group, then snaps back when interaction ends. The default 1px transparent
- * border reserves the same footprint so the chip doesn't shift on hover. */
 .compact {
     width: auto;
+    height: rem(30px);
+    padding: 0 var(--mantine-spacing-xs);
     border-color: transparent;
+    border-radius: var(--mantine-radius-xl);
     box-shadow: none;
     background: transparent;
 }
@@ -67,7 +66,7 @@
 .compact:hover,
 .compact:focus-visible,
 .compact[data-open='true'] {
-    border-color: var(--mantine-color-ldGray-2);
+    border-color: transparent;
 
     @mixin light {
         background-color: var(--mantine-color-ldGray-0);
@@ -79,24 +78,10 @@
 
 .compact .label {
     flex: none;
-    width: 0;
+    width: auto;
+    max-width: rem(140px);
     overflow: hidden;
     white-space: nowrap;
-    transition: width 220ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.compact[data-auto='true'] .label {
-    width: auto;
-}
-
-.compact:hover .label,
-.compact:focus-visible .label,
-.compact[data-open='true'] .label {
-    width: 140px;
-}
-
-.compact[data-auto='true']:hover .label,
-.compact[data-auto='true']:focus-visible .label,
-.compact[data-auto='true'][data-open='true'] .label {
-    width: auto;
+    font-weight: 600;
+    color: var(--mantine-color-ldGray-8);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
@@ -3,15 +3,7 @@ import {
     type AiMcpCredentialScope,
     type AiMcpServer,
 } from '@lightdash/common';
-import {
-    Box,
-    Button,
-    Group,
-    Paper,
-    Skeleton,
-    Stack,
-    Text,
-} from '@mantine-8/core';
+import { Box, Button, Group, Paper, Stack, Text } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconBrandGithub,
@@ -255,18 +247,7 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
         ],
     );
 
-    if (isLoading) {
-        return (
-            <Box
-                className={styles.connectionStrip}
-                component="section"
-                aria-label="Loading tools to connect"
-                aria-busy="true"
-            >
-                <Skeleton h={24} w={260} radius="xl" />
-            </Box>
-        );
-    }
+    if (isLoading) return null;
 
     if (justConnectedGithub) {
         return (


### PR DESCRIPTION
## Summary

- Make the compact agent selector in the AI chat input match the model selector's stable subtle button treatment.
- Remove the transient MCP connections skeleton that flashes when switching agents in the launcher.

## Why

The chat input controls used mixed visual vocabulary: the agent selector behaved like an expanding input/chip while the model selector behaved like a stable button. Agent switches could also briefly render an MCP loading strip even when no connection prompt was needed.

## Validation

- `pnpm -F frontend run linter src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css`
- `pnpm -F frontend run formatter src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css --check`
- `git diff --check -- packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css`

Visual smoke was not run because no local Lightdash server was reachable in this checkout.