### PR TITLE
chore(ai-agents): remove review feature flags

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from '@lightdash/common';
+import { FeatureFlags, ForbiddenError } from '@lightdash/common';
 import express, { Express } from 'express';
 import { AppArguments } from '../App';
 import {
@@ -283,6 +283,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentReviewClassifierModel:
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
                     featureFlagService: repository.getFeatureFlagService(),
+                    aiOrganizationSettingsService:
+                        repository.getAiOrganizationSettingsService(),
                     projectModel: models.getProjectModel(),
                     aiWritebackService:
                         repository.getAiWritebackService<AiWritebackService>(),
@@ -437,6 +439,28 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getOrganizationSettingsModel(),
                     projectContextModel:
                         models.getProjectContextModel<ProjectContextModel>(),
+                    isProjectContextEnabled: async ({
+                        user,
+                        organizationUuid,
+                    }) => {
+                        const [reviewsEnabled, aiWritebackFlag] =
+                            await Promise.all([
+                                repository
+                                    .getAiOrganizationSettingsService<AiOrganizationSettingsService>()
+                                    .isAiAgentReviewsEnabled({
+                                        organizationUuid,
+                                    }),
+                                models.getFeatureFlagModel().get({
+                                    featureFlagId: FeatureFlags.AiWriteback,
+                                    user: {
+                                        userUuid: user.userUuid,
+                                        organizationUuid,
+                                        organizationName: user.organizationName,
+                                    },
+                                }),
+                            ]);
+                        return reviewsEnabled && aiWritebackFlag.enabled;
+                    },
                 }),
             instanceConfigurationService: ({
                 models,

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -47,6 +47,7 @@ import {
     buildYmlPathByModel,
     planReviewWriteback,
 } from './ai/reviewWriteback/buildReviewWritebackPrompt';
+import { type AiOrganizationSettingsService } from './AiOrganizationSettingsService';
 import { type AiWritebackService } from './AiWritebackService/AiWritebackService';
 import { type ProjectContextService } from './ProjectContextService/ProjectContextService';
 
@@ -55,6 +56,7 @@ type AiAgentAdminServiceDependencies = {
     aiAgentModel: AiAgentModel;
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
     featureFlagService: FeatureFlagService;
+    aiOrganizationSettingsService: AiOrganizationSettingsService;
     projectModel: ProjectModel;
     aiWritebackService: AiWritebackService;
     projectContextService: ProjectContextService;
@@ -258,6 +260,8 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly featureFlagService: FeatureFlagService;
 
+    private readonly aiOrganizationSettingsService: AiOrganizationSettingsService;
+
     private readonly projectModel: ProjectModel;
 
     private readonly aiWritebackService: AiWritebackService;
@@ -281,6 +285,8 @@ export class AiAgentAdminService extends BaseService {
         this.aiAgentReviewClassifierModel =
             dependencies.aiAgentReviewClassifierModel;
         this.featureFlagService = dependencies.featureFlagService;
+        this.aiOrganizationSettingsService =
+            dependencies.aiOrganizationSettingsService;
         this.projectModel = dependencies.projectModel;
         this.aiWritebackService = dependencies.aiWritebackService;
         this.projectContextService = dependencies.projectContextService;
@@ -360,28 +366,13 @@ export class AiAgentAdminService extends BaseService {
         }
         this.checkOrganizationAdminAccess(user);
 
-        const featureFlag = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiAgentReviewClassifier,
-            user: {
-                userUuid: user.userUuid,
-                organizationUuid,
-                organizationName: user.organizationName ?? '',
-            },
-        });
-
-        if (!featureFlag.enabled) {
-            throw new ForbiddenError(
-                'AI agent review classifier is not enabled',
-            );
-        }
-
         const items = await this.aiAgentReviewClassifierModel.listReviewItems({
             organizationUuid,
             statuses,
         });
 
         const [reviewsEnabled, projectContextEnabled] = await Promise.all([
-            this.isWritebackFeatureEnabled(user),
+            this.areReviewsEnabled(user),
             this.isProjectContextFeatureEnabled(user),
         ]);
         const overrides = await this.reconcileLinkedPullRequests(
@@ -458,23 +449,14 @@ export class AiAgentAdminService extends BaseService {
         return filtered;
     }
 
-    private async isWritebackFeatureEnabled(
-        user: SessionUser,
-    ): Promise<boolean> {
+    private async areReviewsEnabled(user: SessionUser): Promise<boolean> {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             return false;
         }
-        const flagUser = {
-            userUuid: user.userUuid,
+        return this.aiOrganizationSettingsService.isAiAgentReviewsEnabled({
             organizationUuid,
-            organizationName: user.organizationName ?? '',
-        };
-        const classifier = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiAgentReviewClassifier,
-            user: flagUser,
         });
-        return classifier.enabled;
     }
 
     private async isProjectContextFeatureEnabled(
@@ -484,15 +466,20 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             return false;
         }
-        const flag = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiProjectContext,
-            user: {
-                userUuid: user.userUuid,
+        const [reviewsEnabled, aiWritebackFlag] = await Promise.all([
+            this.aiOrganizationSettingsService.isAiAgentReviewsEnabled({
                 organizationUuid,
-                organizationName: user.organizationName ?? '',
-            },
-        });
-        return flag.enabled;
+            }),
+            this.featureFlagService.get({
+                featureFlagId: FeatureFlags.AiWriteback,
+                user: {
+                    userUuid: user.userUuid,
+                    organizationUuid,
+                    organizationName: user.organizationName ?? '',
+                },
+            }),
+        ]);
+        return reviewsEnabled && aiWritebackFlag.enabled;
     }
 
     private hasSemanticWritebackConfig(): boolean {
@@ -736,21 +723,6 @@ export class AiAgentAdminService extends BaseService {
         }
         this.checkOrganizationAdminAccess(user);
 
-        const featureFlag = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiAgentReviewClassifier,
-            user: {
-                userUuid: user.userUuid,
-                organizationUuid,
-                organizationName: user.organizationName ?? '',
-            },
-        });
-
-        if (!featureFlag.enabled) {
-            throw new ForbiddenError(
-                'AI agent review classifier is not enabled',
-            );
-        }
-
         return this.aiAgentReviewClassifierModel.listReviewSignals({
             organizationUuid,
         });
