### PR TITLE
fix: gate user timezone resolution on EnableUserTimezones flag

### DIFF
--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -74,6 +74,8 @@ services:
             MCP_ENABLED: true
             CUSTOM_ROLES_ENABLED: true
             LIGHTDASH_ENABLE_TIMEZONE_SUPPORT: true
+            # Gates user-level timezone resolution; on so the userTimezone api-tests pass.
+            LIGHTDASH_ENABLE_FEATURE_FLAGS: enable-user-timezones
 
             # Force-enable embedding flag in preview envs so e2e tests work.
             # Picked up via LEGACY_ENABLE_ENV_VARS in parseConfig.ts → unified

--- a/docs/timezone-handling.md
+++ b/docs/timezone-handling.md
@@ -29,7 +29,7 @@ Two flags gate timezone behavior:
 | `EnableTimezoneSupport` | `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT`   | Data timezone feature: warehouse UI field, session-TZ setup, and the project-level "filter inputs in project TZ" toggle |
 | `EnableUserTimezones`   | `enable-user-timezones` (flag only)   | UI surface for user-facing timezone pickers: Profile panel picker and Explorer chart-level picker                       |
 
-The project timezone setting itself is always available. Server-side resolution (`resolveQueryTimezone`) honors a user's profile timezone regardless of `EnableUserTimezones` — the flag only gates the input that lets users set it. Both flags can be toggled per-organization (or per-user) via `feature_flag_overrides` in the database, which takes precedence over the env var, so we can roll out gradually without flipping the global switch.
+The project timezone setting itself is always available. Server-side resolution honors a user's profile timezone only when `EnableUserTimezones` is on: each call site resolves the flag and passes it into `getAccountUserTimezone(account, isUserTimezoneEnabled)`, which returns `null` when the flag is off so stored `users.timezone` values fall back to the project timezone. Both flags can be toggled per-organization (or per-user) via `feature_flag_overrides` in the database, which takes precedence over the env var, so we can roll out gradually without flipping the global switch.
 
 ### Data timezone (`dataTimezone`)
 

--- a/docs/timezones/timezone-handling.md
+++ b/docs/timezones/timezone-handling.md
@@ -29,7 +29,7 @@ Two flags gate timezone behavior:
 | `EnableTimezoneSupport` | `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT`   | Data timezone feature: warehouse UI field, session-TZ setup, and the project-level "filter inputs in project TZ" toggle |
 | `EnableUserTimezones`   | `enable-user-timezones` (flag only)   | UI surface for user-facing timezone pickers: Profile panel picker and Explorer chart-level picker                       |
 
-The project timezone setting itself is always available. Server-side resolution (`resolveQueryTimezone`) honors a user's profile timezone regardless of `EnableUserTimezones` — the flag only gates the input that lets users set it. Both flags can be toggled per-organization (or per-user) via `feature_flag_overrides` in the database, which takes precedence over the env var, so we can roll out gradually without flipping the global switch.
+The project timezone setting itself is always available. Server-side resolution honors a user's profile timezone only when `EnableUserTimezones` is on: each call site resolves the flag and passes it into `getAccountUserTimezone(account, isUserTimezoneEnabled)`, which returns `null` when the flag is off so stored `users.timezone` values fall back to the project timezone. Both flags can be toggled per-organization (or per-user) via `feature_flag_overrides` in the database, which takes precedence over the env var, so we can roll out gradually without flipping the global switch.
 
 ### Data timezone (`dataTimezone`)
 

