### PR TITLE
fix(scheduler): deep-link gsheets failure alerts to the sync's run history

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2935,7 +2935,7 @@ export default class SchedulerTask {
         let account: AccountType | undefined;
         let scheduler: SchedulerAndTargets | undefined;
 
-        let deliveryUrl = this.lightdashConfig.siteUrl;
+        let deliveryUrl = `${this.lightdashConfig.siteUrl}/generalSettings/projectManagement/${notification.projectUuid}/scheduledDeliveries?tab=scheduled-deliveries&schedulerUuid=${schedulerUuid}`;
         try {
             if (!this.googleDriveClient.isEnabled) {
                 throw new MissingConfigError(


### PR DESCRIPTION
### Description

The "Open in Lightdash" link in the Google Sheets sync failure notification fell back to the bare site URL for failures that happen before the chart/dashboard view URL is built (e.g. config or lookup errors).

`deliveryUrl` now initialises to the scheduled-deliveries **run history, filtered to the failing scheduler** (using the payload's `projectUuid` + `schedulerUuid`), so the alert always links somewhere useful and lands you on that sync's runs. The specific resource view still overrides it for failures that occur later in the task.


