### PR TITLE
feat(ai-agents): add review retry and fixed actions

### DIFF
--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -1,7 +1,11 @@
+import { Ability } from '@casl/ability';
 import {
     AiAgentReviewRemediation,
+    OrganizationMemberRole,
     PullRequestProvider,
     type AiAgentReviewItemSummary,
+    type PossibleAbilities,
+    type SessionUser,
 } from '@lightdash/common';
 import { getPullRequestComments } from '../../clients/github/Github';
 import {
@@ -94,18 +98,47 @@ const makeRemediation = (
     ...overrides,
 });
 
+const makeAdminUser = (): SessionUser => ({
+    userUuid: USER_UUID,
+    email: 'admin@example.com',
+    firstName: 'Admin',
+    lastName: 'User',
+    organizationUuid: ORGANIZATION_UUID,
+    organizationName: 'Acme',
+    organizationCreatedAt: NOW,
+    userId: 1,
+    role: OrganizationMemberRole.ADMIN,
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: true,
+    isActive: true,
+    createdAt: NOW,
+    updatedAt: NOW,
+    timezone: null,
+    ability: new Ability<PossibleAbilities>([
+        { action: 'manage', subject: 'Organization' },
+    ]),
+    abilityRules: [],
+});
+
 const makeService = ({
     aiAgentModel = {},
     aiAgentReviewClassifierModel = {},
+    featureFlagService = {},
+    aiOrganizationSettingsService = {},
     projectModel = {},
     schedulerClient = {},
     githubAppInstallationsModel = {},
+    gitlabAppInstallationsModel = {},
 }: {
     aiAgentModel?: Record<string, unknown>;
     aiAgentReviewClassifierModel?: Record<string, unknown>;
+    featureFlagService?: Record<string, unknown>;
+    aiOrganizationSettingsService?: Record<string, unknown>;
     projectModel?: Record<string, unknown>;
     schedulerClient?: Record<string, unknown>;
     githubAppInstallationsModel?: Record<string, unknown>;
+    gitlabAppInstallationsModel?: Record<string, unknown>;
 } = {}) =>
     new AiAgentAdminService({
         analytics: { track: jest.fn() },
@@ -131,8 +164,16 @@ const makeService = ({
                 .mockResolvedValue(undefined),
             ...aiAgentReviewClassifierModel,
         },
-        featureFlagService: {},
+        featureFlagService: {
+            get: jest.fn().mockResolvedValue({ enabled: true }),
+            ...featureFlagService,
+        },
+        aiOrganizationSettingsService: {
+            isAiAgentReviewsEnabled: jest.fn().mockResolvedValue(true),
+            ...aiOrganizationSettingsService,
+        },
         projectModel: {
+            get: jest.fn().mockRejectedValue(new Error('Project not found')),
             getPreviewAiAgentUuid: jest
                 .fn()
                 .mockResolvedValue(PREVIEW_AGENT_UUID),
@@ -143,9 +184,13 @@ const makeService = ({
         pullRequestsModel: {},
         githubAppInstallationsModel: {
             getInstallationId: jest.fn().mockResolvedValue('installation-1'),
+            findInstallationId: jest.fn().mockResolvedValue(undefined),
             ...githubAppInstallationsModel,
         },
-        gitlabAppInstallationsModel: {},
+        gitlabAppInstallationsModel: {
+            findInstallationId: jest.fn().mockResolvedValue(undefined),
+            ...gitlabAppInstallationsModel,
+        },
         schedulerClient: {
             aiAgentReviewRemediationPreview: jest
                 .fn()
@@ -153,7 +198,11 @@ const makeService = ({
             ...schedulerClient,
         },
         userModel: {},
-        lightdashConfig: { siteUrl: SITE_URL },
+        lightdashConfig: {
+            siteUrl: SITE_URL,
+            appRuntime: { e2bApiKey: 'e2b-api-key' },
+            aiWriteback: { anthropicApiKey: 'anthropic-api-key' },
+        },
     } as unknown as ConstructorParameters<typeof AiAgentAdminService>[0]);
 
 describe('getAiAgentReviewItemWritebackEligibility', () => {
@@ -305,6 +354,58 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
     });
 });
 
+describe('AiAgentAdminService.updateReviewItemStatus', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('resolves the linked remediation when the review item is resolved', async () => {
+        const resolvedReviewItem = makeReviewItem({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            status: 'resolved',
+            remediation: makeRemediation({ status: 'pr_open' }),
+        });
+        const aiAgentReviewClassifierModel = {
+            getPromotedFingerprintScope: jest.fn().mockResolvedValue({
+                projectUuid: PROJECT_UUID,
+                agentUuid: AGENT_UUID,
+            }),
+            getReviewItem: jest
+                .fn()
+                .mockResolvedValueOnce(
+                    makeReviewItem({
+                        organizationUuid: ORGANIZATION_UUID,
+                        projectUuid: PROJECT_UUID,
+                        agentUuid: AGENT_UUID,
+                        status: 'open',
+                    }),
+                )
+                .mockResolvedValue(resolvedReviewItem),
+            upsertReviewItemState: jest.fn().mockResolvedValue(undefined),
+            updateReviewRemediationStatus: jest
+                .fn()
+                .mockResolvedValue(undefined),
+        };
+        const service = makeService({ aiAgentReviewClassifierModel });
+
+        await service.updateReviewItemStatus(makeAdminUser(), 'fingerprint-1', {
+            status: 'resolved',
+            dismissedReason: null,
+        });
+
+        expect(
+            aiAgentReviewClassifierModel.updateReviewRemediationStatus,
+        ).toHaveBeenCalledWith({
+            remediationUuid: REMEDIATION_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            status: 'resolved',
+            resolvedByUserUuid: USER_UUID,
+        });
+    });
+});
+
 describe('AiAgentAdminService.pollReviewRemediationPreview', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -380,5 +481,44 @@ describe('AiAgentAdminService.pollReviewRemediationPreview', () => {
             previewAgentUuid: PREVIEW_AGENT_UUID,
             previewThreadUuid: PREVIEW_THREAD_UUID,
         });
+    });
+
+    it('marks remediation failed when no preview URL is published in time', async () => {
+        const aiAgentReviewClassifierModel = {
+            updateReviewRemediationStatus: jest
+                .fn()
+                .mockResolvedValue(undefined),
+        };
+        const schedulerClient = {
+            aiAgentReviewRemediationPreview: jest
+                .fn()
+                .mockResolvedValue(undefined),
+        };
+        const service = makeService({
+            aiAgentReviewClassifierModel,
+            schedulerClient,
+        });
+
+        await service.pollReviewRemediationPreview({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            userUuid: USER_UUID,
+            fingerprint: 'fingerprint-1',
+            remediationUuid: REMEDIATION_UUID,
+            prUrl: 'https://github.com/acme/dbt/pull/42',
+            startedAt: Date.now() - 11 * 60_000,
+        });
+
+        expect(
+            aiAgentReviewClassifierModel.updateReviewRemediationStatus,
+        ).toHaveBeenCalledWith({
+            remediationUuid: REMEDIATION_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            status: 'failed',
+            errorMessage: 'Preview URL was not published in time',
+        });
+        expect(
+            schedulerClient.aiAgentReviewRemediationPreview,
+        ).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -847,6 +847,20 @@ export class AiAgentAdminService extends BaseService {
                 },
             });
         }
+        if (
+            update.status === 'resolved' &&
+            reviewItem.remediation &&
+            reviewItem.remediation.status !== 'resolved'
+        ) {
+            await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                {
+                    remediationUuid: reviewItem.remediation.uuid,
+                    organizationUuid,
+                    status: 'resolved',
+                    resolvedByUserUuid: user.userUuid,
+                },
+            );
+        }
         return this.getReviewItem(user, fingerprint);
     }
 
