### PR TITLE
feat(github): detect, log, and surface API rate limits

### DIFF
--- a/packages/backend/src/clients/github/Github.test.ts
+++ b/packages/backend/src/clients/github/Github.test.ts
@@ -1,0 +1,64 @@
+import { isGithubRateLimitError } from './Github';
+
+const octokitError = (
+    status: number,
+    headers: Record<string, string> = {},
+    message = 'Request failed',
+): Error =>
+    Object.assign(new Error(message), { status, response: { headers } });
+
+describe('isGithubRateLimitError', () => {
+    it('detects a primary limit (403 with x-ratelimit-remaining: 0)', () => {
+        expect(
+            isGithubRateLimitError(
+                octokitError(403, { 'x-ratelimit-remaining': '0' }),
+            ),
+        ).toBe(true);
+    });
+
+    it('detects a secondary limit (429)', () => {
+        expect(isGithubRateLimitError(octokitError(429))).toBe(true);
+    });
+
+    it('detects a secondary limit (403 with retry-after)', () => {
+        expect(
+            isGithubRateLimitError(octokitError(403, { 'retry-after': '60' })),
+        ).toBe(true);
+    });
+
+    it('detects a rate limit by message', () => {
+        expect(
+            isGithubRateLimitError(
+                octokitError(
+                    403,
+                    {},
+                    'API rate limit exceeded for installation',
+                ),
+            ),
+        ).toBe(true);
+    });
+
+    it('is false for a 404 (missing file)', () => {
+        expect(isGithubRateLimitError(octokitError(404, {}, 'Not Found'))).toBe(
+            false,
+        );
+    });
+
+    it('is false for a permission 403 with quota remaining', () => {
+        expect(
+            isGithubRateLimitError(
+                octokitError(
+                    403,
+                    { 'x-ratelimit-remaining': '4999' },
+                    'Resource not accessible by integration',
+                ),
+            ),
+        ).toBe(false);
+    });
+
+    it('is false for a generic error / non-octokit value', () => {
+        expect(isGithubRateLimitError(new Error('socket hang up'))).toBe(false);
+        expect(isGithubRateLimitError(null)).toBe(false);
+        expect(isGithubRateLimitError(undefined)).toBe(false);
+    });
+});

--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -172,6 +172,55 @@ export const getLastCommit = async ({
     return response.data[0];
 };
 
+/**
+ * True when a thrown octokit error is a rate-limit response. GitHub signals it
+ * two ways: a primary limit (403 with `x-ratelimit-remaining: 0`) and a
+ * secondary/burst limit (429, or 403 carrying a `retry-after` header, or a
+ * "rate limit" message). Checked at the throw site because callers wrap the
+ * error into UnexpectedGitError (dropping status + headers) downstream.
+ */
+export const isGithubRateLimitError = (error: unknown): boolean => {
+    const status = (error as { status?: number } | null)?.status;
+    const responseHeaders =
+        (error as { response?: { headers?: Record<string, string> } } | null)
+            ?.response?.headers ?? {};
+    const remaining = responseHeaders['x-ratelimit-remaining'];
+    const retryAfter = responseHeaders['retry-after'];
+    return (
+        status === 429 ||
+        (status === 403 && (remaining === '0' || retryAfter !== undefined)) ||
+        /rate limit/i.test(getErrorMessage(error))
+    );
+};
+
+/**
+ * Log a rate-limit response loudly (with the reset/retry hints) so throttling is
+ * never silent — several callers swallow or wrap the underlying error. No-op for
+ * non-rate-limit errors. `context` identifies the call site (e.g. the path).
+ */
+const logGithubRateLimit = (error: unknown, context: string): void => {
+    if (!isGithubRateLimitError(error)) return;
+    const responseHeaders =
+        (error as { response?: { headers?: Record<string, string> } } | null)
+            ?.response?.headers ?? {};
+    const status = (error as { status?: number } | null)?.status;
+    Logger.warn(
+        `[github] rate limit hit (${context}): status=${
+            status ?? '?'
+        } remaining=${responseHeaders['x-ratelimit-remaining'] ?? '?'} retryAfter=${
+            responseHeaders['retry-after'] ?? '?'
+        } reset=${responseHeaders['x-ratelimit-reset'] ?? '?'}`,
+        {
+            event: 'github.rate_limit',
+            context,
+            status,
+            remaining: responseHeaders['x-ratelimit-remaining'],
+            retryAfter: responseHeaders['retry-after'],
+            reset: responseHeaders['x-ratelimit-reset'],
+        },
+    );
+};
+
 export const getFileContent = async ({
     fileName,
     owner,
@@ -218,6 +267,7 @@ export const getFileContent = async ({
         ) {
             throw new NotFoundError(`file ${fileName} not found in Github`);
         }
+        logGithubRateLimit(error, `getContent ${fileName}`);
         throw new UnexpectedGitError(getErrorMessage(error));
     }
 };
@@ -277,6 +327,7 @@ export const getRepoTree = async ({
                 `repo ${owner}/${repo} (ref ${branch}) not found in Github`,
             );
         }
+        logGithubRateLimit(error, `getTree ${owner}/${repo}@${branch}`);
         throw new UnexpectedGitError(getErrorMessage(error));
     }
 };

