### PR TITLE
feat(backend): deprecation logging, deadlines, headers & Sentry for endpoints

### DIFF
--- a/.claude/skills/deprecate-endpoint/SKILL.md
+++ b/.claude/skills/deprecate-endpoint/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: deprecate-endpoint
+description: Use when deprecating, sunsetting, or removing a backend HTTP API endpoint in Lightdash — wiring deprecation logging, deadline/sunset dates, response headers, and Sentry alerting onto a TSOA controller route. Covers the first-party-caller precondition and the shared deprecation middleware.
+allowed-tools: Read, Grep, Glob, Edit, Bash
+---
+
+# Deprecate an HTTP Endpoint
+
+Checklist for deprecating a backend HTTP endpoint. The runtime behavior
+(warn→error logging, Sentry alerting, response headers) lives in one shared
+middleware — you only wire it on and supply a date + replacement hint.
+
+The authoritative policy is `packages/backend/src/controllers/CLAUDE.md` →
+"Deprecating Endpoints". This skill is the actionable checklist.
+
+## Scope — endpoints only
+
+Only HTTP route handlers (TSOA controllers) get the deprecation middleware.
+Internal service/model methods, type fields, DB columns, and config fields are
+**not** endpoints — mark those with a plain `@deprecated` JSDoc and stop there.
+
+## First, check current state
+
+Read the handler before editing. It may already have some of the pieces
+(`@deprecated` JSDoc, `@Deprecated()`, the middleware) — only add what's missing.
+
+## Precondition (hard blocker)
+
+**Only deprecate an endpoint once nothing first-party calls it anymore.** The
+frontend, CLI, EE code, and other internal consumers must already be migrated to
+the replacement. A deprecated route logs an error and reports to Sentry once past
+its deadline, so any straggler caller becomes noise/alerts.
+
+Verify before touching the controller — search every first-party surface for the
+route path and its API hooks, including EE and test suites:
+
+```bash
+grep -rn "<route-fragment>" packages/frontend/src packages/cli/src \
+  packages/common/src packages/backend/src/ee packages/api-tests packages/e2e
+```
+
+Watch for version differences: a v2 call (`version: 'v2'` / `/api/v2/...`) to a
+similar path is the *replacement*, not a caller of the v1 route. A test that hits
+the route counts as a caller — it will trigger logs/Sentry once past sunset. If
+any first-party caller remains, migrate it first (or stop — it cannot be
+deprecated yet).
+
+## Wire it up
+
+In the controller, on the route handler:
+
+- [ ] Add the `@deprecated` JSDoc line naming the replacement. TSOA reads this
+      tag to set `deprecated: true` in the OpenAPI spec.
+- [ ] Add the TSOA `@Deprecated()` decorator — the explicit, consistent way to
+      mark it (decorator order doesn't matter). Keep both this and the JSDoc.
+- [ ] Add `getDeprecatedRouteMiddleware` to the handler's `@Middlewares([...])`
+      (use the same text for `suffixMessage` as the `@deprecated` JSDoc):
+
+```ts
+import { getDeprecatedRouteMiddleware } from './authentication';
+
+@Middlewares([
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    getDeprecatedRouteMiddleware(new Date('2026-06-08'), {
+        suffixMessage: 'Use GET /api/v2/.../roleAssignments instead.',
+    }),
+])
+@Deprecated()
+```
+
+- `new Date(...)` is the date you are deprecating it (today). The removal/sunset
+  date **defaults to deprecatedOn + 3 months**; only pass `{ removeOn: ... }` when
+  a different sunset has been agreed.
+- If the handler has no `@Middlewares` block (e.g. some embed routes), add one
+  containing just the middleware.
+
+## You get this for free
+
+`getDeprecatedRouteMiddleware` (`controllers/authentication/deprecation.ts`)
+already does, per call:
+
+- `Deprecation`, `Sunset`, and legacy `Warning` response headers.
+- A warning log, escalating to an **error log + Sentry `DeprecatedRouteError`**
+  (`@lightdash/common`) once the sunset is within two weeks or has passed.
+
+Do not add per-endpoint logging/headers. (Some older routes also fire a
+`trackDeprecatedRouteCalled` analytics event — that's optional; the middleware is
+the standard.)
+
+## Later: removal
+
+Once the sunset passes (the route is now error-logging + Sentry-alerting on every
+call), the follow-up task is to delete the handler and its route, then
+`pnpm generate-api` again. That's a separate change, not part of deprecating.

--- a/docs/superpowers/specs/2026-06-08-deprecated-endpoint-logging-design.md
+++ b/docs/superpowers/specs/2026-06-08-deprecated-endpoint-logging-design.md
@@ -1,0 +1,151 @@
+# Deprecated endpoint logging, deadlines & headers — design
+
+Date: 2026-06-08
+
+## Goal
+
+Every deprecated **HTTP endpoint** must:
+
+1. Emit a **warning log** on each call.
+2. Emit an **error log** instead when its removal deadline is within two weeks or already passed.
+3. Have an explicit **deadline (sunset) date**.
+4. Return **deprecation response headers**.
+
+Deprecated endpoints are not expected to be called by the frontend, CLI, or any
+first-party client. Per-call logging is therefore acceptable and intentional —
+any log line is a signal that something still depends on a route slated for
+removal. No throttling/sampling.
+
+## Scope
+
+In scope: deprecated **HTTP route handlers** in `packages/backend/src/controllers/`
+(and `ee/controllers/`), whether currently marked by the TSOA `@Deprecated()`
+decorator or only by a `@deprecated` JSDoc comment.
+
+Explicitly out of scope:
+
+- Internal callable methods marked `@deprecated` (services/models/utils) — not
+  endpoints, no HTTP response, no natural deadline.
+- Non-callable `@deprecated` declarations — type fields, DB columns, config
+  fields. Nothing to instrument at runtime.
+
+## Design
+
+### 1. Middleware: `getDeprecatedRouteMiddleware`
+
+Location: `packages/backend/src/controllers/authentication/middlewares.ts`
+(enhances the existing function).
+
+New signature — primary argument is the date the endpoint was **deprecated**; the
+removal deadline defaults to `deprecatedOn + 3 months` and can be overridden:
+
+```ts
+getDeprecatedRouteMiddleware(
+    deprecatedOn: Date,
+    options?: { removeOn?: Date; suffixMessage?: string },
+): RequestHandler
+```
+
+- `removeOn` default: `deprecatedOn` with month advanced by 3
+  (`d = new Date(deprecatedOn); d.setMonth(d.getMonth() + 3)`). No new date
+  dependency.
+- There is **no** shared deadline constant. Each endpoint supplies its own
+  `deprecatedOn` (sourced from git history — when the deprecation was added).
+
+#### Response headers
+
+Set on every call:
+
+- `Deprecation: <deprecatedOn as HTTP-date>` (RFC 9745)
+- `Sunset: <removeOn as HTTP-date>` (RFC 8594)
+- `Warning: 299 - "This API endpoint is deprecated and will be removed after <removeOn>. <suffixMessage>"`
+  (retained for backward compatibility with existing clients).
+
+#### Logging
+
+Per call, compute `msUntilRemoval = removeOn.getTime() - now`:
+
+- `msUntilRemoval > 14 days` → `Logger.warn(...)`
+- `msUntilRemoval <= 14 days` (within two weeks **or** already passed) →
+  `Logger.error(...)`
+
+Log message includes: HTTP method, route path, `deprecatedOn` (ISO),
+`removeOn` (ISO), and the replacement hint (`suffixMessage`).
+
+#### Testability
+
+Extract the warn-vs-error decision and the date math into small pure helpers so
+they can be unit-tested without constructing the full middleware/Express stack:
+
+- `getDefaultSunsetDate(deprecatedOn: Date): Date`
+- `shouldEscalateToError(removeOn: Date, now: Date): boolean` (true when
+  `removeOn - now <= 14 days`)
+
+### 2. Wire every deprecated endpoint
+
+For each in-scope route handler, add
+`getDeprecatedRouteMiddleware(deprecatedOn, { suffixMessage })` to its
+`@Middlewares([...])` array, where:
+
+- `deprecatedOn` = the date the route was deprecated, from git history.
+- `suffixMessage` = the replacement hint, reused from the endpoint's existing
+  `@deprecated` JSDoc text.
+
+Also keep the `@Deprecated()` decorator and `@deprecated` JSDoc on each (they
+drive OpenAPI). For endpoints currently marked only by JSDoc, the JSDoc stays as
+the source of the replacement message; adding the `@Deprecated()` decorator for
+OpenAPI parity is optional and not required by this change.
+
+The 4 routes already using `deprecatedResultsRoute` (in `runQueryController` and
+`savedChartController`) inherit the enhanced behavior automatically.
+`deprecatedResultsRoute` itself is migrated to the new signature: its real
+`deprecatedOn` from git, with `removeOn: new Date('2025-04-30')` passed
+explicitly to preserve its historical sunset date.
+
+Endpoints to instrument (final list confirmed against source during
+implementation; verify each to avoid double-wiring):
+
+- `dashboardController` — 1
+- `projectController` — `getQueryResults`, `calculateTotalFromQuery`,
+  `updateProjectUserRole`, `deleteProjectUserRole`
+- `organizationController` — 1
+- `groupsController` — 3
+- `catalogController` — 4
+- `validationController` — 1
+- `ee/controllers/embedController` — calculate-total / subtotals routes
+
+Because the real deprecation dates are all more than 3 months in the past, the
+default `removeOn` lands in the past for these endpoints → they emit **error**
+logs, correctly surfacing overdue deprecations.
+
+### 3. Documentation
+
+Add a **"Deprecating endpoints"** section to
+`packages/backend/src/controllers/CLAUDE.md` covering:
+
+- **What**: applies to HTTP endpoints only (not internal methods, types, DB
+  columns, or config fields).
+- **When**: endpoints sunset 3 months after deprecation by default; override
+  `removeOn` only when a different window is agreed.
+- **How**: add `getDeprecatedRouteMiddleware(deprecatedOn, { suffixMessage })`
+  to the endpoint's `@Middlewares([...])`, keep the `@Deprecated()` decorator
+  and `@deprecated` JSDoc, set the replacement hint as `suffixMessage`.
+- **Behavior**: warn logs per call escalate to error logs within two weeks of
+  (or after) the sunset date; `Deprecation`/`Sunset`/`Warning` headers are
+  returned automatically.
+
+## Testing
+
+- New unit test for `middlewares.ts` deprecation helpers/middleware:
+  - `getDefaultSunsetDate` returns `deprecatedOn + 3 months`.
+  - `shouldEscalateToError`: far-future deadline → false; within 14 days → true;
+    past → true.
+  - Middleware sets `Deprecation`, `Sunset`, and `Warning` headers.
+  - Middleware calls `Logger.warn` for a far-future deadline and `Logger.error`
+    for a near/past deadline (mocked `Logger`, injected `now`).
+
+## Out of scope / non-goals
+
+- No throttling or sampling of deprecation logs.
+- No instrumentation of non-endpoint `@deprecated` items.
+- No removal of the legacy `Warning` header.

--- a/packages/backend/src/controllers/CLAUDE.md
+++ b/packages/backend/src/controllers/CLAUDE.md
@@ -110,6 +110,46 @@ export class ProjectController extends BaseController {
 
 </importantToKnow>
 
+## Deprecating Endpoints
+
+**What:** This applies to HTTP endpoints only. Internal service/model methods,
+type fields, DB columns, and config fields are not endpoints — mark them with a
+`@deprecated` JSDoc comment but do not add deprecation middleware.
+
+**When:** Only deprecate an endpoint once nothing first-party calls it anymore —
+the frontend, CLI, and other internal consumers must already be migrated off it.
+A deprecated endpoint is removed 3 months after it was deprecated by default.
+That window is the `getDeprecatedRouteMiddleware` default; override it only when a
+different sunset date has been agreed.
+
+**How:** Add `getDeprecatedRouteMiddleware(deprecatedOn, { suffixMessage })` to
+the endpoint's `@Middlewares([...])`, where `deprecatedOn` is the date the
+endpoint was deprecated and `suffixMessage` names the replacement. Keep the TSOA
+`@Deprecated()` decorator and the `@deprecated` JSDoc (they drive OpenAPI).
+
+```typescript
+@Middlewares([
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    getDeprecatedRouteMiddleware(new Date('2025-08-26'), {
+        suffixMessage: 'Use ProjectRoleAssignments instead.',
+    }),
+])
+@Deprecated()
+@Patch('{projectUuid}/access/{userUuid}')
+```
+
+**Behavior** (`authentication/deprecation.ts`):
+
+- Every call logs. It logs a warning, escalating to an error once the removal
+  date is within two weeks or has passed. Deprecated endpoints are not expected
+  to be called by any first-party client, so any log line is a signal that
+  something still depends on a route slated for removal.
+- When it escalates to an error, it also reports a `DeprecatedRouteError`
+  (`@lightdash/common`) to Sentry so overdue routes surface in alerting.
+- Responses carry `Deprecation` (deprecation date), `Sunset` (removal date), and
+  a legacy `Warning` header.
+
 <links>
 @packages/backend/src/controllers/baseController.ts - Base controller implementation
 @packages/backend/src/controllers/authentication/index.ts - Authentication strategies

--- a/packages/backend/src/controllers/authentication/deprecation.test.ts
+++ b/packages/backend/src/controllers/authentication/deprecation.test.ts
@@ -1,0 +1,117 @@
+import { DeprecatedRouteError } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
+import { Request, Response } from 'express';
+import Logger from '../../logging/logger';
+import {
+    getDefaultSunsetDate,
+    getDeprecatedRouteMiddleware,
+    shouldEscalateToError,
+} from './deprecation';
+
+jest.mock('../../logging/logger', () => ({
+    __esModule: true,
+    default: { warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('@sentry/node', () => ({ captureException: jest.fn() }));
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('getDefaultSunsetDate', () => {
+    it('returns the deprecation date advanced by three months', () => {
+        expect(getDefaultSunsetDate(new Date('2026-01-15T00:00:00Z'))).toEqual(
+            new Date('2026-04-15T00:00:00Z'),
+        );
+    });
+});
+
+describe('shouldEscalateToError', () => {
+    const now = new Date('2026-06-08T00:00:00Z');
+
+    it('is false when the removal date is more than two weeks away', () => {
+        expect(
+            shouldEscalateToError(new Date('2026-07-01T00:00:00Z'), now),
+        ).toBe(false);
+    });
+
+    it('is true when the removal date is within two weeks', () => {
+        expect(
+            shouldEscalateToError(new Date('2026-06-15T00:00:00Z'), now),
+        ).toBe(true);
+    });
+
+    it('is true when the removal date has passed', () => {
+        expect(
+            shouldEscalateToError(new Date('2026-03-08T00:00:00Z'), now),
+        ).toBe(true);
+    });
+});
+
+describe('getDeprecatedRouteMiddleware', () => {
+    const buildResponse = () => {
+        const headers: Record<string, string> = {};
+        const res = {
+            setHeader: jest.fn((key: string, value: string) => {
+                headers[key] = value;
+            }),
+        };
+        return { res: res as unknown as Response, headers };
+    };
+    const req = { method: 'GET', path: '/api/v1/old' } as unknown as Request;
+    const next = jest.fn();
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('sets Deprecation, Sunset and Warning headers', () => {
+        const { res, headers } = buildResponse();
+        const deprecatedOn = new Date('2026-01-15T00:00:00Z');
+        const removeOn = new Date('2099-01-01T00:00:00Z');
+        getDeprecatedRouteMiddleware(deprecatedOn, {
+            removeOn,
+            suffixMessage: 'Use X instead.',
+        })(req, res, next);
+
+        expect(headers.Deprecation).toBe(deprecatedOn.toUTCString());
+        expect(headers.Sunset).toBe(removeOn.toUTCString());
+        expect(headers.Warning).toContain('deprecated');
+        expect(headers.Warning).toContain('Use X instead.');
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults the removal date to three months after deprecation', () => {
+        const { res, headers } = buildResponse();
+        getDeprecatedRouteMiddleware(new Date('2026-01-15T00:00:00Z'))(
+            req,
+            res,
+            next,
+        );
+        expect(headers.Sunset).toBe(
+            new Date('2026-04-15T00:00:00Z').toUTCString(),
+        );
+    });
+
+    it('logs a warning and does not report to Sentry when the removal date is far in the future', () => {
+        const { res } = buildResponse();
+        getDeprecatedRouteMiddleware(new Date(Date.now()), {
+            removeOn: new Date(Date.now() + 365 * DAY_MS),
+        })(req, res, next);
+
+        expect(Logger.warn).toHaveBeenCalledTimes(1);
+        expect(Logger.error).not.toHaveBeenCalled();
+        expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('logs an error and reports a DeprecatedRouteError to Sentry when the removal date has passed', () => {
+        const { res } = buildResponse();
+        getDeprecatedRouteMiddleware(new Date('2020-01-01T00:00:00Z'), {
+            removeOn: new Date('2020-04-01T00:00:00Z'),
+        })(req, res, next);
+
+        expect(Logger.error).toHaveBeenCalledTimes(1);
+        expect(Logger.warn).not.toHaveBeenCalled();
+        expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+        expect(
+            (Sentry.captureException as jest.Mock).mock.calls[0][0],
+        ).toBeInstanceOf(DeprecatedRouteError);
+    });
+});

--- a/packages/backend/src/controllers/authentication/deprecation.ts
+++ b/packages/backend/src/controllers/authentication/deprecation.ts
@@ -8,7 +8,7 @@ const ERROR_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
 
 export const getDefaultSunsetDate = (deprecatedOn: Date): Date => {
     const sunset = new Date(deprecatedOn);
-    sunset.setMonth(sunset.getMonth() + SUNSET_MONTHS_FROM_DEPRECATION);
+    sunset.setUTCMonth(sunset.getUTCMonth() + SUNSET_MONTHS_FROM_DEPRECATION);
     return sunset;
 };
 

--- a/packages/backend/src/controllers/authentication/deprecation.ts
+++ b/packages/backend/src/controllers/authentication/deprecation.ts
@@ -1,0 +1,69 @@
+import { DeprecatedRouteError } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
+import { RequestHandler } from 'express';
+import Logger from '../../logging/logger';
+
+const SUNSET_MONTHS_FROM_DEPRECATION = 3;
+const ERROR_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+
+export const getDefaultSunsetDate = (deprecatedOn: Date): Date => {
+    const sunset = new Date(deprecatedOn);
+    sunset.setMonth(sunset.getMonth() + SUNSET_MONTHS_FROM_DEPRECATION);
+    return sunset;
+};
+
+export const shouldEscalateToError = (removeOn: Date, now: Date): boolean =>
+    removeOn.getTime() - now.getTime() <= ERROR_WINDOW_MS;
+
+type DeprecatedRouteOptions = {
+    removeOn?: Date;
+    suffixMessage?: string;
+};
+
+/**
+ * Handles a deprecated API route: sets deprecation response headers and logs
+ * every call. Logs escalate from warn to error once the removal date is within
+ * two weeks or has passed.
+ * @param deprecatedOn - The date the endpoint was deprecated
+ * @param options.removeOn - Removal date (defaults to deprecatedOn + 3 months)
+ * @param options.suffixMessage - Replacement hint appended to logs and headers
+ */
+export const getDeprecatedRouteMiddleware = (
+    deprecatedOn: Date,
+    options?: DeprecatedRouteOptions,
+): RequestHandler => {
+    const removeOn = options?.removeOn ?? getDefaultSunsetDate(deprecatedOn);
+    const suffix = options?.suffixMessage ? ` ${options.suffixMessage}` : '';
+
+    return (req, res, next) => {
+        res.setHeader('Deprecation', deprecatedOn.toUTCString());
+        res.setHeader('Sunset', removeOn.toUTCString());
+        res.setHeader(
+            'Warning',
+            `299 - "This API endpoint is deprecated and will be removed after ${removeOn.toUTCString()}.${suffix}"`,
+        );
+
+        const message = `Deprecated endpoint called: ${req.method} ${req.path} (deprecated ${deprecatedOn.toISOString()}, removal ${removeOn.toISOString()}).${suffix}`;
+        if (shouldEscalateToError(removeOn, new Date())) {
+            Logger.error(message);
+            Sentry.captureException(
+                new DeprecatedRouteError(message, {
+                    method: req.method,
+                    path: req.path,
+                    deprecatedOn: deprecatedOn.toISOString(),
+                    removeOn: removeOn.toISOString(),
+                }),
+            );
+        } else {
+            Logger.warn(message);
+        }
+
+        next();
+    };
+};
+
+export const deprecatedResultsRoute: RequestHandler =
+    getDeprecatedRouteMiddleware(new Date('2025-03-20'), {
+        removeOn: new Date('2025-04-30'),
+        suffixMessage: `Please use 'POST /api/v2/projects/{projectUuid}/query' in conjuntion with 'GET /api/v2/projects/{projectUuid}/query/{queryUuid}' instead.`,
+    });

--- a/packages/backend/src/controllers/authentication/index.ts
+++ b/packages/backend/src/controllers/authentication/index.ts
@@ -23,6 +23,7 @@
 // 6. passport.GoogleStrategy creates a full user object and attaches it to `req.user`
 // 7. Follow steps 4-6 from "How a user is logs in"
 
+export * from './deprecation';
 export * from './middlewares';
 export * from './strategies/apiKeyStrategy';
 export * from './strategies/azureStrategy';

--- a/packages/backend/src/controllers/authentication/middlewares.ts
+++ b/packages/backend/src/controllers/authentication/middlewares.ts
@@ -274,30 +274,6 @@ export const getOidcRedirectURL =
         return new URL('/', lightdashConfig.siteUrl).href;
     };
 
-/**
- * This middleware is used to handle deprecated API routes.
- * It sets a warning header and returns a 299 status code.
- * @param date - The date when the deprecated route will be removed
- * @param suffixMessage - An optional suffix message to add to the warning header
- * @returns
- */
-export const getDeprecatedRouteMiddleware =
-    (date: Date, suffixMessage?: string): RequestHandler =>
-    (_req, res, next) => {
-        const newRouteMessage = suffixMessage ? ` ${suffixMessage}` : '';
-        res.setHeader(
-            'Warning',
-            `299 - "This API endpoint is deprecated and will be removed after ${date}.${newRouteMessage}"`,
-        );
-        next();
-    };
-
-export const deprecatedResultsRoute: RequestHandler =
-    getDeprecatedRouteMiddleware(
-        new Date('2025-04-30'),
-        `Please use 'POST /api/v2/projects/{projectUuid}/query' in conjuntion with 'GET /api/v2/projects/{projectUuid}/query/{queryUuid}' instead.`,
-    );
-
 export const invalidUserErrorHandler: ErrorRequestHandler = (
     err,
     req,

--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -51,6 +51,7 @@ import { toSessionUser } from '../auth/account';
 import { CatalogSearchContext } from '../models/CatalogModel/CatalogModel';
 import {
     allowApiKeyAuthentication,
+    getDeprecatedRouteMiddleware,
     isAuthenticated,
     unauthorisedInDemo,
 } from './authentication';
@@ -827,7 +828,14 @@ export class CatalogController extends BaseController {
      * @summary Get metrics tree
      * @deprecated Use POST /metrics/tree instead for large metric lists
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-02-05'), {
+            suffixMessage:
+                'Use POST /metrics/tree instead for large metric lists.',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Get('/metrics/tree')
     @OperationId('getMetricsTreeLegacy')
@@ -858,7 +866,14 @@ export class CatalogController extends BaseController {
      * @summary Get metrics tree
      * @deprecated Superseded by saved metrics trees (`/metrics/trees/{uuidOrSlug}`).
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-04-28'), {
+            suffixMessage:
+                'Superseded by saved metrics trees (`/metrics/trees/{uuidOrSlug}`).',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Post('/metrics/tree')
     @OperationId('getMetricsTree')
@@ -893,6 +908,10 @@ export class CatalogController extends BaseController {
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2026-04-28'), {
+            suffixMessage:
+                'Edges are now persisted via the saved metrics tree update endpoint (`PATCH /metrics/trees/{uuid}`).',
+        }),
     ])
     @SuccessResponse('200', 'Success')
     @Post('/metrics/tree/edges')
@@ -927,6 +946,10 @@ export class CatalogController extends BaseController {
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2026-04-28'), {
+            suffixMessage:
+                'Edges are now persisted via the saved metrics tree update endpoint (`PATCH /metrics/trees/{uuid}`).',
+        }),
     ])
     @SuccessResponse('200', 'Success')
     @Delete(

--- a/packages/backend/src/controllers/dashboardController.ts
+++ b/packages/backend/src/controllers/dashboardController.ts
@@ -29,6 +29,7 @@ import express from 'express';
 import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
+    getDeprecatedRouteMiddleware,
     isAuthenticated,
     unauthorisedInDemo,
 } from './authentication';
@@ -182,7 +183,11 @@ export class DashboardController extends BaseController {
      * Get schedulers for a dashboard
      * @summary List dashboard schedulers
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-01-26')),
+    ])
     @SuccessResponse('200', 'Success')
     @Get('/schedulers')
     @OperationId('getDashboardSchedulers')

--- a/packages/backend/src/controllers/groupsController.ts
+++ b/packages/backend/src/controllers/groupsController.ts
@@ -33,6 +33,7 @@ import {
 } from '../database/entities/projectGroupAccess';
 import {
     allowApiKeyAuthentication,
+    getDeprecatedRouteMiddleware,
     isAuthenticated,
     unauthorisedInDemo,
 } from './authentication';
@@ -223,6 +224,9 @@ export class GroupsController extends BaseController {
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2025-08-26'), {
+            suffixMessage: 'Use ProjectRoleAssignments instead.',
+        }),
     ])
     @Post('{groupUuid}/projects/{projectUuid}')
     @OperationId('addProjectAccessToGroup')
