### PR TITLE
fix(apps): allow data app preview assets under Safari's opaque iframe origin

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -458,9 +458,19 @@ Preview requests use short-lived JWTs (signed with `LIGHTDASH_SECRET`), not sess
 Each preview response includes a strict CSP header:
 
 - `default-src 'none'` — deny everything by default
-- `script-src 'self'` — only execute scripts from the app's own origin
-- `connect-src 'self'` — allow same-origin `fetch`/`XHR` so html-to-image can inline `@font-face` sources and `<img>`/background URLs during [screenshot capture](#screenshot-capture). The iframe's opaque origin (sandboxed without `allow-same-origin`) means those fetches are uncredentialed, so authenticated API calls still only flow through the parent-mediated `postMessage` bridge (which CSP cannot govern, since it is a DOM API and not a network request).
+- `script-src 'self' {servingOrigin}` — only execute scripts from the app's own origin
+- `connect-src 'self' {servingOrigin}` — allow same-origin `fetch`/`XHR` so html-to-image can inline `@font-face` sources and `<img>`/background URLs during [screenshot capture](#screenshot-capture). The iframe's opaque origin (sandboxed without `allow-same-origin`) means those fetches are uncredentialed, so authenticated API calls still only flow through the parent-mediated `postMessage` bridge (which CSP cannot govern, since it is a DOM API and not a network request).
 - `frame-ancestors {lightdashOrigin}` — only allow embedding from Lightdash
+
+> **Why `'self'` isn't enough — the `{servingOrigin}` term.** The iframe is sandboxed
+> *without* `allow-same-origin`, so its document origin is opaque. WebKit/Safari resolves
+> the CSP `'self'` keyword against that opaque origin (which matches nothing) and blocks the
+> app's own scripts, styles, and fetches — the app renders as a blank page. Chromium/Firefox
+> resolve `'self'` against the response URL's origin, so they were unaffected. The fix lists
+> the serving origin explicitly alongside `'self'` on every fetch directive (`script-src`,
+> `style-src`, `connect-src`, `img-src`, `font-src`, `base-uri`). The serving origin is
+> `APP_RUNTIME_PREVIEW_ORIGIN` in production (cross-origin previews) and the same-origin
+> `lightdashOrigin` in dev. See `buildCspHeader` in `appPreviewRouter.ts`.
 
 ---
 

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -32,32 +32,47 @@ const buildCspHeader = (
     config: AppRuntimeConfig,
     frameAncestors: string[],
 ): string => {
-    const { cdnOrigin, cspAllowedOrigins } = config;
+    const { cdnOrigin, cspAllowedOrigins, previewOrigin, lightdashOrigin } =
+        config;
 
-    const extra = cspAllowedOrigins.length
-        ? ` ${cspAllowedOrigins.join(' ')}`
-        : '';
+    // The preview iframe is sandboxed without `allow-same-origin`, so its
+    // document origin is opaque. WebKit/Safari resolves the CSP `'self'`
+    // keyword against that opaque origin — which matches nothing — and blocks
+    // the app's own scripts, styles, and fetches. Chromium/Firefox resolve
+    // `'self'` against the response URL's origin, so they load fine. Listing
+    // the serving origin explicitly alongside `'self'` makes the policy work
+    // in all three. The iframe is served from `previewOrigin` in production
+    // (cross-origin previews) and same-origin (`lightdashOrigin`) in dev.
+    const selfOrigin = previewOrigin || lightdashOrigin;
+
+    // Compose a source list, dropping the null cdnOrigin / empty entries.
+    const sources = (...parts: (string | false | null)[]): string =>
+        ["'self'", selfOrigin, ...parts, cdnOrigin]
+            .filter((s): s is string => Boolean(s))
+            .join(' ');
 
     const directives: string[] = [
         `default-src 'none'`,
-        `script-src 'self'${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
-        `style-src 'self' 'unsafe-inline'${extra}${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
+        `script-src ${sources()}`,
+        `style-src ${sources("'unsafe-inline'", ...cspAllowedOrigins)}`,
         // Allow same-origin fetch so html-to-image can inline @font-face
         // sources and <img>/background URLs when capturing screenshots.
         // The iframe is sandboxed (`allow-scripts allow-modals`) with an
         // opaque origin, so any fetch it makes is uncredentialed and can't
         // exfiltrate user data — the postMessage bridge remains the only
         // path to the authenticated Lightdash API.
-        `connect-src 'self'${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
-        `img-src 'self' data:${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
-        `font-src 'self'${extra}${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
+        `connect-src ${sources()}`,
+        `img-src ${sources('data:')}`,
+        `font-src ${sources(...cspAllowedOrigins)}`,
         `frame-ancestors ${frameAncestors.join(' ')}`,
         `object-src 'none'`,
-        // Constrain <base> to same origin instead of blocking it outright —
-        // html-to-image serializes the cloned DOM into an SVG <foreignObject>
-        // whose rendering can trip a base-uri check, and a `'none'` policy
-        // there aborts the whole screenshot.
-        `base-uri 'self'`,
+        // Constrain <base> to the serving origin instead of blocking it
+        // outright — html-to-image serializes the cloned DOM into an SVG
+        // <foreignObject> whose rendering can trip a base-uri check, and a
+        // `'none'` policy there aborts the whole screenshot. `'self'` alone
+        // fails under Safari's opaque sandbox origin (see above), so the
+        // explicit origin is listed here too.
+        `base-uri ${sources()}`,
     ];
 
     return directives.join('; ');


### PR DESCRIPTION
Closes #24062


### Description:

The preview iframe is sandboxed without `allow-same-origin`, so its document origin is opaque. WebKit/Safari resolves the CSP `'self'` keyword against that opaque origin (which matches nothing) and refuses the app's own scripts, styles, and fetches — the app renders blank. Chromium/Firefox resolve `'self'` against the response URL's origin, so they were unaffected.

List the serving origin (`previewOrigin || lightdashOrigin`) explicitly alongside `'self'` on every fetch directive. It's the same origin the bundle is already served from, so this adds no new trusted origin and is purely additive.