### PR TITLE
fix: validate field search limit

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5256,7 +5256,7 @@ export class ProjectService extends BaseService {
         table: string;
         initialFieldId: string;
         search: string;
-        limit: number;
+        limit: unknown;
         filters: AndFilterGroup | undefined;
     }) {
         const { organizationUuid } =
@@ -5284,7 +5284,7 @@ export class ProjectService extends BaseService {
         table: string,
         initialFieldId: string,
         search: string,
-        limit: number,
+        limit: unknown,
         filters: AndFilterGroup | undefined,
         forceRefresh: boolean = false,
         parameters?: ParametersValuesMap,
@@ -5443,7 +5443,7 @@ export class ProjectService extends BaseService {
                 fieldId: getItemId(field),
                 searchCharCount: search.length,
                 resultsCount: resultsArray.length,
-                searchLimit: limit,
+                searchLimit: metricQuery.limit,
             },
         });
 

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -180,6 +180,21 @@ describe('getFieldValuesMetricQuery', () => {
         ).rejects.toThrow(ParameterError);
     });
 
+    test('throws ParameterError when limit contains SQL tokens at runtime', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: 'a',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: '1 OFFSET 1',
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow('Query limit must be a non-negative integer');
+    });
+
     test('throws ParameterError when table is empty string', async () => {
         await expect(
             getFieldValuesMetricQuery({

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -27,6 +27,22 @@ type ExploreResolver = {
     ): Promise<Explore | ExploreError | undefined>;
 };
 
+const parseFieldValuesLimit = (limit: unknown, maxLimit: number): number => {
+    if (
+        typeof limit !== 'number' ||
+        !Number.isSafeInteger(limit) ||
+        limit < 0
+    ) {
+        throw new ParameterError('Query limit must be a non-negative integer');
+    }
+
+    if (limit > maxLimit) {
+        throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
+    }
+
+    return limit;
+};
+
 export async function getFieldValuesMetricQuery({
     projectUuid,
     table,
@@ -41,7 +57,7 @@ export async function getFieldValuesMetricQuery({
     table: string;
     initialFieldId: string;
     search: string;
-    limit: number;
+    limit: unknown;
     maxLimit: number;
     filters: AndFilterGroup | undefined;
     exploreResolver: ExploreResolver;
@@ -51,9 +67,7 @@ export async function getFieldValuesMetricQuery({
     field: Dimension;
     fieldId: string;
 }> {
-    if (limit > maxLimit) {
-        throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
-    }
+    const parsedLimit = parseFieldValuesLimit(limit, maxLimit);
 
     if (!table) {
         throw new ParameterError(
@@ -148,7 +162,7 @@ export async function getFieldValuesMetricQuery({
                 descending: false,
             },
         ],
-        limit,
+        limit: parsedLimit,
     };
 
     return { metricQuery, explore, field, fieldId };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

 Closes:  https://linear.app/lightdash/issue/SPK-473/veria-29-sql-injection-in-field-value-search-via-unvalidated-limit<!-- reference the related issue e.g. #150 -->

### Description:



- Normal API call with limit: 1 still returns HTTP 200.
- Exploit payload limit: "1 OFFSET 1" now returns HTTP 400: Query limit must be a non-negative integer.

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->