@@ -766,20 +738,6 @@ export class AiAgentAdminService extends BaseService {
             throw new ForbiddenError('Organization not found');
         }
         this.checkOrganizationAdminAccess(user);
-
-        const featureFlag = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiAgentReviewClassifier,
-            user: {
-                userUuid: user.userUuid,
-                organizationUuid,
-                organizationName: user.organizationName ?? '',
-            },
-        });
-        if (!featureFlag.enabled) {
-            throw new ForbiddenError(
-                'AI agent review classifier is not enabled',
-            );
-        }
 
         if (update.status === 'dismissed' && !update.dismissedReason) {
             throw new ParameterError(
@@ -850,20 +808,6 @@ export class AiAgentAdminService extends BaseService {
         }
         this.checkOrganizationAdminAccess(user);
 
-        const featureFlag = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiAgentReviewClassifier,
-            user: {
-                userUuid: user.userUuid,
-                organizationUuid,
-                organizationName: user.organizationName ?? '',
-            },
-        });
-        if (!featureFlag.enabled) {
-            throw new ForbiddenError(
-                'AI agent review classifier is not enabled',
-            );
-        }
-
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
                 organizationUuid,
@@ -872,10 +816,12 @@ export class AiAgentAdminService extends BaseService {
         if (!reviewItem) {
             throw new NotFoundError('Review item not found');
         }
-        const projectContextEnabled =
+        const [reviewsEnabled, projectContextEnabled] = await Promise.all([
+            this.areReviewsEnabled(user),
             reviewItem.primaryRootCause === 'project_context'
-                ? await this.isProjectContextFeatureEnabled(user)
-                : false;
+                ? this.isProjectContextFeatureEnabled(user)
+                : false,
+        ]);
         const staleAwareItem = withStaleWritebackOverride(
             reviewItem,
             Date.now(),
@@ -886,7 +832,7 @@ export class AiAgentAdminService extends BaseService {
         );
         const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
             item: staleAwareItem,
-            reviewsEnabled: true,
+            reviewsEnabled,
             projectContextEnabled,
             projectAccess: staleAwareItem.projectUuid
                 ? (projectAccessByUuid.get(staleAwareItem.projectUuid) ?? null)
@@ -1121,7 +1067,7 @@ export class AiAgentAdminService extends BaseService {
         }
 
         const [reviewsEnabled, projectContextEnabled] = await Promise.all([
-            this.isWritebackFeatureEnabled(user),
+            this.areReviewsEnabled(user),
             this.isProjectContextFeatureEnabled(user),
         ]);
         const projectAccessByUuid = await this.getProjectWritebackAccessByUuid(

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -311,7 +311,7 @@ describe('AiAgentReviewClassifierService', () => {
     beforeEach(() => {
         jest.resetAllMocks();
         featureFlagService.get.mockResolvedValue({
-            id: FeatureFlags.AiAgentReviewClassifier,
+            id: FeatureFlags.AiWriteback,
             enabled: true,
         });
         aiOrganizationSettingsModel.findByOrganizationUuid.mockResolvedValue({
@@ -355,23 +355,6 @@ describe('AiAgentReviewClassifierService', () => {
             },
         ]);
         judgeTurn.mockResolvedValue(makeJudgeOutput());
-    });
-
-    it('throws when the feature flag is disabled', async () => {
-        featureFlagService.get.mockResolvedValueOnce({
-            id: FeatureFlags.AiAgentReviewClassifier,
-            enabled: false,
-        });
-
-        await expect(
-            service.run({
-                organizationUuid: ORGANIZATION_UUID,
-                startedAt: NOW,
-                endedAt: NOW,
-            }),
-        ).rejects.toThrow(ForbiddenError);
-
-        expect(model.createRun).not.toHaveBeenCalled();
     });
 
     it('throws when review collection is not opted in for the organization', async () => {
@@ -534,11 +517,11 @@ describe('AiAgentReviewClassifierService', () => {
         expect(result.reviewItemCount).toBe(1);
     });
 
-    it('drops project context entries when the project context flag is disabled', async () => {
+    it('drops project context entries when AI writeback is disabled', async () => {
         featureFlagService.get.mockImplementation(({ featureFlagId }) =>
             Promise.resolve({
                 id: featureFlagId,
-                enabled: featureFlagId !== FeatureFlags.AiProjectContext,
+                enabled: false,
             }),
         );
         judgeTurn.mockResolvedValueOnce(makeProjectContextJudgeOutput());

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -379,8 +379,8 @@ export class AiAgentReviewClassifierService extends BaseService {
         const runAgentConfig = args.candidates[0]
             ? await this.captureAgentConfigSnapshot(args.candidates[0])
             : AiAgentReviewClassifierService.emptyAgentConfigEvidence();
-        const projectContextFlag = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiProjectContext,
+        const aiWritebackFlag = await this.featureFlagService.get({
+            featureFlagId: FeatureFlags.AiWriteback,
             user: {
                 userUuid: args.requestedByUserUuid ?? 'system',
                 organizationUuid: args.organizationUuid,
@@ -431,7 +431,7 @@ export class AiAgentReviewClassifierService extends BaseService {
                     classifiedTurn: await this.classifyTurnWithJudge(
                         candidate,
                         runAgentConfig,
-                        { projectContextEnabled: projectContextFlag.enabled },
+                        { projectContextEnabled: aiWritebackFlag.enabled },
                     ),
                 })),
             );
@@ -1059,19 +1059,6 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
         organizationUuid: string;
         organizationName?: string;
     }): Promise<boolean> {
-        const featureFlag = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiAgentReviewClassifier,
-            user: {
-                userUuid: args.requestedByUserUuid ?? 'system',
-                organizationUuid: args.organizationUuid,
-                organizationName: args.organizationName ?? '',
-            },
-        });
-
-        if (!featureFlag.enabled) {
-            return false;
-        }
-
         const settings =
             await this.aiOrganizationSettingsModel.findByOrganizationUuid(
                 args.organizationUuid,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -656,23 +656,9 @@ export class AiAgentService extends BaseService {
 
         const userUuid = args.userUuid ?? 'system';
 
-        void this.featureFlagService
-            .get({
-                featureFlagId: FeatureFlags.AiAgentReviewClassifier,
-                user: {
-                    userUuid,
-                    organizationUuid,
-                    organizationName: '',
-                },
-            })
-            .then(async (flag) => {
-                if (!flag.enabled) {
-                    return undefined;
-                }
-                const reviewsEnabled =
-                    await this.aiOrganizationSettingsService.isAiAgentReviewsEnabled(
-                        { organizationUuid },
-                    );
+        void this.aiOrganizationSettingsService
+            .isAiAgentReviewsEnabled({ organizationUuid })
+            .then(async (reviewsEnabled) => {
                 if (!reviewsEnabled) {
                     return undefined;
                 }
@@ -5301,14 +5287,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 })),
             ),
         });
-        const { enabled: projectContextEnabled } =
-            await this.featureFlagService.get({
-                user,
-                featureFlagId: FeatureFlags.AiProjectContext,
-            });
-        const projectContext = projectContextEnabled
-            ? await this.projectContextModel.getDocument(prompt.projectUuid)
-            : [];
         const { enabled: agentRevampEnabled } =
             await this.featureFlagService.get({
                 user,
@@ -5331,6 +5309,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             );
             aiWritebackEnabled = false;
         }
+        const projectContextEnabled =
+            aiWritebackEnabled &&
+            (await this.aiOrganizationSettingsService.isAiAgentReviewsEnabled(
+                user,
+            ));
+        const projectContext = projectContextEnabled
+            ? await this.projectContextModel.getDocument(prompt.projectUuid)
+            : [];
 
         // Preview-deploy setup rides the writeback infra, so it requires both
         // the writeback flag (and trusted identity, applied above) and its own

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -330,6 +330,11 @@ export type ProjectServiceArguments = {
             entries: ProjectContextEntry[],
         ): Promise<void>;
     };
+    isProjectContextEnabled?: (args: {
+        user: Pick<SessionUser, 'userUuid'> &
+            Partial<Pick<SessionUser, 'organizationName'>>;
+        organizationUuid: string;
+    }) => Promise<boolean>;
 };
 
 export class ProjectService extends BaseService {
@@ -414,6 +419,10 @@ export class ProjectService extends BaseService {
           }
         | undefined;
 
+    isProjectContextEnabled:
+        | ProjectServiceArguments['isProjectContextEnabled']
+        | undefined;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -451,6 +460,7 @@ export class ProjectService extends BaseService {
         contentVerificationModel,
         organizationSettingsModel,
         projectContextModel,
+        isProjectContextEnabled,
     }: ProjectServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -491,6 +501,7 @@ export class ProjectService extends BaseService {
         this.contentVerificationModel = contentVerificationModel;
         this.organizationSettingsModel = organizationSettingsModel;
         this.projectContextModel = projectContextModel;
+        this.isProjectContextEnabled = isProjectContextEnabled;
     }
 
     static getMetricQueryExecutionProperties({
@@ -5469,15 +5480,13 @@ export class ProjectService extends BaseService {
             return undefined;
         }
 
-        const { enabled } = await this.featureFlagModel.get({
-            user: {
-                userUuid: user.userUuid,
-                organizationUuid,
-                organizationName: user.organizationName,
-            },
-            featureFlagId: FeatureFlags.AiProjectContext,
-        });
-        return enabled ? adapter.getProjectContext() : undefined;
+        const enabled = this.isProjectContextEnabled
+            ? await this.isProjectContextEnabled({ user, organizationUuid })
+            : true;
+        if (!enabled) {
+            return undefined;
+        }
+        return adapter.getProjectContext();
     }
 
     private async replaceProjectContext(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5482,7 +5482,7 @@ export class ProjectService extends BaseService {
 
         const enabled = this.isProjectContextEnabled
             ? await this.isProjectContextEnabled({ user, organizationUuid })
-            : true;
+            : false;
         if (!enabled) {
             return undefined;
         }

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -193,11 +193,6 @@ export enum FeatureFlags {
     PivotRowGrouping = 'pivot-row-grouping',
 
     /**
-     * Enable AI agent review classifier experiments.
-     */
-    AiAgentReviewClassifier = 'ai-agent-review-classifier',
-
-    /**
      * Show a persistent trial warning banner for an organization on shared
      * instances. This does not block product access.
      */
@@ -253,14 +248,6 @@ export enum FeatureFlags {
      * always on; this flag only controls who can see/configure the panel.
      */
     ProLimits = 'pro-limits',
-
-    /**
-     * Enable the (in-progress) project_context living document: ingest
-     * lightdash.project_context.yml on compile and inject the selected
-     * entries into the AI agent system prompt. Shared across the
-     * project_context slices so the whole feature ships atomically.
-     */
-    AiProjectContext = 'ai-project-context',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlags } from '@lightdash/common';
 import {
     Anchor,
     Badge,
@@ -17,7 +16,6 @@ import { BetaBadge } from '../../../../../../components/common/BetaBadge';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { SettingsCard } from '../../../../../../components/common/Settings/SettingsCard';
-import { useServerFeatureFlag } from '../../../../../../hooks/useServerOrClientFeatureFlag';
 import {
     useAiOrganizationSettings,
     useUpdateAiOrganizationSettings,
@@ -33,9 +31,6 @@ export const AiGeneralSettingsPage = () => {
         useAiOrganizationSettings();
     const { mutate: updateSettings, isLoading: isUpdatingSettings } =
         useUpdateAiOrganizationSettings();
-    const { data: aiAgentReviewClassifierFlag } = useServerFeatureFlag(
-        FeatureFlags.AiAgentReviewClassifier,
-    );
 
     const aiRouterQuery = useAiRouterConfig();
     const isRouterEnabled = aiRouterQuery.data?.enabled ?? false;
@@ -131,22 +126,20 @@ export const AiGeneralSettingsPage = () => {
                                     projects, Lightdash can suggest pull
                                     requests that improve context and dbt
                                     definitions.
-                                    {settings.aiAgentReviewsEnabled &&
-                                        aiAgentReviewClassifierFlag?.enabled ===
-                                            true && (
-                                            <>
-                                                {' '}
-                                                See findings in{' '}
-                                                <Anchor
-                                                    component={Link}
-                                                    to="/generalSettings/ai/reviews"
-                                                    fz="inherit"
-                                                >
-                                                    Ask AI &gt; Reviews
-                                                </Anchor>
-                                                .
-                                            </>
-                                        )}
+                                    {settings.aiAgentReviewsEnabled && (
+                                        <>
+                                            {' '}
+                                            See findings in{' '}
+                                            <Anchor
+                                                component={Link}
+                                                to="/generalSettings/ai/reviews"
+                                                fz="inherit"
+                                            >
+                                                Ask AI &gt; Reviews
+                                            </Anchor>
+                                            .
+                                        </>
+                                    )}
                                 </Text>
                             </Box>
                             <Switch

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -141,13 +141,7 @@ const Settings: FC = () => {
         (aiOrganizationSettingsQuery.data.isCopilotEnabled ||
             aiOrganizationSettingsQuery.data.isTrial);
 
-    const { data: aiAgentReviewClassifierFlag } = useServerFeatureFlag(
-        FeatureFlags.AiAgentReviewClassifier,
-    );
-    const isAiAgentReviewClassifierEnabled =
-        aiAgentReviewClassifierFlag?.enabled === true;
     const shouldShowAiAgentReviews =
-        isAiAgentReviewClassifierEnabled &&
         aiOrganizationSettingsQuery.data?.aiAgentReviewsEnabled === true;
 
     const { data: serviceAccountsFlag } = useServerFeatureFlag(


### PR DESCRIPTION
## Summary

- Remove the `ai-agent-review-classifier` and `ai-project-context` feature flags.
- Gate AI review collection/UI on the org-level `aiAgentReviewsEnabled` setting.
- Treat project context as enabled only when AI reviews are enabled and `ai-writeback` is enabled.
- Update review/writeback tests for the new gating model.

## Validation

- `pnpm -F @lightdash/common build`
- `pnpm -F @lightdash/warehouses build`
- `pnpm -F @lightdash/formula build`
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- `pnpm -F backend test-sequential -- AiAgentReviewClassifierService.test.ts AiAgentAdminService.test.ts ProjectService.test.ts`