### PR TITLE
fix(scheduler): only notify delivery failures on the final attempt (PROD-8164)

### DIFF
--- a/packages/backend/src/scheduler/SchedulerDeliveryError.test.ts
+++ b/packages/backend/src/scheduler/SchedulerDeliveryError.test.ts
@@ -1,0 +1,73 @@
+import { NotFoundError } from '@lightdash/common';
+import {
+    resolveSchedulerDeliveryFailureAction,
+    SchedulerDeliveryError,
+} from './SchedulerDeliveryError';
+
+const buildError = (isNonRetryable: boolean) =>
+    new SchedulerDeliveryError({
+        cause: new Error('warehouse timeout'),
+        isNonRetryable,
+        createdByUserUuid: 'user-1',
+        notification: {
+            organizationUuid: 'org-1',
+            recipientEmail: 'creator@example.com',
+            schedulerName: 'Weekly sync',
+            deliveryUrl: 'https://app/scheduler',
+        },
+    });
+
+describe('SchedulerDeliveryError', () => {
+    // The worker re-throws `err.cause`, so preserving the original error is the
+    // one constructor behaviour worth pinning down.
+    test('preserves the original error as its cause', () => {
+        const cause = new NotFoundError('sheet is gone');
+        const err = new SchedulerDeliveryError({
+            cause,
+            isNonRetryable: true,
+            createdByUserUuid: 'user-1',
+            notification: {
+                organizationUuid: 'org-1',
+                recipientEmail: undefined,
+                schedulerName: 'Weekly sync',
+                deliveryUrl: 'https://app/scheduler',
+            },
+        });
+
+        expect(err).toBeInstanceOf(SchedulerDeliveryError);
+        expect(err.cause).toBe(cause);
+    });
+});
+
+describe('resolveSchedulerDeliveryFailureAction', () => {
+    test('does nothing when the error is not a SchedulerDeliveryError', () => {
+        expect(resolveSchedulerDeliveryFailureAction(undefined, true)).toEqual({
+            notify: false,
+            disable: false,
+        });
+    });
+
+    test('stays silent on a retryable, non-final attempt', () => {
+        expect(
+            resolveSchedulerDeliveryFailureAction(buildError(false), false),
+        ).toEqual({ notify: false, disable: false });
+    });
+
+    test('notifies once on the final attempt of a retryable error', () => {
+        expect(
+            resolveSchedulerDeliveryFailureAction(buildError(false), true),
+        ).toEqual({ notify: true, disable: false });
+    });
+
+    test('notifies and disables a non-retryable error immediately, even mid-retry', () => {
+        expect(
+            resolveSchedulerDeliveryFailureAction(buildError(true), false),
+        ).toEqual({ notify: true, disable: true });
+    });
+
+    test('notifies and disables a non-retryable error on the final attempt', () => {
+        expect(
+            resolveSchedulerDeliveryFailureAction(buildError(true), true),
+        ).toEqual({ notify: true, disable: true });
+    });
+});

--- a/packages/backend/src/scheduler/SchedulerDeliveryError.ts
+++ b/packages/backend/src/scheduler/SchedulerDeliveryError.ts
@@ -1,0 +1,58 @@
+import { getErrorMessage } from '@lightdash/common';
+
+export type SchedulerDeliveryNotificationContext = {
+    organizationUuid: string | undefined;
+    recipientEmail: string | undefined;
+    schedulerName: string;
+    deliveryUrl: string;
+};
+
+/**
+ * Carries a delivery failure (and the context needed to notify) from the task to
+ * the worker. `cause` is the original error and is what the worker re-throws —
+ * the envelope never reaches graphile, so logs/Sentry keep the real error type.
+ */
+export class SchedulerDeliveryError extends Error {
+    readonly isNonRetryable: boolean;
+
+    readonly createdByUserUuid: string;
+
+    readonly notification: SchedulerDeliveryNotificationContext;
+
+    constructor(args: {
+        cause: unknown;
+        isNonRetryable: boolean;
+        createdByUserUuid: string;
+        notification: SchedulerDeliveryNotificationContext;
+    }) {
+        super(getErrorMessage(args.cause), { cause: args.cause });
+        this.name = 'SchedulerDeliveryError';
+        this.isNonRetryable = args.isNonRetryable;
+        this.createdByUserUuid = args.createdByUserUuid;
+        this.notification = args.notification;
+    }
+}
+
+export type SchedulerDeliveryFailureAction = {
+    notify: boolean;
+    disable: boolean;
+};
+
+/**
+ * Notify only on a terminal outcome — non-retryable, or the final attempt — so
+ * transient failures that later recover stay silent. A non-envelope error
+ * (thrown before the task could classify it) is treated as retryable and silent.
+ */
+export const resolveSchedulerDeliveryFailureAction = (
+    deliveryError: SchedulerDeliveryError | undefined,
+    isFinalAttempt: boolean,
+): SchedulerDeliveryFailureAction => {
+    if (!deliveryError) {
+        return { notify: false, disable: false };
+    }
+    const { isNonRetryable } = deliveryError;
+    return {
+        notify: isNonRetryable || isFinalAttempt,
+        disable: isNonRetryable,
+    };
+};

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -168,6 +168,7 @@ import { ValidationService } from '../services/ValidationService/ValidationServi
 import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
 import { sanitizeGenericFileName } from '../utils/FileDownloadUtils/FileDownloadUtils';
 import { SchedulerClient } from './SchedulerClient';