--- a/packages/backend/src/ee/services/ai/repoFs/githubRepoSource.test.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/githubRepoSource.test.ts
@@ -1,0 +1,62 @@
+import { NotFoundError, UnexpectedGitError } from '@lightdash/common';
+import { getFileContent } from '../../../../clients/github/Github';
+import { createGithubRepoSource } from './githubRepoSource';
+
+jest.mock('../../../../clients/github/Github');
+
+const mockGetFileContent = getFileContent as jest.MockedFunction<
+    typeof getFileContent
+>;
+
+const source = () =>
+    createGithubRepoSource({
+        owner: 'acme',
+        repo: 'jaffle',
+        branch: 'main',
+        token: 'tok',
+    });
+
+describe('githubRepoSource.readFile error handling', () => {
+    beforeEach(() => {
+        mockGetFileContent.mockReset();
+    });
+
+    it('returns content for a found file', async () => {
+        mockGetFileContent.mockResolvedValue({
+            content: 'select 1 as id',
+            sha: 'abc',
+        });
+        await expect(source().readFile('models/x.sql')).resolves.toBe(
+            'select 1 as id',
+        );
+    });
+
+    it('returns null for a missing / too-large file (NotFoundError)', async () => {
+        mockGetFileContent.mockRejectedValue(
+            new NotFoundError('file not found in Github'),
+        );
+        await expect(
+            source().readFile('models/missing.sql'),
+        ).resolves.toBeNull();
+    });
+
+    it('re-throws a rate limit instead of returning null (no silent empty)', async () => {
+        // Simulated GitHub throttle: getFileContent wraps the 403/429 into
+        // UnexpectedGitError. readFile must surface it, not treat it as absent.
+        mockGetFileContent.mockRejectedValue(
+            new UnexpectedGitError('API rate limit exceeded for installation'),
+        );
+        await expect(source().readFile('models/x.sql')).rejects.toThrow(
+            'rate limit',
+        );
+    });
+
+    it('re-throws other unexpected errors (network / 5xx)', async () => {
+        mockGetFileContent.mockRejectedValue(
+            new UnexpectedGitError('socket hang up'),
+        );
+        await expect(source().readFile('models/x.sql')).rejects.toThrow(
+            'socket hang up',
+        );
+    });
+});

--- a/packages/backend/src/ee/services/ai/repoFs/githubRepoSource.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/githubRepoSource.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage, NotFoundError } from '@lightdash/common';
 import { getFileContent, getRepoTree } from '../../../../clients/github/Github';
 import Logger from '../../../../logging/logger';
 import { RepoSource } from './RepoFs';
@@ -87,17 +88,36 @@ export const createGithubRepoSource = ({
                     },
                 );
                 return content;
-            } catch {
+            } catch (error) {
                 const durationMs = Date.now() - start;
-                Logger.debug(
-                    `[repoShell] github file miss in ${durationMs}ms: ${prefix}${path}`,
+                // getFileContent throws NotFoundError for a genuine 404 — and
+                // also for too-large/binary files (no inline content) — which the
+                // RepoSource contract represents as `null` (absent).
+                if (error instanceof NotFoundError) {
+                    Logger.debug(
+                        `[repoShell] github file miss in ${durationMs}ms: ${prefix}${path}`,
+                        {
+                            event: 'ai.repofs.github.file_miss',
+                            path: `${prefix}${path}`,
+                            durationMs,
+                        },
+                    );
+                    return null;
+                }
+                // Anything else (rate limit, network, 5xx) is NOT "file absent".
+                // Returning null here would make grep/cat silently behave as if
+                // the file were empty — wrong results with no signal. Surface it.
+                Logger.warn(
+                    `[repoShell] github file read failed in ${durationMs}ms: ${prefix}${path} — ${getErrorMessage(
+                        error,
+                    )}`,
                     {
-                        event: 'ai.repofs.github.file_miss',
+                        event: 'ai.repofs.github.file_error',
                         path: `${prefix}${path}`,
                         durationMs,
                     },
                 );
-                return null;
+                throw error;
             }
         },
     };

