### PR TITLE
fix: show user management table result status

### DIFF
--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx
@@ -61,7 +61,7 @@ const GroupsTable: FC<GroupsTableProps> = ({ onAddClick, onEditGroup }) => {
     const [debouncedSearchValue] = useDebouncedValue(debouncedSearch, 300);
 
     // Use infinite query for pagination
-    const { data, fetchNextPage, isError, isFetching, isLoading } =
+    const { data, fetchNextPage, hasNextPage, isError, isFetching, isLoading } =
         useInfiniteOrganizationGroups({
             searchInput: debouncedSearchValue.search,
             includeMembers: GROUP_MEMBERS_PER_PAGE,
@@ -237,7 +237,6 @@ const GroupsTable: FC<GroupsTableProps> = ({ onAddClick, onEditGroup }) => {
         enableSorting: false,
         enableRowVirtualization: true,
         enableTopToolbar: true,
-        enableBottomToolbar: false,
         mantinePaperProps: {
             shadow: undefined,
             style: {
@@ -308,6 +307,36 @@ const GroupsTable: FC<GroupsTableProps> = ({ onAddClick, onEditGroup }) => {
                 canManage={canManageGroups}
                 onAddClick={onAddClick}
             />
+        ),
+        renderBottomToolbar: () => (
+            <Box
+                p={`${theme.spacing.sm} ${theme.spacing.xl} ${theme.spacing.md} ${theme.spacing.xl}`}
+                fz="xs"
+                fw={500}
+                c="ldGray.8"
+                style={{
+                    borderTop: `1px solid ${theme.colors.ldGray[3]}`,
+                }}
+            >
+                {isFetching ? (
+                    <Text c="ldGray.8" fz="xs">
+                        Loading more...
+                    </Text>
+                ) : (
+                    <Group gap="two">
+                        <Text fz="xs" c="ldGray.8">
+                            {hasNextPage
+                                ? 'Scroll for more groups'
+                                : 'All groups loaded'}
+                        </Text>
+                        <Text fz="xs" fw={400} c="ldGray.6">
+                            {hasNextPage
+                                ? `(${totalFetched} of ${totalDBRowCount} loaded)`
+                                : `(${totalFetched})`}
+                        </Text>
+                    </Group>
+                )}
+            </Box>
         ),
         icons: {
             IconArrowsSort: () => (

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -89,7 +89,7 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
     const [debouncedSearchValue] = useDebouncedValue(debouncedSearch, 300);
 
     // Use infinite query for pagination
-    const { data, fetchNextPage, isError, isFetching, isLoading } =
+    const { data, fetchNextPage, hasNextPage, isError, isFetching, isLoading } =
         useInfiniteOrganizationUsers({
             searchInput: debouncedSearchValue.search,
             includeGroups: isGroupManagementEnabled ? 10000 : undefined,
@@ -367,7 +367,6 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
         enableSorting: false,
         enableRowVirtualization: true,
         enableTopToolbar: true,
-        enableBottomToolbar: false,
         mantinePaperProps: {
             shadow: undefined,
             style: {
@@ -438,6 +437,36 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
                 canInvite={canInvite}
                 onInviteClick={onInviteClick}
             />
+        ),
+        renderBottomToolbar: () => (
+            <Box
+                p={`${theme.spacing.sm} ${theme.spacing.xl} ${theme.spacing.md} ${theme.spacing.xl}`}
+                fz="xs"
+                fw={500}
+                c="ldGray.8"
+                style={{
+                    borderTop: `1px solid ${theme.colors.ldGray[3]}`,
+                }}
+            >
+                {isFetching ? (
+                    <Text c="ldGray.8" fz="xs">
+                        Loading more...
+                    </Text>
+                ) : (
+                    <Group gap="two">
+                        <Text fz="xs" c="ldGray.8">
+                            {hasNextPage
+                                ? 'Scroll for more users'
+                                : 'All users loaded'}
+                        </Text>
+                        <Text fz="xs" fw={400} c="ldGray.6">
+                            {hasNextPage
+                                ? `(${totalFetched} of ${totalDBRowCount} loaded)`
+                                : `(${totalFetched})`}
+                        </Text>
+                    </Group>
+                )}
+            </Box>
         ),
         icons: {
             IconArrowsSort: () => (


### PR DESCRIPTION
### Description
- Add bottom result-status footer to Users and Groups settings tables.
- Show loading, partial loaded, and all-loaded states so overflowed rows are discoverable.

### Testing
- pnpm -F frontend exec tsc --project tsconfig.fast.json --noEmit --pretty false
- pnpm -F frontend run linter ./src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx ./src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx

Closes: PROD-8011
Closes: #23675