### PR TITLE
feat(ai-agents): one-click "Connect GitLab" MCP setup

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1835,6 +1835,17 @@ export type AiAgentGithubMcpConnectedEvent = BaseTrack & {
     };
 };
 
+export type AiAgentGitlabMcpConnectedEvent = BaseTrack & {
+    event: 'ai_agent.gitlab_mcp_connected';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        mcpServerId: string;
+        method: 'one_click' | 'one_click_reconnect';
+    };
+};
+
 export type AiAgentDeletedEvent = BaseTrack & {
     event: 'ai_agent.deleted';
     userId: string;
@@ -2296,6 +2307,7 @@ type TypedEvent =
     | DeprecatedRouteCalled
     | AiAgentCreatedEvent
     | AiAgentGithubMcpConnectedEvent
+    | AiAgentGitlabMcpConnectedEvent
     | AiAgentDeletedEvent
     | AiAgentUpdatedEvent
     | AiAgentDocumentCreatedEvent

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -30,6 +30,7 @@ import {
     ApiAiAgentVerifiedArtifactsResponse,
     ApiAiAgentVerifiedQuestionsResponse,
     ApiAiMcpGithubAvailabilityResponse,
+    ApiAiMcpGitlabAvailabilityResponse,
     ApiAiMcpOAuthCredentialRequest,
     ApiAiMcpServerListResponse,
     ApiAiMcpServerResponse,
@@ -39,6 +40,7 @@ import {
     ApiAppendInstructionResponse,
     ApiCloneThreadResponse,
     ApiConnectGithubMcpServerBody,
+    ApiConnectGitlabMcpServerBody,
     ApiCreateAiAgent,
     ApiCreateAiAgentResponse,
     ApiCreateAiMcpServer,
@@ -256,6 +258,50 @@ export class AiAgentController extends BaseController {
                 toSessionUser(req.account),
                 projectUuid,
                 body.personalAccessToken,
+                body.credentialScope,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/mcpServers/gitlab/availability')
+    @OperationId('getGitlabMcpAvailability')
+    async getGitlabMcpAvailability(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiAiMcpGitlabAvailabilityResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().getGitlabMcpAvailability(
+                toSessionUser(req.account),
+                projectUuid,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('201', 'Created')
+    @Post('/mcpServers/gitlab/connect')
+    @OperationId('connectGitlabMcpServer')
+    async connectGitlabMcpServer(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: ApiConnectGitlabMcpServerBody,
+    ): Promise<ApiAiMcpServerResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().connectGitlabMcpServer(
+                toSessionUser(req.account),
+                projectUuid,
                 body.credentialScope,
             ),
         };

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -272,6 +272,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getPreviewDeploySetupService<PreviewDeploySetupService>(),
                     githubAppInstallationsModel:
                         models.getGithubAppInstallationsModel(),
+                    gitlabAppInstallationsModel:
+                        models.getGitlabAppInstallationsModel(),
                     aiAgentToolsService:
                         repository.getAiAgentToolsService<AiAgentToolsService>(),
                     prometheusMetrics,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -21,6 +21,7 @@ import {
     AiDuplicateSlackPromptError,
     AiMcpCredentialScope,
     AiMcpGithubAvailability,
+    AiMcpGitlabAvailability,
     AiMetricQueryWithFilters,
     AiModelOption,
     AiPromptContext,
@@ -52,12 +53,15 @@ import {
     followUpToolsText,
     ForbiddenError,
     getErrorMessage,
+    getGitlabMcpServerUrl,
     getGroupByDimensions,
     getItemId,
     getItemMap,
     getWebAiChartConfig,
     GITHUB_MCP_SERVER_NAME,
     GITHUB_MCP_SERVER_URL,
+    GITLAB_MCP_SERVER_NAME,
+    isGitlabMcpServerUrl,
     isGitProjectType,
     isSlackPrompt,
     isToolProposeChangeSuccessResult,
@@ -134,6 +138,7 @@ import {
     getInstallationToken,
     getPullRequestComments,
 } from '../../../clients/github/Github';
+import { getOrRefreshToken } from '../../../clients/gitlab/Gitlab';
 import { type SlackClient } from '../../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
@@ -144,6 +149,7 @@ import {
 import { ChangesetModel } from '../../../models/ChangesetModel';
 import { ContentVerificationModel } from '../../../models/ContentVerificationModel';
 import { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
+import { GitlabAppInstallationsModel } from '../../../models/GitlabAppInstallations/GitlabAppInstallationsModel';
 import { GroupsModel } from '../../../models/GroupsModel';
 import { OpenIdIdentityModel } from '../../../models/OpenIdIdentitiesModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
@@ -305,6 +311,7 @@ type AiAgentServiceDependencies = {
     aiWritebackService: AiWritebackService;
     previewDeploySetupService: PreviewDeploySetupService;
     githubAppInstallationsModel: GithubAppInstallationsModel;
+    gitlabAppInstallationsModel: GitlabAppInstallationsModel;
     aiAgentToolsService: AiAgentToolsService;
     prometheusMetrics?: PrometheusMetrics;
 };
@@ -457,6 +464,8 @@ export class AiAgentService extends BaseService {
     private readonly aiAgentDocumentModel: AiAgentDocumentModel;
 
     private readonly githubAppInstallationsModel: GithubAppInstallationsModel;
+
+    private readonly gitlabAppInstallationsModel: GitlabAppInstallationsModel;
 
     private readonly projectContextModel: ProjectContextModel;
 
@@ -633,6 +642,8 @@ export class AiAgentService extends BaseService {
         this.previewDeploySetupService = dependencies.previewDeploySetupService;
         this.githubAppInstallationsModel =
             dependencies.githubAppInstallationsModel;
+        this.gitlabAppInstallationsModel =
+            dependencies.gitlabAppInstallationsModel;
         this.aiAgentToolsService = dependencies.aiAgentToolsService;
         this.aiAgentMcpRuntimeClient = new AiAgentMcpRuntimeClient({
             aiAgentModel: this.aiAgentModel,
@@ -2780,6 +2791,291 @@ export class AiAgentService extends BaseService {
                 ? {
                       ...server,
                       resolvedCredential: { type: 'bearer', bearerToken },
+                  }
+                : server,
+        );
+    }
+
+    /**
+     * Resolve a fresh GitLab MCP bearer token plus the instance MCP URL from the
+     * org's GitLab app connection (refreshing the OAuth token if stale, the same
+     * way writeback does). Returns null when the org has no GitLab connection or
+     * the GitLab integration isn't configured.
+     */
+    private async resolveGitlabMcpCredentials(
+        organizationUuid: string | undefined,
+    ): Promise<{ url: string; bearerToken: string } | null> {
+        if (!organizationUuid) {
+            return null;
+        }
+        const { clientId, clientSecret } = this.lightdashConfig.gitlab;
+        if (!clientId || !clientSecret) {
+            return null;
+        }
+        let auth: {
+            token: string;
+            refreshToken: string;
+            gitlabInstanceUrl: string;
+        };
+        try {
+            auth =
+                await this.gitlabAppInstallationsModel.getAuth(
+                    organizationUuid,
+                );
+        } catch {
+            return null;
+        }
+        // The org's stored OAuth token can be expired or revoked — if it can't
+        // be refreshed, treat the org as not connected rather than letting the
+        // raw GitLab OAuth error escape (which would leak into the connect toast
+        // and, worse, throw during the per-run agent credential refresh).
+        let refreshed: { token: string; refreshToken: string };
+        try {
+            refreshed = await getOrRefreshToken(
+                auth.token,
+                auth.refreshToken,
+                clientId,
+                clientSecret,
+                auth.gitlabInstanceUrl,
+            );
+        } catch (error) {
+            Logger.warn(
+                `[AiAgent][MCP][${GITLAB_MCP_SERVER_NAME}] Could not refresh the org GitLab token for ${organizationUuid}; treating as not connected. ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            return null;
+        }
+        if (refreshed.token !== auth.token) {
+            await this.gitlabAppInstallationsModel.updateAuth(
+                organizationUuid,
+                refreshed.token,
+                refreshed.refreshToken,
+            );
+        }
+        return {
+            url: getGitlabMcpServerUrl(auth.gitlabInstanceUrl),
+            bearerToken: refreshed.token,
+        };
+    }
+
+    public async getGitlabMcpAvailability(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<AiMcpGitlabAvailability> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            return { available: false, alreadyConnected: false };
+        }
+
+        const { enabled: oneClickEnabled } = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.GitlabMcpOneClick,
+        });
+        if (!oneClickEnabled) {
+            return { available: false, alreadyConnected: false };
+        }
+
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        if (!isCopilotEnabled) {
+            return { available: false, alreadyConnected: false };
+        }
+
+        const auditedAbility = this.createAuditedAbility(user);
+        const canManageMcpServers = auditedAbility.can(
+            'manage',
+            subject('AiAgent', { organizationUuid, projectUuid }),
+        );
+
+        // The org must actually have a GitLab connection to one-click-connect.
+        const hasGitlabInstall =
+            !!(await this.gitlabAppInstallationsModel.findInstallationId(
+                organizationUuid,
+            ));
+
+        const servers = await this.aiAgentModel.listMcpServers(
+            projectUuid,
+            user.userUuid,
+        );
+        const gitlabServer = servers.find((server) =>
+            isGitlabMcpServerUrl(server.url),
+        );
+
+        const available =
+            (canManageMcpServers && hasGitlabInstall) || !!gitlabServer;
+        if (!available) {
+            return { available: false, alreadyConnected: false };
+        }
+
+        const credential = gitlabServer
+            ? await this.aiAgentModel.resolveCredential(
+                  gitlabServer.uuid,
+                  user.userUuid,
+              )
+            : undefined;
+
+        return { available: true, alreadyConnected: !!credential };
+    }
+
+    public async connectGitlabMcpServer(
+        user: SessionUser,
+        projectUuid: string,
+        credentialScope: AiMcpCredentialScope,
+    ) {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        const { enabled: oneClickEnabled } = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.GitlabMcpOneClick,
+        });
+        if (!oneClickEnabled) {
+            throw new ForbiddenError(
+                'One-click GitLab MCP setup is not enabled',
+            );
+        }
+
+        const credentials =
+            await this.resolveGitlabMcpCredentials(organizationUuid);
+        if (!credentials) {
+            throw new ParameterError(
+                "We couldn't connect to GitLab for this organization. Make sure GitLab is connected in the project settings (and reconnect it if it has expired), then try again.",
+            );
+        }
+        const { url, bearerToken } = credentials;
+
+        const existing = await this.aiAgentModel.listMcpServers(
+            projectUuid,
+            user.userUuid,
+        );
+        const gitlabServer = existing.find((server) =>
+            isGitlabMcpServerUrl(server.url),
+        );
+
+        if (gitlabServer) {
+            if (credentialScope === 'shared') {
+                await this.assertCanManageMcpServers(user, projectUuid);
+            } else {
+                await this.assertCanUsePersonalMcpCredentials(
+                    user,
+                    projectUuid,
+                );
+            }
+
+            try {
+                await this.aiAgentMcpRuntimeClient.testConnection({
+                    name: GITLAB_MCP_SERVER_NAME,
+                    url,
+                    authType: 'bearer',
+                    bearerToken,
+                    onUncaughtError: (error) => {
+                        Logger.error(
+                            `[AiAgent][MCP][${GITLAB_MCP_SERVER_NAME}] Uncaught MCP client error while reconnecting`,
+                            error,
+                        );
+                    },
+                });
+            } catch (error) {
+                Logger.error(
+                    `[AiAgent][MCP][${GITLAB_MCP_SERVER_NAME}] Failed to reconnect with the org GitLab token`,
+                    error,
+                );
+                throw new ParameterError(
+                    "We couldn't connect to GitLab. Check the organization's GitLab connection, then try again.",
+                );
+            }
+
+            await this.aiAgentModel.upsertCredential({
+                serverUuid: gitlabServer.uuid,
+                scope: credentialScope,
+                userUuid: credentialScope === 'user' ? user.userUuid : null,
+                credentials: { type: 'bearer', bearerToken },
+                actorUserUuid: user.userUuid,
+            });
+            await this.aiAgentModel.updateMcpServerRuntimeState({
+                serverUuid: gitlabServer.uuid,
+                connectionStatus: 'connected',
+                error: null,
+                actorUserUuid: user.userUuid,
+            });
+
+            this.analytics.track({
+                event: 'ai_agent.gitlab_mcp_connected',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    mcpServerId: gitlabServer.uuid,
+                    method: 'one_click_reconnect',
+                },
+            });
+
+            const refreshed = await this.aiAgentModel.listMcpServers(
+                projectUuid,
+                user.userUuid,
+            );
+            return (
+                refreshed.find((server) => isGitlabMcpServerUrl(server.url)) ??
+                gitlabServer
+            );
+        }
+
+        const server = await this.createMcpServer(user, projectUuid, {
+            name: GITLAB_MCP_SERVER_NAME,
+            url,
+            authType: 'bearer',
+            credentialScope,
+            credentials: { bearerToken },
+        });
+
+        this.analytics.track({
+            event: 'ai_agent.gitlab_mcp_connected',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                mcpServerId: server.uuid,
+                method: 'one_click',
+            },
+        });
+
+        return server;
+    }
+
+    /**
+     * GitLab MCP servers authenticate with the org's GitLab OAuth token, which
+     * expires. Refresh a fresh token per run (mirroring the GitHub MCP and
+     * writeback flows) so the connection can never expire mid-session.
+     */
+    private async refreshGitlabMcpCredentials(
+        organizationUuid: string | undefined,
+        servers: AiMcpServerWithSensitiveData[],
+    ): Promise<AiMcpServerWithSensitiveData[]> {
+        const hasGitlabMcp = servers.some(
+            (server) =>
+                isGitlabMcpServerUrl(server.url) &&
+                server.authType === 'bearer',
+        );
+        if (!hasGitlabMcp || !organizationUuid) {
+            return servers;
+        }
+
+        const credentials =
+            await this.resolveGitlabMcpCredentials(organizationUuid);
+        if (!credentials) {
+            return servers;
+        }
+
+        return servers.map((server) =>
+            isGitlabMcpServerUrl(server.url) && server.authType === 'bearer'
+                ? {
+                      ...server,
+                      resolvedCredential: {
+                          type: 'bearer',
+                          bearerToken: credentials.bearerToken,
+                      },
                   }
                 : server,
         );
@@ -5270,11 +5566,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 projectUuid: prompt.projectUuid,
             });
         const agentMcpServersWithSensitiveData =
-            await this.refreshGithubMcpCredentials(
+            await this.refreshGitlabMcpCredentials(
                 user.organizationUuid,
-                await this.aiAgentModel.getAgentMcpServersWithSensitiveData(
-                    agentSettings.uuid,
-                    user.userUuid,
+                await this.refreshGithubMcpCredentials(
+                    user.organizationUuid,
+                    await this.aiAgentModel.getAgentMcpServersWithSensitiveData(
+                        agentSettings.uuid,
+                        user.userUuid,
+                    ),
                 ),
             );
         const mcpServers = this.aiAgentMcpRuntimeClient.attachRuntimeProviders({

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10869,6 +10869,49 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiMcpGitlabAvailability: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                alreadyConnected: { dataType: 'boolean', required: true },
+                available: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiMcpGitlabAvailability_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiMcpGitlabAvailability', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiMcpGitlabAvailabilityResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiMcpGitlabAvailability_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiConnectGitlabMcpServerBody: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                credentialScope: {
+                    ref: 'AiMcpCredentialScope',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiMcpServerTool: {
         dataType: 'refAlias',
         type: {
@@ -12350,11 +12393,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -12412,11 +12455,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -12453,11 +12496,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12659,7 +12702,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12667,11 +12710,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12686,7 +12725,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12694,7 +12733,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12746,11 +12789,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13090,6 +13133,40 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
+                                                                explore: {
+                                                                    dataType:
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                        },
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13098,26 +13175,6 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
                                                                                 isFromJoinedTable:
                                                                                     {
                                                                                         dataType:
@@ -13154,16 +13211,36 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                                 fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldValueType:
+                                                                                description:
                                                                                     {
                                                                                         dataType:
-                                                                                            'string',
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
                                                                                         required: true,
                                                                                     },
                                                                                 fieldType:
@@ -13176,14 +13253,14 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'dimension',
+                                                                                                        'metric',
                                                                                                     ],
                                                                                                 },
                                                                                                 {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'metric',
+                                                                                                        'dimension',
                                                                                                     ],
                                                                                                 },
                                                                                             ],
@@ -13214,40 +13291,6 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
-                                                                explore: {
-                                                                    dataType:
-                                                                        'nestedObjectLiteral',
-                                                                    nestedProperties:
-                                                                        {
-                                                                            joinedTables:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                    },
-                                                                                    required: true,
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                        },
-                                                                    required: true,
-                                                                },
                                                                 status: {
                                                                     dataType:
                                                                         'enum',
@@ -13276,17 +13319,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -13509,6 +13552,32 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                prAction: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['opened'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['updated'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                    required: true,
+                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13518,11 +13587,6 @@ const models: TsoaRoute.Models = {
                                                             enums: [null],
                                                         },
                                                     ],
-                                                    required: true,
-                                                },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -13577,11 +13641,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13642,11 +13706,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13823,11 +13887,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13842,11 +13906,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13861,11 +13925,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -43592,6 +43656,130 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'connectGithubMcpServer',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getGitlabMcpAvailability: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/mcpServers/gitlab/availability',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getGitlabMcpAvailability,
+        ),
+
+        async function AiAgentController_getGitlabMcpAvailability(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getGitlabMcpAvailability,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getGitlabMcpAvailability',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_connectGitlabMcpServer: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiConnectGitlabMcpServerBody',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/mcpServers/gitlab/connect',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.connectGitlabMcpServer,
+        ),
+
+        async function AiAgentController_connectGitlabMcpServer(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_connectGitlabMcpServer,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'connectGitlabMcpServer',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12460,6 +12460,44 @@
                 "required": ["credentialScope", "personalAccessToken"],
                 "type": "object"
             },
+            "AiMcpGitlabAvailability": {
+                "properties": {
+                    "alreadyConnected": {
+                        "type": "boolean"
+                    },
+                    "available": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["alreadyConnected", "available"],
+                "type": "object"
+            },
+            "ApiSuccess_AiMcpGitlabAvailability_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiMcpGitlabAvailability"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiMcpGitlabAvailabilityResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiMcpGitlabAvailability_"
+            },
+            "ApiConnectGitlabMcpServerBody": {
+                "properties": {
+                    "credentialScope": {
+                        "$ref": "#/components/schemas/AiMcpCredentialScope"
+                    }
+                },
+                "required": ["credentialScope"],
+                "type": "object"
+            },
             "AiMcpServerTool": {
                 "properties": {
                     "updatedAt": {
@@ -13912,8 +13950,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13971,8 +14009,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13996,19 +14034,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -14075,16 +14100,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -14114,8 +14139,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -14285,66 +14310,6 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "description",
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
-                                                                                "fieldFilterType",
-                                                                                "fieldValueType",
-                                                                                "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
-                                                                                "label",
-                                                                                "name"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "joinedTables": {
@@ -14371,6 +14336,66 @@
                                                                         ],
                                                                         "type": "object"
                                                                     },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "metric",
+                                                                                        "dimension"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldValueType",
+                                                                                "fieldFilterType",
+                                                                                "description",
+                                                                                "fieldType",
+                                                                                "table",
+                                                                                "fieldId",
+                                                                                "label",
+                                                                                "name"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -14381,8 +14406,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "fields",
                                                                     "explore",
+                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14395,10 +14420,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -14406,8 +14431,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "reason",
                                                                                 "exploreLabel",
+                                                                                "reason",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -14518,17 +14543,26 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "prUrl": {
+                                                    "prAction": {
                                                         "type": "string",
+                                                        "enum": [
+                                                            "opened",
+                                                            "updated",
+                                                            null
+                                                        ],
                                                         "nullable": true
                                                     },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "prUrl": {
+                                                        "type": "string",
+                                                        "nullable": true
                                                     }
                                                 },
-                                                "required": ["prUrl", "status"],
+                                                "required": ["status", "prUrl"],
                                                 "type": "object"
                                             },
                                             {
@@ -19595,7 +19629,7 @@
                     "output"
                 ],
                 "type": "object",
-                "description": "Result of a (synchronous) AI writeback run.\n\n- `output` is the text the agent produced.\n- `exitCode` is the sandbox command's exit status.\n- `prUrl` is the URL of the pull request opened from the agent's changes, or\n  `null` when the agent made no file changes (nothing to raise a PR for).\n- `projectName` is the Lightdash project the run targeted.\n- `repository` is the GitHub repository (`owner/repo`) the run targeted."
+                "description": "Result of a (synchronous) AI writeback run.\n\n- `output` is the text the agent produced.\n- `exitCode` is the sandbox command's exit status.\n- `prUrl` is the URL of the pull request opened from the agent's changes, or\n  `null` when the agent made no file changes (nothing to raise a PR for).\n- `prAction` is whether that PR was newly opened or an existing one updated,\n  or `null` when no PR was touched.\n- `projectName` is the Lightdash project the run targeted.\n- `repository` is the GitHub repository (`owner/repo`) the run targeted."
             },
             "ApiSuccess_AiWritebackRunResult_": {
                 "properties": {
@@ -37805,7 +37839,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3096.0",
+        "version": "0.3103.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -39999,6 +40033,92 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/ApiConnectGithubMcpServerBody"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/mcpServers/gitlab/availability": {
+            "get": {
+                "operationId": "getGitlabMcpAvailability",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiMcpGitlabAvailabilityResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/mcpServers/gitlab/connect": {
+            "post": {
+                "operationId": "connectGitlabMcpServer",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiMcpServerResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiConnectGitlabMcpServerBody"
                             }
                         }
                     }

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -389,6 +389,36 @@ export type AiMcpGithubAvailability = {
 export type ApiAiMcpGithubAvailabilityResponse =
     ApiSuccess<AiMcpGithubAvailability>;
 
+// The hosted GitLab MCP server. Unlike GitHub it is not a single fixed host:
+// GitLab can be self-hosted, so the MCP lives at `{instanceUrl}/api/v4/mcp`
+// (GitLab's Streamable-HTTP MCP endpoint). The one-click "Connect GitLab" flow
+// builds this URL from the org's connected GitLab instance and authenticates
+// with the org's OAuth token (refreshed server-side), so no manual auth step is
+// needed.
+export const GITLAB_MCP_SERVER_NAME = 'GitLab';
+export const GITLAB_MCP_PATH = '/api/v4/mcp';
+
+export const getGitlabMcpServerUrl = (gitlabInstanceUrl: string): string =>
+    `${gitlabInstanceUrl.replace(/\/+$/, '')}${GITLAB_MCP_PATH}`;
+
+export const isGitlabMcpServerUrl = (url: string): boolean =>
+    url.endsWith(GITLAB_MCP_PATH);
+
+// True one-click: no user token needed — the org's GitLab OAuth token is used.
+export type ApiConnectGitlabMcpServerBody = {
+    credentialScope: AiMcpCredentialScope;
+};
+
+export type AiMcpGitlabAvailability = {
+    // The org has a GitLab app connection AND the caller has permission to
+    // manage that integration (manage:GitIntegration).
+    available: boolean;
+    // A GitLab MCP server already exists for this project.
+    alreadyConnected: boolean;
+};
+export type ApiAiMcpGitlabAvailabilityResponse =
+    ApiSuccess<AiMcpGitlabAvailability>;
+
 export type ApiAiAgentThreadSummaryListResponse = {
     status: 'ok';
     results: AiAgentThreadSummary[];

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -248,6 +248,14 @@ export enum FeatureFlags {
     GithubMcpOneClick = 'github-mcp-one-click',
 
     /**
+     * Enable one-click "Connect GitLab" setup for AI agent MCP servers. When
+     * enabled (and the org has a GitLab app connection the user can manage),
+     * the agent MCP settings offer a button that provisions the hosted GitLab
+     * MCP using the org's existing OAuth token — no manual URL/auth.
+     */
+    GitlabMcpOneClick = 'gitlab-mcp-one-click',
+
+    /**
      * Gate the org-level export Limits settings panel (per-org query max rows
      * and CSV cells limit). Backend enforcement of any stored overrides is
      * always on; this flag only controls who can see/configure the panel.

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentNewThreadMcpConnections.tsx
@@ -1,5 +1,6 @@
 import {
     GITHUB_MCP_SERVER_NAME,
+    GITLAB_MCP_SERVER_NAME,
     type AiMcpCredentialScope,
     type AiMcpServer,
 } from '@lightdash/common';
@@ -15,6 +16,7 @@ import {
 import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconBrandGithub,
+    IconBrandGitlab,
     IconCircleCheck,
     IconInfoCircle,
     IconSparkles,
@@ -25,7 +27,9 @@ import { useProjectUpdateAiAgentMutation } from '../hooks/useProjectAiAgents';
 import {
     useAgentAiMcpServers,
     useConnectGithubMcpServerMutation,
+    useConnectGitlabMcpServerMutation,
     useGithubMcpAvailability,
+    useGitlabMcpAvailability,
     useStartMcpOAuthConnectionMutation,
 } from '../hooks/useProjectAiMcpServers';
 import styles from './AiAgentNewThreadMcpConnections.module.css';
@@ -163,6 +167,12 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
     );
     const { mutateAsync: connectGithubMcp, isLoading: isConnectingGithubMcp } =
         useConnectGithubMcpServerMutation(projectUuid);
+    const { data: gitlabMcpAvailability } = useGitlabMcpAvailability(
+        projectUuid,
+        { enabled: !!projectUuid },
+    );
+    const { mutateAsync: connectGitlabMcp, isLoading: isConnectingGitlabMcp } =
+        useConnectGitlabMcpServerMutation(projectUuid);
     const { mutateAsync: updateAgentMcpServers, isLoading: isAttachingGithub } =
         useProjectUpdateAiAgentMutation(projectUuid, {
             showSuccessToast: false,
@@ -180,6 +190,9 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
     const canOneClickConnectGithub =
         githubMcpAvailability?.available === true &&
         githubMcpAvailability?.alreadyConnected === false;
+    const canOneClickConnectGitlab =
+        gitlabMcpAvailability?.available === true &&
+        gitlabMcpAvailability?.alreadyConnected === false;
 
     const appNames = useMemo(() => {
         const oauthAppNames = Array.from(
@@ -187,10 +200,16 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
                 mcpServersNeedingConnection.map((mcpServer) => mcpServer.name),
             ),
         );
-        return canOneClickConnectGithub
-            ? [...oauthAppNames, GITHUB_MCP_SERVER_NAME]
-            : oauthAppNames;
-    }, [mcpServersNeedingConnection, canOneClickConnectGithub]);
+        const oneClickNames = [
+            ...(canOneClickConnectGithub ? [GITHUB_MCP_SERVER_NAME] : []),
+            ...(canOneClickConnectGitlab ? [GITLAB_MCP_SERVER_NAME] : []),
+        ];
+        return [...oauthAppNames, ...oneClickNames];
+    }, [
+        mcpServersNeedingConnection,
+        canOneClickConnectGithub,
+        canOneClickConnectGitlab,
+    ]);
 
     const connectionNote = useMemo(() => {
         for (const mcpServer of mcpServersNeedingConnection) {
@@ -254,6 +273,38 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
             updateAgentMcpServers,
         ],
     );
+
+    // True one-click for GitLab: the org's OAuth token is used, so there's no
+    // token to paste — connect (shared scope) and attach to the agent directly.
+    const handleConnectGitlabMcp = useCallback(async () => {
+        try {
+            const server = await connectGitlabMcp({
+                credentialScope: 'shared',
+            });
+            if (!server) {
+                return;
+            }
+            const attachedUuids = (mcpServers ?? []).map(
+                (mcpServer) => mcpServer.uuid,
+            );
+            if (!attachedUuids.includes(server.uuid)) {
+                await updateAgentMcpServers({
+                    uuid: agentUuid,
+                    mcpServerUuids: [...attachedUuids, server.uuid],
+                });
+            }
+        } catch {
+            // Toasts are handled in the mutation.
+        } finally {
+            await refetchAgentMcpServers();
+        }
+    }, [
+        agentUuid,
+        connectGitlabMcp,
+        mcpServers,
+        refetchAgentMcpServers,
+        updateAgentMcpServers,
+    ]);
 
     if (isLoading) {
         return (
@@ -329,7 +380,11 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
         );
     }
 
-    if (mcpServersNeedingConnection.length === 0 && !canOneClickConnectGithub) {
+    if (
+        mcpServersNeedingConnection.length === 0 &&
+        !canOneClickConnectGithub &&
+        !canOneClickConnectGitlab
+    ) {
         return null;
     }
 
@@ -350,6 +405,20 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
             onClick={githubConfirmModalHandlers.open}
         >
             GitHub
+        </Button>
+    ) : null;
+
+    const gitlabConnectButton = canOneClickConnectGitlab ? (
+        <Button
+            key="gitlab-connect"
+            size="compact-xs"
+            variant="subtle"
+            color="gray"
+            leftSection={<MantineIcon icon={IconBrandGitlab} />}
+            loading={isConnectingGitlabMcp || isAttachingGithub}
+            onClick={() => void handleConnectGitlabMcp()}
+        >
+            GitLab
         </Button>
     ) : null;
 
@@ -418,6 +487,7 @@ export const AiAgentNewThreadMcpConnections: FC<Props> = ({
                             );
                         })}
                         {githubConnectButton}
+                        {gitlabConnectButton}
                     </Group>
                 </Stack>
             </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
@@ -1,10 +1,12 @@
 import type {
     ApiAiMcpGithubAvailabilityResponse,
+    ApiAiMcpGitlabAvailabilityResponse,
     ApiAiMcpOAuthCredentialRequest,
     ApiAiAgentMcpServerToolListResponse,
     ApiAiMcpServerListResponse,
     ApiAiMcpServerResponse,
     ApiConnectGithubMcpServerBody,
+    ApiConnectGitlabMcpServerBody,
     ApiAiMcpServerToolListResponse,
     ApiCreateAiMcpServer,
     ApiError,
@@ -74,6 +76,28 @@ const connectGithubMcpServer = async (
     lightdashApi<ApiAiMcpServerResponse['results']>({
         version: 'v1',
         url: `/projects/${projectUuid}/aiAgents/mcpServers/github/connect`,
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+const getGitlabMcpAvailability = async (
+    projectUuid: string,
+): Promise<ApiAiMcpGitlabAvailabilityResponse['results']> =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    lightdashApi<any>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/mcpServers/gitlab/availability`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const connectGitlabMcpServer = async (
+    projectUuid: string,
+    body: ApiConnectGitlabMcpServerBody,
+): Promise<ApiAiMcpServerResponse['results']> =>
+    lightdashApi<ApiAiMcpServerResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/mcpServers/gitlab/connect`,
         method: 'POST',
         body: JSON.stringify(body),
     });
@@ -399,6 +423,53 @@ export const useConnectGithubMcpServerMutation = (projectUuid: string) => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to connect GitHub',
+                apiError: error,
+            });
+        },
+    });
+};
+
+const GITLAB_MCP_AVAILABILITY_KEY = 'gitlabMcpAvailability';
+
+export const useGitlabMcpAvailability = (
+    projectUuid: string | undefined,
+    options?: UseQueryOptions<
+        ApiAiMcpGitlabAvailabilityResponse['results'],
+        ApiError
+    >,
+) =>
+    useQuery<ApiAiMcpGitlabAvailabilityResponse['results'], ApiError>({
+        queryKey: [GITLAB_MCP_AVAILABILITY_KEY, projectUuid],
+        queryFn: () => getGitlabMcpAvailability(projectUuid!),
+        enabled: !!projectUuid && options?.enabled !== false,
+        ...options,
+    });
+
+export const useConnectGitlabMcpServerMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+
+    return useMutation<
+        ApiAiMcpServerResponse['results'],
+        ApiError,
+        ApiConnectGitlabMcpServerBody
+    >({
+        mutationFn: (body) => connectGitlabMcpServer(projectUuid, body),
+        onSuccess: async (result) => {
+            showToastSuccess({
+                title: 'GitLab connected',
+                subtitle: `${result.name} is ready to use with your agents.`,
+            });
+            await queryClient.invalidateQueries({
+                queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+            });
+            await queryClient.invalidateQueries({
+                queryKey: [GITLAB_MCP_AVAILABILITY_KEY, projectUuid],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to connect GitLab',
                 apiError: error,
             });
         },


### PR DESCRIPTION
## Summary

Mirrors the existing one-click **"Connect GitHub"** MCP setup for **GitLab**, so an AI agent can connect to the hosted GitLab MCP server using the organization's existing GitLab connection — no manual MCP URL/auth.

Unlike GitHub (which collects a fine-grained PAT and swaps in the App-installation token at runtime), GitLab is a **true one-click**: the org's GitLab OAuth token is reused, so there's no token to paste. GitLab can be self-hosted, so the MCP URL is derived from the connected instance (`{instanceUrl}/api/v4/mcp`) rather than a fixed host.

Off by default behind `gitlab-mcp-one-click`, so it can ship incrementally.

## Changes
- **common** — `FeatureFlags.GitlabMcpOneClick`; `GITLAB_MCP_SERVER_NAME` + `getGitlabMcpServerUrl`/`isGitlabMcpServerUrl` helpers; `AiMcpGitlabAvailability` / `ApiConnectGitlabMcpServerBody` / response types.
- **backend** — `getGitlabMcpAvailability` / `connectGitlabMcpServer` / `refreshGitlabMcpCredentials` on `AiAgentService` (the bearer token is refreshed per run from the org's GitLab OAuth install via `getOrRefreshToken`, same pattern as writeback); two TSOA routes (`GET/POST .../mcpServers/gitlab/availability|connect`); a `gitlab_mcp_connected` analytics event; `GitlabAppInstallationsModel` injected into the service.
- **frontend** — `useGitlabMcpAvailability` / `useConnectGitlabMcpServerMutation` hooks; a "GitLab" connect button in `AiAgentNewThreadMcpConnections`, gated on availability (one-click, no modal).

## Testing
- Typecheck clean across common / backend / frontend; `generate-api` regenerated routes + swagger; lint/format applied.
- Not yet exercised end-to-end against a live GitLab MCP (feature flag is off).

## Open question for review
The exact GitLab hosted-MCP endpoint (`{instanceUrl}/api/v4/mcp`) and that it accepts the org OAuth token as a bearer is my best-reasonable design from GitLab's MCP docs — it mirrors the GitHub flow and compiles, but should be confirmed against a live GitLab MCP before enabling the flag.

Linear: PROD-8162

🤖 Generated with [Claude Code](https://claude.com/claude-code)