--- a/packages/backend/src/ee/services/ai/repoFs/limitedShell.test.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/limitedShell.test.ts
@@ -231,6 +231,27 @@ describe('repoFs limited shell', () => {
         expect(calls).toEqual([]); // never hit the Contents API
     });
 
+    it('surfaces a read failure (e.g. rate limit) instead of treating the file as empty', async () => {
+        // A source that throws on read (simulating a GitHub rate limit) must make
+        // the command error, not silently behave as if the file had no matches.
+        const rateLimitedSource: RepoSource = {
+            label: 'acme/jaffle@main',
+            listAllPaths: async () => ({
+                files: [{ path: 'models/orders.sql', size: 10 }],
+                truncated: false,
+            }),
+            readFile: async () => {
+                throw new Error('API rate limit exceeded');
+            },
+        };
+        await expect(
+            runRepoShellCommand(
+                new RepoFs(rateLimitedSource),
+                'grep -rl select models',
+            ),
+        ).rejects.toThrow('rate limit');
+    });
+
     it('refuses to escape the chroot via .. even on a truncated tree', async () => {
         const reads: string[] = [];
         const truncatedSource: RepoSource = {


### PR DESCRIPTION
## Why

A GitHub API rate-limit response is currently **invisible**: `getRepoTree`/`getFileContent` wrap non-404 errors into `UnexpectedGitError` (dropping octokit's `status` + headers), and repoShell's reader then swallows that into a `null` "missing file". So throttling silently produces wrong results (e.g. a grep reports no matches in a file it was actually blocked from reading) with no signal in logs.

This matters because repoShell crawls can burst: reads run at concurrency 10 (~50/s), so a large crawl can exceed GitHub's secondary limit (~900 reads/min per endpoint) and chip at the per-installation primary budget (5,000/hr, shared with writeback etc.).

## What

Detect rate limits **at the throw site**, where octokit's status + headers still exist, and log a `WARN` with the `retry-after` / `reset` / `remaining` hints:
- `isGithubRateLimitError(error)` (exported, unit-tested) — true for primary limits (403 + `x-ratelimit-remaining: 0`) and secondary/burst limits (429, 403 + `retry-after`, or a "rate limit" message). Permission-403s and 404s are not misclassified.
- `logGithubRateLimit(error, context)` — logs once for both the recursive tree fetch and per-file Contents reads; no-op otherwise.

Behaviour is otherwise unchanged (still throws `UnexpectedGitError`) — this only adds the log so throttling is never missed.

## Testing

- `Github.test.ts` (new): 7 cases for the detector (primary, secondary x2, message-based, 404, permission-403, non-octokit). All pass.
- backend typecheck + lint clean.
- Note: a real GitHub 429 can't be forced locally, so the detector is verified by unit tests rather than a live run.

Follow-up (not in this PR): repoShell's reader still returns `null` on a rate-limited read (treats it as a missing file) — now logged, but could re-throw to surface it instead of silently emptying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added: surface read failures instead of silent empty files

`githubRepoSource.readFile` caught *every* error and returned `null`, so a rate limit (or network/5xx) on a per-file read was indistinguishable from a missing file — `grep`/`cat` silently behaved as if the file were empty.

Now only `NotFoundError` (genuine 404, and too-large/binary files per the `RepoSource` contract) maps to `null`; anything else is logged at `warn` (with the path) and **re-thrown**, so the command fails visibly.

*Simulated test:* `githubRepoSource.test.ts` mocks `getFileContent` to throw `UnexpectedGitError('API rate limit exceeded')` → `readFile` re-throws (not null); `NotFoundError` → null; plus an end-to-end `limitedShell` case where a throwing read makes `grep` error rather than return empty.
