### PR TITLE
fix(backend): resolve rollback migration files locally before GitHub

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -173,7 +173,7 @@ pnpm -F backend migrate-or-rollback-database
 #### What it does
 
 1. **Checks Migration Status**: Analyzes current database migration state
-2. **Handles Missing Files**: Downloads missing migration files from GitHub if needed
+2. **Handles Missing Files**: Resolves missing migration files from the local image first, falling back to downloading and transpiling the TypeScript source from GitHub
 3. **Executes Operations**: Runs migrations forward or rollbacks as required
 4. **Cleanup**: Removes temporary downloaded files
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -166,6 +166,7 @@
         "simple-git": "3.36.0",
         "slackify-markdown": "4.4.0",
         "sshpk": "1.18.0",
+        "sucrase": "3.35.1",
         "tar-stream": "3.1.8",
         "uuid": "8.3.2",
         "vitest": "4.1.6",

--- a/packages/backend/src/migrateOrRollbackDatabase.test.ts
+++ b/packages/backend/src/migrateOrRollbackDatabase.test.ts
@@ -1,0 +1,86 @@
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as https from 'https';
+import * as path from 'path';
+
+jest.mock('https');
+jest.mock('./knexfile', () => ({
+    __esModule: true,
+    default: { development: {}, production: {} },
+}));
+
+// eslint-disable-next-line import/first
+import { resolveMigrationFile } from './migrateOrRollbackDatabase';
+
+const TEMP_DIR = path.join(__dirname, '..', '..', 'temp_migrations');
+const mockedGet = https.get as unknown as jest.Mock;
+
+function mockHttpsGet(statusCode: number, body: string) {
+    mockedGet.mockImplementation((_url: unknown, cb: unknown) => {
+        const res = new EventEmitter() as EventEmitter & {
+            statusCode: number;
+        };
+        res.statusCode = statusCode;
+        process.nextTick(() => {
+            (cb as (r: typeof res) => void)(res);
+            res.emit('data', body);
+            res.emit('end');
+        });
+        return new EventEmitter();
+    });
+    return mockedGet;
+}
+
+afterEach(() => {
+    jest.clearAllMocks();
+    fs.rmSync(TEMP_DIR, { recursive: true, force: true });
+});
+
+describe('resolveMigrationFile', () => {
+    it('uses the local EE migration file when present (license-removed case)', async () => {
+        const name = '20231214111216_embedding.ts';
+        const result = await resolveMigrationFile(name);
+
+        expect(result).toBe(path.join(TEMP_DIR, name));
+        expect(fs.readFileSync(result, 'utf8')).toContain(
+            'export async function up',
+        );
+    });
+
+    it('downloads and transpiles .ts from GitHub when absent locally (version-downgrade case)', async () => {
+        const tsSource = [
+            "import { Knex } from 'knex';",
+            'export async function up(knex: Knex): Promise<void> {',
+            "    await knex.raw('SELECT 1');",
+            '}',
+            'export async function down(knex: Knex): Promise<void> {',
+            "    await knex.raw('SELECT 2');",
+            '}',
+        ].join('\n');
+        const spy = mockHttpsGet(200, tsSource);
+
+        const name = '99999999999999_absent_locally.js';
+        const result = await resolveMigrationFile(name);
+
+        expect(result).toBe(path.join(TEMP_DIR, name));
+        // It must request the .ts source, not the (uncommitted) .js artifact
+        expect(String(spy.mock.calls[0][0])).toContain(
+            'database/migrations/99999999999999_absent_locally.ts',
+        );
+
+        const compiled = fs.readFileSync(result, 'utf8');
+        expect(compiled).not.toContain(': Promise<void>'); // types stripped
+        // eslint-disable-next-line import/no-dynamic-require, global-require
+        const mod = require(result);
+        expect(typeof mod.up).toBe('function');
+        expect(typeof mod.down).toBe('function');
+    });
+
+    it('throws when the migration is found neither locally nor on GitHub', async () => {
+        mockHttpsGet(404, '404: Not Found');
+
+        await expect(
+            resolveMigrationFile('88888888888888_missing.js'),
+        ).rejects.toThrow(/not found in the local image or on GitHub/);
+    });
+});

