### PR TITLE
feat(comments): resolve & unresolve dashboard tile comment threads

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1456,7 +1456,11 @@ export type AiWritebackEvent =
     | AiWritebackFailedEvent;
 
 export type CommentsEvent = BaseTrack & {
-    event: 'comment.created' | 'comment.deleted' | 'comment.resolved';
+    event:
+        | 'comment.created'
+        | 'comment.deleted'
+        | 'comment.resolved'
+        | 'comment.unresolved';
     userId: string;
     properties: {
         dashboardTileUuid: string;

--- a/packages/backend/src/controllers/commentsController.ts
+++ b/packages/backend/src/controllers/commentsController.ts
@@ -15,6 +15,7 @@ import {
     Patch,
     Path,
     Post,
+    Query,
     Request,
     Response,
     Route,
@@ -89,6 +90,7 @@ export class CommentsController extends BaseController {
     async getComments(
         @Path() dashboardUuidOrSlug: string,
         @Request() req: express.Request,
+        @Query() resolved?: boolean,
     ): Promise<ApiGetComments> {
         assertRegisteredAccount(req.account);
         const results = await this.services
@@ -96,6 +98,7 @@ export class CommentsController extends BaseController {
             .findCommentsForDashboard(
                 toSessionUser(req.account),
                 dashboardUuidOrSlug,
+                { resolved },
             );
         this.setStatus(200);
         return {
@@ -105,11 +108,12 @@ export class CommentsController extends BaseController {
     }
 
     /**
-     * Resolves a comment on a dashboard
+     * Resolves or unresolves a comment on a dashboard
      * @summary Resolve comment
      * @param req express request
      * @param dashboardUuid the uuid of the dashboard
      * @param commentId the uuid of the comment
+     * @param body whether the comment should be resolved
      */
     @Middlewares([
         allowApiKeyAuthentication,
@@ -123,6 +127,7 @@ export class CommentsController extends BaseController {
         @Path() dashboardUuid: string,
         @Path() commentId: string,
         @Request() req: express.Request,
+        @Body() body: { resolved: boolean },
     ): Promise<ApiResolveComment> {
         assertRegisteredAccount(req.account);
         await this.services
@@ -131,6 +136,7 @@ export class CommentsController extends BaseController {
                 toSessionUser(req.account),
                 dashboardUuid,
                 commentId,
+                body.resolved,
             );
         this.setStatus(200);
         return {

--- a/packages/backend/src/controllers/v2/ProjectDashboardController.ts
+++ b/packages/backend/src/controllers/v2/ProjectDashboardController.ts
@@ -14,6 +14,7 @@ import {
     OperationId,
     Patch,
     Path,
+    Query,
     Request,
     Response,
     Route,
@@ -134,6 +135,7 @@ export class ProjectDashboardControllerV2 extends BaseController {
         @Path() projectUuid: string,
         @Path() dashboardUuidOrSlug: string,
         @Request() req: express.Request,
+        @Query() resolved?: boolean,
     ): Promise<ApiGetComments> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -146,6 +148,7 @@ export class ProjectDashboardControllerV2 extends BaseController {
                     dashboardUuidOrSlug,
                     {
                         projectUuid,
+                        resolved,
                     },
                 ),
         };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -13918,17 +13918,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -13966,14 +13966,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
@@ -67795,6 +67795,7 @@ export function RegisterRoutes(app: Router) {
             dataType: 'string',
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        resolved: { in: 'query', name: 'resolved', dataType: 'boolean' },
     };
     app.get(
         '/api/v1/comments/dashboards/:dashboardUuidOrSlug',
@@ -67860,6 +67861,15 @@ export function RegisterRoutes(app: Router) {
             dataType: 'string',
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                resolved: { dataType: 'boolean', required: true },
+            },
+        },
     };
     app.patch(
         '/api/v1/comments/dashboards/:dashboardUuid/:commentId',
@@ -72691,6 +72701,7 @@ export function RegisterRoutes(app: Router) {
             dataType: 'string',
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        resolved: { in: 'query', name: 'resolved', dataType: 'boolean' },
     };
     app.get(
         '/api/v2/projects/:projectUuid/dashboards/:dashboardUuidOrSlug/comments',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14722,10 +14722,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -14734,8 +14734,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -14749,8 +14749,8 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
                                                                 "nullable": true
@@ -38272,7 +38272,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3122.2",
+        "version": "0.3124.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -58902,6 +58902,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "resolved",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
                     }
                 ]
             }
@@ -58931,7 +58939,7 @@
                         }
                     }
                 },
-                "description": "Resolves a comment on a dashboard",
+                "description": "Resolves or unresolves a comment on a dashboard",
                 "summary": "Resolve comment",
                 "tags": ["Comments"],
                 "security": [],
@@ -58954,7 +58962,25 @@
                             "type": "string"
                         }
                     }
-                ]
+                ],
+                "requestBody": {
+                    "description": "whether the comment should be resolved",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "resolved": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": ["resolved"],
+                                "type": "object",
+                                "description": "whether the comment should be resolved"
+                            }
+                        }
+                    }
+                }
             },
             "delete": {
                 "operationId": "deleteComment",
@@ -62792,6 +62818,14 @@
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "resolved",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ]

