### PR TITLE
fix: validate dashboard chart sorts

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -176,6 +176,7 @@ import {
     exploreHasFilteredAttribute,
     getFilteredExplore,
 } from '../UserAttributesService/UserAttributeUtils';
+import { getValidatedDashboardSorts } from './dashboardSorts';
 import { getPivotedColumns } from './getPivotedColumns';
 import {
     getColumnSubtotalQueryFromSource,
@@ -4808,12 +4809,14 @@ export class AsyncQueryService extends ProjectService {
                 explore,
             });
 
+        const validatedDashboardSorts = getValidatedDashboardSorts(
+            dashboardSorts,
+            metricQueryWithFilters,
+        );
+
         const metricQueryWithDashboardOverrides: MetricQuery = {
             ...metricQueryWithFilters,
-            sorts:
-                dashboardSorts && dashboardSorts.length > 0
-                    ? dashboardSorts
-                    : savedChart.metricQuery.sorts,
+            sorts: validatedDashboardSorts ?? savedChart.metricQuery.sorts,
         };
 
         const { maxLimit, csvCellsLimit } =

--- a/packages/backend/src/services/AsyncQueryService/dashboardSorts.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/dashboardSorts.test.ts
@@ -1,0 +1,116 @@
+import {
+    CustomDimensionType,
+    DimensionType,
+    MetricType,
+} from '@lightdash/common';
+import { getValidatedDashboardSorts } from './dashboardSorts';
+
+describe('getValidatedDashboardSorts', () => {
+    it('drops dashboard sorts that are not in the chart metric query', () => {
+        expect(
+            getValidatedDashboardSorts(
+                [
+                    {
+                        fieldId: 'payments_payment_method',
+                        descending: false,
+                    },
+                    {
+                        fieldId: 'payments_payment_method" DESC --',
+                        descending: false,
+                    },
+                ],
+                {
+                    exploreName: 'payments',
+                    dimensions: ['payments_payment_method'],
+                    metrics: ['payments_total_revenue'],
+                    filters: {},
+                    sorts: [],
+                    limit: 10,
+                    tableCalculations: [],
+                },
+            ),
+        ).toEqual([
+            {
+                fieldId: 'payments_payment_method',
+                descending: false,
+            },
+        ]);
+    });
+
+    it('drops custom fields that are defined but not selected', () => {
+        expect(
+            getValidatedDashboardSorts(
+                [
+                    {
+                        fieldId: 'payments_unselected_custom_dimension',
+                        descending: false,
+                    },
+                    {
+                        fieldId: 'payments_unselected_custom_metric',
+                        descending: true,
+                    },
+                ],
+                {
+                    exploreName: 'payments',
+                    dimensions: ['payments_payment_method'],
+                    metrics: ['payments_total_revenue'],
+                    filters: {},
+                    sorts: [],
+                    limit: 10,
+                    tableCalculations: [],
+                    customDimensions: [
+                        {
+                            id: 'payments_unselected_custom_dimension',
+                            name: 'unselected_custom_dimension',
+                            table: 'payments',
+                            type: CustomDimensionType.SQL,
+                            sql: '${TABLE}.unselected_custom_dimension',
+                            dimensionType: DimensionType.STRING,
+                        },
+                    ],
+                    additionalMetrics: [
+                        {
+                            name: 'unselected_custom_metric',
+                            table: 'payments',
+                            type: MetricType.SUM,
+                            sql: '${TABLE}.unselected_custom_metric',
+                        },
+                    ],
+                },
+            ),
+        ).toBeUndefined();
+    });
+
+    it('keeps sort fields that are selected for the query but hidden in the chart', () => {
+        expect(
+            getValidatedDashboardSorts(
+                [
+                    {
+                        fieldId: 'orders_total_order_amount',
+                        descending: true,
+                    },
+                ],
+                {
+                    exploreName: 'orders',
+                    dimensions: [
+                        'customers_customer_id',
+                        'orders_is_completed',
+                    ],
+                    metrics: [
+                        'orders_total_order_amount',
+                        'orders_unique_order_count',
+                    ],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                },
+            ),
+        ).toEqual([
+            {
+                fieldId: 'orders_total_order_amount',
+                descending: true,
+            },
+        ]);
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/dashboardSorts.ts
+++ b/packages/backend/src/services/AsyncQueryService/dashboardSorts.ts
@@ -1,0 +1,24 @@
+import { getItemId, type MetricQuery, type SortField } from '@lightdash/common';
+
+export const getValidatedDashboardSorts = (
+    dashboardSorts: SortField[],
+    metricQuery: MetricQuery,
+): SortField[] | undefined => {
+    if (dashboardSorts.length === 0) {
+        return undefined;
+    }
+
+    const availableSortFieldIds = new Set([
+        ...metricQuery.dimensions,
+        ...metricQuery.metrics,
+        ...metricQuery.tableCalculations.map((tableCalculation) =>
+            getItemId(tableCalculation),
+        ),
+    ]);
+
+    const validSorts = dashboardSorts.filter((sort) =>
+        availableSortFieldIds.has(sort.fieldId),
+    );
+
+    return validSorts.length > 0 ? validSorts : undefined;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/SPK-474/veria-31-arbitrary-sql-execution-via-unvalidated-dashboard-chart-sorts<!-- reference the related issue e.g. #150 -->

### Description:

test-frontend test-backend

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->