### PR TITLE
fix: surface explore compilation errors in dashboard preview

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -541,7 +541,11 @@ export class AsyncQueryService extends ProjectService {
         );
 
         if (isExploreError(explore)) {
-            throw new NotFoundError(`Explore "${exploreName}" has an error.`);
+            throw new NotFoundError(
+                `Explore "${exploreName}" has an error: ${explore.errors
+                    .map((error) => error.message)
+                    .join(', ')}`,
+            );
         }
 
         if (

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6234,7 +6234,9 @@ export class ProjectService extends BaseService {
                 }
                 if (isExploreError(explore)) {
                     throw new NotFoundError(
-                        `Explore "${exploreName}" has an error.`,
+                        `Explore "${exploreName}" has an error: ${explore.errors
+                            .map((error) => error.message)
+                            .join(', ')}`,
                     );
                 }
                 if (includeUnfilteredTables) {


### PR DESCRIPTION
Closes: PROD-6925
Closes: #21931

### Description:

Dashboards whose explore failed to compile showed a generic `Explore "X" has an error.` with no actionable detail, making them hard to debug. The two backend code paths that detect a broken explore now append the underlying compilation messages from `explore.errors`, so the message becomes `Explore "X" has an error: <real reason>`. The dashboard chart tile already renders the backend error message verbatim, so no frontend change is needed.