@@ -257,6 +261,9 @@ export class GroupsController extends BaseController {
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2025-08-26'), {
+            suffixMessage: 'Use ProjectRoleAssignments instead.',
+        }),
     ])
     @Patch('{groupUuid}/projects/{projectUuid}')
     @OperationId('updateProjectAccessForGroup')
@@ -292,6 +299,9 @@ export class GroupsController extends BaseController {
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2025-08-26'), {
+            suffixMessage: 'Use ProjectRoleAssignments instead.',
+        }),
     ])
     @Delete('{groupUuid}/projects/{projectUuid}')
     @OperationId('removeProjectAccessFromGroup')

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -52,6 +52,7 @@ import express from 'express';
 import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
+    getDeprecatedRouteMiddleware,
     isAuthenticated,
     unauthorisedInDemo,
 } from './authentication';
@@ -296,6 +297,10 @@ export class OrganizationController extends BaseController {
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2025-08-27'), {
+            suffixMessage:
+                'Use the /api/v2/org/assignments/user/{userId} endpoint instead.',
+        }),
     ])
     @Patch('/users/{userUuid}')
     @OperationId('UpdateOrganizationMember')

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -82,6 +82,7 @@ import { toSessionUser } from '../auth/account';
 import type { DbTagUpdate } from '../database/entities/tags';
 import {
     allowApiKeyAuthentication,
+    getDeprecatedRouteMiddleware,
     isAuthenticated,
     unauthorisedInDemo,
 } from './authentication';
