### PR TITLE
refactor(explorer): extract VirtualizedTreeList inline styles to CSS module

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.module.css
@@ -1,0 +1,29 @@
+.scrollContainer {
+    height: 100%;
+    overflow: auto;
+}
+
+/* Breathing room below the last item so a short or fully-scrolled tree reads
+   as ended rather than being clipped by the viewport. */
+.scrollContainer::after {
+    content: '';
+    display: block;
+    height: 40px;
+}
+
+/* Spacer sized to the virtualizer's total height (set inline); positions the
+   absolutely-placed tree items. */
+.sizer {
+    position: relative;
+    width: 100%;
+}
+
+.item {
+    top: 0;
+    left: 0;
+    width: 100%;
+}
+
+.item[data-sticky-header] {
+    z-index: 1;
+}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.tsx
@@ -3,6 +3,7 @@ import type { Range } from '@tanstack/react-virtual';
 import { defaultRangeExtractor, useVirtualizer } from '@tanstack/react-virtual';
 import { memo, useCallback, useMemo, useRef, type FC } from 'react';
 import type { FlattenedTreeData } from './types';
+import classes from './VirtualizedTreeList.module.css';
 import VirtualTreeItem from './VirtualTreeItem';
 
 interface VirtualizedTreeListProps {
@@ -105,17 +106,11 @@ const VirtualizedTreeListComponent: FC<VirtualizedTreeListProps> = ({
             <div
                 ref={parentRef}
                 data-testid="virtualized-tree-scroll-container"
-                style={{
-                    height: '100%',
-                    overflow: 'auto',
-                }}
+                className={classes.scrollContainer}
             >
                 <div
-                    style={{
-                        height: `${virtualizer.getTotalSize()}px`,
-                        width: '100%',
-                        position: 'relative',
-                    }}
+                    className={classes.sizer}
+                    style={{ height: `${virtualizer.getTotalSize()}px` }}
                 >
                     {virtualItems.map((virtualItem) => {
                         const item = items[virtualItem.index];
@@ -128,24 +123,16 @@ const VirtualizedTreeListComponent: FC<VirtualizedTreeListProps> = ({
                             <div
                                 key={item.id}
                                 data-index={virtualItem.index}
-                                style={{
-                                    ...(isStickyItem
-                                        ? {
-                                              zIndex: 1,
-                                          }
-                                        : {}),
-                                    ...(isActiveStickyItem
-                                        ? {
-                                              position: 'sticky',
-                                          }
+                                data-sticky-header={isStickyItem || undefined}
+                                className={classes.item}
+                                style={
+                                    isActiveStickyItem
+                                        ? { position: 'sticky' }
                                         : {
                                               position: 'absolute',
                                               transform: `translateY(${virtualItem.start}px)`,
-                                          }),
-                                    top: 0,
-                                    left: 0,
-                                    width: '100%',
-                                }}
+                                          }
+                                }
                             >
                                 <VirtualTreeItem
                                     item={item}


### PR DESCRIPTION
Closes #24060
Linear: PROD-8196

### Description:

The custom dimensions section of the explore sidebar (and the tree as a whole) ended flush against the bottom of the viewport, making a short or fully-scrolled list look clipped rather than ended.

Adds breathing room below the last item via a `::after` spacer on the scroll container, so there is a clear visual gap signalling the end of the list.

While here, extracted the static inline styles from `VirtualizedTreeList` into a CSS module (`VirtualizedTreeList.module.css`):
- scroll container, sizer, and item positioning styles moved to classes
- sticky-header `z-index` now driven by a `data-sticky-header` attribute selector

Only genuinely dynamic styles (virtualizer height, per-item `translateY`, and the conditional sticky/absolute position) remain inline.