### PR TITLE
fix: bigquery identifier handling

### DIFF
--- a/packages/formula/src/codegen/dialects.ts
+++ b/packages/formula/src/codegen/dialects.ts
@@ -351,8 +351,10 @@ const BIGQUERY_WEEK_DAY_NAMES: Record<WeekDay, string> = {
 
 const BIGQUERY_CONFIG: DialectConfig = {
     // BigQuery identifiers escape inner backticks with a leading backslash
-    // rather than Spark's doubled-backtick convention.
-    quoteIdentifier: (name) => `\`${name.replace(/`/g, '\\`')}\``,
+    // rather than Spark's doubled-backtick convention. Escape backslashes
+    // first so they cannot consume the escape added before a backtick.
+    quoteIdentifier: (name) =>
+        `\`${name.replace(/\\/g, '\\\\').replace(/`/g, '\\`')}\``,
     generateStringLiteral: backslashEscapedStringLiteral,
     // BigQuery's MOD() requires matching numeric types, so both operands are
     // explicitly cast to NUMERIC.

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -1266,6 +1266,23 @@ describe('codegen', () => {
             );
         });
 
+        it('escapes BigQuery backslashes before backticks in default sort columns', () => {
+            expect(
+                compile('=LAG(revenue)', {
+                    dialect: 'bigquery',
+                    columns,
+                    defaultOrderBy: [
+                        {
+                            column: 'custom\\` DESC, (SELECT 1) --_order',
+                            direction: 'DESC',
+                        },
+                    ],
+                }),
+            ).toBe(
+                'LAG(`revenue`) OVER (ORDER BY `custom\\\\\\` DESC, (SELECT 1) --_order` DESC)',
+            );
+        });
+
         it('flows through dialect LAG hooks — Redshift 3-arg COALESCE wrapper still gets the default order', () => {
             // Redshift's generateLagLead rewrites to COALESCE(LAG(a, b), default);
             // the inner LAG should still pick up the default ORDER BY.


### PR DESCRIPTION
Relates: https://linear.app/lightdash/issue/SPK-484/veria-30-sql-injection-in-bigquery-analytics-via-flawed-identifier

## Summary

- Updates identifier handling.
- Adds focused regression coverage.

## Testing

- pnpm formula:build
- pnpm -F @lightdash/formula test -- tests/codegen.test.ts
- pnpm formula:test:fast
- Local API smoke test

frontend-test backend-test

test-backend test-frontend