### PR TITLE
fix(export): include pivot table totals in CSV/XLSX downloads

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -9,6 +9,8 @@ import {
     applyDashboardFiltersForTile,
     assertIsAccountWithOrg,
     assertUnreachable,
+    buildWarehouseColumnTotals,
+    buildWarehouseRowTotals,
     CalculateSubtotalsFromQuery,
     CalculateTotalFromQuery,
     CompiledDimension,
@@ -34,6 +36,7 @@ import {
     formatRawRows,
     formatRawValue,
     formatRow,
+    formatRows,
     getAccountUserTimezone,
     getAvailableFilterFieldIds,
     getColumnTimezone,
@@ -101,6 +104,7 @@ import {
     type Organization,
     type ParameterDefinitions,
     type ParametersValuesMap,
+    type PivotRowTotalsByIndex,
     type PivotValuesColumn,
     type Project,
     type QueryHistory,
@@ -1215,6 +1219,91 @@ export class AsyncQueryService extends ProjectService {
         });
     }
 
+    /**
+     * Pivot totals are exclusively warehouse-computed — the export renderer has
+     * no client-side fallback, so without this they come out blank. Mirrors the
+     * UI: re-run the source query collapsed across the pivot (`calculate-total`)
+     * and key the results so the pivot worker can match each rendered cell. A
+     * failed totals query (e.g. source can't be totalled) never fails the
+     * export — that total is simply left blank, as it is in the UI.
+     */
+    private async getExportWarehouseTotals({
+        account,
+        projectUuid,
+        sourceQueryUuid,
+        pivotConfig,
+        pivotDetails,
+    }: {
+        account: Account;
+        projectUuid: string;
+        sourceQueryUuid: string;
+        pivotConfig: PivotConfig;
+        pivotDetails: NonNullable<ReadyQueryResultsPage['pivotDetails']>;
+    }): Promise<{
+        warehouseRowTotals?: PivotRowTotalsByIndex;
+        warehouseColumnTotals?: Record<string, number>;
+    }> {
+        let warehouseColumnTotals: Record<string, number> | undefined;
+        let warehouseRowTotals: PivotRowTotalsByIndex | undefined;
+
+        if (pivotConfig.columnTotals) {
+            try {
+                const { rows, fields } =
+                    await this.executeCalculateTotalAndGetResults({
+                        account,
+                        projectUuid,
+                        queryUuid: sourceQueryUuid,
+                        kind: 'columnTotal',
+                    });
+                warehouseColumnTotals = buildWarehouseColumnTotals(
+                    formatRows(rows, fields),
+                );
+            } catch (error) {
+                this.logger.warn(
+                    'Failed to compute column totals for pivot export',
+                    {
+                        projectUuid,
+                        sourceQueryUuid,
+                        error: getErrorMessage(error),
+                    },
+                );
+            }
+        }
+
+        const { indexColumn } = pivotDetails;
+        const indexFieldIds = indexColumn
+            ? (Array.isArray(indexColumn) ? indexColumn : [indexColumn]).map(
+                  (col) => col.reference,
+              )
+            : [];
+        if (pivotConfig.rowTotals && indexFieldIds.length > 0) {
+            try {
+                const { rows, fields } =
+                    await this.executeCalculateTotalAndGetResults({
+                        account,
+                        projectUuid,
+                        queryUuid: sourceQueryUuid,
+                        kind: 'rowTotal',
+                    });
+                warehouseRowTotals = buildWarehouseRowTotals(
+                    formatRows(rows, fields),
+                    indexFieldIds,
+                );
+            } catch (error) {
+                this.logger.warn(
+                    'Failed to compute row totals for pivot export',
+                    {
+                        projectUuid,
+                        sourceQueryUuid,
+                        error: getErrorMessage(error),
+                    },
+                );
+            }
+        }
+
+        return { warehouseRowTotals, warehouseColumnTotals };
+    }
+
     private async downloadAsyncQueryResults({
         account,
         projectUuid,
@@ -1376,6 +1465,24 @@ export class AsyncQueryService extends ProjectService {
                   }
                 : undefined;
 
+        // Warehouse-computed totals for the pivot export — without these the
+        // renderer leaves total cells blank (no client-side fallback).
+        const { warehouseRowTotals, warehouseColumnTotals } =
+            downloadPivotConfig &&
+            pivotDetails &&
+            (downloadPivotConfig.rowTotals || downloadPivotConfig.columnTotals)
+                ? await this.getExportWarehouseTotals({
+                      account,
+                      projectUuid,
+                      sourceQueryUuid: queryUuid,
+                      pivotConfig: downloadPivotConfig,
+                      pivotDetails,
+                  })
+                : {
+                      warehouseRowTotals: undefined,
+                      warehouseColumnTotals: undefined,
+                  };
+
         switch (type) {
             case DownloadFileType.CSV:
                 // Check if this is a pivot table download
@@ -1391,6 +1498,8 @@ export class AsyncQueryService extends ProjectService {
                         projectUuid,
                         storageClient: resultsStorageClient,
                         pivotDetails,
+                        warehouseRowTotals,
+                        warehouseColumnTotals,
                         options: {
                             onlyRaw,
                             showTableNames,
@@ -1456,6 +1565,8 @@ export class AsyncQueryService extends ProjectService {
                                   )
                               ).csvCellsLimit,
                               pivotDetails,
+                              warehouseRowTotals,
+                              warehouseColumnTotals,
                               options: {
                                   onlyRaw,
                                   showTableNames,
@@ -5951,6 +6062,52 @@ export class AsyncQueryService extends ProjectService {
             account,
             projectUuid,
             queryUuid,
+            cacheMetadata,
+            fields,
+        });
+    }
+
+    /**
+     * Execute a calculate-total query (row/column totals) derived from a source
+     * query and wait for all results. Mirrors `executeMetricQueryAndGetResults`
+     * but starts from `executeAsyncCalculateTotalFromQueryHistory`.
+     */
+    private async executeCalculateTotalAndGetResults(
+        args: {
+            account: Account;
+            projectUuid: string;
+            queryUuid: string;
+            kind: CalculateTotalKind;
+            subtotalDimensions?: string[];
+            invalidateCache?: boolean;
+        },
+        pollingOptions?: PollingOptions,
+    ): Promise<{
+        rows: Record<string, unknown>[];
+        cacheMetadata: CacheMetadata;
+        fields: ItemsMap;
+        pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+        displayTimezone: string | null;
+    }> {
+        const { account, projectUuid } = args;
+
+        const {
+            queryUuid: totalsQueryUuid,
+            cacheMetadata,
+            fields,
+        } = await this.executeAsyncCalculateTotalFromQueryHistory(args);
+
+        await this.pollForQueryCompletion({
+            account,
+            projectUuid,
+            queryUuid: totalsQueryUuid,
+            ...pollingOptions,
+        });
+
+        return this.getReadyQueryResults({
+            account,
+            projectUuid,
+            queryUuid: totalsQueryUuid,
             cacheMetadata,
             fields,
         });

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -18,6 +18,7 @@ import {
     timeIntervalToExcelNumFmt,
     toExcelWallClockDate,
     UnexpectedServerError,
+    type PivotRowTotalsByIndex,
     type ReadyQueryResultsPage,
 } from '@lightdash/common';
 import * as Excel from 'exceljs';
@@ -143,6 +144,8 @@ export class ExcelService {
         onlyRaw,
         customLabels,
         pivotDetails,
+        warehouseRowTotals,
+        warehouseColumnTotals,
         enableImprovedExcelDates = false,
         timezone,
     }: {
@@ -152,6 +155,8 @@ export class ExcelService {
         onlyRaw: boolean;
         customLabels: Record<string, string> | undefined;
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+        warehouseRowTotals?: PivotRowTotalsByIndex;
+        warehouseColumnTotals?: Record<string, number>;
         enableImprovedExcelDates?: boolean;
         timezone?: string;
     }): Promise<Excel.Buffer> {
@@ -177,6 +182,8 @@ export class ExcelService {
                 onlyRaw,
                 customLabels,
                 pivotDetails,
+                warehouseRowTotals,
+                warehouseColumnTotals,
                 timezone,
             });
         }
@@ -188,6 +195,8 @@ export class ExcelService {
             customLabels,
             onlyRaw,
             pivotDetails,
+            warehouseRowTotals,
+            warehouseColumnTotals,
         });
 
         // Build date column metadata: for each data column, determine if
@@ -306,6 +315,8 @@ export class ExcelService {
         onlyRaw,
         customLabels,
         pivotDetails,
+        warehouseRowTotals,
+        warehouseColumnTotals,
         timezone,
     }: {
         formattedRows: ResultRow[];
@@ -314,6 +325,8 @@ export class ExcelService {
         onlyRaw: boolean;
         customLabels: Record<string, string> | undefined;
         pivotDetails: NonNullable<ReadyQueryResultsPage['pivotDetails']>;
+        warehouseRowTotals?: PivotRowTotalsByIndex;
+        warehouseColumnTotals?: Record<string, number>;
         timezone?: string;
     }): Promise<Excel.Buffer> {
         const csvResults = pivotResultsAsCsv({
@@ -323,6 +336,8 @@ export class ExcelService {
             customLabels,
             onlyRaw,
             pivotDetails,
+            warehouseRowTotals,
+            warehouseColumnTotals,
         });
 
         const workbook = new Excel.Workbook();
@@ -376,6 +391,8 @@ export class ExcelService {
         lightdashConfig,
         options,
         pivotDetails,
+        warehouseRowTotals,
+        warehouseColumnTotals,
         timezone,
         csvCellsLimit,
     }: {
@@ -385,6 +402,8 @@ export class ExcelService {
         exportsStorageClient: FileStorageClient;
         lightdashConfig: LightdashConfig;
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+        warehouseRowTotals?: PivotRowTotalsByIndex;
+        warehouseColumnTotals?: Record<string, number>;
         options: {
             onlyRaw: boolean;
             showTableNames: boolean;
@@ -445,6 +464,8 @@ export class ExcelService {
             onlyRaw,
             customLabels,
             pivotDetails,
+            warehouseRowTotals,
+            warehouseColumnTotals,
             enableImprovedExcelDates: lightdashConfig.enableImprovedExcelDates,
             timezone,
         });

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -8,6 +8,7 @@ import {
     PivotConfig,
     pivotResultsAsCsv,
     UnexpectedServerError,
+    type PivotRowTotalsByIndex,
     type ReadyQueryResultsPage,
 } from '@lightdash/common';
 import { stringify } from 'csv-stringify';
@@ -107,6 +108,8 @@ export class PivotTableService extends BaseService {
         storageClient,
         options,
         pivotDetails,
+        warehouseRowTotals,
+        warehouseColumnTotals,
         organizationUuid,
         createdByUserUuid,
         expirationSecondsOverride,
@@ -118,6 +121,8 @@ export class PivotTableService extends BaseService {
         projectUuid: string;
         storageClient: S3ResultsFileStorageClient;
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+        warehouseRowTotals?: PivotRowTotalsByIndex;
+        warehouseColumnTotals?: Record<string, number>;
         options: {
             onlyRaw: boolean;
             showTableNames: boolean;
@@ -186,6 +191,8 @@ export class PivotTableService extends BaseService {
             truncated: finalTruncated,
             customLabels,
             pivotDetails,
+            warehouseRowTotals,
+            warehouseColumnTotals,
             organizationUuid,
             createdByUserUuid,
             expirationSecondsOverride,
@@ -214,6 +221,8 @@ export class PivotTableService extends BaseService {
         truncated,
         customLabels,
         pivotDetails,
+        warehouseRowTotals,
+        warehouseColumnTotals,
         organizationUuid,
         createdByUserUuid,
         expirationSecondsOverride,
@@ -225,6 +234,8 @@ export class PivotTableService extends BaseService {
         itemMap: ItemsMap;
         pivotConfig: PivotConfig;
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+        warehouseRowTotals?: PivotRowTotalsByIndex;
+        warehouseColumnTotals?: Record<string, number>;
         exploreId: string;
         onlyRaw: boolean;
         truncated: boolean;
@@ -268,6 +279,8 @@ export class PivotTableService extends BaseService {
             customLabels,
             onlyRaw,
             pivotDetails,
+            warehouseRowTotals,
+            warehouseColumnTotals,
             timezone,
             formatTemporalsForSpreadsheet: true,
         });

--- a/packages/common/src/pivot/buildWarehouseTotals.test.ts
+++ b/packages/common/src/pivot/buildWarehouseTotals.test.ts
@@ -1,0 +1,58 @@
+import type { ResultRow } from '../types/results';
+import {
+    buildPivotRowTotalKey,
+    buildWarehouseColumnTotals,
+    buildWarehouseRowTotals,
+} from './pivotQueryResults';
+
+const cell = (raw: unknown): ResultRow[string] => ({
+    value: { raw, formatted: String(raw) },
+});
+
+const row = (values: Record<string, unknown>): ResultRow =>
+    Object.fromEntries(
+        Object.entries(values).map(([key, raw]) => [key, cell(raw)]),
+    );
+
+describe('buildWarehouseColumnTotals', () => {
+    it('flattens the first row into numeric column totals', () => {
+        const rows = [row({ revenue_card: 100, revenue_cash: 50.5 })];
+        expect(buildWarehouseColumnTotals(rows)).toEqual({
+            revenue_card: 100,
+            revenue_cash: 50.5,
+        });
+    });
+
+    it('coerces numeric strings and drops non-numeric cells', () => {
+        const rows = [row({ revenue: '123.4', label: 'Total', missing: null })];
+        expect(buildWarehouseColumnTotals(rows)).toEqual({ revenue: 123.4 });
+    });
+
+    it('returns an empty map when there are no rows', () => {
+        expect(buildWarehouseColumnTotals([])).toEqual({});
+    });
+});
+
+describe('buildWarehouseRowTotals', () => {
+    it('keys each row by its index values and excludes index fields', () => {
+        const indexFieldIds = ['order_date'];
+        const rows = [
+            row({ order_date: '2024-01-01', revenue: 10, count: 2 }),
+            row({ order_date: '2024-01-02', revenue: 20, count: 4 }),
+        ];
+
+        const result = buildWarehouseRowTotals(rows, indexFieldIds);
+
+        const key1 = buildPivotRowTotalKey([['order_date', '2024-01-01']]);
+        const key2 = buildPivotRowTotalKey([['order_date', '2024-01-02']]);
+        expect(result[key1]).toEqual({ revenue: 10, count: 2 });
+        expect(result[key2]).toEqual({ revenue: 20, count: 4 });
+    });
+
+    it('drops non-numeric metric cells', () => {
+        const rows = [row({ dim: 'a', revenue: 'not-a-number', count: 3 })];
+        const result = buildWarehouseRowTotals(rows, ['dim']);
+        const key = buildPivotRowTotalKey([['dim', 'a']]);
+        expect(result[key]).toEqual({ count: 3 });
+    });
+});

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -72,6 +72,69 @@ export const buildPivotRowTotalKey = (
             .map(([fieldId, raw]) => [fieldId, normalizePivotMatchRaw(raw)]),
     );
 
+// Coerce a warehouse cell's raw value to a finite number, or null. Numeric
+// strings are accepted (some warehouses return decimals as strings); null,
+// undefined, empty and non-numeric values are rejected.
+const toFiniteNumber = (raw: unknown): number | null => {
+    if (raw === null || raw === undefined || raw === '') return null;
+    const numeric = Number(raw);
+    return Number.isFinite(numeric) ? numeric : null;
+};
+
+/**
+ * Flatten the single wide totals row from a `calculate-total`
+ * (`kind: 'columnTotal'`) response into the `warehouseColumnTotals` map keyed by
+ * pivot SQL column name. Non-numeric cells are dropped — the lookup only uses
+ * numbers. Shared by the frontend hook and the backend export path so both
+ * produce identical column totals.
+ */
+export const buildWarehouseColumnTotals = (
+    rows: ResultRow[],
+): Record<string, number> => {
+    const firstRow = rows[0];
+    if (!firstRow) return {};
+    const totals: Record<string, number> = {};
+    for (const [key, cell] of Object.entries(firstRow)) {
+        const numeric = toFiniteNumber(cell?.value?.raw);
+        if (numeric !== null) {
+            totals[key] = numeric;
+        }
+    }
+    return totals;
+};
+
+/**
+ * Build the `warehouseRowTotals` map from a `calculate-total`
+ * (`kind: 'rowTotal'`) response — one flat row per index-value combination, each
+ * keyed by its index-dimension values (`buildPivotRowTotalKey`) → metric fieldId
+ * → numeric total. `indexFieldIds` must match the index dims the pivot worker
+ * uses so the keys align. Shared by the frontend hook and the backend export
+ * path.
+ */
+export const buildWarehouseRowTotals = (
+    rows: ResultRow[],
+    indexFieldIds: string[],
+): PivotRowTotalsByIndex => {
+    const indexFieldIdSet = new Set(indexFieldIds);
+    const map: PivotRowTotalsByIndex = {};
+    for (const row of rows) {
+        const key = buildPivotRowTotalKey(
+            indexFieldIds.map((fieldId) => [fieldId, row[fieldId]?.value?.raw]),
+        );
+        const metricTotals: Record<string, number> = {};
+        for (const [fieldId, cell] of Object.entries(row)) {
+            if (!indexFieldIdSet.has(fieldId)) {
+                const numeric = toFiniteNumber(cell?.value?.raw);
+                if (numeric !== null) {
+                    metricTotals[fieldId] = numeric;
+                }
+            }
+        }
+        map[key] = metricTotals;
+    }
+    return map;
+};
+
 // Backend `.formatted` strings don't resolve ${ld.parameters.*} placeholders
 // (parameters live on the client). For flat tables, useColumns re-formats per
 // cell. The pivot path stores backend values verbatim, so we do the same
@@ -1334,6 +1397,10 @@ type PivotResultsParams = {
     // When true, shiftable temporal cells (header + body, both modes) emit
     // the wall-clock format spreadsheet apps auto-detect as a date.
     formatTemporalsForSpreadsheet?: boolean;
+    // Warehouse-computed totals (from `calculate-total`). Without them the
+    // pivot worker leaves total cells blank — there is no client-side fallback.
+    warehouseRowTotals?: PivotRowTotalsByIndex;
+    warehouseColumnTotals?: Record<string, number>;
 };
 
 export const pivotResultsAsData = ({
@@ -1346,6 +1413,8 @@ export const pivotResultsAsData = ({
     pivotDetails,
     timezone,
     formatTemporalsForSpreadsheet = false,
+    warehouseRowTotals,
+    warehouseColumnTotals,
 }: PivotResultsParams): PivotResultsData => {
     const getFieldLabel = (fieldId: string) => {
         const customLabel = customLabels?.[fieldId];
@@ -1360,6 +1429,8 @@ export const pivotResultsAsData = ({
         pivotDetails,
         pivotConfig,
         groupedSubtotals: undefined,
+        warehouseRowTotals,
+        warehouseColumnTotals,
     });
 
     const formatField = onlyRaw ? 'raw' : 'formatted';

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1503,7 +1503,75 @@ export const pivotResultsAsData = ({
         return [...noIndexPrefix, ...cells];
     });
 
-    return { headers, dataRows, fieldIds, hasIndex };
+    // Column totals render as footer row(s) below the data — mirroring the
+    // pivot table UI. Each row is [index labels, per-column totals, blank row
+    // total cells], matching the header/data column order. Only present when
+    // column totals are enabled (and therefore the table has an index).
+    const columnTotalRows: PivotResultsDataCell[][] = (
+        pivotedResults.columnTotals ?? []
+    ).map((totalRow, totalRowIndex) => {
+        const totalFieldsRow =
+            pivotedResults.columnTotalFields?.[totalRowIndex] ?? [];
+        const lastTotalField = last(totalFieldsRow);
+        const lastHeaderRow = last(pivotedResults.headerValues) ?? [];
+
+        const labelCells: PivotResultsDataCell[] = totalFieldsRow.map(
+            (totalField) => {
+                const label = totalField
+                    ? `Total${
+                          totalField.fieldId
+                              ? ` ${getFieldLabel(totalField.fieldId)}`
+                              : ''
+                      }`
+                    : '';
+                return { raw: label, formatted: label, fieldId: '' };
+            },
+        );
+
+        const dataCells: PivotResultsDataCell[] = totalRow.map(
+            (total, colIndex) => {
+                if (total === null || total === undefined) {
+                    return {
+                        raw: '',
+                        formatted: undefinedCharacter,
+                        fieldId: '',
+                    };
+                }
+                // The total's metric is the per-row metric (metricsAsRows) or
+                // the data column's metric (metricsAsColumns).
+                const headerCell = lastHeaderRow[colIndex];
+                let fieldId: string | undefined;
+                if (pivotConfig.metricsAsRows) {
+                    fieldId = lastTotalField?.fieldId;
+                } else if (headerCell && 'fieldId' in headerCell) {
+                    fieldId = headerCell.fieldId;
+                }
+                const field = fieldId ? itemMap[fieldId] : undefined;
+                const formatted = onlyRaw
+                    ? String(total)
+                    : formatItemValue(field, total, false);
+                return { raw: total, formatted, fieldId: fieldId ?? '' };
+            },
+        );
+
+        const rowTotalCells: PivotResultsDataCell[] =
+            pivotConfig.rowTotals && pivotedResults.rowTotalFields?.[0]
+                ? pivotedResults.rowTotalFields[0].map(() => ({
+                      raw: '',
+                      formatted: '',
+                      fieldId: '',
+                  }))
+                : [];
+
+        return [...labelCells, ...dataCells, ...rowTotalCells];
+    });
+
+    return {
+        headers,
+        dataRows: [...dataRows, ...columnTotalRows],
+        fieldIds,
+        hasIndex,
+    };
 };
 
 export const pivotResultsAsCsv = (params: PivotResultsParams) => {

--- a/packages/common/src/pivot/pivotResultsAsCsv.test.ts
+++ b/packages/common/src/pivot/pivotResultsAsCsv.test.ts
@@ -141,6 +141,41 @@ describe('pivotResultsAsCsv', () => {
         });
     });
 
+    it('appends a column totals footer row when columnTotals is enabled', () => {
+        const baseParams = {
+            pivotConfig: PIVOT_CONFIG,
+            rows: SQL_PIVOTED_ROWS,
+            itemMap: buildItemsMap(),
+            customLabels: undefined,
+            onlyRaw: false,
+            pivotDetails: SQL_PIVOT_DETAILS,
+        };
+        const withoutTotals = pivotResultsAsCsv(baseParams);
+
+        const withTotals = pivotResultsAsCsv({
+            ...baseParams,
+            pivotConfig: { ...PIVOT_CONFIG, columnTotals: true },
+            warehouseColumnTotals: {
+                payments_total_revenue_any_bank_transfer: 806.18,
+                payments_total_revenue_any_coupon: 258.64,
+                payments_total_revenue_any_credit_card: 1452.16,
+                payments_total_revenue_any_gift_card: 536.89,
+            },
+        });
+
+        // Exactly one extra row (the column totals footer)
+        expect(withTotals.length).toBe(withoutTotals.length + 1);
+
+        const footer = withTotals[withTotals.length - 1];
+        // Footer width matches the body rows
+        expect(footer.length).toBe(withTotals[withTotals.length - 2].length);
+        // "Total" label in the index column, then the per-column totals
+        expect(footer[0]).toBe('Total');
+        expect(footer).toContain('806.18');
+        expect(footer).toContain('258.64');
+        expect(footer).toContain('536.89');
+    });
+
     describe('passthrough dimension filtering (PROD-7873)', () => {
         // SQL-pivot path: when a hidden dim is carried through SQL as
         // `passthroughDimensions` so its values can be referenced by

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -1,5 +1,6 @@
 import {
-    buildPivotRowTotalKey,
+    buildWarehouseColumnTotals,
+    buildWarehouseRowTotals,
     getSubtotalKey,
     QueryHistoryStatus,
     type ApiError,
@@ -91,15 +92,9 @@ const fetchTotals = async (
         throw new Error('Unexpected query status while polling totals');
     }
 
-    const firstRow = query.rows[0];
-    if (!firstRow) return {};
-
-    // Flatten ResultRow cells (`{ value: { raw } }`) back to `{ key: raw }`.
-    const flat: Record<string, unknown> = {};
-    for (const [key, cell] of Object.entries(firstRow)) {
-        flat[key] = cell?.value?.raw;
-    }
-    return flat as AsyncTotalsMap;
+    // Polling endpoint defaults to page=1, so the READY response already
+    // contains the single totals row — no separate stream fetch needed.
+    return buildWarehouseColumnTotals(query.rows);
 };
 
 export const useAsyncCalculateTotal = ({
@@ -170,23 +165,7 @@ const fetchRowTotals = async (
 
     const rows = await fetchAllResultRows(projectUuid, queryUuid);
 
-    const indexFieldIdSet = new Set(indexFieldIds);
-    const map: PivotRowTotalsByIndex = {};
-    for (const row of rows) {
-        const key = buildPivotRowTotalKey(
-            indexFieldIds.map((fieldId) => [fieldId, row[fieldId]?.value.raw]),
-        );
-        const metricTotals: Record<string, number> = {};
-        for (const [fieldId, cell] of Object.entries(row)) {
-            if (indexFieldIdSet.has(fieldId)) continue;
-            const numeric = Number(cell?.value.raw);
-            if (Number.isFinite(numeric)) {
-                metricTotals[fieldId] = numeric;
-            }
-        }
-        map[key] = metricTotals;
-    }
-    return map;
+    return buildWarehouseRowTotals(rows, indexFieldIds);
 };
 
 export const useAsyncCalculateRowTotal = ({


### PR DESCRIPTION
Closes: PROD-8201
Closes: #24071

### Description:
Pivot row/column totals render in the UI but came out blank in CSV/XLSX exports because totals are warehouse-computed with no client-side fallback and the export path never fetched them. This PR computes the totals at export time (reusing the existing `calculate-total` machinery via a new `executeCalculateTotalAndGetResults`), threads them through `PivotTableService` and `ExcelService` into the shared pivot renderer, and adds reusable `buildWarehouseRowTotals`/`buildWarehouseColumnTotals` helpers in `common` that the frontend hook now reuses too. Totals are fetched only when the table viz has the corresponding row/column totals toggle enabled, and a failed totals query leaves the cells blank rather than failing the export.

#### Row & Column totals
<img width="2672" height="536" alt="CleanShot 2026-06-09 at 17 28 01@2x" src="https://github.com/user-attachments/assets/4cd17c60-4ff6-46e9-b535-99b35d26b7f4" />

#### Column totals
<img width="2088" height="504" alt="CleanShot 2026-06-09 at 17 29 17@2x" src="https://github.com/user-attachments/assets/7ef3b2d1-063a-44e8-8886-40aa8c0b2149" />

#### Row totals 
<img width="2632" height="462" alt="CleanShot 2026-06-09 at 17 30 05@2x" src="https://github.com/user-attachments/assets/a64ba3d3-9586-4ca0-9705-b4982e8c2f32" />
