### PR TITLE
feat(data-apps): duplicate data apps into preview environments

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -305,20 +305,41 @@ remap their `savedChartUuid` / `savedSqlUuid`. The orchestration lives in `Promo
   tiles get. Soft-deleted apps behind placeholder tiles are skipped — the tile keeps its original reference and renders
   the existing "app no longer exists" placeholder upstream.
 
-### Preview environments (copy-on-preview — out of scope)
+### Preview environments (copy-on-preview)
 
-Data apps are **not yet duplicated** when a project is copied to a preview environment. The preview-copy step in
-`ProjectModel.duplicateContent` copies `dashboard_tile_data_apps` rows but leaves their `app_uuid` pointing at the source
-project's app rather than creating a fresh `apps` row in the preview, so any data app tile in a preview is a read-through
-window to the source project's app:
+When a project is copied to a preview environment, **every data app is duplicated into the preview** — both standalone
+apps and apps embedded as `DATA_APP` dashboard tiles. The preview gets its own `apps` + `app_versions` rows and its own
+S3 artifacts, so apps render and can be iterated on entirely inside the preview.
 
-- **Preview rendering.** If the user opening the preview has view access to the source app, the tile renders normally.
-  Otherwise the `DashboardDataAppTile` error states show a "Data app not found" / "No access" placeholder and the rest
-  of the dashboard renders fine.
-- **Iterating inside the preview.** Not supported — the preview project has no `apps` row of its own.
+The copy is the mirror image of [promotion](#promotion): promotion snapshots a preview app *up* into production;
+preview duplication snapshots production apps *down* into a fresh preview. It reuses the same per-app primitives
+(`copyVersionS3Prefix`, `buildCopiedResources`, the org-shared design guard) that `duplicateApp` / `promoteApp` use.
 
-Copying `apps` + `app_versions` + S3 artifacts into previews is tracked in
-[PROD-7778 follow-up](https://linear.app/lightdash/issue/PROD-7778/preview-environments-arent-considering-data-apps).
+Orchestration lives in `AppGenerateService.duplicateAppsForPreview`, called once from
+`ProjectService.copyContentOnPreview` right after `ProjectModel.duplicateContent` has copied the rest of the project:
+
+- **What gets copied per app.** The latest ready version's S3 artifacts (`dist.tar` + `source.tar` + assets) are
+  server-side copied into a new v1; name, description, template, design, and chart/dashboard resource refs carry over.
+  No sandbox is created — one spins up lazily on the first iteration. Apps with no ready version are skipped (their tile,
+  if any, keeps its read-through reference). `created_by_user_uuid` is preserved so personal apps stay owned by their
+  original author inside the preview.
+- **Spaces.** `ProjectModel.duplicateContent` now returns the source→preview space-uuid mapping; each app lands in the
+  preview's mirror of its source space (ancestors already created by the content copy). Personal apps
+  (`space_uuid IS NULL`) stay personal.
+- **The round trip — `upstream_app_uuid`.** Each preview copy's `upstream_app_uuid` is set back to the production app it
+  was copied from. That is the same link `promoteApp` writes on first promotion, so iterating on the copy inside the
+  preview and then promoting **updates the original production app** rather than creating a duplicate. Preview
+  duplication and promotion are two halves of one loop.
+- **Tile remap.** `duplicateContent` copies `dashboard_tile_data_apps` rows with `app_uuid` still pointing at the source
+  apps; `AppModel.remapPreviewDashboardTileApps` then repoints the preview's tiles onto the duplicated apps. The update
+  is **scoped to dashboards in the preview project** (via a `dashboard_versions → dashboards → spaces → projects`
+  subquery) — critical, because the source project's tiles carry the same `app_uuid` and must never be touched.
+- **Best-effort.** A per-app failure (S3 or DB) is logged, its orphaned S3 copy cleaned up, and the app skipped — it
+  cannot abort the rest of the copy or block preview creation. The whole step is also non-fatal to the surrounding
+  content copy. Core (non-EE) builds resolve the lazy `getAppGenerateService` accessor to `undefined` and skip
+  duplication entirely.
+
+Tracked in [PROD-7819](https://linear.app/lightdash/issue/PROD-7819/make-it-possible-to-build-data-apps-in-previews-and-promote-them).
 
 ---
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -463,6 +463,15 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                             ]);
                         return reviewsEnabled && aiWritebackFlag.enabled;
                     },
+                    // Lazy accessor (not the instance) to duplicate the
+                    // upstream project's data apps when a preview is created.
+                    // AppGenerateService depends on ProjectService, so resolving
+                    // it eagerly here would cycle. The EE projectService
+                    // provider overrides the core one, so the thunk must be
+                    // wired here too — otherwise preview app duplication is a
+                    // silent no-op in EE builds.
+                    getAppGenerateService: () =>
+                        repository.getAppGenerateService<AppGenerateService>(),
                 }),
             instanceConfigurationService: ({
                 models,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -4209,6 +4209,202 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         return { appUuid: newAppUuid, version: newVersion };
     }
 
+    /**
+     * Duplicate every data app from an upstream project into a freshly created
+     * preview project, then repoint the preview's data-app dashboard tiles onto
+     * the duplicated apps. Called once, system-initiated, during preview
+     * creation (`ProjectService.copyContentOnPreview`) right after the rest of
+     * the project content has been copied.
+     *
+     * Each app is copied like a standalone duplicate (latest ready version's S3
+     * artifacts server-side copied into a new v1, no sandbox) with two
+     * differences:
+     *  - it lands in the preview's mirror of the source app's space (or as a
+     *    personal app for spaceless source apps), using the source→preview
+     *    space map produced by `ProjectModel.duplicateContent`; and
+     *  - its `upstream_app_uuid` is set back to the source app, so iterating in
+     *    the preview and then promoting *updates* the original upstream app
+     *    rather than creating a duplicate — the round trip that pairs with
+     *    `promoteApp`.
+     *
+     * Best-effort and non-fatal: a per-app failure is logged and skipped so it
+     * cannot block preview creation; tiles for a skipped app keep their
+     * original upstream reference (rendered read-through, as before this
+     * feature). No per-app permission checks — this is a privileged copy of the
+     * whole project, exactly like `ProjectModel.duplicateContent`.
+     */
+    async duplicateAppsForPreview(
+        sourceProjectUuid: string,
+        previewProjectUuid: string,
+        spaceMapping: { sourceSpaceUuid: string; previewSpaceUuid: string }[],
+    ): Promise<void> {
+        const sourceApps =
+            await this.appModel.listAppsByProject(sourceProjectUuid);
+        if (sourceApps.length === 0) {
+            return;
+        }
+
+        const previewProject =
+            await this.projectModel.getSummary(previewProjectUuid);
+        const previewSpaceBySource = new Map(
+            spaceMapping.map((s) => [s.sourceSpaceUuid, s.previewSpaceUuid]),
+        );
+        const { client: s3Client, bucket } = this.getS3Client();
+
+        const mappings: { sourceAppUuid: string; previewAppUuid: string }[] =
+            [];
+
+        /* eslint-disable no-await-in-loop */
+        for (const sourceApp of sourceApps) {
+            const previewAppUuid = await this.copyAppForPreview(
+                sourceApp,
+                sourceProjectUuid,
+                previewProjectUuid,
+                previewProject.organizationUuid,
+                previewSpaceBySource,
+                s3Client,
+                bucket,
+            );
+            if (previewAppUuid) {
+                mappings.push({
+                    sourceAppUuid: sourceApp.app_id,
+                    previewAppUuid,
+                });
+            }
+        }
+        /* eslint-enable no-await-in-loop */
+
+        // Repoint the preview's dashboard tiles (copied still pointing at the
+        // upstream apps) onto the duplicated apps.
+        await this.appModel.remapPreviewDashboardTileApps(
+            previewProjectUuid,
+            mappings,
+        );
+
+        this.logger.info(
+            `Preview duplication: copied ${mappings.length}/${sourceApps.length} data app(s) from project ${sourceProjectUuid} into preview ${previewProjectUuid}`,
+        );
+    }
+
+    /**
+     * Copy a single upstream app into the preview project, returning the new
+     * app's uuid — or null when there is nothing to copy (no ready version) or
+     * the copy failed (logged, S3 cleaned up). Failures are non-fatal so one
+     * bad app can't abort the whole preview duplication.
+     */
+    private async copyAppForPreview(
+        sourceApp: DbApp,
+        sourceProjectUuid: string,
+        previewProjectUuid: string,
+        previewOrganizationUuid: string,
+        previewSpaceBySource: Map<string, string>,
+        s3Client: S3Client,
+        bucket: string,
+    ): Promise<string | null> {
+        const sourceVersion = await this.appModel.getLatestReadyVersion(
+            sourceApp.app_id,
+        );
+        if (!sourceVersion) {
+            // No successful build to copy — nothing to render in the preview.
+            // The tile (if any) keeps its read-through reference.
+            return null;
+        }
+
+        // Place the copy in the preview's mirror of the source space. Spaceless
+        // (personal) apps stay personal. A source space missing from the map
+        // shouldn't happen (all spaces are copied first) but falls back to a
+        // personal app rather than failing the copy.
+        const previewSpaceUuid = sourceApp.space_uuid
+            ? (previewSpaceBySource.get(sourceApp.space_uuid) ?? null)
+            : null;
+        if (sourceApp.space_uuid && !previewSpaceUuid) {
+            this.logger.warn(
+                `Preview duplication: source space ${sourceApp.space_uuid} for app ${sourceApp.app_id} not found in preview ${previewProjectUuid}; copying as a personal app`,
+            );
+        }
+
+        // Designs are org-scoped and the preview shares the source org, so the
+        // design carries over — but guard against a since-deleted one.
+        const targetDesignUuid =
+            sourceApp.design_uuid &&
+            (await this.organizationDesignModel.findInOrganization(
+                previewOrganizationUuid,
+                sourceApp.design_uuid,
+            ))
+                ? sourceApp.design_uuid
+                : null;
+
+        const resources = AppGenerateService.buildCopiedResources(
+            sourceVersion.resources ?? null,
+        );
+
+        const newAppUuid = uuidv4();
+        const newVersion = 1;
+
+        const sourceDisplayName = sourceApp.name || 'untitled app';
+        const sourcePreviewPath = `/projects/${sourceProjectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/preview`;
+        const prompt = `Duplicate [${sourceDisplayName}](${sourcePreviewPath})`;
+
+        // Keep the S3 copy inside the try so an S3 failure is per-app (logged
+        // and skipped, like a DB failure) instead of throwing out of the loop
+        // and aborting the remaining apps and the tile remap.
+        let copiedKeys: string[] = [];
+
+        try {
+            copiedKeys = await AppGenerateService.copyVersionS3Prefix(
+                s3Client,
+                bucket,
+                { appUuid: sourceApp.app_id, version: sourceVersion.version },
+                { appUuid: newAppUuid, version: newVersion },
+            );
+            await this.appModel.createWithVersion(
+                {
+                    app_id: newAppUuid,
+                    project_uuid: previewProjectUuid,
+                    // Preserve the original author so personal apps stay owned
+                    // by their creator inside the preview.
+                    created_by_user_uuid: sourceApp.created_by_user_uuid,
+                    name: sourceApp.name,
+                    description: sourceApp.description,
+                    template: sourceApp.template,
+                    space_uuid: previewSpaceUuid,
+                    design_uuid: targetDesignUuid,
+                },
+                { version: newVersion, prompt },
+                'ready',
+                resources,
+            );
+            // Link back to the upstream app so a later promote updates it
+            // instead of creating a duplicate.
+            await this.appModel.setUpstreamAppUuid(
+                newAppUuid,
+                sourceApp.app_id,
+            );
+            await this.appModel.updateStatusMessage(
+                newAppUuid,
+                newVersion,
+                'Copied from upstream project',
+            );
+        } catch (error) {
+            // Drop the orphaned S3 copy and skip this app — a single failure
+            // must not abort the rest of the preview copy.
+            await this.cleanupRestoredS3Keys(
+                s3Client,
+                bucket,
+                newAppUuid,
+                copiedKeys,
+            );
+            this.logger.error(
+                `Preview duplication: failed to copy app ${sourceApp.app_id} into preview ${previewProjectUuid}: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            return null;
+        }
+
+        return newAppUuid;
+    }
+
     async cancelVersion(
         user: SessionUser,
         projectUuid: string,

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -494,6 +494,60 @@ export class AppModel {
     }
 
     /**
+     * List every non-deleted app in a project. Used by preview duplication to
+     * mirror the upstream project's apps into a freshly created preview.
+     */
+    async listAppsByProject(projectUuid: string): Promise<DbApp[]> {
+        return this.database(AppsTableName)
+            .where({ project_uuid: projectUuid })
+            .whereNull('deleted_at')
+            .select('*');
+    }
+
+    /**
+     * Repoint a preview project's data-app dashboard tiles from the source
+     * (upstream) apps they were copied with onto the preview's own duplicated
+     * apps. The update is scoped to dashboards living in the preview project so
+     * the upstream project's tiles — which carry the same `app_uuid` — are
+     * never touched.
+     */
+    async remapPreviewDashboardTileApps(
+        previewProjectUuid: string,
+        mappings: { sourceAppUuid: string; previewAppUuid: string }[],
+    ): Promise<void> {
+        if (mappings.length === 0) {
+            return;
+        }
+        const previewVersionIds = this.database(DashboardVersionsTableName)
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_id`,
+                `${DashboardVersionsTableName}.dashboard_id`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${DashboardsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, previewProjectUuid)
+            .select(`${DashboardVersionsTableName}.dashboard_version_id`);
+
+        /* eslint-disable no-await-in-loop */
+        for (const { sourceAppUuid, previewAppUuid } of mappings) {
+            await this.database(DashboardTileDataAppsTableName)
+                .where('app_uuid', sourceAppUuid)
+                .whereIn('dashboard_version_id', previewVersionIds.clone())
+                .update({ app_uuid: previewAppUuid });
+        }
+        /* eslint-enable no-await-in-loop */
+    }
+
+    /**
      * Sync the metadata of an existing production app from its preview source
      * during a follow-up promotion. Only touches the fields promotion owns —
      * versions are appended separately, the link and ownership stay put.

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2394,7 +2394,9 @@ export class ProjectModel {
         projectUuid: string,
         previewProjectUuid: string,
         spaces: Pick<SpaceSummary, 'uuid'>[],
-    ) {
+    ): Promise<{
+        spaceMapping: { sourceSpaceUuid: string; previewSpaceUuid: string }[];
+    }> {
         Logger.info(
             `Copying content from ${projectUuid} to ${previewProjectUuid}`,
         );
@@ -3469,6 +3471,16 @@ export class ProjectModel {
                 preview_project_uuid: previewProjectUuid,
                 content_mapping: contentMapping,
             });
+
+            // Return the source→preview space mapping so callers (preview data
+            // app duplication) can place copied entities into the mirrored
+            // preview spaces.
+            return {
+                spaceMapping: spaceMapping.map((s) => ({
+                    sourceSpaceUuid: s.uuid,
+                    previewSpaceUuid: s.newUuid,
+                })),
+            };
         });
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -217,6 +217,7 @@ import { type DbPreAggregateDefinitionIn } from '../../ee/database/entities/preA
 import { PreAggregateModel } from '../../ee/models/PreAggregateModel';
 import { enhanceExploresForPreAggregates } from '../../ee/preAggregates/enhanceExploresForPreAggregates';
 import { preAggregatePostProcessor } from '../../ee/preAggregates/postProcessor';
+import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
 import { buildMaterializationMetricQuery } from '../../ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery';
 import { errorHandler } from '../../errors';
 import Logger from '../../logging/logger';
@@ -335,6 +336,11 @@ export type ProjectServiceArguments = {
             Partial<Pick<SessionUser, 'organizationName'>>;
         organizationUuid: string;
     }) => Promise<boolean>;
+    // Lazily resolves the EE data-app service so preview creation can duplicate
+    // the upstream project's data apps. A thunk — not the instance — because
+    // AppGenerateService depends on ProjectService, so eager injection would
+    // create a construction cycle. Resolves undefined in core (non-EE) builds.
+    getAppGenerateService?: () => AppGenerateService | undefined;
 };
 
 export class ProjectService extends BaseService {
@@ -423,6 +429,8 @@ export class ProjectService extends BaseService {
         | ProjectServiceArguments['isProjectContextEnabled']
         | undefined;
 
+    getAppGenerateService: (() => AppGenerateService | undefined) | undefined;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -461,6 +469,7 @@ export class ProjectService extends BaseService {
         organizationSettingsModel,
         projectContextModel,
         isProjectContextEnabled,
+        getAppGenerateService,
     }: ProjectServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -502,6 +511,7 @@ export class ProjectService extends BaseService {
         this.organizationSettingsModel = organizationSettingsModel;
         this.projectContextModel = projectContextModel;
         this.isProjectContextEnabled = isProjectContextEnabled;
+        this.getAppGenerateService = getAppGenerateService;
     }
 
     static getMetricQueryExecutionProperties({
@@ -7761,11 +7771,34 @@ export class ProjectService extends BaseService {
             async () => {
                 const spaces = await this.spaceModel.find({ projectUuid }); // Get all spaces in the project
 
-                await this.projectModel.duplicateContent(
-                    projectUuid,
-                    previewProjectUuid,
-                    spaces,
-                );
+                const { spaceMapping } =
+                    await this.projectModel.duplicateContent(
+                        projectUuid,
+                        previewProjectUuid,
+                        spaces,
+                    );
+
+                // Duplicate the upstream project's data apps into the preview
+                // and remap the copied dashboard tiles onto them. EE-only —
+                // resolves undefined in core builds. Best-effort: a failure
+                // here must not undo the content copy that already committed,
+                // so swallow and log rather than propagate.
+                const appGenerateService = this.getAppGenerateService?.();
+                if (appGenerateService) {
+                    try {
+                        await appGenerateService.duplicateAppsForPreview(
+                            projectUuid,
+                            previewProjectUuid,
+                            spaceMapping,
+                        );
+                    } catch (e) {
+                        this.logger.error(
+                            `Failed to duplicate data apps from ${projectUuid} to preview ${previewProjectUuid}: ${getErrorMessage(
+                                e,
+                            )}`,
+                        );
+                    }
+                }
             },
         );
     }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -765,6 +765,16 @@ export class ServiceRepository
                         this.models.getContentVerificationModel(),
                     organizationSettingsModel:
                         this.models.getOrganizationSettingsModel(),
+                    // Lazy accessor (not the instance) to duplicate the
+                    // upstream project's data apps when a preview is created.
+                    // AppGenerateService depends on ProjectService, so
+                    // resolving it eagerly here would cycle. Only wired when EE
+                    // license is active; core builds resolve undefined and skip
+                    // data-app duplication.
+                    getAppGenerateService: () =>
+                        this.providers.appGenerateService
+                            ? this.getAppGenerateService<AppGenerateService>()
+                            : undefined,
                 }),
         );
     }


### PR DESCRIPTION
Closes PROD-7819

### Description:
When a preview project is created, every data app from the upstream project is now duplicated into the preview — both standalone apps and apps embedded as DATA_APP dashboard tiles. The preview gets its own apps + app_versions rows and S3 artifacts, so apps render and can be iterated on entirely inside the preview.

Each preview copy's upstream_app_uuid is set back to the production app it came from, so iterating in the preview and then promoting updates the original app rather than creating a duplicate — the round trip that pairs with promoteApp.

- AppModel: listAppsByProject + remapPreviewDashboardTileApps (the tile remap is scoped to the preview project so the source project's tiles, which share the same app_uuid, are never touched)
- ProjectModel.duplicateContent: return the source->preview space mapping
- AppGenerateService.duplicateAppsForPreview: per-app copy (S3 + v1 + upstream link), best-effort, reusing the promote/duplicate primitives
- ProjectService.copyContentOnPreview: invoke the EE step after content copy via a lazy getAppGenerateService thunk
- wire the thunk in both the core ServiceRepository factory and the EE projectService provider (ee/index.ts), since EE overrides the core one