@@ -143,7 +144,11 @@ export class ProjectController extends BaseController {
      * @param req express request
      * @param excludeChartsSavedInDashboard Whether to exclude charts that are saved in dashboards
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2024-12-09')),
+    ])
     @SuccessResponse('200', 'Success')
     @Get('{projectUuid}/chart-summaries')
     @Deprecated()
@@ -288,6 +293,10 @@ export class ProjectController extends BaseController {
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2025-08-26'), {
+            suffixMessage:
+                'Use ProjectRolesController.UpdateProjectUserRoleAssignment instead.',
+        }),
     ])
     @SuccessResponse('200', 'Success')
     @Patch('{projectUuid}/access/{userUuid}')
@@ -324,6 +333,10 @@ export class ProjectController extends BaseController {
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2025-08-26'), {
+            suffixMessage:
+                'Use ProjectRolesController.DeleteProjectUserRoleAssignment instead.',
+        }),
     ])
     @SuccessResponse('200', 'Success')
     @Delete('{projectUuid}/access/{userUuid}')
@@ -384,6 +397,10 @@ export class ProjectController extends BaseController {
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2025-02-17'), {
+            suffixMessage:
+                'Use /api/v1/projects/<project id>/sqlRunner/run instead.',
+        }),
     ])
     @SuccessResponse('200', 'Success')
     @Post('{projectUuid}/sqlQuery')
