### PR TITLE
fix(ai-agents): let evals page scroll with the document

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
@@ -16,7 +16,6 @@ import { type FC, type ReactNode } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
 import {
     useAiAgentEvaluation,
     useAiAgentEvaluationRuns,
@@ -200,10 +199,7 @@ export const EvalSectionLayout: FC<EvalSectionLayoutProps> = ({ children }) => {
     };
 
     return (
-        <PanelGroup
-            direction="horizontal"
-            style={{ height: `calc(100vh - ${NAVBAR_HEIGHT}px)` }}
-        >
+        <PanelGroup direction="horizontal">
             <Panel
                 id="eval-content"
                 defaultSize={isSidebarOpen ? 40 : 100}


### PR DESCRIPTION
## Summary

On the AI Agent Evals page, when there were enough evaluations to exceed the viewport height, the list was clipped at the bottom with no way to scroll to the items below the fold. This was made worse by browser zoom, which shrinks the effective viewport.

## Root cause

`EvalSectionLayout` forced `height: calc(100vh - NAVBAR_HEIGHT)` on the `PanelGroup`, capping the content to the viewport. Since nothing inside scrolled, content beyond that height was silently clipped.

## Fix

Drop the fixed height so the evals content flows and scrolls with the document, matching the agent **Setup** tab layout (content sits inside `AppShell.Main`, which already provides `mih` and bottom padding, and the page scrolls naturally while the navbar and agent sidebar stay fixed).


Closes: PROD-8189
Closes: #24033
