### PR TITLE
fix: sanitize HTML in markdown rendering components

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -4,6 +4,8 @@ import MDEditor from '@uiw/react-md-editor';
 import { format, parseISO } from 'date-fns';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import { useTimeAgo } from '../../../../../hooks/useTimeAgo';
 import useApp from '../../../../../providers/App/useApp';
 import { PinnedContextCard } from '../PinnedContextCard/PinnedContextCard';
@@ -106,6 +108,10 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                                     key={`text-${idx}`}
                                     source={segment.text}
                                     className={`${styles.markdown} ${styles.inlineMarkdown}`}
+                                    rehypePlugins={[
+                                        rehypeRaw,
+                                        [rehypeSanitize, defaultSchema],
+                                    ]}
                                 />
                             ) : (
                                 <ContentReferenceLink
@@ -133,6 +139,10 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                     <MDEditor.Markdown
                         source={message.message}
                         className={styles.markdown}
+                        rehypePlugins={[
+                            rehypeRaw,
+                            [rehypeSanitize, defaultSchema],
+                        ]}
                     />
                 )}
             </Card>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/OperationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/OperationRenderer.tsx
@@ -2,6 +2,8 @@ import { assertUnreachable, capitalize } from '@lightdash/common';
 import { Paper, Stack, Text } from '@mantine-8/core';
 import MDEditor from '@uiw/react-md-editor';
 import rehypeExternalLinks from 'rehype-external-links';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import {
     mdEditorComponents,
     rehypeRemoveHeaderLinks,
@@ -26,7 +28,11 @@ const ReplaceOrAddOperation = ({ value, name }: ReplaceOperationProps) => {
                 source={value}
                 style={mdStyle}
                 rehypeRewrite={rehypeRemoveHeaderLinks}
-                rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }]]}
+                rehypePlugins={[
+                    rehypeRaw,
+                    [rehypeSanitize, defaultSchema],
+                    [rehypeExternalLinks, { target: '_blank' }],
+                ]}
                 components={mdEditorComponents}
             />
         </Paper>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-472/veria-3-stored-cross-site-scripting-xss-via-unsanitized-markdown-in-ai



![CleanShot 2026-06-08 at 17.01.49.png](https://app.graphite.com/user-attachments/assets/338fb0bb-cdb5-4eeb-905b-d44fdafa15f2.png)



<!-- reference the related issue e.g. #150 -->

### Description:

Adds HTML sanitization to all markdown rendering components. Raw HTML embedded in markdown content (such as `<script>` tags and event handler attributes like `onerror`) is now stripped before rendering, while safe HTML elements and attributes (e.g., valid anchor tags) are preserved.