@@ -413,7 +430,14 @@ export class ProjectController extends BaseController {
      * @param body The metric query to calculate totals for
      * @param req express request
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-05-29'), {
+            suffixMessage:
+                'Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total instead, which computes totals from a previously-executed async query.',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Post('{projectUuid}/calculate-total')
     @OperationId('CalculateTotalFromQuery')
@@ -437,7 +461,14 @@ export class ProjectController extends BaseController {
      * @deprecated Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total with kind 'columnSubtotal' instead.
      * @summary Calculate subtotals from query
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-06-04'), {
+            suffixMessage:
+                "Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total with kind 'columnSubtotal' instead.",
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Post('{projectUuid}/calculate-subtotals')
     @OperationId('CalculateSubtotalsFromQuery')

--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -43,6 +43,7 @@ import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
     deprecatedResultsRoute,
+    getDeprecatedRouteMiddleware,
     isAuthenticated,
     unauthorisedInDemo,
 } from './authentication';
@@ -116,7 +117,11 @@ export class SavedChartController extends BaseController {
      * @summary Get chart and results
      */
     @Deprecated()
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2025-03-20')),
+    ])
     @SuccessResponse('200', 'Success')
     @Post('/chart-and-results')
     @OperationId('PostDashboardTile')
@@ -292,7 +297,14 @@ export class SavedChartController extends BaseController {
      * @param chartUuid chartUuid for the chart to run
      * @param req express request
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-05-29'), {
+            suffixMessage:
+                'Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total instead, which computes totals from a previously-executed async query.',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Post('/calculate-total')
     @OperationId('CalculateTotalFromSavedChart')
@@ -378,7 +390,11 @@ export class SavedChartController extends BaseController {
      * Get schedulers for a saved chart
      * @summary List saved chart schedulers
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-01-26')),
+    ])
     @SuccessResponse('200', 'Success')
     @Get('/schedulers')
     @OperationId('getSavedChartSchedulers')