--- a/packages/backend/src/migrateOrRollbackDatabase.ts
+++ b/packages/backend/src/migrateOrRollbackDatabase.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as https from 'https';
 import knex from 'knex';
 import * as path from 'path';
+import { transform } from 'sucrase';
 import knexConfig from './knexfile';
 
 // Determine the environment
@@ -16,7 +17,19 @@ const GITHUB_CONFIG = {
     baseUrl: 'https://raw.githubusercontent.com',
 };
 
-// Temporary directory for downloaded files
+// Compiled migration directories that ship inside the image (relative to this file).
+const LOCAL_MIGRATION_DIRS = [
+    path.join(__dirname, 'database', 'migrations'),
+    path.join(__dirname, 'ee', 'database', 'migrations'),
+];
+
+// Source migration directories on GitHub, used as a fallback for missing files.
+const GITHUB_MIGRATION_BASE_PATHS = [
+    'packages/backend/src/database/migrations',
+    'packages/backend/src/ee/database/migrations',
+];
+
+// Temporary directory for resolved files
 const MIGRATIONS_TEMP_DIR = path.join(__dirname, '..', '..', 'temp_migrations');
 
 /**
@@ -43,42 +56,49 @@ function httpsGet(url: string): Promise<string> {
 }
 
 /**
- * Download a migration file from GitHub
- * Tries both regular and EE migration paths automatically
+ * Resolve a migration file into the temp directory so its `down` can run.
+ * Local disk first (EE files that ship in the image but are dropped from the
+ * knexfile when the license key is removed); otherwise download the `.ts` source
+ * from GitHub and transpile it (files absent after an image version downgrade).
  */