@@ -1359,7 +1373,7 @@ export class AiAgentAdminService extends BaseService {
                 {
                     remediationUuid,
                     organizationUuid,
-                    status: 'pr_open',
+                    status: 'failed',
                     errorMessage: 'Preview URL was not published in time',
                 },
             );

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -860,6 +860,23 @@ export class AiAgentAdminService extends BaseService {
                     resolvedByUserUuid: user.userUuid,
                 },
             );
+        } else if (
+            terminalReviewStatuses.has(update.status) &&
+            reviewItem.remediation &&
+            activeRemediationStatuses.has(reviewItem.remediation.status)
+        ) {
+            // Dismissing or duplicating must also close an active remediation —
+            // otherwise the one-active-per-fingerprint index blocks all future
+            // writebacks for this fingerprint. Closed as failed (not resolved)
+            // so "resolved" keeps meaning the fix was confirmed.
+            await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
+                {
+                    remediationUuid: reviewItem.remediation.uuid,
+                    organizationUuid,
+                    status: 'failed',
+                    errorMessage: `Review item was marked as ${update.status}`,
+                },
+            );
         }
         return this.getReviewItem(user, fingerprint);
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -611,11 +611,14 @@ const ReviewItemPrCell = ({
 
     const propInFlight =
         reviewItem.prWritebackStatus === 'queued' ||
-        reviewItem.prWritebackStatus === 'running';
-    // Poll the single item while writeback runs so live phase messages surface.
+        reviewItem.prWritebackStatus === 'running' ||
+        reviewItem.remediation?.status === 'pr_open';
+    // Poll the single item while writeback runs and while the preview thread is
+    // being discovered from the PR comments.
     const { data: polled } = useAiAgentAdminReviewItem(reviewItem.fingerprint, {
         enabled: propInFlight,
-        refetchInterval: propInFlight ? 2500 : false,
+        refetchInterval:
+            reviewItem.remediation?.status === 'pr_open' ? 10_000 : 2500,
     });
     const current = polled ?? reviewItem;
 
@@ -634,6 +637,16 @@ const ReviewItemPrCell = ({
     const previewsDiff = current.primaryRootCause === 'project_context';
 
     const phase = current.prWritebackMessage ?? 'Opening pull request…';
+    const workThreadUrl =
+        current.remediation?.previewProjectUuid &&
+        current.remediation.previewAgentUuid &&
+        current.remediation.previewThreadUuid
+            ? `/projects/${current.remediation.previewProjectUuid}/ai-agents/${current.remediation.previewAgentUuid}/threads/${current.remediation.previewThreadUuid}?reviewItem=${encodeURIComponent(current.fingerprint)}`
+            : null;
+    const remediationError =
+        current.remediation?.status === 'failed'
+            ? current.remediation.errorMessage
+            : null;
 
     return (
         <>
@@ -662,6 +675,25 @@ const ReviewItemPrCell = ({
                                 color="gray"
                             >
                                 View PR
+                            </Button>
+                        )}
+
+                        {workThreadUrl && (
+                            <Button
+                                component="a"
+                                href={workThreadUrl}
+                                onClick={(event) => event.stopPropagation()}
+                                size="compact-xs"
+                                fz="xs"
+                                variant="default"
+                                leftSection={
+                                    <MantineIcon
+                                        icon={IconMessages}
+                                        size="xs"
+                                    />
+                                }
+                            >
+                                Test fix
                             </Button>
                         )}
 
@@ -701,6 +733,21 @@ const ReviewItemPrCell = ({
                                 {getSuggestedNextStep(current)}
                             </Text>
                         </Group>
+                    )}
+
+                    {remediationError && (
+                        <Tooltip
+                            label={remediationError}
+                            withArrow
+                            openDelay={300}
+                        >
+                            <Group gap={4} wrap="nowrap" maw={220}>
+                                <MantineIcon icon={IconInfoCircle} size="xs" />
+                                <Text fz="xs" c="red.6" fw={500} lineClamp={1}>
+                                    {remediationError}
+                                </Text>
+                            </Group>
+                        </Tooltip>
                     )}
 
                     {!canCreatePr &&

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -226,8 +226,12 @@ export const useUpdateAiAgentReviewItemStatus = () => {
         { fingerprint: string; body: UpdateAiAgentReviewItemStatus }
     >({
         mutationFn: updateAiAgentReviewItemStatus,
-        onSuccess: () => {
+        onSuccess: (updatedItem, { fingerprint }) => {
             showToastSuccess({ title: 'Review item updated' });
+            queryClient.setQueryData(
+                ['ai-agent-admin-review-item', fingerprint],
+                updatedItem,
+            );
             void queryClient.invalidateQueries({
                 queryKey: ['ai-agent-admin-review-items'],
             });

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,6 +1,20 @@
-import { Center, Loader } from '@mantine-8/core';
+import {
+    Alert,
+    Button,
+    Center,
+    Group,
+    Loader,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import {
+    IconCircleCheck,
+    IconGitPullRequest,
+    IconRefresh,
+} from '@tabler/icons-react';
 import { useCallback, useMemo } from 'react';
-import { useOutletContext, useParams } from 'react-router';
+import { useOutletContext, useParams, useSearchParams } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
@@ -8,6 +22,10 @@ import {
     contextItemsToContentMentionSuggestions,
     mergeContentMentionSuggestionItems,
 } from '../../features/aiCopilot/components/ChatElements/contentMentions';
+import {
+    useAiAgentAdminReviewItem,
+    useUpdateAiAgentReviewItemStatus,
+} from '../../features/aiCopilot/hooks/useAiAgentAdmin';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { useAiAgentThreadArtifact } from '../../features/aiCopilot/hooks/useAiAgentThreadArtifact';
@@ -33,6 +51,8 @@ import { type AgentContext } from './AgentPage';
 
 const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const { agentUuid, threadUuid, projectUuid, promptUuid } = useParams();
+    const [searchParams] = useSearchParams();
+    const reviewFingerprint = searchParams.get('reviewItem');
     const { user } = useApp();
 
     const {
@@ -115,6 +135,13 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         threadUuid!,
         refetch,
     );
+    const { data: reviewItem } = useAiAgentAdminReviewItem(
+        reviewFingerprint ?? '',
+        {
+            enabled: !!reviewFingerprint,
+        },
+    );
+    const updateReviewItemStatus = useUpdateAiAgentReviewItemStatus();
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const sqlMode = useAiAgentStoreSelector(
@@ -218,6 +245,32 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
             toolHints,
         });
     };
+    const isBusy = isCreatingMessage || isStreaming || isPending;
+    const reviewRemediation = reviewItem?.remediation ?? null;
+    const reviewRemediationForThread =
+        reviewRemediation?.previewThreadUuid === threadUuid
+            ? reviewRemediation
+            : null;
+    const retryPrompt = reviewRemediationForThread?.retryPrompt ?? null;
+    const linkedPrUrl = reviewRemediationForThread?.linkedPrUrl ?? null;
+    const isReviewFixed = reviewItem?.status === 'resolved';
+    const handleRetryOriginalQuestion = () => {
+        if (!retryPrompt) return;
+        handleSubmit({
+            message: retryPrompt,
+            toolHints: [],
+        });
+    };
+    const handleMarkFixed = () => {
+        if (!reviewItem || isReviewFixed) return;
+        updateReviewItemStatus.mutate({
+            fingerprint: reviewItem.fingerprint,
+            body: {
+                status: 'resolved',
+                dismissedReason: null,
+            },
+        });
+    };
 
     if (isLoadingThread || !thread || agentQuery.isLoading) {
         return (
@@ -239,35 +292,103 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
             showAddToEvalsButton={canManage}
             onDashboardLinkClick={handleDashboardLinkClick}
         >
-            <AgentChatInput
-                disabled={inputDisabled}
-                disabledReason={inputDisabledReason}
-                loading={isCreatingMessage || isStreaming || isPending}
-                onSubmit={handleSubmit}
-                placeholder={`Ask ${agent.name} anything about your data...`}
-                messageCount={thread.messages?.length || 0}
-                projectUuid={projectUuid}
-                agentUuid={agentUuid}
-                threadUuid={threadUuid}
-                contentMentionPriorityItems={contentMentionItems}
-                latestAssistantMessageUuid={
-                    [...(thread.messages ?? [])]
-                        .reverse()
-                        .find((m) => m.role === 'assistant')?.uuid
-                }
-                sqlMode={sqlModeAvailable ? sqlMode : undefined}
-                onSqlModeChange={
-                    sqlModeAvailable && threadUuid
-                        ? (enabled) =>
-                              dispatch(
-                                  setThreadSqlMode({
-                                      threadUuid,
-                                      enabled,
-                                  }),
-                              )
-                        : undefined
-                }
-            />
+            <Stack gap="xs">
+                {reviewItem && retryPrompt && (
+                    <Alert color="gray" variant="light" px="md" py="sm">
+                        <Group justify="space-between" align="center" gap="sm">
+                            <Stack gap={2}>
+                                <Text fz="sm" fw={600}>
+                                    {reviewItem.title}
+                                </Text>
+                                <Text fz="xs" c="dimmed">
+                                    Retry the original question in this preview,
+                                    then mark the review fixed when the answer
+                                    behaves as expected.
+                                </Text>
+                            </Stack>
+                            <Group gap="xs" wrap="nowrap">
+                                {linkedPrUrl && (
+                                    <Button
+                                        component="a"
+                                        href={linkedPrUrl}
+                                        target="_blank"
+                                        size="xs"
+                                        variant="subtle"
+                                        color="gray"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconGitPullRequest}
+                                                size="sm"
+                                            />
+                                        }
+                                    >
+                                        View PR
+                                    </Button>
+                                )}
+                                <Button
+                                    size="xs"
+                                    variant="default"
+                                    disabled={inputDisabled || isBusy}
+                                    onClick={handleRetryOriginalQuestion}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconRefresh}
+                                            size="sm"
+                                        />
+                                    }
+                                >
+                                    Retry question
+                                </Button>
+                                <Button
+                                    size="xs"
+                                    color="green"
+                                    variant={isReviewFixed ? 'light' : 'filled'}
+                                    disabled={isReviewFixed}
+                                    loading={updateReviewItemStatus.isLoading}
+                                    onClick={handleMarkFixed}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconCircleCheck}
+                                            size="sm"
+                                        />
+                                    }
+                                >
+                                    {isReviewFixed ? 'Fixed' : 'Mark fixed'}
+                                </Button>
+                            </Group>
+                        </Group>
+                    </Alert>
+                )}
+                <AgentChatInput
+                    disabled={inputDisabled}
+                    disabledReason={inputDisabledReason}
+                    loading={isBusy}
+                    onSubmit={handleSubmit}
+                    placeholder={`Ask ${agent.name} anything about your data...`}
+                    messageCount={thread.messages?.length || 0}
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                    threadUuid={threadUuid}
+                    contentMentionPriorityItems={contentMentionItems}
+                    latestAssistantMessageUuid={
+                        [...(thread.messages ?? [])]
+                            .reverse()
+                            .find((m) => m.role === 'assistant')?.uuid
+                    }
+                    sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                    onSqlModeChange={
+                        sqlModeAvailable && threadUuid
+                            ? (enabled) =>
+                                  dispatch(
+                                      setThreadSqlMode({
+                                          threadUuid,
+                                          enabled,
+                                      }),
+                                  )
+                            : undefined
+                    }
+                />
+            </Stack>
         </AgentChatDisplay>
     );
 };


### PR DESCRIPTION
## Summary
- add Test fix entrypoint from review items to preview work threads
- show review context in preview work threads
- add Retry question action using the original failed prompt
- add Mark fixed action that resolves the review item and linked remediation
- cover remediation closure with a backend regression test

## Validation
- `git diff --check`
- `pnpm -F backend test -- AiAgentAdminService.test.ts --runInBand`
- `pnpm -F backend typecheck`
- `pnpm -F @lightdash/frontend typecheck`