+import { SchedulerDeliveryError } from './SchedulerDeliveryError';
 
 export type SchedulerTaskArguments = {
     lightdashConfig: LightdashConfig;
@@ -469,6 +470,7 @@ export default class SchedulerTask {
     protected async getNotificationPageData(
         scheduler: CreateSchedulerAndTargets,
         jobId: string,
+        isFinalAttempt: boolean,
         expirationSecondsOverride?: number,
     ): Promise<NotificationPayloadBase['page']> {
         const {
@@ -589,7 +591,7 @@ export default class SchedulerTask {
                             );
                     }
                 } catch (error) {
-                    if (this.slackClient.isEnabled) {
+                    if (this.slackClient.isEnabled && isFinalAttempt) {
                         await this.slackClient.postMessageToNotificationChannel(
                             {
                                 organizationUuid,
@@ -631,7 +633,7 @@ export default class SchedulerTask {
                     }
                     pdfFile = unfurlPdf.pdfFile;
                 } catch (error) {
-                    if (this.slackClient.isEnabled) {
+                    if (this.slackClient.isEnabled && isFinalAttempt) {
                         await this.slackClient.postMessageToNotificationChannel(
                             {
                                 organizationUuid,
@@ -1177,6 +1179,7 @@ export default class SchedulerTask {
                 (await this.getNotificationPageData(
                     scheduler,
                     jobId,
+                    true, // maxAttempts 1 — always the final attempt
                     slackExpiration,
                 ));
 
@@ -1555,6 +1558,7 @@ export default class SchedulerTask {
                 (await this.getNotificationPageData(
                     scheduler,
                     jobId,
+                    true, // maxAttempts 1 — always the final attempt
                     msTeamsExpiration,
                 ));
 
@@ -2532,6 +2536,7 @@ export default class SchedulerTask {
                 (await this.getNotificationPageData(
                     scheduler,
                     jobId,
+                    true, // maxAttempts 1 — always the final attempt
                     emailExpiration,
                 ));
 
@@ -3410,60 +3415,74 @@ export default class SchedulerTask {
                 e instanceof UnexpectedGoogleSheetsError ||
                 e instanceof WarehouseConnectionError;
 
-            if (
-                this.slackClient.isEnabled &&
-                account?.organization?.organizationUuid &&
-                scheduler
-            ) {
-                await this.slackClient.postMessageToNotificationChannel({
-                    organizationUuid: account.organization.organizationUuid,
-                    text: `Error uploading Google Sheets: ${scheduler.name}`,
-                    blocks: getNotificationChannelErrorBlocks(
-                        scheduler.name,
-                        e,
-                        deliveryUrl,
-                        'Google Sync',
-                        shouldDisableSync,
-                    ),
-                });
-            }
-
-            // Send failure email to scheduler creator for all errors
-            try {
-                if (account?.user.email) {
-                    await this.emailClient.sendGoogleSheetsErrorNotificationEmail(
-                        account.user.email,
-                        scheduler?.name || 'Unknown',
-                        deliveryUrl,
-                        getErrorMessage(e),
-                        shouldDisableSync,
-                        jobId,
-                    );
-                }
-            } catch (emailError) {
-                // Don't throw - continue with existing error handling
-                Logger.error(
-                    `Failed to send Google Sheets failure email: ${emailError}`,
-                );
-            }
-
-            // Disable scheduler if it should be disabled
-            if (shouldDisableSync) {
-                console.warn(
-                    `Disabling Google sheets scheduler with non-retryable error: ${e}`,
-                );
-
-                await this.schedulerService.setSchedulerEnabled(
-                    sessionUser!, // This error from gdriveClient happens after user initialized
-                    schedulerUuid,
-                    false,
-                );
-
-                return; // Do not cascade error
-            }
-
-            throw e; // Cascade error to it can be retried by graphile
+            // Notify/disable is the worker's job (it knows the attempt count);
+            // here we just report the failure with the context it needs.
+            throw new SchedulerDeliveryError({
+                cause: e,
+                isNonRetryable: shouldDisableSync,
+                createdByUserUuid:
+                    scheduler?.createdBy ?? notification.userUuid,
+                notification: {
+                    organizationUuid: account?.organization?.organizationUuid,
+                    recipientEmail: account?.user.email,
+                    schedulerName: scheduler?.name ?? 'Unknown',
+                    deliveryUrl,
+                },
+            });
         }
+    }
+
+    protected async notifyGsheetsDeliveryFailure(
+        err: SchedulerDeliveryError,
+        jobId: string,
+    ): Promise<void> {
+        const { isNonRetryable, notification } = err;
+        const { organizationUuid, recipientEmail, schedulerName, deliveryUrl } =
+            notification;
+
+        if (this.slackClient.isEnabled && organizationUuid) {
+            await this.slackClient.postMessageToNotificationChannel({
+                organizationUuid,
+                text: `Error uploading Google Sheets: ${schedulerName}`,
+                blocks: getNotificationChannelErrorBlocks(
+                    schedulerName,
+                    err.cause,
+                    deliveryUrl,
+                    'Google Sync',
+                    isNonRetryable,
+                ),
+            });
+        }
+
+        try {
+            if (recipientEmail) {
+                await this.emailClient.sendGoogleSheetsErrorNotificationEmail(
+                    recipientEmail,
+                    schedulerName,
+                    deliveryUrl,
+                    getErrorMessage(err.cause),
+                    isNonRetryable,
+                    jobId,
+                );
+            }
+        } catch (emailError) {
+            Logger.error(
+                `Failed to send Google Sheets failure email: ${emailError}`,
+            );
+        }
+    }
+
+    protected async disableGsheetsScheduler(
+        schedulerUuid: string,
+        createdByUserUuid: string,
+    ): Promise<void> {
+        const sessionUser =
+            await this.userService.getSessionByUserUuid(createdByUserUuid);
+        await this.schedulerService.setSchedulerEnabled(
+            sessionUser,
+            schedulerUuid,
+            false,
+        );
     }
 
     protected async logScheduledTarget(
@@ -3548,6 +3567,7 @@ export default class SchedulerTask {
         jobId: string,
         scheduledTime: Date,
         schedulerPayload: ScheduledDeliveryPayload,
+        isFinalAttempt: boolean,
     ) {
         const schedulerUuid = getSchedulerUuid(schedulerPayload);
 
@@ -3867,6 +3887,7 @@ export default class SchedulerTask {
                         const channelPage = await this.getNotificationPageData(
                             scheduler,
                             jobId,
+                            isFinalAttempt,
                             expiration,
                         );
                         for (const channel of channels) {
@@ -5550,6 +5571,7 @@ export default class SchedulerTask {
                 (await this.getNotificationPageData(
                     scheduler,
                     jobId,
+                    true, // maxAttempts 1 — always the final attempt
                     googleChatExpiration,
                 ));
 

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -19,6 +19,10 @@ import { DEFAULT_DB_MAX_CONNECTIONS } from '../knexfile';
 import Logger from '../logging/logger';
 import { type OrganizationNameResolver } from '../sentry/organizationNameResolver';
 import { SchedulerClient } from './SchedulerClient';
+import {
+    resolveSchedulerDeliveryFailureAction,
+    SchedulerDeliveryError,
+} from './SchedulerDeliveryError';
 import { tryJobOrTimeout } from './SchedulerJobTimeout';
 import SchedulerTask, { type SchedulerTaskArguments } from './SchedulerTask';
 import { traceTasks } from './SchedulerTaskTracer';
@@ -338,6 +342,8 @@ export class SchedulerWorker extends SchedulerTask {
                 payload,
                 helpers,
             ) => {
+                const isFinalAttempt =
+                    helpers.job.attempts >= helpers.job.max_attempts;
                 await tryJobOrTimeout(
                     SchedulerClient.processJob(
                         SCHEDULER_TASKS.HANDLE_SCHEDULED_DELIVERY,
@@ -349,6 +355,7 @@ export class SchedulerWorker extends SchedulerTask {
                                 helpers.job.id,
                                 helpers.job.run_at,
                                 payload,
+                                isFinalAttempt,
                             );
                         },
                     ),
@@ -677,36 +684,69 @@ export class SchedulerWorker extends SchedulerTask {
                 );
             },
             [SCHEDULER_TASKS.UPLOAD_GSHEETS]: async (payload, helpers) => {
-                await tryJobOrTimeout(
-                    SchedulerClient.processJob(
-                        SCHEDULER_TASKS.UPLOAD_GSHEETS,
-                        helpers.job.id,
-                        helpers.job.run_at,
-                        payload,
-                        async () => {
-                            await this.uploadGsheets(helpers.job.id, payload);
-                        },
-                    ),
-                    helpers.job,
-                    this.lightdashConfig.scheduler.jobTimeout,
-                    async (job, e) => {
-                        await this.schedulerService.logSchedulerJob({
-                            task: SCHEDULER_TASKS.UPLOAD_GSHEETS,
-                            schedulerUuid: payload.schedulerUuid,
-                            jobId: job.id,
-                            scheduledTime: job.run_at,
-                            jobGroup: payload.jobGroup,
-                            targetType: 'gsheets',
-                            status: SchedulerJobStatus.ERROR,
-                            details: {
-                                error: getErrorMessage(e),
-                                projectUuid: payload.projectUuid,
-                                organizationUuid: payload.organizationUuid,
-                                createdByUserUuid: payload.userUuid,
+                const isFinalAttempt =
+                    helpers.job.attempts >= helpers.job.max_attempts;
+                try {
+                    await tryJobOrTimeout(
+                        SchedulerClient.processJob(
+                            SCHEDULER_TASKS.UPLOAD_GSHEETS,
+                            helpers.job.id,
+                            helpers.job.run_at,
+                            payload,
+                            async () => {
+                                await this.uploadGsheets(
+                                    helpers.job.id,
+                                    payload,
+                                );
                             },
-                        });
-                    },
-                );
+                        ),
+                        helpers.job,
+                        this.lightdashConfig.scheduler.jobTimeout,
+                        async (job, e) => {
+                            await this.schedulerService.logSchedulerJob({
+                                task: SCHEDULER_TASKS.UPLOAD_GSHEETS,
+                                schedulerUuid: payload.schedulerUuid,
+                                jobId: job.id,
+                                scheduledTime: job.run_at,
+                                jobGroup: payload.jobGroup,
+                                targetType: 'gsheets',
+                                status: SchedulerJobStatus.ERROR,
+                                details: {
+                                    error: getErrorMessage(e),
+                                    projectUuid: payload.projectUuid,
+                                    organizationUuid: payload.organizationUuid,
+                                    createdByUserUuid: payload.userUuid,
+                                },
+                            });
+                        },
+                    );
+                } catch (e) {
+                    const deliveryError =
+                        e instanceof SchedulerDeliveryError ? e : undefined;
+                    const action = resolveSchedulerDeliveryFailureAction(
+                        deliveryError,
+                        isFinalAttempt,
+                    );
+
+                    if (action.notify && deliveryError) {
+                        await this.notifyGsheetsDeliveryFailure(
+                            deliveryError,
+                            helpers.job.id,
+                        );
+                    }
+
+                    if (action.disable && deliveryError) {
+                        await this.disableGsheetsScheduler(
+                            payload.schedulerUuid,
+                            deliveryError.createdByUserUuid,
+                        );
+                        return; // Swallow so graphile does not retry
+                    }
+
+                    // Re-throw the original error (not the envelope) so graphile
+                    // and Sentry see the real type.
+                    throw deliveryError ? deliveryError.cause : e;
+                }
             },
             [SCHEDULER_TASKS.UPLOAD_GSHEET_FROM_QUERY]: async (
                 payload,


### PR DESCRIPTION
### Description

Gsheets sync and image/PDF delivery failures were notified on every failed retry. A sync that failed transiently on attempts 1–5 but recovered on attempt 6 still sent up to 5 false-alarm emails and Slack messages, with no way to tell a genuinely broken sync from one that recovered.

Notification ownership now lives in the scheduler worker handler, which knows the attempt count:

- `uploadGsheets` is report-only: on failure it throws a `SchedulerDeliveryError` carrying the original error as `cause` plus the notification context, instead of notifying itself.
- The worker notifies only on a terminal outcome — a non-retryable error, or the final attempt of a retryable one — and disables the sync for non-retryable errors. The original error is re-thrown to graphile, so retry handling, logs and Sentry grouping are unchanged.
- The scheduled image/PDF delivery path gates its notification-channel posts on `isFinalAttempt` too. Only image-dashboard deliveries retry (`maxAttempts: 2`); single-attempt jobs always pass the final attempt, so their behaviour is unchanged.

Closes: PROD-8164
Closes: #23976