--- a/packages/backend/src/controllers/validationController.ts
+++ b/packages/backend/src/controllers/validationController.ts
@@ -28,11 +28,7 @@ import {
 } from '@tsoa/runtime';
 import express from 'express';
 import { toSessionUser } from '../auth/account';
-import {
-    allowApiKeyAuthentication,
-    getDeprecatedRouteMiddleware,
-    isAuthenticated,
-} from './authentication';
+import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
 @Route('/api/v1/projects/{projectUuid}/validate')
@@ -88,22 +84,13 @@ export class ValidationController extends BaseController {
 
     /**
      * Get validation results for a project. This will return the results of the latest validation job.
-     * @deprecated Use ListValidationResults instead for paginated results
      * @summary Get validation results
      * @param projectUuid the projectId for the validation
      * @param req express request
      * @param fromSettings boolean to know if this request is made from the settings page, for analytics
      * @param jobId optional jobId to get results for a specific job, used on CLI
      */
-    @Middlewares([
-        allowApiKeyAuthentication,
-        isAuthenticated,
-        getDeprecatedRouteMiddleware(new Date('2026-02-11'), {
-            removeOn: new Date('2026-09-08'),
-            suffixMessage:
-                'Use ListValidationResults instead for paginated results.',
-        }),
-    ])
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/')
     @OperationId('GetLatestValidationResults')

--- a/packages/backend/src/controllers/validationController.ts
+++ b/packages/backend/src/controllers/validationController.ts
@@ -28,7 +28,11 @@ import {
 } from '@tsoa/runtime';
 import express from 'express';
 import { toSessionUser } from '../auth/account';
-import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
+import {
+    allowApiKeyAuthentication,
+    getDeprecatedRouteMiddleware,
+    isAuthenticated,
+} from './authentication';
 import { BaseController } from './baseController';
 
 @Route('/api/v1/projects/{projectUuid}/validate')
@@ -91,7 +95,15 @@ export class ValidationController extends BaseController {
      * @param fromSettings boolean to know if this request is made from the settings page, for analytics
      * @param jobId optional jobId to get results for a specific job, used on CLI
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-02-11'), {
+            removeOn: new Date('2026-09-08'),
+            suffixMessage:
+                'Use ListValidationResults instead for paginated results.',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Get('/')
     @OperationId('GetLatestValidationResults')

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -57,6 +57,7 @@ import {
 import express from 'express';
 import {
     allowApiKeyAuthentication,
+    getDeprecatedRouteMiddleware,
     isAuthenticated,
 } from '../../controllers/authentication';
 import { BaseController } from '../../controllers/baseController';
@@ -428,6 +429,12 @@ export class EmbedController extends BaseController {
      * @summary Calculate totals for embed saved chart
      * @deprecated Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total instead.
      */
+    @Middlewares([
+        getDeprecatedRouteMiddleware(new Date('2026-05-29'), {
+            suffixMessage:
+                'Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total instead.',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Post('/chart/:savedChartUuid/calculate-total')
     @OperationId('embedCalculateTotalFromSavedChart')
@@ -463,6 +470,12 @@ export class EmbedController extends BaseController {
      * @deprecated Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total with kind 'columnSubtotal' instead.
      * @summary Calculate subtotals for embed chart
      */
+    @Middlewares([
+        getDeprecatedRouteMiddleware(new Date('2026-06-04'), {
+            suffixMessage:
+                "Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total with kind 'columnSubtotal' instead.",
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Post('/chart/:savedChartUuid/calculate-subtotals')
     @OperationId('embedCalculateSubtotalsFromSavedChart')
@@ -507,6 +520,12 @@ export class EmbedController extends BaseController {
      * @summary Calculate totals for embed query
      * @deprecated Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total instead.
      */
+    @Middlewares([
+        getDeprecatedRouteMiddleware(new Date('2026-05-29'), {
+            suffixMessage:
+                'Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total instead.',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Post('/calculate-total')
     @OperationId('embedCalculateTotalFromQuery')
@@ -535,6 +554,12 @@ export class EmbedController extends BaseController {
      * @deprecated Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total with kind 'columnSubtotal' instead.
      * @summary Calculate subtotals for embed query
      */
+    @Middlewares([
+        getDeprecatedRouteMiddleware(new Date('2026-06-04'), {
+            suffixMessage:
+                "Use POST /api/v2/projects/{projectUuid}/query/{queryUuid}/calculate-total with kind 'columnSubtotal' instead.",
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Post('/calculate-subtotals')
     @OperationId('embedCalculateSubtotalsFromQuery')

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -510,6 +510,20 @@ export class NotImplementedError extends LightdashError {
         });
     }
 }
+export class DeprecatedRouteError extends LightdashError {
+    constructor(
+        message = 'Deprecated route called past its removal deadline',
+        data: { [key: string]: AnyType } = {},
+    ) {
+        super({
+            message,
+            name: 'DeprecatedRouteError',
+            statusCode: 410,
+            data,
+        });
+    }
+}
+
 export const getErrorMessage = (e: unknown) => {
     if (e instanceof Error && e.message) return e.message;
     return `Unknown ${typeof e} error`;


### PR DESCRIPTION
Closes: PROD-8182

### Description:
Deprecated backend HTTP endpoints now log on every call — a warning that escalates to an error plus a Sentry `DeprecatedRouteError` once the removal/sunset date is within two weeks or has passed — return `Deprecation`/`Sunset`/`Warning` response headers, and carry an explicit deadline that defaults to three months after deprecation. The shared `getDeprecatedRouteMiddleware` is wired onto every deprecated endpoint across the controllers, a `DeprecatedRouteError` class is added to `@lightdash/common`, and a `deprecate-endpoint` skill plus controller docs capture the policy (endpoints only; first-party callers must be migrated off first). An audit found one endpoint still called by the frontend and CLI (`GET /api/v1/projects/{projectUuid}/validate`); since a deprecated endpoint must have no first-party callers, it was left un-deprecated.

### Monitoring & alerting (self-hosted):
Every call to a deprecated endpoint emits a log line and sets response headers. Self-hosted operators can alert on these to catch lingering callers before a route is removed.

**1. Warning log — endpoint is deprecated, removal date still more than two weeks away.** Emitted at `warn` level on every call:

```
2026-06-09 12:34:56 [Lightdash] warn: Deprecated endpoint called: PATCH /api/v1/projects/3675b69e/access/9c1b (deprecated 2025-08-26T00:00:00.000Z, removal 2025-11-26T00:00:00.000Z). Use ProjectRoleAssignments instead.
```

With `LIGHTDASH_LOG_FORMAT=json` the same event looks like:

```json
{
  "level": "warn",
  "message": "Deprecated endpoint called: PATCH /api/v1/projects/3675b69e/access/9c1b (deprecated 2025-08-26T00:00:00.000Z, removal 2025-11-26T00:00:00.000Z). Use ProjectRoleAssignments instead.",
  "timestamp": "2026-06-09 12:34:56"
}
```

**2. Error log — removal date is within two weeks or has passed.** The same event escalates to `error` level:

```
2026-06-09 12:34:56 [Lightdash] error: Deprecated endpoint called: GET /api/v1/projects/3675b69e/results (deprecated 2025-03-20T00:00:00.000Z, removal 2025-04-30T00:00:00.000Z). Please use 'POST /api/v2/projects/{projectUuid}/query' in conjuntion with 'GET /api/v2/projects/{projectUuid}/query/{queryUuid}' instead.
```

**3. Sentry alert.** When a call escalates to error, a `DeprecatedRouteError` is also reported to Sentry (`statusCode` 410) with structured `data`:

```
DeprecatedRouteError: Deprecated endpoint called: GET /api/v1/projects/3675b69e/results (deprecated 2025-03-20T00:00:00.000Z, removal 2025-04-30T00:00:00.000Z). ...
  data: {
    "method": "GET",
    "path": "/api/v1/projects/3675b69e/results",
    "deprecatedOn": "2025-03-20T00:00:00.000Z",
    "removeOn": "2025-04-30T00:00:00.000Z"
  }
```

Alert on Sentry issues with `error.type: DeprecatedRouteError`.

**4. Response headers** (returned on every call, regardless of escalation):

```
Deprecation: Wed, 26 Aug 2025 00:00:00 GMT
Sunset: Wed, 26 Nov 2025 00:00:00 GMT
Warning: 299 - "This API endpoint is deprecated and will be removed after Wed, 26 Nov 2025 00:00:00 GMT. Use ProjectRoleAssignments instead."
```

**Suggested alerts:**
- Any log matching `Deprecated endpoint called:` → a first-party or external client is still hitting a route slated for removal. Investigate and migrate the caller.
- Any `error`-level occurrence of the above, or any Sentry `DeprecatedRouteError` → the route is within two weeks of (or past) its removal date and still in use; treat as urgent.
