### PR TITLE
feat(omnibar): surface settings pages in global search

### DIFF
--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -269,6 +269,7 @@ export enum SearchItemType {
     FIELD = 'field',
     PAGE = 'page',
     DATA_APP = 'data_app',
+    SETTINGS = 'settings',
 }
 
 export function getSearchItemTypeFromResultKey(

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -1,7 +1,7 @@
 import {
     getSearchResultId,
+    SearchItemType,
     type SearchFilters,
-    type SearchItemType,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -33,13 +33,13 @@ import { useProject } from '../../../hooks/useProject';
 import { useValidationUserAbility } from '../../../hooks/validation/useValidation';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
+import { useOmnibarSettingsItems } from '../hooks/useOmnibarSettingsItems';
 import useSearch, { OMNIBAR_MIN_QUERY_LENGTH } from '../hooks/useSearch';
 import {
     allSearchItemTypes,
     type FocusedItemIndex,
     type SearchItem,
 } from '../types/searchItem';
-import { isSearchResultEmpty } from '../utils/isSearchResultEmpty';
 import classes from './Omnibar.module.css';
 import OmnibarEmptyState from './OmnibarEmptyState';
 import OmnibarFilters from './OmnibarFilters';
@@ -74,6 +74,8 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
         filters: searchFilters,
         source: 'omnibar',
     });
+
+    const settingsItems = useOmnibarSettingsItems(debouncedValue ?? '');
 
     const [isOmnibarOpen, { open: openOmnibar, close: closeOmnibar }] =
         useDisclosure(false);
@@ -129,7 +131,8 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
                 id: getSearchResultId(item.item),
             },
         });
