### PR TITLE
fix: render newlines in custom warehouse permission error messages

### DIFF
--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -77,7 +77,9 @@ const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
     if (apiError.sentryEventId || apiError.sentryTraceId) {
         return (
             <Stack spacing="xxs">
-                <Text mb={0}>{apiError.message}</Text>
+                <Text mb={0} style={{ whiteSpace: 'pre-wrap' }}>
+                    {apiError.message}
+                </Text>
                 <Text mb={0} weight="bold">
                     Contact support with the following information:
                 </Text>
@@ -98,7 +100,11 @@ const ApiErrorDisplayStatic = ({ apiError }: { apiError: ApiErrorDetail }) => {
         );
     }
 
-    return <span>{apiError.message}</span>;
+    return (
+        <Text mb={0} style={{ whiteSpace: 'pre-wrap' }}>
+            {apiError.message}
+        </Text>
+    );
 };
 
 const ApiErrorDisplayWithHealth = ({
@@ -162,7 +168,11 @@ const ApiErrorDisplayWithHealth = ({
         if (showSupportButton) {
             return (
                 <Stack spacing="xxs" align="start">
-                    <Text mb={0} color="red.6">
+                    <Text
+                        mb={0}
+                        color="red.6"
+                        style={{ whiteSpace: 'pre-wrap' }}
+                    >
                         {apiError.message}
                     </Text>
                     <Group spacing="xs">
@@ -205,7 +215,9 @@ const ApiErrorDisplayWithHealth = ({
         // Self-hosted: show IDs with copy button
         return (
             <Stack spacing="xxs">
-                <Text mb={0}>{apiError.message}</Text>
+                <Text mb={0} style={{ whiteSpace: 'pre-wrap' }}>
+                    {apiError.message}
+                </Text>
                 <Text mb={0} weight="bold">
                     Contact support with the following information:
                 </Text>
@@ -226,7 +238,11 @@ const ApiErrorDisplayWithHealth = ({
         );
     }
 
-    return <span>{apiError.message}</span>;
+    return (
+        <Text mb={0} style={{ whiteSpace: 'pre-wrap' }}>
+            {apiError.message}
+        </Text>
+    );
 };
 
 const ApiErrorDisplay = ({

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -236,6 +236,26 @@ describe('SnowflakeErrorParsing', () => {
             "You don't have access to the {snowflakeTable} table. Please go to 'analytics_{snowflakeSchema}' in sailpoint and request access",
         );
     });
+
+    it('should convert literal \\n escape sequences into real newlines', () => {
+        process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE =
+            'No access to {snowflakeTable}.\\n1) Step one\\n2) Step two';
+
+        const error = {
+            message:
+                "Object 'DB.MY_SCHEMA.MY_TABLE' does not exist or not authorized.",
+            code: 'COMPILATION',
+            data: { type: 'COMPILATION' },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = warehouse.parseError(error as any);
+
+        expect(result.message).toBe(
+            'No access to MY_TABLE.\n1) Step one\n2) Step two',
+        );
+        expect(result.message).not.toContain('\\n');
+    });
 });
 
 describe('SnowflakeWarehouseClient.parseError - warehouse access errors', () => {
@@ -362,5 +382,25 @@ describe('SnowflakeWarehouseClient.parseError - warehouse access errors', () => 
         const result = warehouse.parseError(error as any);
 
         expect(result.message).toBe('Some other SQL error');
+    });
+
+    it('should convert literal \\n escape sequences into real newlines', () => {
+        process.env.SNOWFLAKE_WAREHOUSE_ERROR_MESSAGE =
+            'No access to warehouse {warehouseName}.\\n1) Step one\\n2) Step two';
+
+        const error = {
+            message:
+                "No active warehouse selected in the current session. Select an active warehouse with the 'use warehouse' command",
+            code: 'SESSION_ERROR',
+            data: { type: 'SESSION_ERROR' },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = warehouse.parseError(error as any);
+
+        expect(result.message).toBe(
+            'No access to warehouse TEST_WAREHOUSE.\n1) Step one\n2) Step two',
+        );
+        expect(result.message).not.toContain('\\n');
     });
 });

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -1101,7 +1101,10 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         // Check for unauthorized access errors and use custom message if configured
         if (originalMessage.includes('does not exist or not authorized')) {
             const customErrorMessage =
-                process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE;
+                process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE?.replace(
+                    /\\n/g,
+                    '\n',
+                );
             if (customErrorMessage) {
                 const formattedMessage = this.formatCustomErrorMessage(
                     originalMessage,
@@ -1118,7 +1121,10 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             )
         ) {
             const customErrorMessage =
-                process.env.SNOWFLAKE_WAREHOUSE_ERROR_MESSAGE;
+                process.env.SNOWFLAKE_WAREHOUSE_ERROR_MESSAGE?.replace(
+                    /\\n/g,
+                    '\n',
+                );
             if (customErrorMessage) {
                 const formattedMessage =
                     this.formatWarehouseErrorMessage(customErrorMessage);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2513

### Description:

Custom Snowflake permission error messages (configured via `SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE` / `SNOWFLAKE_WAREHOUSE_ERROR_MESSAGE`) were rendering with literal `\n` text instead of line breaks. Env vars store `\n` as two literal characters, so the backend now converts those into real newlines when reading both vars. The error toast (`ApiErrorDisplay`) also lacked whitespace preservation, so it would collapse newlines — it now uses `white-space: pre-wrap`, matching the results panel, which fixes multi-line rendering for these and any other newline-containing error messages. Added unit tests covering the `\n` conversion for both env vars.


<img width="2400" height="2454" alt="02-results-table-error-fullpage" src="https://github.com/user-attachments/assets/c118e379-7c3a-4b03-8f6e-e512bf56a1e4" />