--- a/packages/backend/src/models/CommentModel/CommentModel.ts
+++ b/packages/backend/src/models/CommentModel/CommentModel.ts
@@ -195,6 +195,7 @@ export class CommentModel {
         dashboardUuid: string,
         userUuid: string,
         canUserRemoveAnyComment: boolean,
+        resolved: boolean,
     ): Promise<Record<string, Comment[]>> {
         const dashboard = await this.database(DashboardsTableName)
             .leftJoin(
@@ -235,7 +236,7 @@ export class CommentModel {
                 `${DashboardTileCommentsTableName}.dashboard_tile_uuid`,
                 tileUuids,
             )
-            .andWhere(`${DashboardTileCommentsTableName}.resolved`, false)
+            .andWhere(`${DashboardTileCommentsTableName}.resolved`, resolved)
             .orderBy(`${DashboardTileCommentsTableName}.created_at`, 'asc');
 
         return CommentModel.parseComments(
@@ -262,7 +263,15 @@ export class CommentModel {
     async resolveComment(commentId: string): Promise<void> {
         await this.database(DashboardTileCommentsTableName)
             .update({ resolved: true })
-            .where('comment_id', commentId);
+            .where('comment_id', commentId)
+            .orWhere('reply_to', commentId);
+    }
+
+    async unresolveComment(commentId: string): Promise<void> {
+        await this.database(DashboardTileCommentsTableName)
+            .update({ resolved: false })
+            .where('comment_id', commentId)
+            .orWhere('reply_to', commentId);
     }
 
     async getComment(commentId: string) {

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -205,7 +205,7 @@ export class CommentService extends BaseService {
     async findCommentsForDashboard(
         user: SessionUser,
         dashboardUuidOrSlug: string,
-        options?: { projectUuid?: string },
+        options?: { projectUuid?: string; resolved?: boolean },
     ): Promise<Record<string, Comment[]>> {
         this.throwIfDisabled();
 
@@ -249,6 +249,7 @@ export class CommentService extends BaseService {
             dashboard.uuid,
             user.userUuid,
             canUserRemoveAnyComment,
+            options?.resolved ?? false,
         );
     }
 
@@ -256,6 +257,7 @@ export class CommentService extends BaseService {
         user: SessionUser,
         dashboardUuid: string,
         commentId: string,
+        resolved: boolean,
     ): Promise<void> {
         this.throwIfDisabled();
 
@@ -284,7 +286,7 @@ export class CommentService extends BaseService {
         const comment = await this.commentModel.getComment(commentId);
 
         this.analytics.track({
-            event: 'comment.resolved',
+            event: resolved ? 'comment.resolved' : 'comment.unresolved',
             userId: user.userUuid,
             properties: {
                 isReply: !!comment.replyTo,
@@ -295,7 +297,9 @@ export class CommentService extends BaseService {
             },
         });
 
-        return this.commentModel.resolveComment(commentId);
+        return resolved
+            ? this.commentModel.resolveComment(commentId)
+            : this.commentModel.unresolveComment(commentId);
     }
 
     async deleteComment(

--- a/packages/frontend/src/features/comments/components/CommentDetail.tsx
+++ b/packages/frontend/src/features/comments/components/CommentDetail.tsx
@@ -11,7 +11,13 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { useHover } from '@mantine/hooks';
-import { IconDotsVertical, IconMessage, IconTrash } from '@tabler/icons-react';
+import {
+    IconArrowBackUp,
+    IconCircleCheck,
+    IconDotsVertical,
+    IconMessage,
+    IconTrash,
+} from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { getNameInitials } from '../utils';
@@ -22,8 +28,12 @@ type Props = {
     comment: Comment;
     canRemove: boolean;
     canReply: boolean;
+    canResolve: boolean;
+    canUnresolve: boolean;
     onRemove: () => void;
     onReply?: () => void;
+    onResolve?: () => void;
+    onUnresolve?: () => void;
 };
 
 export const CommentDetail: FC<Props> = ({
@@ -32,6 +42,10 @@ export const CommentDetail: FC<Props> = ({
     onRemove,
     canReply,
     onReply,
+    canResolve,
+    onResolve,
+    canUnresolve,
+    onUnresolve,
 }) => {
     const { ref, hovered } = useHover();
 
@@ -78,7 +92,9 @@ export const CommentDetail: FC<Props> = ({
                                     </ActionIcon>
                                 </Tooltip>
                             )}
-                            {canRemove && (
+                            {(canRemove ||
+                                (canResolve && onResolve) ||
+                                (canUnresolve && onUnresolve)) && (
                                 <Menu
                                     position="right"
                                     withArrow
@@ -100,19 +116,50 @@ export const CommentDetail: FC<Props> = ({
                                         p={0}
                                         onMouseDown={(e) => e.stopPropagation()}
                                     >
-                                        <Menu.Item
-                                            p="xs"
-                                            fz="xs"
-                                            leftSection={
-                                                <MantineIcon
-                                                    color="red"
-                                                    icon={IconTrash}
-                                                />
-                                            }
-                                            onClick={() => onRemove()}
-                                        >
-                                            Delete
-                                        </Menu.Item>
+                                        {canResolve && onResolve && (
+                                            <Menu.Item
+                                                p="xs"
+                                                fz="xs"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        color="green"
+                                                        icon={IconCircleCheck}
+                                                    />
+                                                }
+                                                onClick={() => onResolve()}
+                                            >
+                                                Resolve
+                                            </Menu.Item>
+                                        )}
+                                        {canUnresolve && onUnresolve && (
+                                            <Menu.Item
+                                                p="xs"
+                                                fz="xs"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconArrowBackUp}
+                                                    />
+                                                }
+                                                onClick={() => onUnresolve()}
+                                            >
+                                                Unresolve
+                                            </Menu.Item>
+                                        )}
+                                        {canRemove && (
+                                            <Menu.Item
+                                                p="xs"
+                                                fz="xs"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        color="red"
+                                                        icon={IconTrash}
+                                                    />
+                                                }
+                                                onClick={() => onRemove()}
+                                            >
+                                                Delete
+                                            </Menu.Item>
+                                        )}
                                     </Menu.Dropdown>
                                 </Menu>
                             )}

--- a/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
@@ -1,7 +1,17 @@
 import { type Comment } from '@lightdash/common';
-import { Box, Button, Collapse, Divider, Stack } from '@mantine-8/core';
+import {
+    Badge,
+    Box,
+    Button,
+    Collapse,
+    Divider,
+    Group,
+    Stack,
+} from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
+import { IconCircleCheck } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import {
@@ -90,62 +100,79 @@ export const DashboardCommentAndReplies: FC<Props> = ({
 
     return (
         <Stack gap="two" ref={targetRef}>
-            <CommentDetail
-                comment={comment}
-                canReply={!isResolved && canCreateDashboardComments}
-                onReply={() => handleReply()}
-                // can remove any comment or the comment is created by the current user
-                canRemove={comment.canRemove}
-                onRemove={() => handleRemove(comment.commentId)}
-                // resolving/unresolving the parent applies to the whole thread
-                canResolve={!isResolved && canManageDashboardComments}
-                onResolve={() => handleResolve(comment.commentId)}
-                canUnresolve={isResolved && canManageDashboardComments}
-                onUnresolve={() => handleUnresolve(comment.commentId)}
-            />
-
-            {comment.replies && comment.replies.length > 0 && (
-                <Box ml="xl">
-                    <Divider
+            {isResolved && (
+                <Group gap="xs">
+                    <Badge
                         size="xs"
-                        labelPosition="right"
-                        label={
-                            <Button
-                                size="compact-xs"
-                                variant="subtle"
-                                fz="xs"
-                                onClick={toggleReplies}
-                            >
-                                {comment.replies.length}{' '}
-                                {comment.replies.length === 1
-                                    ? 'reply'
-                                    : 'replies'}
-                            </Button>
+                        variant="light"
+                        color="gray"
+                        leftSection={
+                            <MantineIcon icon={IconCircleCheck} size={12} />
                         }
-                    />
-
-                    <Collapse in={isRepliesOpen}>
-                        <Stack gap="xs">
-                            {comment.replies.map((reply) => (
-                                <CommentDetail
-                                    key={reply.commentId}
-                                    comment={reply}
-                                    // Can't reply to a reply
-                                    canReply={false}
-                                    // can remove any comment or the comment is created by the current user
-                                    canRemove={reply.canRemove}
-                                    onRemove={() =>
-                                        handleRemove(reply.commentId)
-                                    }
-                                    // replies are resolved/unresolved together with the parent
-                                    canResolve={false}
-                                    canUnresolve={false}
-                                />
-                            ))}
-                        </Stack>
-                    </Collapse>
-                </Box>
+                    >
+                        Resolved
+                    </Badge>
+                </Group>
             )}
+
+            <Stack gap="two" opacity={isResolved ? 0.7 : undefined}>
+                <CommentDetail
+                    comment={comment}
+                    canReply={!isResolved && canCreateDashboardComments}
+                    onReply={() => handleReply()}
+                    // can remove any comment or the comment is created by the current user
+                    canRemove={comment.canRemove}
+                    onRemove={() => handleRemove(comment.commentId)}
+                    // resolving/unresolving the parent applies to the whole thread
+                    canResolve={!isResolved && canManageDashboardComments}
+                    onResolve={() => handleResolve(comment.commentId)}
+                    canUnresolve={isResolved && canManageDashboardComments}
+                    onUnresolve={() => handleUnresolve(comment.commentId)}
+                />
+
+                {comment.replies && comment.replies.length > 0 && (
+                    <Box ml="xl">
+                        <Divider
+                            size="xs"
+                            labelPosition="right"
+                            label={
+                                <Button
+                                    size="compact-xs"
+                                    variant="subtle"
+                                    fz="xs"
+                                    onClick={toggleReplies}
+                                >
+                                    {comment.replies.length}{' '}
+                                    {comment.replies.length === 1
+                                        ? 'reply'
+                                        : 'replies'}
+                                </Button>
+                            }
+                        />
+
+                        <Collapse in={isRepliesOpen}>
+                            <Stack gap="xs">
+                                {comment.replies.map((reply) => (
+                                    <CommentDetail
+                                        key={reply.commentId}
+                                        comment={reply}
+                                        // Can't reply to a reply
+                                        canReply={false}
+                                        // can remove any comment or the comment is created by the current user
+                                        canRemove={reply.canRemove}
+                                        onRemove={() =>
+                                            handleRemove(reply.commentId)
+                                        }
+                                        // replies are resolved/unresolved together with the parent
+                                        canResolve={false}
+                                        canUnresolve={false}
+                                    />
+                                ))}
+                            </Stack>
+                        </Collapse>
+                    </Box>
+                )}
+            </Stack>
 
             <Collapse in={!isResolved && !!isReplyingTo} ml="lg">
                 <CommentForm

--- a/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
@@ -1,7 +1,18 @@
 import { type Comment } from '@lightdash/common';
-import { Box, Button, Collapse, Divider, Stack } from '@mantine-8/core';
+import {
+    Badge,
+    Box,
+    Button,
+    Collapse,
+    Divider,
+    Stack,
+    Text,
+} from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
+import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { PolymorphicGroupButton } from '../../../components/common/PolymorphicGroupButton';
 import useApp from '../../../providers/App/useApp';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import {
@@ -38,6 +49,7 @@ export const DashboardCommentAndReplies: FC<Props> = ({
     );
 
     const [isRepliesOpen, { toggle: toggleReplies }] = useDisclosure(false);
+    const [isThreadOpen, { toggle: toggleThread }] = useDisclosure(false);
     const [isReplyingTo, setIsReplyingTo] = useState<string | undefined>(
         undefined,
     );
@@ -88,8 +100,8 @@ export const DashboardCommentAndReplies: FC<Props> = ({
         }
     }, [isRepliesOpen, comment.commentId, toggleReplies]);
 
-    return (
-        <Stack gap="two" ref={targetRef}>
+    const thread = (
+        <>
             <CommentDetail
                 comment={comment}
                 canReply={!isResolved && canCreateDashboardComments}
@@ -173,6 +185,47 @@ export const DashboardCommentAndReplies: FC<Props> = ({
                     mode="reply"
                 />
             </Collapse>
+        </>
+    );
+
+    // Resolved threads render collapsed in the list (GitHub-style) and expand inline.
+    if (isResolved) {
+        return (
+            <Stack gap="two" ref={targetRef}>
+                <PolymorphicGroupButton
+                    component="button"
+                    type="button"
+                    gap="xs"
+                    wrap="nowrap"
+                    w="100%"
+                    onClick={toggleThread}
+                >
+                    <MantineIcon
+                        icon={isThreadOpen ? IconChevronDown : IconChevronRight}
+                        color="ldGray.6"
+                    />
+                    <Box flex={1} miw={0}>
+                        <Text fz="xs" c="dimmed" lineClamp={1} ta="left">
+                            {comment.text}
+                        </Text>
+                    </Box>
+                    <Badge size="xs" variant="light" color="gray">
+                        Resolved
+                    </Badge>
+                </PolymorphicGroupButton>
+
+                <Collapse in={isThreadOpen}>
+                    <Stack gap="two" mt="two">
+                        {thread}
+                    </Stack>
+                </Collapse>
+            </Stack>
+        );
+    }
+
+    return (
+        <Stack gap="two" ref={targetRef}>
+            {thread}
         </Stack>
     );
 };

--- a/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
@@ -4,7 +4,11 @@ import { useDisclosure } from '@mantine/hooks';
 import { useCallback, useState, type FC } from 'react';
 import useApp from '../../../providers/App/useApp';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
-import { useCreateComment, useRemoveComment } from '../hooks/useComments';
+import {
+    useCreateComment,
+    useRemoveComment,
+    useResolveComment,
+} from '../hooks/useComments';
 import { CommentDetail } from './CommentDetail';
 import { CommentForm } from './CommentForm';
 
@@ -14,6 +18,7 @@ type Props = {
     dashboardTileUuid: string;
     comment: Comment;
     targetRef: React.RefObject<HTMLDivElement | null> | null;
+    isResolved?: boolean;
 };
 
 export const DashboardCommentAndReplies: FC<Props> = ({
@@ -22,10 +27,14 @@ export const DashboardCommentAndReplies: FC<Props> = ({
     dashboardTileUuid,
     dashboardUuid,
     targetRef,
+    isResolved = false,
 }) => {
     const { user } = useApp();
     const canCreateDashboardComments = !!useDashboardContext(
         (c) => c.dashboardCommentsCheck?.canCreateDashboardComments,
+    );
+    const canManageDashboardComments = !!useDashboardContext(
+        (c) => c.dashboardCommentsCheck?.canManageDashboardComments,
     );
 
     const [isRepliesOpen, { toggle: toggleReplies }] = useDisclosure(false);
@@ -36,6 +45,7 @@ export const DashboardCommentAndReplies: FC<Props> = ({
     const { mutateAsync: createReply, isLoading: isCreatingReply } =
         useCreateComment();
     const { mutateAsync: removeComment } = useRemoveComment();
+    const { mutateAsync: resolveComment } = useResolveComment();
 
     const handleRemove = useCallback(
         async (commentId: string) => {
@@ -45,6 +55,28 @@ export const DashboardCommentAndReplies: FC<Props> = ({
             });
         },
         [dashboardUuid, removeComment],
+    );
+
+    const handleResolve = useCallback(
+        async (commentId: string) => {
+            await resolveComment({
+                dashboardUuid,
+                commentId,
+                resolved: true,
+            });
+        },
+        [dashboardUuid, resolveComment],
+    );
+
+    const handleUnresolve = useCallback(
+        async (commentId: string) => {
+            await resolveComment({
+                dashboardUuid,
+                commentId,
+                resolved: false,
+            });
+        },
+        [dashboardUuid, resolveComment],
     );
 
     const handleReply = useCallback(() => {
@@ -60,11 +92,16 @@ export const DashboardCommentAndReplies: FC<Props> = ({
         <Stack gap="two" ref={targetRef}>
             <CommentDetail
                 comment={comment}
-                canReply={canCreateDashboardComments}
+                canReply={!isResolved && canCreateDashboardComments}
                 onReply={() => handleReply()}
                 // can remove any comment or the comment is created by the current user
                 canRemove={comment.canRemove}
                 onRemove={() => handleRemove(comment.commentId)}
+                // resolving/unresolving the parent applies to the whole thread
+                canResolve={!isResolved && canManageDashboardComments}
+                onResolve={() => handleResolve(comment.commentId)}
+                canUnresolve={isResolved && canManageDashboardComments}
+                onUnresolve={() => handleUnresolve(comment.commentId)}
             />
 
             {comment.replies && comment.replies.length > 0 && (
@@ -100,6 +137,9 @@ export const DashboardCommentAndReplies: FC<Props> = ({
                                     onRemove={() =>
                                         handleRemove(reply.commentId)
                                     }
+                                    // replies are resolved/unresolved together with the parent
+                                    canResolve={false}
+                                    canUnresolve={false}
                                 />
                             ))}
                         </Stack>
@@ -107,7 +147,7 @@ export const DashboardCommentAndReplies: FC<Props> = ({
                 </Box>
             )}
 
-            <Collapse in={!!isReplyingTo} ml="lg">
+            <Collapse in={!isResolved && !!isReplyingTo} ml="lg">
                 <CommentForm
                     userName={user.data?.firstName + ' ' + user.data?.lastName}
                     onSubmit={(

--- a/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
@@ -1,17 +1,7 @@
 import { type Comment } from '@lightdash/common';
-import {
-    Badge,
-    Box,
-    Button,
-    Collapse,
-    Divider,
-    Group,
-    Stack,
-} from '@mantine-8/core';
+import { Box, Button, Collapse, Divider, Stack } from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconCircleCheck } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
-import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import {
@@ -100,79 +90,62 @@ export const DashboardCommentAndReplies: FC<Props> = ({
 
     return (
         <Stack gap="two" ref={targetRef}>
-            {isResolved && (
-                <Group gap="xs">
-                    <Badge
+            <CommentDetail
+                comment={comment}
+                canReply={!isResolved && canCreateDashboardComments}
+                onReply={() => handleReply()}
+                // can remove any comment or the comment is created by the current user
+                canRemove={comment.canRemove}
+                onRemove={() => handleRemove(comment.commentId)}
+                // resolving/unresolving the parent applies to the whole thread
+                canResolve={!isResolved && canManageDashboardComments}
+                onResolve={() => handleResolve(comment.commentId)}
+                canUnresolve={isResolved && canManageDashboardComments}
+                onUnresolve={() => handleUnresolve(comment.commentId)}
+            />
+
+            {comment.replies && comment.replies.length > 0 && (
+                <Box ml="xl">
+                    <Divider
                         size="xs"
-                        variant="light"
-                        color="gray"
-                        leftSection={
-                            <MantineIcon icon={IconCircleCheck} size={12} />
+                        labelPosition="right"
+                        label={
+                            <Button
+                                size="compact-xs"
+                                variant="subtle"
+                                fz="xs"
+                                onClick={toggleReplies}
+                            >
+                                {comment.replies.length}{' '}
+                                {comment.replies.length === 1
+                                    ? 'reply'
+                                    : 'replies'}
+                            </Button>
                         }
-                    >
-                        Resolved
-                    </Badge>
-                </Group>
+                    />
+
+                    <Collapse in={isRepliesOpen}>
+                        <Stack gap="xs">
+                            {comment.replies.map((reply) => (
+                                <CommentDetail
+                                    key={reply.commentId}
+                                    comment={reply}
+                                    // Can't reply to a reply
+                                    canReply={false}
+                                    // can remove any comment or the comment is created by the current user
+                                    canRemove={reply.canRemove}
+                                    onRemove={() =>
+                                        handleRemove(reply.commentId)
+                                    }
+                                    // replies are resolved/unresolved together with the parent
+                                    canResolve={false}
+                                    canUnresolve={false}
+                                />
+                            ))}
+                        </Stack>
+                    </Collapse>
+                </Box>
             )}
-
-            <Stack gap="two" opacity={isResolved ? 0.7 : undefined}>
-                <CommentDetail
-                    comment={comment}
-                    canReply={!isResolved && canCreateDashboardComments}
-                    onReply={() => handleReply()}
-                    // can remove any comment or the comment is created by the current user
-                    canRemove={comment.canRemove}
-                    onRemove={() => handleRemove(comment.commentId)}
-                    // resolving/unresolving the parent applies to the whole thread
-                    canResolve={!isResolved && canManageDashboardComments}
-                    onResolve={() => handleResolve(comment.commentId)}
-                    canUnresolve={isResolved && canManageDashboardComments}
-                    onUnresolve={() => handleUnresolve(comment.commentId)}
-                />
-
-                {comment.replies && comment.replies.length > 0 && (
-                    <Box ml="xl">
-                        <Divider
-                            size="xs"
-                            labelPosition="right"
-                            label={
-                                <Button
-                                    size="compact-xs"
-                                    variant="subtle"
-                                    fz="xs"
-                                    onClick={toggleReplies}
-                                >
-                                    {comment.replies.length}{' '}
-                                    {comment.replies.length === 1
-                                        ? 'reply'
-                                        : 'replies'}
-                                </Button>
-                            }
-                        />
-
-                        <Collapse in={isRepliesOpen}>
-                            <Stack gap="xs">
-                                {comment.replies.map((reply) => (
-                                    <CommentDetail
-                                        key={reply.commentId}
-                                        comment={reply}
-                                        // Can't reply to a reply
-                                        canReply={false}
-                                        // can remove any comment or the comment is created by the current user
-                                        canRemove={reply.canRemove}
-                                        onRemove={() =>
-                                            handleRemove(reply.commentId)
-                                        }
-                                        // replies are resolved/unresolved together with the parent
-                                        canResolve={false}
-                                        canUnresolve={false}
-                                    />
-                                ))}
-                            </Stack>
-                        </Collapse>
-                    </Box>
-                )}
-            </Stack>
 
             <Collapse in={!isResolved && !!isReplyingTo} ml="lg">
                 <CommentForm

--- a/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
@@ -1,18 +1,7 @@
 import { type Comment } from '@lightdash/common';
-import {
-    Badge,
-    Box,
-    Button,
-    Collapse,
-    Divider,
-    Stack,
-    Text,
-} from '@mantine-8/core';
+import { Box, Button, Collapse, Divider, Stack } from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
-import MantineIcon from '../../../components/common/MantineIcon';
-import { PolymorphicGroupButton } from '../../../components/common/PolymorphicGroupButton';
 import useApp from '../../../providers/App/useApp';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import {
@@ -49,7 +38,6 @@ export const DashboardCommentAndReplies: FC<Props> = ({
     );
 
     const [isRepliesOpen, { toggle: toggleReplies }] = useDisclosure(false);
-    const [isThreadOpen, { toggle: toggleThread }] = useDisclosure(false);
     const [isReplyingTo, setIsReplyingTo] = useState<string | undefined>(
         undefined,
     );
@@ -100,8 +88,8 @@ export const DashboardCommentAndReplies: FC<Props> = ({
         }
     }, [isRepliesOpen, comment.commentId, toggleReplies]);
 
-    const thread = (
-        <>
+    return (
+        <Stack gap="two" ref={targetRef}>
             <CommentDetail
                 comment={comment}
                 canReply={!isResolved && canCreateDashboardComments}
@@ -185,47 +173,6 @@ export const DashboardCommentAndReplies: FC<Props> = ({
                     mode="reply"
                 />
             </Collapse>
-        </>
-    );
-
-    // Resolved threads render collapsed in the list (GitHub-style) and expand inline.
-    if (isResolved) {
-        return (
-            <Stack gap="two" ref={targetRef}>
-                <PolymorphicGroupButton
-                    component="button"
-                    type="button"
-                    gap="xs"
-                    wrap="nowrap"
-                    w="100%"
-                    onClick={toggleThread}
-                >
-                    <MantineIcon
-                        icon={isThreadOpen ? IconChevronDown : IconChevronRight}
-                        color="ldGray.6"
-                    />
-                    <Box flex={1} miw={0}>
-                        <Text fz="xs" c="dimmed" lineClamp={1} ta="left">
-                            {comment.text}
-                        </Text>
-                    </Box>
-                    <Badge size="xs" variant="light" color="gray">
-                        Resolved
-                    </Badge>
-                </PolymorphicGroupButton>
-
-                <Collapse in={isThreadOpen}>
-                    <Stack gap="two" mt="two">
-                        {thread}
-                    </Stack>
-                </Collapse>
-            </Stack>
-        );
-    }
-
-    return (
-        <Stack gap="two" ref={targetRef}>
-            {thread}
         </Stack>
     );
 };

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -211,14 +211,15 @@ export const DashboardTileComments: FC<
                             }
                         />
                     ))}
-                    {!canCreateDashboardComments && !hasComments && (
-                        <Text fz="xs">No comments yet</Text>
+                    {!hasComments && (
+                        <Text fz="xs" c="dimmed">
+                            No open comments
+                        </Text>
                     )}
-                </Stack>
-                {resolvedComments.length > 0 && (
-                    <>
-                        <Divider />
-                        <Box p="sm" pt="xs">
+
+                    {resolvedComments.length > 0 && (
+                        <Box>
+                            {hasComments && <Divider mb="xs" />}
                             <Button
                                 size="compact-xs"
                                 variant="subtle"
@@ -256,8 +257,8 @@ export const DashboardTileComments: FC<
                                 </Stack>
                             </Collapse>
                         </Box>
-                    </>
-                )}
+                    )}
+                </Stack>
 
                 {(hasComments || resolvedComments.length > 0) && <Divider />}
                 <Box p="sm" pt="xs">

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -12,7 +12,11 @@ import {
     type PopoverProps,
 } from '@mantine-8/core';
 import { useDisclosure, useScrollIntoView } from '@mantine/hooks';
-import { IconMessage } from '@tabler/icons-react';
+import {
+    IconChevronDown,
+    IconChevronUp,
+    IconMessage,
+} from '@tabler/icons-react';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
@@ -234,6 +238,15 @@ export const DashboardTileComments: FC<
                                 color="gray"
                                 fz="xs"
                                 onClick={toggleShowResolved}
+                                rightSection={
+                                    <MantineIcon
+                                        icon={
+                                            showResolved
+                                                ? IconChevronUp
+                                                : IconChevronDown
+                                        }
+                                    />
+                                }
                             >
                                 {showResolved ? 'Hide' : 'Show'} resolved (
                                 {resolvedComments.length})

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -219,7 +219,7 @@ export const DashboardTileComments: FC<
 
                     {resolvedComments.length > 0 && (
                         <Box>
-                            {hasComments && <Divider mb="xs" />}
+                            {hasComments && <Divider mx="-sm" mb="xs" />}
                             <Button
                                 size="compact-xs"
                                 variant="subtle"

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -215,19 +215,6 @@ export const DashboardTileComments: FC<
                         <Text fz="xs">No comments yet</Text>
                     )}
                 </Stack>
-                {hasComments && <Divider />}
-                <Box p="sm" pt="xs">
-                    {canCreateDashboardComments && (
-                        <CommentForm
-                            userName={
-                                user.data?.firstName + ' ' + user.data?.lastName
-                            }
-                            onSubmit={handleOnSubmit}
-                            isSubmitting={isLoading}
-                        />
-                    )}
-                </Box>
-
                 {resolvedComments.length > 0 && (
                     <>
                         <Divider />
@@ -271,6 +258,19 @@ export const DashboardTileComments: FC<
                         </Box>
                     </>
                 )}
+
+                {(hasComments || resolvedComments.length > 0) && <Divider />}
+                <Box p="sm" pt="xs">
+                    {canCreateDashboardComments && (
+                        <CommentForm
+                            userName={
+                                user.data?.firstName + ' ' + user.data?.lastName
+                            }
+                            onSubmit={handleOnSubmit}
+                            isSubmitting={isLoading}
+                        />
+                    )}
+                </Box>
             </Popover.Dropdown>
 
             <Popover.Target ref={targetRefComments}>

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -2,6 +2,8 @@ import { NotificationResourceType } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
+    Button,
+    Collapse,
     Divider,
     Indicator,
     Popover,
@@ -9,7 +11,7 @@ import {
     Text,
     type PopoverProps,
 } from '@mantine-8/core';
-import { useScrollIntoView } from '@mantine/hooks';
+import { useDisclosure, useScrollIntoView } from '@mantine/hooks';
 import { IconMessage } from '@tabler/icons-react';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -19,7 +21,7 @@ import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useGetNotifications } from '../../notifications';
 import { useUpdateNotification } from '../../notifications/hooks/useNotifications';
-import { useCreateComment } from '../hooks/useComments';
+import { useCreateComment, useGetResolvedComments } from '../hooks/useComments';
 import { useScrollToDashboardCommentViaSearchParam } from '../hooks/useScrollToDashboardCommentViaSearchParam';
 import { CommentForm } from './CommentForm';
 import { DashboardCommentAndReplies } from './DashboardCommentAndReplies';
@@ -37,16 +39,27 @@ export const DashboardTileComments: FC<
     const { track } = useTracking();
 
     const [openedComments, setOpenedComments] = useState(opened);
+    const [showResolved, { toggle: toggleShowResolved }] = useDisclosure(false);
 
     const projectUuid = useDashboardContext((c) => c.projectUuid);
     const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
     const canCreateDashboardComments = useDashboardContext(
         (c) => c.dashboardCommentsCheck?.canCreateDashboardComments,
     );
+    const canViewDashboardComments = useDashboardContext(
+        (c) => c.dashboardCommentsCheck?.canViewDashboardComments,
+    );
     const dashboard = useDashboardContext((c) => c.dashboard);
     const comments = useDashboardContext(
         (c) => c.dashboardComments && c.dashboardComments[dashboardTileUuid],
     );
+
+    const { data: resolvedCommentsByTile } = useGetResolvedComments(
+        dashboardUuid ?? '',
+        projectUuid,
+        !!openedComments && !!canViewDashboardComments && !!dashboardUuid,
+    );
+    const resolvedComments = resolvedCommentsByTile?.[dashboardTileUuid] ?? [];
 
     const targetRefComments = useRef<HTMLDivElement>(null);
 
@@ -210,6 +223,41 @@ export const DashboardTileComments: FC<
                         />
                     )}
                 </Box>
+
+                {resolvedComments.length > 0 && (
+                    <>
+                        <Divider />
+                        <Box p="sm" pt="xs">
+                            <Button
+                                size="compact-xs"
+                                variant="subtle"
+                                color="gray"
+                                fz="xs"
+                                onClick={toggleShowResolved}
+                            >
+                                {showResolved ? 'Hide' : 'Show'} resolved (
+                                {resolvedComments.length})
+                            </Button>
+                            <Collapse in={showResolved}>
+                                <Stack gap="xs" mt="xs">
+                                    {resolvedComments.map((resolvedComment) => (
+                                        <DashboardCommentAndReplies
+                                            key={resolvedComment.commentId}
+                                            comment={resolvedComment}
+                                            projectUuid={projectUuid}
+                                            dashboardUuid={dashboardUuid}
+                                            dashboardTileUuid={
+                                                dashboardTileUuid
+                                            }
+                                            targetRef={null}
+                                            isResolved
+                                        />
+                                    ))}
+                                </Stack>
+                            </Collapse>
+                        </Box>
+                    </>
+                )}
             </Popover.Dropdown>
 
             <Popover.Target ref={targetRefComments}>

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -2,6 +2,8 @@ import { NotificationResourceType } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
+    Button,
+    Collapse,
     Divider,
     Indicator,
     Popover,
@@ -9,8 +11,12 @@ import {
     Text,
     type PopoverProps,
 } from '@mantine-8/core';
-import { useScrollIntoView } from '@mantine/hooks';
-import { IconMessage } from '@tabler/icons-react';
+import { useDisclosure, useScrollIntoView } from '@mantine/hooks';
+import {
+    IconChevronDown,
+    IconChevronUp,
+    IconMessage,
+} from '@tabler/icons-react';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
@@ -37,6 +43,7 @@ export const DashboardTileComments: FC<
     const { track } = useTracking();
 
     const [openedComments, setOpenedComments] = useState(opened);
+    const [showResolved, { toggle: toggleShowResolved }] = useDisclosure(false);
 
     const projectUuid = useDashboardContext((c) => c.projectUuid);
     const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
@@ -56,14 +63,7 @@ export const DashboardTileComments: FC<
         projectUuid,
         !!openedComments && !!canViewDashboardComments && !!dashboardUuid,
     );
-    const allComments = useMemo(() => {
-        const resolved = resolvedCommentsByTile?.[dashboardTileUuid] ?? [];
-        return [...(comments ?? []), ...resolved].sort(
-            (a, b) =>
-                new Date(a.createdAt).getTime() -
-                new Date(b.createdAt).getTime(),
-        );
-    }, [comments, resolvedCommentsByTile, dashboardTileUuid]);
+    const resolvedComments = resolvedCommentsByTile?.[dashboardTileUuid] ?? [];
 
     const targetRefComments = useRef<HTMLDivElement>(null);
 
@@ -169,6 +169,8 @@ export const DashboardTileComments: FC<
         return null;
     }
 
+    const hasComments = comments && comments.length > 0;
+
     return (
         <Popover
             withArrow
@@ -196,30 +198,69 @@ export const DashboardTileComments: FC<
                         overflowY: 'auto',
                     }}
                 >
-                    {allComments.map((comment, index) => (
+                    {comments?.map((comment, index) => (
                         <DashboardCommentAndReplies
                             key={comment.commentId}
                             comment={comment}
-                            isResolved={comment.resolved}
                             projectUuid={projectUuid}
                             dashboardUuid={dashboardUuid}
                             dashboardTileUuid={dashboardTileUuid}
                             targetRef={
                                 // Assign the target ref to the last comment
-                                index === allComments.length - 1
-                                    ? targetRef
-                                    : null
+                                index === comments.length - 1 ? targetRef : null
                             }
                         />
                     ))}
-                    {allComments.length === 0 && (
+                    {!hasComments && (
                         <Text fz="xs" c="dimmed">
-                            No comments yet
+                            No open comments
                         </Text>
+                    )}
+
+                    {resolvedComments.length > 0 && (
+                        <Box>
+                            {hasComments && <Divider mx="-sm" mb="xs" />}
+                            <Button
+                                size="compact-xs"
+                                variant="subtle"
+                                color="gray"
+                                fz="xs"
+                                onClick={toggleShowResolved}
+                                rightSection={
+                                    <MantineIcon
+                                        icon={
+                                            showResolved
+                                                ? IconChevronUp
+                                                : IconChevronDown
+                                        }
+                                    />
+                                }
+                            >
+                                {showResolved ? 'Hide' : 'Show'} resolved (
+                                {resolvedComments.length})
+                            </Button>
+                            <Collapse in={showResolved}>
+                                <Stack gap="xs" mt="xs">
+                                    {resolvedComments.map((resolvedComment) => (
+                                        <DashboardCommentAndReplies
+                                            key={resolvedComment.commentId}
+                                            comment={resolvedComment}
+                                            projectUuid={projectUuid}
+                                            dashboardUuid={dashboardUuid}
+                                            dashboardTileUuid={
+                                                dashboardTileUuid
+                                            }
+                                            targetRef={null}
+                                            isResolved
+                                        />
+                                    ))}
+                                </Stack>
+                            </Collapse>
+                        </Box>
                     )}
                 </Stack>
 
-                {allComments.length > 0 && <Divider />}
+                {(hasComments || resolvedComments.length > 0) && <Divider />}
                 <Box p="sm" pt="xs">
                     {canCreateDashboardComments && (
                         <CommentForm

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -2,8 +2,6 @@ import { NotificationResourceType } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
-    Button,
-    Collapse,
     Divider,
     Indicator,
     Popover,
@@ -11,12 +9,8 @@ import {
     Text,
     type PopoverProps,
 } from '@mantine-8/core';
-import { useDisclosure, useScrollIntoView } from '@mantine/hooks';
-import {
-    IconChevronDown,
-    IconChevronUp,
-    IconMessage,
-} from '@tabler/icons-react';
+import { useScrollIntoView } from '@mantine/hooks';
+import { IconMessage } from '@tabler/icons-react';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
@@ -43,7 +37,6 @@ export const DashboardTileComments: FC<
     const { track } = useTracking();
 
     const [openedComments, setOpenedComments] = useState(opened);
-    const [showResolved, { toggle: toggleShowResolved }] = useDisclosure(false);
 
     const projectUuid = useDashboardContext((c) => c.projectUuid);
     const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
@@ -63,7 +56,14 @@ export const DashboardTileComments: FC<
         projectUuid,
         !!openedComments && !!canViewDashboardComments && !!dashboardUuid,
     );
-    const resolvedComments = resolvedCommentsByTile?.[dashboardTileUuid] ?? [];
+    const allComments = useMemo(() => {
+        const resolved = resolvedCommentsByTile?.[dashboardTileUuid] ?? [];
+        return [...(comments ?? []), ...resolved].sort(
+            (a, b) =>
+                new Date(a.createdAt).getTime() -
+                new Date(b.createdAt).getTime(),
+        );
+    }, [comments, resolvedCommentsByTile, dashboardTileUuid]);
 
     const targetRefComments = useRef<HTMLDivElement>(null);
 
@@ -169,8 +169,6 @@ export const DashboardTileComments: FC<
         return null;
     }
 
-    const hasComments = comments && comments.length > 0;
-
     return (
         <Popover
             withArrow
@@ -198,69 +196,30 @@ export const DashboardTileComments: FC<
                         overflowY: 'auto',
                     }}
                 >
-                    {comments?.map((comment, index) => (
+                    {allComments.map((comment, index) => (
                         <DashboardCommentAndReplies
                             key={comment.commentId}
                             comment={comment}
+                            isResolved={comment.resolved}
                             projectUuid={projectUuid}
                             dashboardUuid={dashboardUuid}
                             dashboardTileUuid={dashboardTileUuid}
                             targetRef={
                                 // Assign the target ref to the last comment
-                                index === comments.length - 1 ? targetRef : null
+                                index === allComments.length - 1
+                                    ? targetRef
+                                    : null
                             }
                         />
                     ))}
-                    {!hasComments && (
+                    {allComments.length === 0 && (
                         <Text fz="xs" c="dimmed">
-                            No open comments
+                            No comments yet
                         </Text>
-                    )}
-
-                    {resolvedComments.length > 0 && (
-                        <Box>
-                            {hasComments && <Divider mx="-sm" mb="xs" />}
-                            <Button
-                                size="compact-xs"
-                                variant="subtle"
-                                color="gray"
-                                fz="xs"
-                                onClick={toggleShowResolved}
-                                rightSection={
-                                    <MantineIcon
-                                        icon={
-                                            showResolved
-                                                ? IconChevronUp
-                                                : IconChevronDown
-                                        }
-                                    />
-                                }
-                            >
-                                {showResolved ? 'Hide' : 'Show'} resolved (
-                                {resolvedComments.length})
-                            </Button>
-                            <Collapse in={showResolved}>
-                                <Stack gap="xs" mt="xs">
-                                    {resolvedComments.map((resolvedComment) => (
-                                        <DashboardCommentAndReplies
-                                            key={resolvedComment.commentId}
-                                            comment={resolvedComment}
-                                            projectUuid={projectUuid}
-                                            dashboardUuid={dashboardUuid}
-                                            dashboardTileUuid={
-                                                dashboardTileUuid
-                                            }
-                                            targetRef={null}
-                                            isResolved
-                                        />
-                                    ))}
-                                </Stack>
-                            </Collapse>
-                        </Box>
                     )}
                 </Stack>
 
-                {(hasComments || resolvedComments.length > 0) && <Divider />}
+                {allComments.length > 0 && <Divider />}
                 <Box p="sm" pt="xs">
                     {canCreateDashboardComments && (
                         <CommentForm

--- a/packages/frontend/src/features/comments/hooks/useComments.ts
+++ b/packages/frontend/src/features/comments/hooks/useComments.ts
@@ -77,48 +77,41 @@ const getDashboardComments = async ({
     });
 };
 
-export const useGetComments = (
+const useDashboardComments = (
     dashboardUuid: string,
     projectUuid: string | undefined,
     enabled: boolean,
+    resolved: boolean,
 ) =>
     useQuery<ApiGetComments['results'], ApiError>(
-        ['comments', dashboardUuid, projectUuid, { resolved: false }],
+        ['comments', dashboardUuid, projectUuid, { resolved }],
         async () => {
             if (!projectUuid) throw new Error('projectUuid is required');
             return getDashboardComments({
                 dashboardUuid,
                 projectUuid,
-                resolved: false,
+                resolved,
             });
         },
         {
-            refetchInterval: 3 * 60 * 1000, // 3 minutes
+            // Only poll the active (unresolved) comments
+            refetchInterval: resolved ? undefined : 3 * 60 * 1000,
             retry: (_, error) => error.error.statusCode !== 403,
             enabled: enabled && !!projectUuid,
         },
     );
 
+export const useGetComments = (
+    dashboardUuid: string,
+    projectUuid: string | undefined,
+    enabled: boolean,
+) => useDashboardComments(dashboardUuid, projectUuid, enabled, false);
+
 export const useGetResolvedComments = (
     dashboardUuid: string,
     projectUuid: string | undefined,
     enabled: boolean,
-) =>
-    useQuery<ApiGetComments['results'], ApiError>(
-        ['comments', dashboardUuid, projectUuid, { resolved: true }],
-        async () => {
-            if (!projectUuid) throw new Error('projectUuid is required');
-            return getDashboardComments({
-                dashboardUuid,
-                projectUuid,
-                resolved: true,
-            });
-        },
-        {
-            retry: (_, error) => error.error.statusCode !== 403,
-            enabled: enabled && !!projectUuid,
-        },
-    );
+) => useDashboardComments(dashboardUuid, projectUuid, enabled, true);
 
 type RemoveCommentParams = { commentId: string } & Pick<
     CreateDashboardTileComment,

--- a/packages/frontend/src/features/comments/hooks/useComments.ts
+++ b/packages/frontend/src/features/comments/hooks/useComments.ts
@@ -67,13 +67,15 @@ const getDashboardComments = async ({
     resolved,
 }: Pick<CreateDashboardTileComment, 'dashboardUuid' | 'projectUuid'> & {
     resolved: boolean;
-}) =>
-    lightdashApi<ApiGetComments['results']>({
-        url: `/projects/${projectUuid}/dashboards/${dashboardUuid}/comments?resolved=${resolved}`,
+}) => {
+    const queryParams = new URLSearchParams({ resolved: String(resolved) });
+    return lightdashApi<ApiGetComments['results']>({
+        url: `/projects/${projectUuid}/dashboards/${dashboardUuid}/comments?${queryParams.toString()}`,
         version: 'v2',
         method: 'GET',
         body: undefined,
     });
+};
 
 export const useGetComments = (
     dashboardUuid: string,
@@ -81,7 +83,7 @@ export const useGetComments = (
     enabled: boolean,
 ) =>
     useQuery<ApiGetComments['results'], ApiError>(
-        ['comments', dashboardUuid, projectUuid],
+        ['comments', dashboardUuid, projectUuid, { resolved: false }],
         async () => {
             if (!projectUuid) throw new Error('projectUuid is required');
             return getDashboardComments({
@@ -103,7 +105,7 @@ export const useGetResolvedComments = (
     enabled: boolean,
 ) =>
     useQuery<ApiGetComments['results'], ApiError>(
-        ['comments', dashboardUuid, projectUuid, 'resolved'],
+        ['comments', dashboardUuid, projectUuid, { resolved: true }],
         async () => {
             if (!projectUuid) throw new Error('projectUuid is required');
             return getDashboardComments({

--- a/packages/frontend/src/features/comments/hooks/useComments.ts
+++ b/packages/frontend/src/features/comments/hooks/useComments.ts
@@ -3,6 +3,7 @@ import {
     type ApiDeleteComment,
     type ApiError,
     type ApiGetComments,
+    type ApiResolveComment,
     type Comment,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -63,9 +64,12 @@ export const useCreateComment = () => {
 const getDashboardComments = async ({
     dashboardUuid,
     projectUuid,
-}: Pick<CreateDashboardTileComment, 'dashboardUuid' | 'projectUuid'>) =>
+    resolved,
+}: Pick<CreateDashboardTileComment, 'dashboardUuid' | 'projectUuid'> & {
+    resolved: boolean;
+}) =>
     lightdashApi<ApiGetComments['results']>({
-        url: `/projects/${projectUuid}/dashboards/${dashboardUuid}/comments`,
+        url: `/projects/${projectUuid}/dashboards/${dashboardUuid}/comments?resolved=${resolved}`,
         version: 'v2',
         method: 'GET',
         body: undefined,
@@ -80,10 +84,35 @@ export const useGetComments = (
         ['comments', dashboardUuid, projectUuid],
         async () => {
             if (!projectUuid) throw new Error('projectUuid is required');
-            return getDashboardComments({ dashboardUuid, projectUuid });
+            return getDashboardComments({
+                dashboardUuid,
+                projectUuid,
+                resolved: false,
+            });
         },
         {
             refetchInterval: 3 * 60 * 1000, // 3 minutes
+            retry: (_, error) => error.error.statusCode !== 403,
+            enabled: enabled && !!projectUuid,
+        },
+    );
+
+export const useGetResolvedComments = (
+    dashboardUuid: string,
+    projectUuid: string | undefined,
+    enabled: boolean,
+) =>
+    useQuery<ApiGetComments['results'], ApiError>(
+        ['comments', dashboardUuid, projectUuid, 'resolved'],
+        async () => {
+            if (!projectUuid) throw new Error('projectUuid is required');
+            return getDashboardComments({
+                dashboardUuid,
+                projectUuid,
+                resolved: true,
+            });
+        },
+        {
             retry: (_, error) => error.error.statusCode !== 403,
             enabled: enabled && !!projectUuid,
         },
@@ -112,6 +141,43 @@ export const useRemoveComment = () => {
         (data) => removeComment(data),
         {
             mutationKey: ['remove-comment'],
+            onSuccess: async (_, { dashboardUuid }) => {
+                await Promise.all([
+                    queryClient.invalidateQueries(['comments', dashboardUuid]),
+                    queryClient.invalidateQueries([
+                        'comments',
+                        params.dashboardUuid,
+                    ]),
+                ]);
+            },
+        },
+    );
+};
+
+type ResolveCommentParams = { commentId: string; resolved: boolean } & Pick<
+    CreateDashboardTileComment,
+    'dashboardUuid'
+>;
+
+const resolveComment = async ({
+    commentId,
+    dashboardUuid,
+    resolved,
+}: ResolveCommentParams) =>
+    lightdashApi<ApiResolveComment>({
+        url: `/comments/dashboards/${dashboardUuid}/${commentId}`,
+        method: 'PATCH',
+        body: JSON.stringify({ resolved }),
+    });
+
+export const useResolveComment = () => {
+    const queryClient = useQueryClient();
+    const params = useParams();
+
+    return useMutation<ApiResolveComment, ApiError, ResolveCommentParams>(
+        (data) => resolveComment(data),
+        {
+            mutationKey: ['resolve-comment'],
             onSuccess: async (_, { dashboardUuid }) => {
                 await Promise.all([
                     queryClient.invalidateQueries(['comments', dashboardUuid]),

--- a/packages/frontend/src/features/comments/hooks/useDashboardCommentsCheck.ts
+++ b/packages/frontend/src/features/comments/hooks/useDashboardCommentsCheck.ts
@@ -16,6 +16,11 @@ export const useDashboardCommentsCheck = (
         'DashboardComments',
     );
 
+    const canManageDashboardComments = !!user?.ability?.can(
+        'manage',
+        'DashboardComments',
+    );
+
     // Default-on; opt out via DISABLE_DASHBOARD_COMMENTS=true on the backend.
     const isDashboardCommentsEnabled =
         health.data?.dashboardComments?.enabled ?? true;
@@ -25,5 +30,7 @@ export const useDashboardCommentsCheck = (
             isDashboardCommentsEnabled && canViewDashboardComments,
         canCreateDashboardComments:
             isDashboardCommentsEnabled && canCreateDashboardComments,
+        canManageDashboardComments:
+            isDashboardCommentsEnabled && canManageDashboardComments,
     };
 };


### PR DESCRIPTION
Closes: PROD-2495
Closes: #9457

### Description:

Adds the ability to **resolve** a dashboard tile comment thread — hiding it and clearing the tile's comment count indicator while preserving the thread (not deleting it). Resolved threads can be viewed read-only via a **"Show resolved (N)"** toggle in the tile comment popover and reopened with an **Unresolve** action. Resolving/unresolving applies to the whole thread (parent + replies), and is gated to users with `manage:DashboardComments`. The backend resolve plumbing already existed; this wires up the frontend, parameterises the comments query by resolved state (`?resolved=true|false`), and adds the unresolve path (`comment.unresolved` analytics event).


<img width="2134" height="1186" alt="CleanShot 2026-06-09 at 17 14 12@2x" src="https://github.com/user-attachments/assets/3e9c874c-3391-4f1b-a7a1-40572e3a2377" />
<img width="2134" height="1186" alt="CleanShot 2026-06-09 at 17 14 22@2x" src="https://github.com/user-attachments/assets/37f725ba-8408-40fb-bca0-d04d20cc4987" />
<img width="2208" height="1188" alt="CleanShot 2026-06-09 at 17 20 41@2x" src="https://github.com/user-attachments/assets/eee378fa-1180-43fb-add1-95b465dadc20" />
<img width="2236" height="1180" alt="CleanShot 2026-06-09 at 17 21 12@2x" src="https://github.com/user-attachments/assets/6b7d4a01-fa37-4ea7-a340-994ef0f465f9" />