-        if (redirect) {
+        // Settings pages always navigate in place, never a new tab.
+        if (redirect && item.type !== SearchItemType.SETTINGS) {
             window.open(
                 item.location.pathname + (item.location.search || ''),
                 '_blank',
@@ -161,14 +164,29 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
     const hasEnteredQuery = query !== undefined && query !== '';
     const hasEnteredMinQueryLength =
         hasEnteredQuery && query.length >= OMNIBAR_MIN_QUERY_LENGTH;
-    const hasSearchResults =
-        searchResults && !isSearchResultEmpty(searchResults);
 
-    const sortedGroupEntries = useMemo(
-        () =>
-            searchResults ? getSearchResultsGroupsSorted(searchResults) : [],
-        [searchResults],
-    );
+    const sortedGroupEntries = useMemo(() => {
+        const contentGroups = searchResults
+            ? getSearchResultsGroupsSorted(searchResults)
+            : [];
+
+        const showSettings =
+            settingsItems.length > 0 &&
+            (!searchFilters?.type ||
+                searchFilters.type === SearchItemType.SETTINGS);
+
+        return showSettings
+            ? [
+                  ...contentGroups,
+                  [SearchItemType.SETTINGS, settingsItems] as [
+                      SearchItemType,
+                      SearchItem[],
+                  ],
+              ]
+            : contentGroups;
+    }, [searchResults, settingsItems, searchFilters?.type]);
+
+    const hasSearchResults = sortedGroupEntries.length > 0;
     useEffect(() => {
         setFocusedItemIndex(undefined);
     }, [query, searchFilters]);

--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
@@ -19,6 +19,7 @@ import {
     IconLayoutDashboard,
     IconLayoutNavbarInactive,
     IconRectangle,
+    IconSettings,
     IconTable,
     IconUser,
     IconX,
@@ -52,6 +53,8 @@ const getOmnibarItemIcon = (itemType: SearchItemType) => {
             return IconCodeCircle;
         case SearchItemType.DATA_APP:
             return IconAppWindow;
+        case SearchItemType.SETTINGS:
+            return IconSettings;
         default:
             return assertUnreachable(
                 itemType,

--- a/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
@@ -62,7 +62,8 @@ const OmnibarItem: FC<Props> = ({
             <Stack gap="two" className={classes.content}>
                 <Group gap="xs" wrap="nowrap">
                     <Text fw={500} size="sm" truncate ref={scrollRef}>
-                        {item.prefix} {item.title}
+                        {item.prefix ? <>{item.prefix} </> : null}
+                        {item.title}
                     </Text>
                     {itemHasVerification(item) && (
                         <Badge
@@ -77,7 +78,11 @@ const OmnibarItem: FC<Props> = ({
                     )}
                 </Group>
 
-                {item.description || item.typeLabel ? (
+                {item.contextLabel ? (
+                    <Text size="xs" truncate c="dimmed">
+                        {item.contextLabel}
+                    </Text>
+                ) : item.description || item.typeLabel ? (
                     <Text size="xs" truncate c="dimmed">
                         {item.typeLabel}
                         {item.typeLabel && item.description ? <> · </> : null}

--- a/packages/frontend/src/features/omnibar/components/utils.ts
+++ b/packages/frontend/src/features/omnibar/components/utils.ts
@@ -13,6 +13,7 @@ import {
     IconFolder,
     IconLayoutDashboard,
     IconLayoutNavbarInactive,
+    IconSettings,
     IconTable,
 } from '@tabler/icons-react';
 import { getChartIcon } from '../../../components/common/ResourceIcon/utils';
@@ -38,6 +39,8 @@ export const getOmnibarItemColor = (itemType: SearchItemType) => {
             return 'blue.7';
         case SearchItemType.DATA_APP:
             return 'orange.6';
+        case SearchItemType.SETTINGS:
+            return 'ldGray.7';
         default:
             return assertUnreachable(
                 itemType,
@@ -47,6 +50,9 @@ export const getOmnibarItemColor = (itemType: SearchItemType) => {
 };
 
 export const getOmnibarItemIcon = (item: SearchItem) => {
+    if (item.icon) {
+        return item.icon;
+    }
     switch (item.type) {
         case SearchItemType.FIELD:
             if (item.typeLabel?.toLowerCase() === 'dimension') {
@@ -72,6 +78,8 @@ export const getOmnibarItemIcon = (item: SearchItem) => {
             return IconLayoutNavbarInactive;
         case SearchItemType.DATA_APP:
             return IconAppWindow;
+        case SearchItemType.SETTINGS:
+            return IconSettings;
         default:
             return assertUnreachable(
                 item.type,

--- a/packages/frontend/src/features/omnibar/hooks/useOmnibarSettingsItems.ts
+++ b/packages/frontend/src/features/omnibar/hooks/useOmnibarSettingsItems.ts
@@ -1,0 +1,33 @@
+import { SearchItemType } from '@lightdash/common';
+import { useMemo } from 'react';
+import { searchSettingsNavigationItemsWithPath } from '../../../hooks/settings/filterSettingsNavigation';
+import { useSettingsContext } from '../../../hooks/settings/useSettingsContext';
+import { useSettingsNavigation } from '../../../hooks/settings/useSettingsNavigation';
+import { type SearchItem } from '../types/searchItem';
+import { OMNIBAR_MIN_QUERY_LENGTH } from './useSearch';
+
+/**
+ * Settings pages matching `query`, as omnibar `SearchItem`s. The nav model is
+ * already permission-gated, so matches never leak pages the user can't reach.
+ */
+export const useOmnibarSettingsItems = (query: string): SearchItem[] => {
+    const context = useSettingsContext();
+    const sections = useSettingsNavigation(context);
+
+    return useMemo(() => {
+        if (query.trim().length < OMNIBAR_MIN_QUERY_LENGTH) {
+            return [];
+        }
+
+        return searchSettingsNavigationItemsWithPath(
+            sections,
+            query,
+        ).map<SearchItem>(({ item, path }) => ({
+            type: SearchItemType.SETTINGS,
+            title: item.label,
+            icon: item.icon,
+            contextLabel: path[path.length - 1],
+            location: { pathname: item.to },
+        }));
+    }, [sections, query]);
+};

--- a/packages/frontend/src/features/omnibar/types/searchItem.ts
+++ b/packages/frontend/src/features/omnibar/types/searchItem.ts
@@ -1,4 +1,5 @@
 import { SearchItemType, type SearchResult } from '@lightdash/common';
+import { type Icon as TablerIcon } from '@tabler/icons-react';
 
 // Display order for the omnibar's "Item type" filter dropdown.
 // Data apps slot just above Spaces so they sit alongside the other
@@ -13,6 +14,7 @@ export const allSearchItemTypes: SearchItemType[] = [
     SearchItemType.TABLE,
     SearchItemType.FIELD,
     SearchItemType.PAGE,
+    SearchItemType.SETTINGS,
 ];
 
 export type SearchItem = {
@@ -20,6 +22,8 @@ export type SearchItem = {
     typeLabel?: 'Table' | 'Joined table' | 'Dimension' | 'Metric';
     title: string;
     prefix?: string;
+    contextLabel?: string;
+    icon?: TablerIcon;
     description?: string;
     location: { pathname: string; search?: string };
     item?: SearchResult;

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemLabel.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemLabel.ts
@@ -20,6 +20,8 @@ export const getSearchItemLabel = (itemType: SearchItemType) => {
             return 'SQL Charts';
         case SearchItemType.DATA_APP:
             return 'Data apps';
+        case SearchItemType.SETTINGS:
+            return 'Settings';
         default:
             return assertUnreachable(
                 itemType,

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
@@ -46,7 +46,6 @@ export const getSearchItemMap = (
 
     const savedCharts = results.savedCharts.map<SearchItem>((item) => ({
         type: SearchItemType.CHART,
-        icon: 'chart',
         title: item.name,
         description: item.description,
         item: item,
@@ -58,7 +57,6 @@ export const getSearchItemMap = (
 
     const sqlCharts = results.sqlCharts.map<SearchItem>((item) => ({
         type: SearchItemType.SQL_CHART,
-        icon: 'chart',
         title: item.name,
         description: item.description || undefined,
         item: item,

--- a/packages/frontend/src/features/omnibar/utils/isSearchResultEmpty.ts
+++ b/packages/frontend/src/features/omnibar/utils/isSearchResultEmpty.ts
@@ -1,5 +1,0 @@
-import { type SearchResultMap } from '../types/searchResultMap';
-
-export const isSearchResultEmpty = (searchResult: SearchResultMap) => {
-    return Object.values(searchResult).every((value) => value.length === 0);
-};

--- a/packages/frontend/src/hooks/settings/filterSettingsNavigation.test.ts
+++ b/packages/frontend/src/hooks/settings/filterSettingsNavigation.test.ts
@@ -1,6 +1,9 @@
 import { IconSearch } from '@tabler/icons-react';
 import { describe, expect, it } from 'vitest';
-import { filterSettingsNavigation } from './filterSettingsNavigation';
+import {
+    filterSettingsNavigation,
+    searchSettingsNavigationItemsWithPath,
+} from './filterSettingsNavigation';
 import {
     type SettingsNavigationItem,
     type SettingsNavigationSection,
@@ -138,5 +141,67 @@ describe('filterSettingsNavigation', () => {
 
     it('returns an empty array when nothing matches', () => {
         expect(filterSettingsNavigation(sections, 'zzz')).toEqual([]);
+    });
+});
+
+describe('searchSettingsNavigationItemsWithPath', () => {
+    it('returns an empty array for an empty or whitespace query', () => {
+        expect(searchSettingsNavigationItemsWithPath(sections, '')).toEqual([]);
+        expect(searchSettingsNavigationItemsWithPath(sections, '   ')).toEqual(
+            [],
+        );
+    });
+
+    it('materializes a top-level item path as its section title', () => {
+        const result = searchSettingsNavigationItemsWithPath(
+            sections,
+            'profile',
+        );
+        expect(result.map((r) => r.item.label)).toEqual(['Profile']);
+        expect(result[0].path).toEqual(['Your settings']);
+    });
+
+    it('materializes a nested item path with its section and ancestors', () => {
+        const result = searchSettingsNavigationItemsWithPath(
+            sections,
+            'threads',
+        );
+        const threads = result.find((r) => r.item.label === 'Threads');
+        expect(threads?.path).toEqual(['Organization settings', 'Ask AI']);
+    });
+
+    it('surfaces nested children when an ancestor label matches', () => {
+        const result = searchSettingsNavigationItemsWithPath(
+            sections,
+            'ask ai',
+        );
+        const general = result.find((r) => r.item.label === 'General');
+        expect(general).toBeDefined();
+        expect(general?.path).toEqual(['Organization settings', 'Ask AI']);
+    });
+
+    it('matches every item in a section by its title', () => {
+        const result = searchSettingsNavigationItemsWithPath(
+            sections,
+            'organization',
+        );
+        const labels = result.map((r) => r.item.label);
+        expect(labels).toEqual(
+            expect.arrayContaining([
+                'Single Sign-On',
+                'User attributes',
+                'Ask AI',
+                'General',
+                'Threads',
+                'Agents',
+            ]),
+        );
+        expect(labels).not.toContain('Profile');
+    });
+
+    it('returns an empty array when nothing matches', () => {
+        expect(searchSettingsNavigationItemsWithPath(sections, 'zzz')).toEqual(
+            [],
+        );
     });
 });

--- a/packages/frontend/src/hooks/settings/filterSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/filterSettingsNavigation.ts
@@ -4,22 +4,12 @@ import {
     type SettingsNavigationSection,
 } from './types';
 
+const FUSE_THRESHOLD = 0.3;
+
 const flattenItems = (
     items: SettingsNavigationItem[],
 ): SettingsNavigationItem[] =>
     items.flatMap((item) => [item, ...flattenItems(item.children)]);
-
-const buildFuse = (
-    sections: SettingsNavigationSection[],
-): Fuse<SettingsNavigationItem> =>
-    new Fuse(flattenItems(sections.flatMap((section) => section.items)), {
-        keys: [
-            { name: 'label', weight: 2 },
-            { name: 'keywords', weight: 1 },
-        ],
-        ignoreLocation: true,
-        threshold: 0.3,
-    });
 
 /**
  * Filters the settings nav model by a free-text query using fuzzy matching
@@ -37,11 +27,15 @@ export const filterSettingsNavigation = (
         return sections;
     }
 
-    const matched = new Set(
-        buildFuse(sections)
-            .search(trimmed)
-            .map((result) => result.item),
-    );
+    const fuse = new Fuse(flattenItems(sections.flatMap((s) => s.items)), {
+        keys: [
+            { name: 'label', weight: 2 },
+            { name: 'keywords', weight: 1 },
+        ],
+        ignoreLocation: true,
+        threshold: FUSE_THRESHOLD,
+    });
+    const matched = new Set(fuse.search(trimmed).map((result) => result.item));
 
     const filterItem = (
         item: SettingsNavigationItem,
@@ -71,4 +65,63 @@ export const filterSettingsNavigation = (
                 ),
         }))
         .filter((section) => section.items.length > 0);
+};
+
+export type SettingsNavigationSearchResult = {
+    item: SettingsNavigationItem;
+    /** Section title + ancestor labels, root first (excludes the leaf). */
+    path: string[];
+};
+
+type FlatSettingsEntry = {
+    item: SettingsNavigationItem;
+    sectionTitle: string;
+    ancestors: string[];
+};
+
+const flattenWithAncestors = (
+    items: SettingsNavigationItem[],
+    sectionTitle: string,
+    ancestors: string[],
+): FlatSettingsEntry[] =>
+    items.flatMap((item) => [
+        { item, sectionTitle, ancestors },
+        ...flattenWithAncestors(item.children, sectionTitle, [
+            ...ancestors,
+            item.label,
+        ]),
+    ]);
+
+/**
+ * Flat fuzzy match across every nav destination, each carrying its breadcrumb.
+ * Matches label, keywords, ancestor labels, and section title — so "ask ai" or
+ * "current project" surface the relevant pages.
+ */
+export const searchSettingsNavigationItemsWithPath = (
+    sections: SettingsNavigationSection[],
+    query: string,
+): SettingsNavigationSearchResult[] => {
+    const trimmed = query.trim();
+    if (trimmed === '') {
+        return [];
+    }
+
+    const entries = sections.flatMap((section) =>
+        flattenWithAncestors(section.items, section.title, []),
+    );
+    const fuse = new Fuse(entries, {
+        keys: [
+            { name: 'item.label', weight: 2 },
+            { name: 'item.keywords', weight: 1 },
+            { name: 'ancestors', weight: 1 },
+            { name: 'sectionTitle', weight: 1 },
+        ],
+        ignoreLocation: true,
+        threshold: FUSE_THRESHOLD,
+    });
+
+    return fuse.search(trimmed).map(({ item: entry }) => ({
+        item: entry.item,
+        path: [entry.sectionTitle, ...entry.ancestors],
+    }));
 };


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-471/surface-settings-pages-in-global-search

## Summary

The omnibar (global ⌘K search) indexed content (dashboards, charts, spaces, fields) but never settings, so there was no way to jump to a settings page from app-wide search. This adds a **Settings** result group. Typing "sso", "tokens", "ask ai", or a whole section name like "current project" now lands on the right settings page(s) from anywhere.

Matching runs entirely client-side against the existing settings nav registry (`useSettingsNavigation`), which is already permission-gated, so results never leak a page the user can't reach and no permission-gated routes get indexed server-side.

## How it works

- New `useOmnibarSettingsItems` hook fuzzy-matches the query (Fuse.js, reusing the sidebar's keyword aliases) against the gated nav model and maps hits to `SearchItem`s under a new `SearchItemType.SETTINGS` group, merged after the content groups.
- Each result carries the settings entry's own icon (brain for Ask AI, key for tokens) and the page label, with its parent section as a dimmed subtitle (the Fields two-line pattern), so the two distinct "General" pages read unambiguously.
- Section-name search: label, keywords, ancestor labels, and section title are all match keys, so "ask ai" surfaces its nested pages and "current project" surfaces every current-project setting.
- Settings results always navigate in place (Enter and Cmd-click included), since they are app-internal destinations rather than content worth a new tab.
- `searchSettingsNavigationItemsWithPath` is a new export alongside the sidebar's `filterSettingsNavigation`, sharing one Fuse config. Sidebar behaviour is unchanged.

```
⌘K  ask ai
 ┌──────────────────────────────────────┐
 │ Settings                             │
 │  [brain]  Ask AI                     │
 │           Organization settings      │
 │  [gear]   General                    │
 │           Ask AI                     │
 │  [chat]   Threads                    │
 │           Ask AI                     │
 │  [bot]    Agents                     │
 │           Ask AI                     │
 └──────────────────────────────────────┘
```

## Test plan

- [x] `pnpm -F common typecheck && pnpm -F frontend typecheck`: clean
- [x] `oxlint` (omnibar + settings): 0 warnings / 0 errors; `oxfmt --check`: clean
- [x] `vitest run filterSettingsNavigation.test.ts`: 16/16 (path-aware matcher, section-title search, unchanged sidebar tests)
- [x] Manual: "sso" / "tokens" / "ask ai" surface the right pages with per-entry icons and parent subtitle
- [x] Manual: "current project" / "organization settings" surface the whole section
- [x] Manual: content search unaffected (chart-type icons intact); "Settings" appears in the Item type filter
- [x] Manual: click, Cmd-click, and arrow + Enter on a settings result all navigate in place (no new tab); no console errors from the gating hooks

## Notes

- Permission safety: results derive solely from `useSettingsNavigation`, gated by CASL plus feature flags. Nothing bypasses that gate.
- `useSettingsContext` (read by `useOmnibarSettingsItems`) resolves a batch of feature flags. The omnibar's search box is mounted on every page, so those flags now resolve app-wide rather than only on the settings page. Happy to defer them behind the modal's open state if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)