### PR TITLE
feat(charts): configurable initial scroll position and visible items

### DIFF
--- a/docs/superpowers/specs/2026-06-08-prod-6994-scrollable-chart-initial-position-design.md
+++ b/docs/superpowers/specs/2026-06-08-prod-6994-scrollable-chart-initial-position-design.md
@@ -1,0 +1,122 @@
+# PROD-6994: Configurable initial scroll position for scrollable charts
+
+## Problem
+
+When "Enable scrollable chart" (`enableDataZoom`) is on, the echarts dataZoom slider
+always opens on the first data item — `startValue: 0, endValue: 10` is hardcoded in
+`useEchartsCartesianConfig.ts`. For flipped (horizontal bar) charts, echarts places
+category index 0 at the bottom of the y-axis, so the chart loads showing the bottom
+items. Users want to choose to start at the end of the data instead (e.g. show the
+top bars by default).
+
+## Goal
+
+Add an option, shown only when scrollable charts are enabled, that controls whether
+the initial zoom window anchors at the **start** or the **end** of the data. Default
+to **start** to preserve existing behavior.
+
+Out of scope (tracked in PROD-8006/8007): making the *number* of visible items
+configurable. The window size stays at the current value (10).
+
+## Design
+
+### 1. Data model — `packages/common/src/types/savedCharts.ts`
+
+Add an optional field to the `XAxis` type:
+
+```ts
+export type XAxis = Axis & {
+    sortType?: XAxisSortType;
+    enableDataZoom?: boolean;
+    /** Where the initial data-zoom window anchors when data zoom is enabled */
+    dataZoomAnchor?: 'start' | 'end';
+};
+```
+
+- Omitted or `'start'` → current behavior (window at first item).
+- `'end'` → window anchored at the last item.
+- A string union (not a boolean) so the persisted value is self-describing and easy
+  to extend; matches the "intentional types" house style.
+
+### 2. Rendering — `packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts`
+
+In the `eChartsOptions` memo (~line 3559), read the anchor alongside `enableDataZoom`:
+
+```ts
+const dataZoomAnchor =
+    validCartesianConfig?.eChartsConfig?.xAxis?.[0]?.dataZoomAnchor ?? 'start';
+```
+
+Compute the window from the anchor and the item count. The window size is the current
+`endValue` (10). Derive the item count from the data already in scope (`dataToRender` /
+sorted results length).
+
+- `'start'` → `startValue: 0`, `endValue: WINDOW_SIZE` (unchanged).
+- `'end'` → `endValue: lastIndex`, `startValue: max(0, lastIndex - WINDOW_SIZE)`.
+
+`zoomLock`, `minValueSpan`, `maxValueSpan`, slider width/height, and the
+`flipAxes ? 'yAxisIndex' : 'xAxisIndex'` selection are unchanged. Add `dataZoomAnchor`
+(and any newly referenced data-length value) to the memo dependency array.
+
+### 3. State setter — `packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts`
+
+Add `setDataZoomAnchor` mirroring `setScrollableChart` (~line 521):
+
+```ts
+const setDataZoomAnchor = useCallback((dataZoomAnchor: 'start' | 'end') => {
+    setDirtyEchartsConfig((prevState) => {
+        const [firstAxis, ...axes] = prevState?.xAxis || [];
+        return {
+            ...prevState,
+            xAxis: [{ ...firstAxis, dataZoomAnchor }, ...axes],
+        };
+    });
+}, []);
+```
+
+Expose it in the hook's return object next to `setScrollableChart` (~line 1296). The
+UI consumes it directly via `visualizationConfig.chartConfig`, so no extra
+context/provider threading is needed.
+
+### 4. UI — `packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx`
+
+When `enableDataZoom` is true, render a Mantine `SegmentedControl` under the existing
+checkbox (~line 271):
+
+- Label: **"Initial scroll position"**
+- Options: **Start** / **End** (values `'start'` / `'end'`)
+- Value: `dirtyEchartsConfig?.xAxis?.[0]?.dataZoomAnchor ?? 'start'`
+- `onChange`: `setDataZoomAnchor`
+- Destructure `setDataZoomAnchor` from the config hook alongside `setScrollableChart`
+  (~line 84).
+
+Follow the frontend style guide (Mantine v8, component props or CSS module for layout,
+no `style`/`sx`).
+
+### 5. Persistence / schema
+
+`XAxis` config is already persisted in the saved chart and serialized to chart-as-code.
+`chart-as-code-1.0.json` is auto-generated and already enumerates `enableDataZoom` and
+`sortType`, so regenerate it:
+
+```bash
+pnpm generate:chart-as-code-schema
+pnpm check:chart-as-code-schema
+```
+
+Run `pnpm generate-api` if controller/service return types are affected (likely not,
+since this is a config-only field, but verify the diff).
+
+## Testing / verification
+
+- `pnpm -F common typecheck:fast`, `pnpm -F frontend typecheck:fast`
+- `pnpm -F frontend lint` on changed files
+- Manual: create a bar chart, flip axes, enable scrollable chart, toggle Start/End and
+  confirm the initial visible window moves between the bottom and top of the chart;
+  confirm a non-flipped chart moves between left and right; confirm the setting persists
+  on save/reload.
+
+## Backwards compatibility
+
+Existing charts have no `dataZoomAnchor`; the `?? 'start'` fallback reproduces today's
+behavior exactly.

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4959,6 +4959,14 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        dataZoomItemCount: { dataType: 'double' },
+                        dataZoomAnchor: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'enum', enums: ['start'] },
+                                { dataType: 'enum', enums: ['end'] },
+                            ],
+                        },
                         enableDataZoom: { dataType: 'boolean' },
                         sortType: { ref: 'XAxisSortType' },
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5724,6 +5724,16 @@
                     },
                     {
                         "properties": {
+                            "dataZoomItemCount": {
+                                "type": "number",
+                                "format": "double",
+                                "description": "Number of items visible at once in the data-zoom window"
+                            },
+                            "dataZoomAnchor": {
+                                "type": "string",
+                                "enum": ["start", "end"],
+                                "description": "Where the initial data-zoom window anchors when data zoom is enabled"
+                            },
                             "enableDataZoom": {
                                 "type": "boolean",
                                 "description": "Enable data zoom slider for this axis"

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -3217,6 +3217,16 @@
                 },
                 {
                     "properties": {
+                        "dataZoomAnchor": {
+                            "description": "Where the initial data-zoom window anchors when data zoom is enabled",
+                            "enum": ["start", "end"],
+                            "type": "string"
+                        },
+                        "dataZoomItemCount": {
+                            "description": "Number of items visible at once in the data-zoom window",
+                            "format": "double",
+                            "type": "number"
+                        },
                         "enableDataZoom": {
                             "description": "Enable data zoom slider for this axis",
                             "type": "boolean"

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -687,6 +687,10 @@ export type XAxis = Axis & {
     sortType?: XAxisSortType;
     /** Enable data zoom slider for this axis */
     enableDataZoom?: boolean;
+    /** Where the initial data-zoom window anchors when data zoom is enabled */
+    dataZoomAnchor?: 'start' | 'end';
+    /** Number of items visible at once in the data-zoom window */
+    dataZoomItemCount?: number;
 };
 
 export enum XAxisSortType {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -13,6 +13,7 @@ import {
     Checkbox,
     Group,
     NumberInput,
+    SegmentedControl,
     Select,
     Stack,
     Switch,
@@ -82,6 +83,8 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         setXAxisSort,
         setXAxisLabelRotation,
         setScrollableChart,
+        setDataZoomAnchor,
+        setDataZoomItemCount,
         dirtyChartType,
     } = visualizationConfig.chartConfig;
 
@@ -268,16 +271,68 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                     </Group>
 
                     {getAxisTypeFromField(xAxisField) === 'category' && (
-                        <Checkbox
-                            label="Enable scrollable chart"
-                            checked={
-                                dirtyEchartsConfig?.xAxis?.[0]
-                                    ?.enableDataZoom || false
-                            }
-                            onChange={(e) =>
-                                setScrollableChart(e.currentTarget.checked)
-                            }
-                        />
+                        <Stack spacing="xs">
+                            <Checkbox
+                                label="Enable scrollable chart"
+                                checked={
+                                    dirtyEchartsConfig?.xAxis?.[0]
+                                        ?.enableDataZoom || false
+                                }
+                                onChange={(e) =>
+                                    setScrollableChart(e.currentTarget.checked)
+                                }
+                            />
+                            {dirtyEchartsConfig?.xAxis?.[0]?.enableDataZoom && (
+                                <>
+                                    <Group spacing="xs">
+                                        <Config.Label>
+                                            Initial scroll position
+                                        </Config.Label>
+                                        <SegmentedControl
+                                            size="xs"
+                                            data={[
+                                                {
+                                                    label: 'Start',
+                                                    value: 'start',
+                                                },
+                                                { label: 'End', value: 'end' },
+                                            ]}
+                                            value={
+                                                dirtyEchartsConfig?.xAxis?.[0]
+                                                    ?.dataZoomAnchor ?? 'start'
+                                            }
+                                            onChange={(value) =>
+                                                setDataZoomAnchor(
+                                                    value === 'end'
+                                                        ? 'end'
+                                                        : 'start',
+                                                )
+                                            }
+                                        />
+                                    </Group>
+                                    <Group spacing="xs">
+                                        <Config.Label>
+                                            Visible items
+                                        </Config.Label>
+                                        <NumberInput
+                                            size="xs"
+                                            maw={80}
+                                            min={2}
+                                            max={100}
+                                            value={
+                                                dirtyEchartsConfig?.xAxis?.[0]
+                                                    ?.dataZoomItemCount ?? 10
+                                            }
+                                            onChange={(value) => {
+                                                if (typeof value === 'number') {
+                                                    setDataZoomItemCount(value);
+                                                }
+                                            }}
+                                        />
+                                    </Group>
+                                </>
+                            )}
+                        </Stack>
                     )}
                 </Config.Section>
             </Config>

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -527,6 +527,24 @@ const useCartesianChartConfig = ({
             };
         });
     }, []);
+    const setDataZoomAnchor = useCallback((dataZoomAnchor: 'start' | 'end') => {
+        setDirtyEchartsConfig((prevState) => {
+            const [firstAxis, ...axes] = prevState?.xAxis || [];
+            return {
+                ...prevState,
+                xAxis: [{ ...firstAxis, dataZoomAnchor }, ...axes],
+            };
+        });
+    }, []);
+    const setDataZoomItemCount = useCallback((dataZoomItemCount: number) => {
+        setDirtyEchartsConfig((prevState) => {
+            const [firstAxis, ...axes] = prevState?.xAxis || [];
+            return {
+                ...prevState,
+                xAxis: [{ ...firstAxis, dataZoomItemCount }, ...axes],
+            };
+        });
+    }, []);
     const addSingleSeries = useCallback((yField: string) => {
         setDirtyLayout((prev) => ({
             ...prev,
@@ -1294,6 +1312,8 @@ const useCartesianChartConfig = ({
         setXAxisSort,
         setXAxisLabelRotation,
         setScrollableChart,
+        setDataZoomAnchor,
+        setDataZoomItemCount,
         updateSeries,
         referenceLines,
         setReferenceLines,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -3561,6 +3561,23 @@ const useEchartsCartesianConfig = (
             validCartesianConfig?.eChartsConfig?.xAxis?.[0]?.enableDataZoom;
         const flipAxes = validCartesianConfig?.layout?.flipAxes;
 
+        const dataZoomAnchor =
+            validCartesianConfig?.eChartsConfig?.xAxis?.[0]?.dataZoomAnchor ??
+            'start';
+        const dataZoomItemCount =
+            validCartesianConfig?.eChartsConfig?.xAxis?.[0]
+                ?.dataZoomItemCount ?? 10;
+        const dataZoomSpan = Math.max(1, dataZoomItemCount - 1);
+        const dataZoomLastIndex = Math.max(0, dataToRender.length - 1);
+        const dataZoomStartValue =
+            dataZoomAnchor === 'end'
+                ? Math.max(0, dataZoomLastIndex - dataZoomSpan)
+                : 0;
+        const dataZoomEndValue =
+            dataZoomAnchor === 'end'
+                ? dataZoomLastIndex
+                : Math.min(dataZoomLastIndex, dataZoomSpan);
+
         const baseOptions = {
             xAxis: sortedAxes.xAxis,
             yAxis: sortedAxes.yAxis,
@@ -3587,12 +3604,12 @@ const useEchartsCartesianConfig = (
                         type: 'slider',
                         show: true,
                         [flipAxes ? 'yAxisIndex' : 'xAxisIndex']: 0,
-                        startValue: 0,
-                        endValue: 10,
+                        startValue: dataZoomStartValue,
+                        endValue: dataZoomEndValue,
                         brushSelect: false,
                         zoomLock: true,
-                        minValueSpan: 5,
-                        maxValueSpan: 30,
+                        minValueSpan: dataZoomSpan,
+                        maxValueSpan: dataZoomSpan,
                         // Reduce scroll bar size
                         ...(flipAxes && {
                             width: 20,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-6994
Closes: PROD-8006
Closes: #22043
Closes: #23655
Relates: #19512

### Description:

Adds two configuration options for scrollable charts (data zoom), shown when "Enable scrollable chart" is enabled: an **Initial scroll position** Start/End control that anchors the opening window to the first or last data item, and a **Visible items** count (2–100, default 10) controlling how many items the locked window shows at once. Both settings persist in the chart config and chart-as-code, with defaults that preserve current behavior.


<img width="3518" height="2562" alt="CleanShot 2026-06-09 at 11 07 12@2x" src="https://github.com/user-attachments/assets/c638f277-895a-412d-8b53-021d36300f92" />