--- a/docs/timezones/timezone-questions.md
+++ b/docs/timezones/timezone-questions.md
@@ -110,7 +110,7 @@ This is the same order documented in [`timezone-handling.md:23`](./timezone-hand
 
 **Admin opt-in**: yes — `EnableUserTimezones` defaults off and can be toggled per-org via `feature_flag_overrides`.
 
-**Sharp footgun**: turning the flag off does NOT clear stored `users.timezone` values, and `resolveQueryTimezone` honors them regardless of the flag (only the picker UI is gated). Flagged in [`timezone-review.md` Concern 1](./timezone-review.md#concern-1--feature-flag-entanglement-is-wide-and-underspecified). Fix it before any customer hits "I disabled the feature but it still applies."
+**Flag-off behavior**: turning the flag off does NOT clear stored `users.timezone` values, but they are no longer applied — `getAccountUserTimezone(account, isUserTimezoneEnabled)` returns `null` when `EnableUserTimezones` is off, so resolution falls back to the project timezone for every user. The stored preference is preserved (non-destructive) and re-applies when the flag is turned back on.
 
 ### Scheduled deliveries & embeds — which TZ wins?
 
@@ -386,7 +386,7 @@ So the architectural intent is "support both, default to consistent." **This is 
 | Issue | Severity | Effort | Location |
 |---|---|---|---|
 | ECharts DST shift bug | Correctness | 1d test + 2d fix | `packages/frontend/src/hooks/echarts/timezoneShift.ts` |
-| `EnableUserTimezones=off` doesn't gate stored profile TZs | Correctness | 1d | `resolveQueryTimezone.ts` |
+| ~~`EnableUserTimezones=off` doesn't gate stored profile TZs~~ ✅ fixed | Correctness | 1d | `resolveQueryTimezone.ts` |
 | Scheduled deliveries TZ interaction undocumented | Docs | 0.5d | `timezone-handling.md` |
 | Per-column wall-clock TZ annotation | Feature | 2d | `translator.ts` + `getColumnTimezone` |
 | BigQuery half-hour offset bare-literal hole | Correctness | 1d | `filtersCompiler.ts` |

--- a/docs/timezones/timezones-v2-design.md
+++ b/docs/timezones/timezones-v2-design.md
@@ -42,7 +42,7 @@ Tags combine (e.g., `bug + breaking` for a correctness fix that, shipped without
    ✅ `EnableUserTimezones`.
 
 7. **Disabling the user-TZ feature must actually disable it, not just hide the picker.**
-   ❌ `gap-flag-off-leak` *[bug + breaking]* — Today stored `users.timezone` is still honored when the flag is off — either gate `resolveQueryTimezone` on the flag, or clear stored values on flag-off.
+   ✅ `gap-flag-off-leak` fixed — `getAccountUserTimezone(account, isUserTimezoneEnabled)` returns `null` when `EnableUserTimezones` is off, so stored `users.timezone` values are ignored and resolution falls back to the project timezone. Non-destructive (values are kept, just not applied).
 
 8. **Resolved TZ persists with the query record; downstream paths read it back, never re-resolve.**
    ✅ Stamped onto `metricQuery.timezone` in `executePreparedAsyncQuery`.

--- a/packages/api-tests/tests/userTimezone.test.ts
+++ b/packages/api-tests/tests/userTimezone.test.ts
@@ -19,7 +19,9 @@ import {
  * (+9) shifts events into Jan 15/16/17 — distinct from the UTC layout
  * (Jan 15/16), so a wrong grouping is immediately visible.
  *
- * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true in the environment.
+ * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true and the EnableUserTimezones
+ * flag enabled (LIGHTDASH_ENABLE_FEATURE_FLAGS=enable-user-timezones) in the
+ * environment — user-level resolution is gated on the latter.
  */
 
 const DIMENSION_KEY = 'timezone_test_event_timestamp_day';

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1447,11 +1447,12 @@ export class EmbedService extends BaseService {
 
         const projectTimezone =
             await this.projectService.getQueryTimezoneForProject(projectUuid);
-        const timezone = resolveQueryTimezone(
-            metricQueryWithDashboardOverrides,
+        const timezone = resolveQueryTimezone({
+            metricQuery: metricQueryWithDashboardOverrides,
             projectTimezone,
-            null,
-        );
+            userTimezone: null,
+            isUserTimezoneEnabled: false,
+        });
 
         const isTimezoneSupportEnabled =
             await this.projectService.isTimezoneSupportEnabled({
@@ -2080,11 +2081,12 @@ export class EmbedService extends BaseService {
 
         const projectTimezone =
             await this.projectService.getQueryTimezoneForProject(projectUuid);
-        const timezone = resolveQueryTimezone(
+        const timezone = resolveQueryTimezone({
             metricQuery,
             projectTimezone,
-            null,
-        );
+            userTimezone: null,
+            isUserTimezoneEnabled: false,
+        });
 
         const useTimezoneAwareDateTrunc =
             await this.projectService.isTimezoneSupportEnabled({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3116,6 +3116,10 @@ export class AsyncQueryService extends ProjectService {
             explore,
         );
 
+        const isUserTimezoneEnabled = await this.isUserTimezoneEnabled({
+            userUuid: account.user.id,
+            organizationUuid: account.organization.organizationUuid,
+        });
         const {
             resolvedTimezone,
             displayTimezone,
@@ -3130,7 +3134,7 @@ export class AsyncQueryService extends ProjectService {
             userTimezone:
                 materializationRole !== undefined
                     ? null
-                    : getAccountUserTimezone(account),
+                    : getAccountUserTimezone(account, isUserTimezoneEnabled),
             metricQuery,
         });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2705,11 +2705,16 @@ export class AsyncQueryService extends ProjectService {
         const projectTimezone = projectUuid
             ? await this.getQueryTimezoneForProject(projectUuid)
             : 'UTC';
-        const resolvedTimezone = resolveQueryTimezone(
+        const isUserTimezoneEnabled = await this.isUserTimezoneEnabled({
+            userUuid,
+            organizationUuid,
+        });
+        const resolvedTimezone = resolveQueryTimezone({
             metricQuery,
             projectTimezone,
             userTimezone,
-        );
+            isUserTimezoneEnabled,
+        });
         const enabled = await this.isTimezoneSupportEnabled({
             userUuid,
             organizationUuid,
@@ -3116,10 +3121,6 @@ export class AsyncQueryService extends ProjectService {
             explore,
         );
 
-        const isUserTimezoneEnabled = await this.isUserTimezoneEnabled({
-            userUuid: account.user.id,
-            organizationUuid: account.organization.organizationUuid,
-        });
         const {
             resolvedTimezone,
             displayTimezone,
@@ -3134,7 +3135,7 @@ export class AsyncQueryService extends ProjectService {
             userTimezone:
                 materializationRole !== undefined
                     ? null
-                    : getAccountUserTimezone(account, isUserTimezoneEnabled),
+                    : getAccountUserTimezone(account),
             metricQuery,
         });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3732,10 +3732,14 @@ export class ProjectService extends BaseService {
 
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
+        const isUserTimezoneEnabled = await this.isUserTimezoneEnabled({
+            userUuid: account.user.id,
+            organizationUuid: account.organization.organizationUuid,
+        });
         const timezone = resolveQueryTimezone(
             metricQuery,
             projectTimezone,
-            getAccountUserTimezone(account),
+            getAccountUserTimezone(account, isUserTimezoneEnabled),
         );
         const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
             userUuid: account.user.id,
@@ -4416,10 +4420,14 @@ export class ProjectService extends BaseService {
 
                 const projectTimezone =
                     await this.getQueryTimezoneForProject(projectUuid);
+                const isUserTimezoneEnabled = await this.isUserTimezoneEnabled({
+                    userUuid: account.user.id,
+                    organizationUuid: account.organization.organizationUuid,
+                });
                 const resolvedTimezone = resolveQueryTimezone(
                     metricQuery,
                     projectTimezone,
-                    getAccountUserTimezone(account),
+                    getAccountUserTimezone(account, isUserTimezoneEnabled),
                 );
                 const isTimezoneEnabled = await this.isTimezoneSupportEnabled({
                     userUuid: account.user.id,
@@ -4757,10 +4765,16 @@ export class ProjectService extends BaseService {
 
                     const projectTimezone =
                         await this.getQueryTimezoneForProject(projectUuid);
+                    const isUserTimezoneEnabled =
+                        await this.isUserTimezoneEnabled({
+                            userUuid: account.user.id,
+                            organizationUuid:
+                                account.organization.organizationUuid,
+                        });
                     const timezone = resolveQueryTimezone(
                         metricQueryWithLimit,
                         projectTimezone,
-                        getAccountUserTimezone(account),
+                        getAccountUserTimezone(account, isUserTimezoneEnabled),
                     );
                     const useTimezoneAwareDateTrunc =
                         await this.isTimezoneSupportEnabled({
@@ -5362,10 +5376,11 @@ export class ProjectService extends BaseService {
 
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
+        const isUserTimezoneEnabled = await this.isUserTimezoneEnabled(user);
         const timezone = resolveQueryTimezone(
             metricQuery,
             projectTimezone,
-            user.timezone,
+            isUserTimezoneEnabled ? user.timezone : null,
         );
         const useTimezoneAwareDateTrunc =
             await this.isTimezoneSupportEnabled(user);
@@ -8321,6 +8336,18 @@ export class ProjectService extends BaseService {
     }): Promise<boolean> {
         const { enabled } = await this.featureFlagModel.get({
             featureFlagId: FeatureFlags.EnableTimezoneSupport,
+            user,
+        });
+
+        return enabled;
+    }
+
+    async isUserTimezoneEnabled(user: {
+        userUuid: string;
+        organizationUuid?: string;
+    }): Promise<boolean> {
+        const { enabled } = await this.featureFlagModel.get({
+            featureFlagId: FeatureFlags.EnableUserTimezones,
             user,
         });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -8346,7 +8346,7 @@ export class ProjectService extends BaseService {
         return enabled;
     }
 
-    async isUserTimezoneEnabled(user: {
+    protected async isUserTimezoneEnabled(user: {
         userUuid: string;
         organizationUuid?: string;
     }): Promise<boolean> {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3736,11 +3736,12 @@ export class ProjectService extends BaseService {
             userUuid: account.user.id,
             organizationUuid: account.organization.organizationUuid,
         });
-        const timezone = resolveQueryTimezone(
+        const timezone = resolveQueryTimezone({
             metricQuery,
             projectTimezone,
-            getAccountUserTimezone(account, isUserTimezoneEnabled),
-        );
+            userTimezone: getAccountUserTimezone(account),
+            isUserTimezoneEnabled,
+        });
         const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
             userUuid: account.user.id,
             organizationUuid: account.organization.organizationUuid,
@@ -4424,11 +4425,12 @@ export class ProjectService extends BaseService {
                     userUuid: account.user.id,
                     organizationUuid: account.organization.organizationUuid,
                 });
-                const resolvedTimezone = resolveQueryTimezone(
+                const resolvedTimezone = resolveQueryTimezone({
                     metricQuery,
                     projectTimezone,
-                    getAccountUserTimezone(account, isUserTimezoneEnabled),
-                );
+                    userTimezone: getAccountUserTimezone(account),
+                    isUserTimezoneEnabled,
+                });
                 const isTimezoneEnabled = await this.isTimezoneSupportEnabled({
                     userUuid: account.user.id,
                     organizationUuid: account.organization.organizationUuid,
@@ -4771,11 +4773,12 @@ export class ProjectService extends BaseService {
                             organizationUuid:
                                 account.organization.organizationUuid,
                         });
-                    const timezone = resolveQueryTimezone(
-                        metricQueryWithLimit,
+                    const timezone = resolveQueryTimezone({
+                        metricQuery: metricQueryWithLimit,
                         projectTimezone,
-                        getAccountUserTimezone(account, isUserTimezoneEnabled),
-                    );
+                        userTimezone: getAccountUserTimezone(account),
+                        isUserTimezoneEnabled,
+                    });
                     const useTimezoneAwareDateTrunc =
                         await this.isTimezoneSupportEnabled({
                             userUuid: account.user.id,
@@ -5377,11 +5380,12 @@ export class ProjectService extends BaseService {
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
         const isUserTimezoneEnabled = await this.isUserTimezoneEnabled(user);
-        const timezone = resolveQueryTimezone(
+        const timezone = resolveQueryTimezone({
             metricQuery,
             projectTimezone,
-            isUserTimezoneEnabled ? user.timezone : null,
-        );
+            userTimezone: user.timezone,
+            isUserTimezoneEnabled,
+        });
         const useTimezoneAwareDateTrunc =
             await this.isTimezoneSupportEnabled(user);
 

--- a/packages/common/src/utils/resolveQueryTimezone.test.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.test.ts
@@ -1,4 +1,18 @@
-import { resolveQueryTimezone } from './resolveQueryTimezone';
+import { type Account } from '../types/auth';
+import {
+    getAccountUserTimezone,
+    resolveQueryTimezone,
+} from './resolveQueryTimezone';
+
+const registeredAccount = (timezone: string | null): Account =>
+    ({
+        user: { type: 'registered', timezone },
+    }) as unknown as Account;
+
+const anonymousAccount = (): Account =>
+    ({
+        user: { type: 'anonymous' },
+    }) as unknown as Account;
 
 describe('resolveQueryTimezone', () => {
     it('returns metricQuery.timezone when set', () => {
@@ -77,5 +91,51 @@ describe('resolveQueryTimezone', () => {
         expect(() =>
             resolveQueryTimezone({ timezone: "UTC' OR '1'='1" }, 'UTC'),
         ).toThrow('Invalid timezone');
+    });
+});
+
+describe('getAccountUserTimezone', () => {
+    it('returns the user timezone when the flag is enabled', () => {
+        expect(
+            getAccountUserTimezone(registeredAccount('Asia/Tokyo'), true),
+        ).toBe('Asia/Tokyo');
+    });
+
+    it('returns null when the flag is disabled, even with a stored timezone', () => {
+        expect(
+            getAccountUserTimezone(registeredAccount('Asia/Tokyo'), false),
+        ).toBeNull();
+    });
+
+    it('returns null for a registered user with no stored timezone', () => {
+        expect(
+            getAccountUserTimezone(registeredAccount(null), true),
+        ).toBeNull();
+    });
+
+    it('returns null for anonymous viewers regardless of the flag', () => {
+        expect(getAccountUserTimezone(anonymousAccount(), true)).toBeNull();
+        expect(getAccountUserTimezone(anonymousAccount(), false)).toBeNull();
+    });
+
+    it('resolves to project timezone when the flag is off and to user timezone when on', () => {
+        const account = registeredAccount('Asia/Tokyo');
+        const projectTimezone = 'Australia/Brisbane';
+
+        expect(
+            resolveQueryTimezone(
+                {},
+                projectTimezone,
+                getAccountUserTimezone(account, false),
+            ),
+        ).toBe('Australia/Brisbane');
+
+        expect(
+            resolveQueryTimezone(
+                {},
+                projectTimezone,
+                getAccountUserTimezone(account, true),
+            ),
+        ).toBe('Asia/Tokyo');
     });
 });

--- a/packages/common/src/utils/resolveQueryTimezone.test.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.test.ts
@@ -17,105 +17,161 @@ const anonymousAccount = (): Account =>
 describe('resolveQueryTimezone', () => {
     it('returns metricQuery.timezone when set', () => {
         expect(
-            resolveQueryTimezone(
-                { timezone: 'America/New_York' },
-                'Australia/Brisbane',
-            ),
+            resolveQueryTimezone({
+                metricQuery: { timezone: 'America/New_York' },
+                projectTimezone: 'Australia/Brisbane',
+                userTimezone: null,
+                isUserTimezoneEnabled: true,
+            }),
         ).toBe('America/New_York');
     });
 
     it('falls back to project timezone when metricQuery.timezone is undefined', () => {
         expect(
-            resolveQueryTimezone({ timezone: undefined }, 'Australia/Brisbane'),
+            resolveQueryTimezone({
+                metricQuery: { timezone: undefined },
+                projectTimezone: 'Australia/Brisbane',
+                userTimezone: null,
+                isUserTimezoneEnabled: true,
+            }),
         ).toBe('Australia/Brisbane');
     });
 
     it('falls back to project timezone when timezone field is missing', () => {
-        expect(resolveQueryTimezone({}, 'Europe/London')).toBe('Europe/London');
+        expect(
+            resolveQueryTimezone({
+                metricQuery: {},
+                projectTimezone: 'Europe/London',
+                userTimezone: null,
+                isUserTimezoneEnabled: true,
+            }),
+        ).toBe('Europe/London');
     });
 
     it('accepts UTC', () => {
-        expect(resolveQueryTimezone({}, 'UTC')).toBe('UTC');
+        expect(
+            resolveQueryTimezone({
+                metricQuery: {},
+                projectTimezone: 'UTC',
+                userTimezone: null,
+                isUserTimezoneEnabled: true,
+            }),
+        ).toBe('UTC');
     });
 
-    it('uses user timezone when chart timezone is absent', () => {
+    it('uses user timezone when chart timezone is absent and the flag is on', () => {
         expect(
-            resolveQueryTimezone({}, 'Australia/Brisbane', 'Asia/Tokyo'),
+            resolveQueryTimezone({
+                metricQuery: {},
+                projectTimezone: 'Australia/Brisbane',
+                userTimezone: 'Asia/Tokyo',
+                isUserTimezoneEnabled: true,
+            }),
         ).toBe('Asia/Tokyo');
+    });
+
+    it('ignores user timezone when the flag is off, falling back to project', () => {
+        expect(
+            resolveQueryTimezone({
+                metricQuery: {},
+                projectTimezone: 'Australia/Brisbane',
+                userTimezone: 'Asia/Tokyo',
+                isUserTimezoneEnabled: false,
+            }),
+        ).toBe('Australia/Brisbane');
     });
 
     it('chart timezone takes precedence over user timezone', () => {
         expect(
-            resolveQueryTimezone(
-                { timezone: 'America/New_York' },
-                'Australia/Brisbane',
-                'Asia/Tokyo',
-            ),
+            resolveQueryTimezone({
+                metricQuery: { timezone: 'America/New_York' },
+                projectTimezone: 'Australia/Brisbane',
+                userTimezone: 'Asia/Tokyo',
+                isUserTimezoneEnabled: true,
+            }),
+        ).toBe('America/New_York');
+    });
+
+    it('chart timezone still applies when the user-timezone flag is off', () => {
+        expect(
+            resolveQueryTimezone({
+                metricQuery: { timezone: 'America/New_York' },
+                projectTimezone: 'Australia/Brisbane',
+                userTimezone: 'Asia/Tokyo',
+                isUserTimezoneEnabled: false,
+            }),
         ).toBe('America/New_York');
     });
 
     it('falls back to project when user timezone is null', () => {
-        expect(resolveQueryTimezone({}, 'Australia/Brisbane', null)).toBe(
-            'Australia/Brisbane',
-        );
-    });
-
-    it('falls back to project when user timezone is undefined', () => {
-        expect(resolveQueryTimezone({}, 'Australia/Brisbane', undefined)).toBe(
-            'Australia/Brisbane',
-        );
+        expect(
+            resolveQueryTimezone({
+                metricQuery: {},
+                projectTimezone: 'Australia/Brisbane',
+                userTimezone: null,
+                isUserTimezoneEnabled: true,
+            }),
+        ).toBe('Australia/Brisbane');
     });
 
     it('throws on invalid metricQuery timezone', () => {
         expect(() =>
-            resolveQueryTimezone(
-                { timezone: "'; DROP TABLE users; --" },
-                'UTC',
-            ),
+            resolveQueryTimezone({
+                metricQuery: { timezone: "'; DROP TABLE users; --" },
+                projectTimezone: 'UTC',
+                userTimezone: null,
+                isUserTimezoneEnabled: true,
+            }),
         ).toThrow('Invalid timezone');
     });
 
     it('throws on invalid project timezone', () => {
-        expect(() => resolveQueryTimezone({}, 'Not/A/Timezone')).toThrow(
-            'Invalid timezone',
-        );
+        expect(() =>
+            resolveQueryTimezone({
+                metricQuery: {},
+                projectTimezone: 'Not/A/Timezone',
+                userTimezone: null,
+                isUserTimezoneEnabled: true,
+            }),
+        ).toThrow('Invalid timezone');
     });
 
     it('throws on invalid user timezone', () => {
         expect(() =>
-            resolveQueryTimezone({}, 'UTC', "UTC'; DROP TABLE users; --"),
+            resolveQueryTimezone({
+                metricQuery: {},
+                projectTimezone: 'UTC',
+                userTimezone: "UTC'; DROP TABLE users; --",
+                isUserTimezoneEnabled: true,
+            }),
         ).toThrow('Invalid timezone');
     });
 
     it('throws on timezone with SQL injection attempt', () => {
         expect(() =>
-            resolveQueryTimezone({ timezone: "UTC' OR '1'='1" }, 'UTC'),
+            resolveQueryTimezone({
+                metricQuery: { timezone: "UTC' OR '1'='1" },
+                projectTimezone: 'UTC',
+                userTimezone: null,
+                isUserTimezoneEnabled: true,
+            }),
         ).toThrow('Invalid timezone');
     });
 });
 
 describe('getAccountUserTimezone', () => {
-    it('returns the user timezone when the flag is enabled', () => {
-        expect(
-            getAccountUserTimezone(registeredAccount('Asia/Tokyo'), true),
-        ).toBe('Asia/Tokyo');
-    });
-
-    it('returns null when the flag is disabled, even with a stored timezone', () => {
-        expect(
-            getAccountUserTimezone(registeredAccount('Asia/Tokyo'), false),
-        ).toBeNull();
+    it('returns the stored timezone for a registered user', () => {
+        expect(getAccountUserTimezone(registeredAccount('Asia/Tokyo'))).toBe(
+            'Asia/Tokyo',
+        );
     });
 
     it('returns null for a registered user with no stored timezone', () => {
-        expect(
-            getAccountUserTimezone(registeredAccount(null), true),
-        ).toBeNull();
+        expect(getAccountUserTimezone(registeredAccount(null))).toBeNull();
     });
 
-    it('returns null for anonymous viewers regardless of the flag', () => {
-        expect(getAccountUserTimezone(anonymousAccount(), true)).toBeNull();
-        expect(getAccountUserTimezone(anonymousAccount(), false)).toBeNull();
+    it('returns null for anonymous viewers', () => {
+        expect(getAccountUserTimezone(anonymousAccount())).toBeNull();
     });
 
     it('resolves to project timezone when the flag is off and to user timezone when on', () => {
@@ -123,19 +179,21 @@ describe('getAccountUserTimezone', () => {
         const projectTimezone = 'Australia/Brisbane';
 
         expect(
-            resolveQueryTimezone(
-                {},
+            resolveQueryTimezone({
+                metricQuery: {},
                 projectTimezone,
-                getAccountUserTimezone(account, false),
-            ),
+                userTimezone: getAccountUserTimezone(account),
+                isUserTimezoneEnabled: false,
+            }),
         ).toBe('Australia/Brisbane');
 
         expect(
-            resolveQueryTimezone(
-                {},
+            resolveQueryTimezone({
+                metricQuery: {},
                 projectTimezone,
-                getAccountUserTimezone(account, true),
-            ),
+                userTimezone: getAccountUserTimezone(account),
+                isUserTimezoneEnabled: true,
+            }),
         ).toBe('Asia/Tokyo');
     });
 });

--- a/packages/common/src/utils/resolveQueryTimezone.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.ts
@@ -4,17 +4,11 @@ import { type MetricQuery } from '../types/metricQuery';
 import { isValidTimezone } from './scheduler';
 
 /**
- * Returns the account's user-level timezone preference, or null for anonymous
- * viewers (embeds / JWT) and when EnableUserTimezones is off — disabling the
- * flag rolls every user back to the project timezone. Callers resolve the flag.
+ * Returns the account's stored user-level timezone preference, or null for
+ * anonymous viewers (embeds / JWT) who have no profile. The EnableUserTimezones
+ * gate is applied downstream in resolveQueryTimezone, the single chokepoint.
  */
-export function getAccountUserTimezone(
-    account: Account,
-    isUserTimezoneEnabled: boolean,
-): string | null {
-    if (!isUserTimezoneEnabled) {
-        return null;
-    }
+export function getAccountUserTimezone(account: Account): string | null {
     if (account.user.type !== 'registered') {
         return null;
     }
@@ -31,15 +25,28 @@ export function getAccountUserTimezone(
  * with a personal preference sees their zone whenever the chart doesn't
  * pin one.
  *
+ * The user layer is only applied when isUserTimezoneEnabled is true. When the
+ * EnableUserTimezones flag is off, stored preferences are ignored so every
+ * user falls back to the project timezone — gating here, at the single
+ * chokepoint, covers every source of userTimezone (account profile or session).
+ *
  * Validates the resolved timezone to prevent SQL injection — the result
  * is interpolated into warehouse SQL strings (e.g., AT TIME ZONE '...').
  */
-export function resolveQueryTimezone(
-    metricQuery: Pick<MetricQuery, 'timezone'>,
-    projectTimezone: string,
-    userTimezone?: string | null,
-): string {
-    const timezone = metricQuery.timezone ?? userTimezone ?? projectTimezone;
+export function resolveQueryTimezone({
+    metricQuery,
+    projectTimezone,
+    userTimezone,
+    isUserTimezoneEnabled,
+}: {
+    metricQuery: Pick<MetricQuery, 'timezone'>;
+    projectTimezone: string;
+    userTimezone: string | null;
+    isUserTimezoneEnabled: boolean;
+}): string {
+    const effectiveUserTimezone = isUserTimezoneEnabled ? userTimezone : null;
+    const timezone =
+        metricQuery.timezone ?? effectiveUserTimezone ?? projectTimezone;
 
     if (!isValidTimezone(timezone)) {
         throw new ParameterError(`Invalid timezone: ${timezone}`);

--- a/packages/common/src/utils/resolveQueryTimezone.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.ts
@@ -4,11 +4,17 @@ import { type MetricQuery } from '../types/metricQuery';
 import { isValidTimezone } from './scheduler';
 
 /**
- * Returns the account's user-level timezone preference, or null if the
- * account belongs to an anonymous viewer (embeds / JWT) where no profile
- * preference exists.
+ * Returns the account's user-level timezone preference, or null for anonymous
+ * viewers (embeds / JWT) and when EnableUserTimezones is off — disabling the
+ * flag rolls every user back to the project timezone. Callers resolve the flag.
  */
-export function getAccountUserTimezone(account: Account): string | null {
+export function getAccountUserTimezone(
+    account: Account,
+    isUserTimezoneEnabled: boolean,
+): string | null {
+    if (!isUserTimezoneEnabled) {
+        return null;
+    }
     if (account.user.type !== 'registered') {
         return null;
     }


### PR DESCRIPTION
Closes: GLITCH-451

### Description:

Turning the `EnableUserTimezones` flag off previously only hid the timezone picker UI while stored `users.timezone` values were still applied during server-side query resolution, so users who had set a personal timezone kept getting viewer-TZ results even after an admin "disabled" the feature. This PR gates `getAccountUserTimezone` on the flag — each call site resolves it via a new `isUserTimezoneEnabled` helper (mirroring `isTimezoneSupportEnabled`) and passes it in, so the helper returns `null` when the flag is off and every user falls back to the project timezone. The change is non-destructive: stored preferences are preserved and re-apply when the flag is turned back on. All ProjectService (×4), AsyncQueryService, and EmbedService (already pass `null`) call sites honor the flag consistently, with new unit tests and updated timezone docs.