-async function downloadMigrationFile(
+export async function resolveMigrationFile(
     migrationName: string,
-    isEE: boolean = false,
 ): Promise<string> {
-    // Define both possible base paths
-    const basePaths = [
-        'packages/backend/src/database/migrations',
-        'packages/backend/src/ee/database/migrations',
-    ];
-
-    const regularBasePath = basePaths[isEE ? 1 : 0];
-    const regularUrl = `${GITHUB_CONFIG.baseUrl}/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/refs/heads/${GITHUB_CONFIG.branch}/${regularBasePath}/${migrationName}`;
-    console.log(`📥 Downloading from ${regularUrl}`);
-    try {
-        const content = await httpsGet(regularUrl);
-
-        // Ensure temp directory exists
-        if (!fs.existsSync(MIGRATIONS_TEMP_DIR)) {
-            fs.mkdirSync(MIGRATIONS_TEMP_DIR, { recursive: true });
-        }
-
-        const localPath = path.join(MIGRATIONS_TEMP_DIR, migrationName);
-        fs.writeFileSync(localPath, content);
-
-        return localPath;
-    } catch (error) {
-        if (!isEE) {
-            // Try EE migrations directory if regular path fails
-            console.log(`📥 Not found. Trying EE migrations directory...`);
-            return downloadMigrationFile(migrationName, true);
-        }
-        throw error;
+    if (!fs.existsSync(MIGRATIONS_TEMP_DIR)) {
+        fs.mkdirSync(MIGRATIONS_TEMP_DIR, { recursive: true });
     }
+    const tempPath = path.join(MIGRATIONS_TEMP_DIR, migrationName);
+
+    for (const dir of LOCAL_MIGRATION_DIRS) {
+        const localPath = path.join(dir, migrationName);
+        if (fs.existsSync(localPath)) {
+            console.log(`📂 Using local migration ${migrationName}`);
+            fs.copyFileSync(localPath, tempPath);
+            return tempPath;
+        }
+    }
+
+    const tsName = migrationName.replace(/\.js$/, '.ts');
+    for (const basePath of GITHUB_MIGRATION_BASE_PATHS) {
+        const url = `${GITHUB_CONFIG.baseUrl}/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/refs/heads/${GITHUB_CONFIG.branch}/${basePath}/${tsName}`;
+        try {
+            /* eslint-disable no-await-in-loop */
+            const source = await httpsGet(url);
+            /* eslint-enable no-await-in-loop */
+            console.log(`🌐 Transpiling downloaded ${tsName}`);
+            const { code } = transform(source, {
+                transforms: ['typescript', 'imports'],
+            });
+            fs.writeFileSync(tempPath, code);
+            return tempPath;
+        } catch {
+            // Try the next base path
+        }
+    }
+
+    throw new Error(
+        `Migration ${migrationName} not found in the local image or on GitHub (${tsName})`,
+    );
 }
 
 function cleanup() {
@@ -143,23 +163,23 @@ async function main(): Promise<void> {
                 const migrationName = migrationsToRollback[i];
                 try {
                     console.log(
-                        `📥 Downloading ${migrationName} (${i + 1}/${
+                        `🔎 Resolving ${migrationName} (${i + 1}/${
                             migrationsToRollback.length
                         })`,
                     );
                     /* eslint-disable no-await-in-loop */
-                    const downloadedFile =
-                        await downloadMigrationFile(migrationName);
+                    const resolvedFile =
+                        await resolveMigrationFile(migrationName);
                     /* eslint-enable no-await-in-loop */
-                    downloadResults.push(downloadedFile);
+                    downloadResults.push(resolvedFile);
                 } catch (error) {
                     const errorMessage =
                         error instanceof Error ? error.message : String(error);
                     console.error(
-                        `❌ Failed to download ${migrationName}: ${errorMessage}`,
+                        `❌ Failed to resolve ${migrationName}: ${errorMessage}`,
                     );
                     throw new Error(
-                        `Failed to download ${migrationName}: ${errorMessage}`,
+                        `Failed to resolve ${migrationName}: ${errorMessage}`,
                     );
                 }
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,7 +246,7 @@ importers:
         version: 1.5.4(ai@6.0.71(zod@3.25.55))(zod@3.25.55)
       '@rudderstack/rudder-sdk-node':
         specifier: 2.1.1
-        version: 2.1.1(tslib@2.8.1)
+        version: 2.1.1(tslib@2.6.2)
       '@sentry/core':
         specifier: 9.31.0
         version: 9.31.0
@@ -508,6 +508,9 @@ importers:
       sshpk:
         specifier: 1.18.0
         version: 1.18.0
+      sucrase:
+        specifier: 3.35.1
+        version: 3.35.1
       tar-stream:
         specifier: 3.1.8
         version: 3.1.8
@@ -516,7 +519,7 @@ importers:
         version: 8.3.2
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.2(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
       winston:
         specifier: 3.13.0
         version: 3.13.0
@@ -634,7 +637,7 @@ importers:
         version: 3.1.9
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@22.13.1)(typescript@6.0.3)
+        version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -710,7 +713,7 @@ importers:
         version: 9.15.1(encoding@0.1.13)
       inquirer:
         specifier: 8.2.7
-        version: 8.2.7(@types/node@22.13.1)
+        version: 8.2.7(@types/node@24.3.1)
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
@@ -777,7 +780,7 @@ importers:
         version: 6.7.0(encoding@0.1.13)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@22.13.1)(typescript@6.0.3)
+        version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -7655,6 +7658,9 @@ packages:
     peerDependencies:
       antlr4ng-cli: 1.0.7
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   anymatch@3.1.2:
     resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
     engines: {node: '>= 8'}
@@ -8525,6 +8531,10 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
@@ -12542,6 +12552,9 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nan@2.18.0:
     resolution: {integrity: sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==}
 
@@ -15159,6 +15172,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   sugarss@5.0.1:
     resolution: {integrity: sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==}
     engines: {node: '>=18.0'}
@@ -15281,6 +15299,13 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   thrift@0.16.0:
     resolution: {integrity: sha512-W8DpGyTPlIaK3f+e1XOCLxefaUWXtrOXAaVIDbfYhmVyriYeAKgsBVFNJUV1F9SQ2SPt2sG44AZQxSGwGj/3VA==}
@@ -15443,6 +15468,9 @@ packages:
   ts-easing@0.2.0:
     resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
 
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   ts-jest@29.1.1:
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -15496,6 +15524,9 @@ packages:
 
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
+  tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -19465,12 +19496,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.13.1)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.3.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.0
     optionalDependencies:
-      '@types/node': 22.13.1
+      '@types/node': 24.3.1
 
   '@ioredis/commands@1.2.0':
     optional: true
@@ -21276,7 +21307,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
-  '@rudderstack/rudder-sdk-node@2.1.1(tslib@2.8.1)':
+  '@rudderstack/rudder-sdk-node@2.1.1(tslib@2.6.2)':
     dependencies:
       axios: 1.16.0
       axios-retry: 4.5.0(axios@1.16.0)
@@ -21288,7 +21319,7 @@ snapshots:
       ms: 2.1.3
       remove-trailing-slash: 0.1.1
       serialize-javascript: 6.0.2
-      tslib: 2.8.1
+      tslib: 2.6.2
       uuid: 11.0.2
     optionalDependencies:
       bull: 4.16.4
@@ -23165,7 +23196,6 @@ snapshots:
   '@types/node@24.3.1':
     dependencies:
       undici-types: 7.10.0
-    optional: true
 
   '@types/nodemailer@7.0.9':
     dependencies:
@@ -23798,14 +23828,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@7.3.2(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)
-
   '@vitest/mocker@4.1.6(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.6
@@ -24133,6 +24155,8 @@ snapshots:
   antlr4ng@2.0.11(antlr4ng-cli@1.0.7):
     dependencies:
       antlr4ng-cli: 1.0.7
+
+  any-promise@1.3.0: {}
 
   anymatch@3.1.2:
     dependencies:
@@ -25109,6 +25133,8 @@ snapshots:
   commander@2.15.1: {}
 
   commander@2.20.3: {}
+
+  commander@4.1.1: {}
 
   commander@5.1.0: {}
 
@@ -28130,9 +28156,9 @@ snapshots:
     dependencies:
       css-in-js-utils: 3.1.0
 
-  inquirer@8.2.7(@types/node@22.13.1):
+  inquirer@8.2.7(@types/node@24.3.1):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@22.13.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.3.1)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -30323,6 +30349,12 @@ snapshots:
   mustache@4.2.0: {}
 
   mute-stream@0.0.8: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nan@2.18.0:
     optional: true
@@ -33474,6 +33506,16 @@ snapshots:
     dependencies:
       commander: 12.1.0
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.1.6
+      mz: 2.7.0
+      pirates: 4.0.4
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
   sugarss@5.0.1(postcss@8.5.10):
     dependencies:
       postcss: 8.5.10
@@ -33628,6 +33670,14 @@ snapshots:
 
   text-table@0.2.0: {}
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   thrift@0.16.0:
     dependencies:
       browser-or-node: 1.3.0
@@ -33763,6 +33813,8 @@ snapshots:
 
   ts-easing@0.2.0: {}
 
+  ts-interface-checker@0.1.13: {}
+
   ts-jest@29.1.1(@babel/core@7.28.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@22.13.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@22.13.1)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
@@ -33799,6 +33851,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.13.5
+    optional: true
 
   ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(typescript@6.0.3):
     dependencies:
@@ -33819,7 +33872,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.13.5
-    optional: true
 
   ts-unused-exports@9.0.4(typescript@6.0.3):
     dependencies:
@@ -33843,6 +33895,8 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.3.0: {}
+
+  tslib@2.6.2: {}
 
   tslib@2.8.1: {}
 
@@ -33997,8 +34051,7 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici-types@7.10.0:
-    optional: true
+  undici-types@7.10.0: {}
 
   undici@6.24.1: {}
 
@@ -34617,24 +34670,6 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@7.3.2(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rollup: 4.60.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.13.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.32.0
-      sugarss: 5.0.1(postcss@8.5.10)
-      terser: 5.46.1
-      tsx: 4.19.4
-      yaml: 2.8.3
-
   vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
@@ -34672,35 +34707,6 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
-
-  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.2(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.3.2(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 22.13.1
-      jsdom: 24.0.0(canvas@3.2.1)
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- no Linear ticket / GitHub issue for this change -->

### Description:

The `migrate-or-rollback-database` tool downloaded missing migration files from GitHub as `.js`, but the repo only commits `.ts` (the `.js` are build artifacts), so every download 404'd on a production image. It now resolves each missing migration from the local image first — handling EE migrations that are dropped from the knexfile when the license key is removed — and falls back to downloading the `.ts` source and transpiling it to CommonJS with `sucrase`, which handles files that are absent after an image version downgrade. Adds a unit test covering the local-first path, the download-and-transpile fallback, and the not-found case, and updates the backend README accordingly.