### PR TITLE
fix(conditional-formatting): stack text and cell colors

### DIFF
--- a/packages/common/src/utils/conditionalFormatting.test.ts
+++ b/packages/common/src/utils/conditionalFormatting.test.ts
@@ -4,6 +4,7 @@ import { FilterOperator } from '../types/filter';
 import {
     createConditionalFormattingConfigWithSingleColor,
     createConditionalFormattingRuleWithValues,
+    getConditionalFormattingConfig,
     getPivotRowContextKey,
     getRowConditionalFormattingColor,
     hasMatchingConditionalRules,
@@ -172,6 +173,52 @@ describe('hasMatchingConditionalRules', () => {
 
             expect(result).toBe(true);
         });
+    });
+});
+
+describe('getConditionalFormattingConfig', () => {
+    it('selects the last matching rule for a specific apply target', () => {
+        const cellConfig =
+            createConditionalFormattingConfigWithSingleColor('#00ff00');
+        cellConfig.rules[0].operator = FilterOperator.GREATER_THAN_OR_EQUAL;
+        cellConfig.rules[0].values = [0];
+
+        const textConfig =
+            createConditionalFormattingConfigWithSingleColor('#ff0000');
+        textConfig.applyTo = ConditionalFormattingColorApplyTo.TEXT;
+        textConfig.rules[0].operator = FilterOperator.LESS_THAN_OR_EQUAL;
+        textConfig.rules[0].values = [10];
+
+        const conditionalFormattings = [cellConfig, textConfig];
+
+        expect(
+            getConditionalFormattingConfig({
+                field: mockNumericField,
+                value: 5,
+                minMaxMap: {},
+                conditionalFormattings,
+                applyTo: ConditionalFormattingColorApplyTo.CELL,
+            }),
+        ).toBe(cellConfig);
+
+        expect(
+            getConditionalFormattingConfig({
+                field: mockNumericField,
+                value: 5,
+                minMaxMap: {},
+                conditionalFormattings,
+                applyTo: ConditionalFormattingColorApplyTo.TEXT,
+            }),
+        ).toBe(textConfig);
+
+        expect(
+            getConditionalFormattingConfig({
+                field: mockNumericField,
+                value: 5,
+                minMaxMap: {},
+                conditionalFormattings,
+            }),
+        ).toBe(textConfig);
     });
 });
 

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -524,12 +524,14 @@ export const getConditionalFormattingConfig = ({
     minMaxMap = {},
     conditionalFormattings,
     rowFields,
+    applyTo,
 }: {
     field: ItemsMap[string] | undefined;
     value: unknown | undefined;
     minMaxMap: ConditionalFormattingMinMaxMap | undefined;
     conditionalFormattings: ConditionalFormattingConfig[] | undefined;
     rowFields?: ConditionalFormattingRowFields;
+    applyTo?: ConditionalFormattingColorApplyTo;
 }) => {
     // For backwards compatibility with old table calculations without type
     const isCalculationTypeUndefined =
@@ -543,9 +545,23 @@ export const getConditionalFormattingConfig = ({
     )
         return undefined;
 
-    return findLast(conditionalFormattings, (config) =>
-        hasMatchingConditionalRules(field, value, minMaxMap, config, rowFields),
-    );
+    return findLast(conditionalFormattings, (config) => {
+        if (
+            applyTo !== undefined &&
+            (config.applyTo ?? ConditionalFormattingColorApplyTo.CELL) !==
+                applyTo
+        ) {
+            return false;
+        }
+
+        return hasMatchingConditionalRules(
+            field,
+            value,
+            minMaxMap,
+            config,
+            rowFields,
+        );
+    });
 };
 
 export const getConditionalFormattingDescription = (

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -13,7 +13,9 @@ import {
     isHexCodeColor,
     isNumericItem,
     type ColumnProperties,
+    type ConditionalFormattingColorRange,
     type ConditionalFormattingConfig,
+    type ConditionalFormattingMinMax,
     type ConditionalFormattingMinMaxMap,
     type ConditionalFormattingRowFields,
     type ItemsMap,
@@ -1003,6 +1005,20 @@ const PivotTable: FC<PivotTableProps> = ({
         },
         [buildRowFieldsFromHeaderInfo, mergeHiddenContextValues],
     );
+    const getEffectiveColorFromRange = useCallback(
+        (
+            val: number,
+            colorRange: ConditionalFormattingColorRange,
+            minMaxRange: ConditionalFormattingMinMax,
+        ) => {
+            const effectiveColorRange =
+                colorScheme === 'dark'
+                    ? transformColorsForDarkMode(colorRange)
+                    : colorRange;
+            return getColorFromRange(val, effectiveColorRange, minMaxRange);
+        },
+        [colorScheme],
+    );
 
     const paddingTop = useMemo(() => {
         return virtualRows.length > 0 ? virtualRows?.[0]?.start || 0 : 0;
@@ -1712,59 +1728,79 @@ const PivotTable: FC<PivotTableProps> = ({
                                           currentHeaderInfo,
                                       );
 
-                                const conditionalFormattingConfig =
+                                const cellConditionalFormattingConfig =
                                     getConditionalFormattingConfig({
                                         field: item,
                                         value: value?.raw,
                                         minMaxMap,
                                         conditionalFormattings,
                                         rowFields: rowFieldsForCell,
+                                        applyTo:
+                                            ConditionalFormattingColorApplyTo.CELL,
+                                    });
+                                const textConditionalFormattingConfig =
+                                    getConditionalFormattingConfig({
+                                        field: item,
+                                        value: value?.raw,
+                                        minMaxMap,
+                                        conditionalFormattings,
+                                        rowFields: rowFieldsForCell,
+                                        applyTo:
+                                            ConditionalFormattingColorApplyTo.TEXT,
                                     });
 
-                                const conditionalFormattingResult =
+                                const cellConditionalFormattingResult =
                                     getConditionalFormattingColor({
                                         field: item,
                                         value: value?.raw,
-                                        config: conditionalFormattingConfig,
+                                        config: cellConditionalFormattingConfig,
                                         minMaxMap,
-                                        getColorFromRange: (
-                                            val,
-                                            colorRange,
-                                            minMaxRange,
-                                        ) => {
-                                            const effectiveColorRange =
-                                                colorScheme === 'dark'
-                                                    ? transformColorsForDarkMode(
-                                                          colorRange,
-                                                      )
-                                                    : colorRange;
-                                            return getColorFromRange(
-                                                val,
-                                                effectiveColorRange,
-                                                minMaxRange,
-                                            );
-                                        },
+                                        getColorFromRange:
+                                            getEffectiveColorFromRange,
                                     });
-
-                                const applyToText =
-                                    conditionalFormattingResult?.applyTo ===
-                                    ConditionalFormattingColorApplyTo.TEXT;
+                                const textConditionalFormattingResult =
+                                    getConditionalFormattingColor({
+                                        field: item,
+                                        value: value?.raw,
+                                        config: textConditionalFormattingConfig,
+                                        minMaxMap,
+                                        getColorFromRange:
+                                            getEffectiveColorFromRange,
+                                    });
 
                                 const conditionalFormatting = (() => {
                                     const tooltipContent =
-                                        getConditionalFormattingDescription(
-                                            item,
-                                            conditionalFormattingConfig,
-                                            rowFieldsForCell,
-                                            getConditionalRuleLabelFromItem,
-                                        );
+                                        [
+                                            getConditionalFormattingDescription(
+                                                item,
+                                                cellConditionalFormattingConfig,
+                                                rowFieldsForCell,
+                                                getConditionalRuleLabelFromItem,
+                                            ),
+                                            getConditionalFormattingDescription(
+                                                item,
+                                                textConditionalFormattingConfig,
+                                                rowFieldsForCell,
+                                                getConditionalRuleLabelFromItem,
+                                            ),
+                                        ]
+                                            .filter(
+                                                (
+                                                    description,
+                                                    index,
+                                                    descriptions,
+                                                ) =>
+                                                    description &&
+                                                    descriptions.indexOf(
+                                                        description,
+                                                    ) === index,
+                                            )
+                                            .join('; ') || undefined;
 
                                     // No cell-level result → fall back to the row fill (if any).
                                     if (
-                                        !conditionalFormattingResult ||
-                                        !isHexCodeColor(
-                                            conditionalFormattingResult.color,
-                                        )
+                                        !cellConditionalFormattingResult &&
+                                        !textConditionalFormattingResult
                                     ) {
                                         return rowBackgroundColor
                                             ? {
@@ -1778,24 +1814,35 @@ const PivotTable: FC<PivotTableProps> = ({
                                             : undefined;
                                     }
 
-                                    // Cell-level result present: cell wins. Keep the row fill as the background
-                                    // under a TEXT rule so the row stays continuous; a CELL rule overrides bg.
-                                    return applyToText
-                                        ? {
-                                              tooltipContent,
-                                              color: conditionalFormattingResult.color,
-                                              backgroundColor:
-                                                  rowBackgroundColor ??
-                                                  undefined,
-                                          }
-                                        : {
-                                              tooltipContent,
-                                              color: readableColor(
-                                                  conditionalFormattingResult.color,
-                                              ),
-                                              backgroundColor:
-                                                  conditionalFormattingResult.color,
-                                          };
+                                    const backgroundColor =
+                                        cellConditionalFormattingResult &&
+                                        isHexCodeColor(
+                                            cellConditionalFormattingResult.color,
+                                        )
+                                            ? cellConditionalFormattingResult.color
+                                            : rowBackgroundColor;
+                                    let color: string | undefined;
+                                    if (
+                                        textConditionalFormattingResult &&
+                                        isHexCodeColor(
+                                            textConditionalFormattingResult.color,
+                                        )
+                                    ) {
+                                        color =
+                                            textConditionalFormattingResult.color;
+                                    } else if (backgroundColor) {
+                                        color = readableColor(backgroundColor);
+                                    }
+
+                                    if (!color && !backgroundColor) {
+                                        return undefined;
+                                    }
+
+                                    return {
+                                        tooltipContent,
+                                        color,
+                                        backgroundColor,
+                                    };
                                 })();
 
                                 // Font color is set by conditionalFormatting above

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -7,6 +7,8 @@ import {
     getReadableTextColor,
     getRowConditionalFormattingColor,
     isNumericItem,
+    type ConditionalFormattingColorRange,
+    type ConditionalFormattingMinMax,
     type ConditionalFormattingRowFields,
     type ResultRow,
 } from '@lightdash/common';
@@ -100,6 +102,20 @@ const TableRow: FC<TableRowProps> = ({
                 }, {}),
         [row],
     );
+    const getEffectiveColorFromRange = useCallback(
+        (
+            val: number,
+            colorRange: ConditionalFormattingColorRange,
+            minMaxRange: ConditionalFormattingMinMax,
+        ) => {
+            const effectiveColorRange =
+                colorScheme === 'dark'
+                    ? transformColorsForDarkMode(colorRange)
+                    : colorRange;
+            return getColorFromRange(val, effectiveColorRange, minMaxRange);
+        },
+        [colorScheme],
+    );
 
     const rowBackgroundColor = useMemo(
         () =>
@@ -118,65 +134,83 @@ const TableRow: FC<TableRowProps> = ({
                 const field = meta?.item;
                 const cellValue = cell.getValue() as ResultRow[0] | undefined;
 
-                const conditionalFormattingConfig =
+                const cellConditionalFormattingConfig =
                     getConditionalFormattingConfig({
                         field,
                         value: cellValue?.value?.raw,
                         minMaxMap,
                         conditionalFormattings,
                         rowFields,
+                        applyTo: ConditionalFormattingColorApplyTo.CELL,
+                    });
+                const textConditionalFormattingConfig =
+                    getConditionalFormattingConfig({
+                        field,
+                        value: cellValue?.value?.raw,
+                        minMaxMap,
+                        conditionalFormattings,
+                        rowFields,
+                        applyTo: ConditionalFormattingColorApplyTo.TEXT,
                     });
 
-                const conditionalFormattingResult =
+                const cellConditionalFormattingResult =
                     getConditionalFormattingColor({
                         field,
                         value: cellValue?.value?.raw,
                         minMaxMap,
-                        config: conditionalFormattingConfig,
-                        getColorFromRange: (val, colorRange, minMaxRange) => {
-                            const effectiveColorRange =
-                                colorScheme === 'dark'
-                                    ? transformColorsForDarkMode(colorRange)
-                                    : colorRange;
-                            return getColorFromRange(
-                                val,
-                                effectiveColorRange,
-                                minMaxRange,
-                            );
-                        },
+                        config: cellConditionalFormattingConfig,
+                        getColorFromRange: getEffectiveColorFromRange,
                     });
-
-                const applyToText =
-                    conditionalFormattingResult?.applyTo ===
-                    ConditionalFormattingColorApplyTo.TEXT;
+                const textConditionalFormattingResult =
+                    getConditionalFormattingColor({
+                        field,
+                        value: cellValue?.value?.raw,
+                        minMaxMap,
+                        config: textConditionalFormattingConfig,
+                        getColorFromRange: getEffectiveColorFromRange,
+                    });
 
                 // Frozen/locked rows should have a fixed background, unless there is a conditional formatting color applied to cell
                 let backgroundColor: string | undefined;
-                if (conditionalFormattingResult && !applyToText) {
-                    backgroundColor = conditionalFormattingResult.color;
+                if (cellConditionalFormattingResult) {
+                    backgroundColor = cellConditionalFormattingResult.color;
                 } else if (rowBackgroundColor) {
                     backgroundColor = rowBackgroundColor;
                 } else if (meta?.frozen) {
                     backgroundColor = FROZEN_COLUMN_BACKGROUND;
                 }
 
-                const tooltipContent = getConditionalFormattingDescription(
-                    field,
-                    conditionalFormattingConfig,
-                    rowFields,
-                    getConditionalRuleLabelFromItem,
-                );
+                const tooltipContent = [
+                    getConditionalFormattingDescription(
+                        field,
+                        cellConditionalFormattingConfig,
+                        rowFields,
+                        getConditionalRuleLabelFromItem,
+                    ),
+                    getConditionalFormattingDescription(
+                        field,
+                        textConditionalFormattingConfig,
+                        rowFields,
+                        getConditionalRuleLabelFromItem,
+                    ),
+                ]
+                    .filter(
+                        (description, index, descriptions) =>
+                            description &&
+                            descriptions.indexOf(description) === index,
+                    )
+                    .join('; ');
 
                 const toggleExpander = row.getToggleExpandedHandler();
                 // When conditional formatting is applied to cell, use calculated contrast color
                 // When applied to text, use the formatting color directly
                 let fontColor: string | undefined;
-                if (conditionalFormattingResult) {
-                    fontColor = applyToText
-                        ? conditionalFormattingResult.color
-                        : getReadableTextColor(
-                              conditionalFormattingResult.color,
-                          );
+                if (textConditionalFormattingResult) {
+                    fontColor = textConditionalFormattingResult.color;
+                } else if (cellConditionalFormattingResult) {
+                    fontColor = getReadableTextColor(
+                        cellConditionalFormattingResult.color,
+                    );
                 } else if (rowBackgroundColor) {
                     fontColor = getReadableTextColor(rowBackgroundColor);
                 }
@@ -210,7 +244,7 @@ const TableRow: FC<TableRowProps> = ({
                             (cellValue?.value?.formatted || '').length >
                             SMALL_TEXT_LENGTH
                         }
-                        tooltipContent={tooltipContent}
+                        tooltipContent={tooltipContent || undefined}
                     >
                         {cell.getIsGrouped() ? (
                             <Group spacing="xxs">


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/23979
Closes: PROD-8165

Summary:
- Allows text and cell background conditional formatting rules to stack on the same table cell.
- Applies to regular and pivot tables.

Tests:
- pnpm -F common test conditionalFormatting.test.ts --runInBand
- pnpm -F common run linter ./src/utils/conditionalFormatting.ts ./src/utils/conditionalFormatting.test.ts
- pnpm -F frontend run linter ./src/components/common/PivotTable/index.tsx ./src/components/common/Table/ScrollableTable/TableBody.tsx
- pnpm -F common typecheck
- pnpm -F frontend typecheck

screens:

<img width="1848" height="1530" alt="CleanShot 2026-06-08 at 20 34 14@2x" src="https://github.com/user-attachments/assets/1f83f8ba-61b9-4b35-b00c-738b45ae514e" />
<img width="1960" height="1410" alt="CleanShot 2026-06-08 at 20 35 01@2x" src="https://github.com/user-attachments/assets/e9a14b43-fdba-4828-99f4-234adda0dabb" />
