### PR TITLE
feat(service-accounts): edit role, scopes, name & projects in place

### DIFF
--- a/packages/backend/src/ee/analytics/index.ts
+++ b/packages/backend/src/ee/analytics/index.ts
@@ -133,7 +133,8 @@ export type ScimAccessTokenEvent = BaseTrack & {
     event:
         | 'scim_access_token.created'
         | 'scim_access_token.deleted'
-        | 'scim_access_token.rotated';
+        | 'scim_access_token.rotated'
+        | 'scim_access_token.updated';
     userId: string;
     properties: {
         organizationId: string;

--- a/packages/backend/src/ee/controllers/serviceAccountsController.ts
+++ b/packages/backend/src/ee/controllers/serviceAccountsController.ts
@@ -2,6 +2,7 @@ import {
     ApiCreateServiceAccountRequest,
     ApiErrorPayload,
     ApiServiceAccountProjectGrantsResponse,
+    ApiUpdateServiceAccountRequest,
     assertRegisteredAccount,
     AuthTokenPrefix,
     ServiceAccount,
@@ -144,6 +145,39 @@ export class ServiceAccountsController extends BaseController {
         return {
             status: 'ok',
             results: undefined,
+        };
+    }
+
+    /**
+     * Update a service account's name and permissions in place by UUID,
+     * without rotating its token.
+     * @summary Update service account
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{tokenUuid}')
+    @OperationId('UpdateServiceAccount')
+    async updateServiceAccount(
+        @Path() tokenUuid: string,
+        @Request() req: express.Request,
+        @Body() body: ApiUpdateServiceAccountRequest,
+    ): Promise<{
+        status: 'ok';
+        results: ServiceAccount;
+    }> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getServiceAccountService().update({
+                user: toSessionUser(req.account),
+                tokenUuid,
+                update: body,
+            }),
         };
     }
 

--- a/packages/backend/src/ee/database/entities/serviceAccounts.ts
+++ b/packages/backend/src/ee/database/entities/serviceAccounts.ts
@@ -40,6 +40,13 @@ type DbRotateServiceAccount = {
     expires_at: Date;
 };
 
+// In-place edit of name + permission scopes. The token, expiry, and project
+// grants are never touched here (see `ServiceAccountModel.update`).
+export type DbUpdateServiceAccount = {
+    description?: string;
+    scopes?: string[];
+};
+
 type DbUpdateUsedDatePersonalAccessToken = {
     last_used_at: Date;
 };
@@ -53,6 +60,7 @@ export type ServiceAccountTable = Knex.CompositeTableType<
     DbServiceAccounts,
     DbCreateServiceAccount,
     | DbRotateServiceAccount
+    | DbUpdateServiceAccount
     | DbUpdateUsedDatePersonalAccessToken
     | DbBackfillServiceAccountUserUuid
 >;

--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -1,6 +1,7 @@
 import {
     AuthTokenPrefix,
     CreateServiceAccount,
+    NotFoundError,
     OrganizationMemberRole,
     ParameterError,
     ServiceAccount,
@@ -8,6 +9,7 @@ import {
     ServiceAccountWithToken,
     SessionUser,
     UnexpectedDatabaseError,
+    UpdateServiceAccount,
 } from '@lightdash/common';
 import * as crypto from 'crypto';
 import { Knex } from 'knex';
@@ -17,6 +19,7 @@ import { DbUser } from '../../database/entities/users';
 import { deprecatedHash, hash } from '../../utils/hash';
 import {
     DbServiceAccounts,
+    DbUpdateServiceAccount,
     ServiceAccountsTableName,
 } from '../database/entities/serviceAccounts';
 
@@ -285,6 +288,110 @@ export class ServiceAccountModel {
                 }),
                 token,
             };
+        });
+    }
+
+    // In-place edit of name + Organization-scope permission. Deliberately
+    // leaves `token_hash` (and expiry / project grants) untouched so existing
+    // integrations keep working — the point of PROD-8133. `description` is
+    // always applied and mirrored onto the SA user's `first_name`. The
+    // permission is only rewritten when `scopes` or `roleUuid` is supplied;
+    // a rename-only edit leaves the scopes / role membership as-is.
+    async update({
+        serviceAccountUuid,
+        data,
+    }: {
+        serviceAccountUuid: string;
+        data: UpdateServiceAccount;
+    }): Promise<ServiceAccount> {
+        // `description` mirrors onto the SA user's NOT NULL `first_name`, so
+        // guard here too (not just at the service) to stay self-defending.
+        if (!data.description || data.description.trim() === '') {
+            throw new ParameterError('Description is required');
+        }
+
+        // Same permission-shape invariant as `save`, minus the "at least one"
+        // requirement: editing the name without changing access is valid.
+        const hasScopes = !!data.scopes && data.scopes.length > 0;
+        const hasRoleUuid = !!data.roleUuid;
+        if (hasScopes && hasRoleUuid) {
+            throw new ParameterError(
+                'Specify either scopes or roleUuid, not both',
+            );
+        }
+
+        return this.database.transaction(async (trx) => {
+            const [existing] = await trx(ServiceAccountsTableName)
+                .where('service_account_uuid', serviceAccountUuid)
+                .select('organization_uuid', 'service_account_user_uuid');
+            if (!existing) {
+                throw new NotFoundError(
+                    `Service account ${serviceAccountUuid} not found`,
+                );
+            }
+            if (!existing.service_account_user_uuid) {
+                throw new UnexpectedDatabaseError(
+                    `Service account ${serviceAccountUuid} is missing service_account_user_uuid`,
+                );
+            }
+
+            const serviceAccountUpdate: DbUpdateServiceAccount = {
+                description: data.description,
+            };
+
+            // Permission change: rewrite the SA row's scopes and the backing
+            // user's org-membership role together so the runtime CASL source
+            // of truth stays consistent. Switching to a custom role clears
+            // the legacy scopes; switching to scopes clears the role link.
+            if (hasScopes || hasRoleUuid) {
+                if (data.roleUuid) {
+                    const [roleRow] = await trx(RolesTableName)
+                        .where('role_uuid', data.roleUuid)
+                        .andWhere(
+                            'organization_uuid',
+                            existing.organization_uuid,
+                        )
+                        .select('role_uuid');
+                    if (!roleRow) {
+                        throw new ParameterError(
+                            `Role ${data.roleUuid} not found in this organization`,
+                        );
+                    }
+                }
+
+                const scopes = data.scopes ?? [];
+                const role = hasRoleUuid
+                    ? OrganizationMemberRole.MEMBER
+                    : ServiceAccountModel.getRoleForScopes(scopes);
+                serviceAccountUpdate.scopes = scopes;
+
+                await trx(OrganizationMembershipsTableName)
+                    .update({ role, role_uuid: data.roleUuid ?? null })
+                    .whereIn(
+                        'user_id',
+                        trx('users')
+                            .where(
+                                'user_uuid',
+                                existing.service_account_user_uuid,
+                            )
+                            .select('user_id'),
+                    );
+            }
+
+            await trx(ServiceAccountsTableName)
+                .update(serviceAccountUpdate)
+                .where('service_account_uuid', serviceAccountUuid);
+            await trx('users')
+                .update({ first_name: data.description })
+                .where('user_uuid', existing.service_account_user_uuid);
+
+            const [row] = await this.serviceAccountSelectQuery()
+                .transacting(trx)
+                .where(
+                    `${ServiceAccountsTableName}.service_account_uuid`,
+                    serviceAccountUuid,
+                );
+            return ServiceAccountModel.mapDbObjectToServiceAccount(row);
         });
     }
 

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.test.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.test.ts
@@ -44,10 +44,15 @@ const buildMocks = (): Mocks => ({
     serviceAccountModel: {
         create: jest.fn(),
         delete: jest.fn().mockResolvedValue(undefined),
+        getTokenbyUuid: jest.fn(),
+        update: jest.fn(),
     } as AnyType,
     projectModel: {
         createServiceAccountProjectAccess: jest.fn(),
         findInvalidCustomRoleUuids: jest.fn().mockResolvedValue([]),
+        getProjectAccessCountsByServiceAccountUserUuids: jest
+            .fn()
+            .mockResolvedValue(new Map<string, number>()),
     } as AnyType,
     analytics: { track: jest.fn() } as AnyType,
     commercialFeatureFlagModel: {} as AnyType,
@@ -309,5 +314,192 @@ describe('ServiceAccountService.create with projectAccess', () => {
             ).rejects.toBeInstanceOf(ForbiddenError);
             expect(mocks.serviceAccountModel.create).not.toHaveBeenCalled();
         });
+    });
+});
+
+describe('ServiceAccountService.update', () => {
+    const nobodyUser = (): SessionUser => {
+        const builder = new AbilityBuilder<MemberAbility>(Ability);
+        return {
+            userUuid: 'nobody',
+            organizationUuid: ORG,
+            ability: builder.build(),
+        } as AnyType;
+    };
+
+    it('rejects non-org-admin before any model call', async () => {
+        const mocks = buildMocks();
+        const service = buildService(mocks);
+        await expect(
+            service.update({
+                user: nobodyUser(),
+                tokenUuid: 'sa-1',
+                update: { description: 'new name' },
+            }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(mocks.serviceAccountModel.getTokenbyUuid).not.toHaveBeenCalled();
+        expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['empty', ''],
+        ['whitespace', '   '],
+    ])(
+        'rejects %s description before touching the model',
+        async (_label, description) => {
+            const mocks = buildMocks();
+            const service = buildService(mocks);
+            await expect(
+                service.update({
+                    user: adminUser(),
+                    tokenUuid: 'sa-1',
+                    update: { description },
+                }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
+        },
+    );
+
+    it('throws NotFound when the SA does not exist', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(undefined);
+        const service = buildService(mocks);
+        await expect(
+            service.update({
+                user: adminUser(),
+                tokenUuid: 'sa-missing',
+                update: { description: 'new name' },
+            }),
+        ).rejects.toBeInstanceOf(NotFoundError);
+        expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
+    });
+
+    it('throws Forbidden when the SA belongs to another org', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue({
+            uuid: 'sa-1',
+            organizationUuid: 'other-org',
+        } as AnyType);
+        const service = buildService(mocks);
+        await expect(
+            service.update({
+                user: adminUser(),
+                tokenUuid: 'sa-1',
+                update: { description: 'new name' },
+            }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
+    });
+
+    it('updates the SA then tracks analytics without sensitive values', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue({
+            uuid: 'sa-1',
+            organizationUuid: ORG,
+            userUuid: 'sa-user-1',
+        } as AnyType);
+        mocks.serviceAccountModel.update.mockResolvedValue({
+            uuid: 'sa-1',
+            description: 'new name',
+        } as AnyType);
+        const service = buildService(mocks);
+
+        const result = await service.update({
+            user: adminUser(),
+            tokenUuid: 'sa-1',
+            update: {
+                description: 'new name',
+                scopes: [ServiceAccountScope.SYSTEM_ADMIN],
+            },
+        });
+
+        expect(result).toEqual({ uuid: 'sa-1', description: 'new name' });
+        expect(mocks.serviceAccountModel.update).toHaveBeenCalledWith({
+            serviceAccountUuid: 'sa-1',
+            data: {
+                description: 'new name',
+                scopes: [ServiceAccountScope.SYSTEM_ADMIN],
+            },
+        });
+        expect(mocks.analytics.track).toHaveBeenCalledTimes(1);
+        const tracked = mocks.analytics.track.mock.calls[0][0];
+        expect(tracked.event).toBe('scim_access_token.updated');
+        expect(tracked.properties).toEqual({ organizationId: ORG });
+    });
+
+    it('rejects a permission change on a project-scoped SA (would orphan grants)', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue({
+            uuid: 'sa-1',
+            organizationUuid: ORG,
+            userUuid: 'sa-user-1',
+        } as AnyType);
+        mocks.projectModel.getProjectAccessCountsByServiceAccountUserUuids.mockResolvedValue(
+            new Map([['sa-user-1', 2]]),
+        );
+        const service = buildService(mocks);
+
+        await expect(
+            service.update({
+                user: adminUser(),
+                tokenUuid: 'sa-1',
+                update: {
+                    description: 'still named',
+                    scopes: [ServiceAccountScope.SYSTEM_ADMIN],
+                },
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
+    });
+
+    it('allows a rename-only edit of a project-scoped SA', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue({
+            uuid: 'sa-1',
+            organizationUuid: ORG,
+            userUuid: 'sa-user-1',
+        } as AnyType);
+        mocks.projectModel.getProjectAccessCountsByServiceAccountUserUuids.mockResolvedValue(
+            new Map([['sa-user-1', 2]]),
+        );
+        mocks.serviceAccountModel.update.mockResolvedValue({
+            uuid: 'sa-1',
+            description: 'renamed',
+        } as AnyType);
+        const service = buildService(mocks);
+
+        await service.update({
+            user: adminUser(),
+            tokenUuid: 'sa-1',
+            update: { description: 'renamed' },
+        });
+
+        // No permission change → no grant lookup needed, update goes through.
+        expect(mocks.serviceAccountModel.update).toHaveBeenCalledWith({
+            serviceAccountUuid: 'sa-1',
+            data: { description: 'renamed' },
+        });
+    });
+
+    it('rejects setting system:member (has no project-access path here)', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue({
+            uuid: 'sa-1',
+            organizationUuid: ORG,
+            userUuid: 'sa-user-1',
+        } as AnyType);
+        const service = buildService(mocks);
+
+        await expect(
+            service.update({
+                user: adminUser(),
+                tokenUuid: 'sa-1',
+                update: {
+                    description: 'name',
+                    scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+                },
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.test.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.test.ts
@@ -53,6 +53,7 @@ const buildMocks = (): Mocks => ({
         getProjectAccessCountsByServiceAccountUserUuids: jest
             .fn()
             .mockResolvedValue(new Map<string, number>()),
+        setServiceAccountProjectAccess: jest.fn().mockResolvedValue(undefined),
     } as AnyType,
     analytics: { track: jest.fn() } as AnyType,
     commercialFeatureFlagModel: {} as AnyType,
@@ -391,13 +392,28 @@ describe('ServiceAccountService.update', () => {
         expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
     });
 
-    it('updates the SA then tracks analytics without sensitive values', async () => {
+    // An org-scoped SA carries a non-member scope; a project-scoped SA carries
+    // system:member. The two helpers build the matching getTokenbyUuid mock.
+    const orgScopedToken = (overrides: AnyType = {}) => ({
+        uuid: 'sa-1',
+        organizationUuid: ORG,
+        userUuid: 'sa-user-1',
+        scopes: [ServiceAccountScope.SYSTEM_VIEWER],
+        ...overrides,
+    });
+    const projectScopedToken = (overrides: AnyType = {}) => ({
+        uuid: 'sa-1',
+        organizationUuid: ORG,
+        userUuid: 'sa-user-1',
+        scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+        ...overrides,
+    });
+
+    it('updates an org-scoped SA then tracks analytics without sensitive values', async () => {
         const mocks = buildMocks();
-        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue({
-            uuid: 'sa-1',
-            organizationUuid: ORG,
-            userUuid: 'sa-user-1',
-        } as AnyType);
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
+            orgScopedToken() as AnyType,
+        );
         mocks.serviceAccountModel.update.mockResolvedValue({
             uuid: 'sa-1',
             description: 'new name',
@@ -419,23 +435,22 @@ describe('ServiceAccountService.update', () => {
             data: {
                 description: 'new name',
                 scopes: [ServiceAccountScope.SYSTEM_ADMIN],
+                roleUuid: undefined,
             },
         });
+        expect(
+            mocks.projectModel.setServiceAccountProjectAccess,
+        ).not.toHaveBeenCalled();
         expect(mocks.analytics.track).toHaveBeenCalledTimes(1);
         const tracked = mocks.analytics.track.mock.calls[0][0];
         expect(tracked.event).toBe('scim_access_token.updated');
         expect(tracked.properties).toEqual({ organizationId: ORG });
     });
 
-    it('rejects a permission change on a project-scoped SA (would orphan grants)', async () => {
+    it('rejects projectAccess on an org-scoped SA', async () => {
         const mocks = buildMocks();
-        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue({
-            uuid: 'sa-1',
-            organizationUuid: ORG,
-            userUuid: 'sa-user-1',
-        } as AnyType);
-        mocks.projectModel.getProjectAccessCountsByServiceAccountUserUuids.mockResolvedValue(
-            new Map([['sa-user-1', 2]]),
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
+            orgScopedToken() as AnyType,
         );
         const service = buildService(mocks);
 
@@ -444,50 +459,21 @@ describe('ServiceAccountService.update', () => {
                 user: adminUser(),
                 tokenUuid: 'sa-1',
                 update: {
-                    description: 'still named',
-                    scopes: [ServiceAccountScope.SYSTEM_ADMIN],
+                    description: 'name',
+                    projectAccess: [
+                        { projectUuid: PROJ_A, role: ProjectMemberRole.VIEWER },
+                    ],
                 },
             }),
         ).rejects.toBeInstanceOf(ParameterError);
         expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
     });
 
-    it('allows a rename-only edit of a project-scoped SA', async () => {
+    it('rejects setting system:member on an org-scoped SA', async () => {
         const mocks = buildMocks();
-        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue({
-            uuid: 'sa-1',
-            organizationUuid: ORG,
-            userUuid: 'sa-user-1',
-        } as AnyType);
-        mocks.projectModel.getProjectAccessCountsByServiceAccountUserUuids.mockResolvedValue(
-            new Map([['sa-user-1', 2]]),
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
+            orgScopedToken() as AnyType,
         );
-        mocks.serviceAccountModel.update.mockResolvedValue({
-            uuid: 'sa-1',
-            description: 'renamed',
-        } as AnyType);
-        const service = buildService(mocks);
-
-        await service.update({
-            user: adminUser(),
-            tokenUuid: 'sa-1',
-            update: { description: 'renamed' },
-        });
-
-        // No permission change → no grant lookup needed, update goes through.
-        expect(mocks.serviceAccountModel.update).toHaveBeenCalledWith({
-            serviceAccountUuid: 'sa-1',
-            data: { description: 'renamed' },
-        });
-    });
-
-    it('rejects setting system:member (has no project-access path here)', async () => {
-        const mocks = buildMocks();
-        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue({
-            uuid: 'sa-1',
-            organizationUuid: ORG,
-            userUuid: 'sa-user-1',
-        } as AnyType);
         const service = buildService(mocks);
 
         await expect(
@@ -501,5 +487,110 @@ describe('ServiceAccountService.update', () => {
             }),
         ).rejects.toBeInstanceOf(ParameterError);
         expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
+    });
+
+    it('replaces project grants on a project-scoped SA', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
+            projectScopedToken() as AnyType,
+        );
+        mocks.serviceAccountModel.update.mockResolvedValue({
+            uuid: 'sa-1',
+            description: 'renamed',
+        } as AnyType);
+        const service = buildService(mocks);
+
+        await service.update({
+            user: adminUser(),
+            tokenUuid: 'sa-1',
+            update: {
+                description: 'renamed',
+                scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+                projectAccess: [
+                    { projectUuid: PROJ_A, role: ProjectMemberRole.EDITOR },
+                    { projectUuid: PROJ_B, roleUuid: CUSTOM_ROLE },
+                ],
+            },
+        });
+
+        // Name updated via the SA model (scopes left as system:member),
+        // grants replaced wholesale via the project model.
+        expect(mocks.serviceAccountModel.update).toHaveBeenCalledWith({
+            serviceAccountUuid: 'sa-1',
+            data: { description: 'renamed' },
+        });
+        expect(
+            mocks.projectModel.setServiceAccountProjectAccess,
+        ).toHaveBeenCalledWith('sa-1', [
+            { projectUuid: PROJ_A, role: ProjectMemberRole.EDITOR },
+            { projectUuid: PROJ_B, roleUuid: CUSTOM_ROLE },
+        ]);
+        expect(mocks.analytics.track).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects emptying all project access on a project-scoped SA', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
+            projectScopedToken() as AnyType,
+        );
+        const service = buildService(mocks);
+
+        await expect(
+            service.update({
+                user: adminUser(),
+                tokenUuid: 'sa-1',
+                update: { description: 'name', projectAccess: [] },
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(
+            mocks.projectModel.setServiceAccountProjectAccess,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('rejects assigning an org role to a project-scoped SA', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
+            projectScopedToken() as AnyType,
+        );
+        const service = buildService(mocks);
+
+        await expect(
+            service.update({
+                user: adminUser(),
+                tokenUuid: 'sa-1',
+                update: {
+                    description: 'name',
+                    scopes: [ServiceAccountScope.SYSTEM_ADMIN],
+                },
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
+    });
+
+    it('allows a rename-only edit of a project-scoped SA (grants untouched)', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
+            projectScopedToken() as AnyType,
+        );
+        mocks.serviceAccountModel.update.mockResolvedValue({
+            uuid: 'sa-1',
+            description: 'renamed',
+        } as AnyType);
+        const service = buildService(mocks);
+
+        await service.update({
+            user: adminUser(),
+            tokenUuid: 'sa-1',
+            update: { description: 'renamed' },
+        });
+
+        expect(mocks.serviceAccountModel.update).toHaveBeenCalledWith({
+            serviceAccountUuid: 'sa-1',
+            data: { description: 'renamed' },
+        });
+        // No projectAccess in the payload → grants left as-is.
+        expect(
+            mocks.projectModel.setServiceAccountProjectAccess,
+        ).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.test.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.test.ts
@@ -447,29 +447,45 @@ describe('ServiceAccountService.update', () => {
         expect(tracked.properties).toEqual({ organizationId: ORG });
     });
 
-    it('rejects projectAccess on an org-scoped SA', async () => {
+    it('switches an org-scoped SA to project-scoped (sets grants + member scope)', async () => {
         const mocks = buildMocks();
         mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
             orgScopedToken() as AnyType,
         );
+        mocks.serviceAccountModel.update.mockResolvedValue({
+            uuid: 'sa-1',
+            description: 'switched',
+        } as AnyType);
         const service = buildService(mocks);
 
-        await expect(
-            service.update({
-                user: adminUser(),
-                tokenUuid: 'sa-1',
-                update: {
-                    description: 'name',
-                    projectAccess: [
-                        { projectUuid: PROJ_A, role: ProjectMemberRole.VIEWER },
-                    ],
-                },
-            }),
-        ).rejects.toBeInstanceOf(ParameterError);
-        expect(mocks.serviceAccountModel.update).not.toHaveBeenCalled();
+        await service.update({
+            user: adminUser(),
+            tokenUuid: 'sa-1',
+            update: {
+                description: 'switched',
+                scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+                projectAccess: [
+                    { projectUuid: PROJ_A, role: ProjectMemberRole.VIEWER },
+                ],
+            },
+        });
+
+        // Grants applied first, then scopes flipped to system:member.
+        expect(
+            mocks.projectModel.setServiceAccountProjectAccess,
+        ).toHaveBeenCalledWith('sa-1', [
+            { projectUuid: PROJ_A, role: ProjectMemberRole.VIEWER },
+        ]);
+        expect(mocks.serviceAccountModel.update).toHaveBeenCalledWith({
+            serviceAccountUuid: 'sa-1',
+            data: {
+                description: 'switched',
+                scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+            },
+        });
     });
 
-    it('rejects setting system:member on an org-scoped SA', async () => {
+    it('rejects system:member with no project access', async () => {
         const mocks = buildMocks();
         mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
             orgScopedToken() as AnyType,
@@ -513,11 +529,14 @@ describe('ServiceAccountService.update', () => {
             },
         });
 
-        // Name updated via the SA model (scopes left as system:member),
-        // grants replaced wholesale via the project model.
+        // Name + member scope set via the SA model, grants replaced wholesale
+        // via the project model.
         expect(mocks.serviceAccountModel.update).toHaveBeenCalledWith({
             serviceAccountUuid: 'sa-1',
-            data: { description: 'renamed' },
+            data: {
+                description: 'renamed',
+                scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+            },
         });
         expect(
             mocks.projectModel.setServiceAccountProjectAccess,
@@ -547,7 +566,41 @@ describe('ServiceAccountService.update', () => {
         ).not.toHaveBeenCalled();
     });
 
-    it('rejects assigning an org role to a project-scoped SA', async () => {
+    it('switches a project-scoped SA to org-scoped (sets role + clears grants)', async () => {
+        const mocks = buildMocks();
+        mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
+            projectScopedToken() as AnyType,
+        );
+        mocks.serviceAccountModel.update.mockResolvedValue({
+            uuid: 'sa-1',
+            description: 'switched',
+        } as AnyType);
+        const service = buildService(mocks);
+
+        await service.update({
+            user: adminUser(),
+            tokenUuid: 'sa-1',
+            update: {
+                description: 'switched',
+                scopes: [ServiceAccountScope.SYSTEM_ADMIN],
+            },
+        });
+
+        // Org permission set first, then project grants cleared.
+        expect(mocks.serviceAccountModel.update).toHaveBeenCalledWith({
+            serviceAccountUuid: 'sa-1',
+            data: {
+                description: 'switched',
+                scopes: [ServiceAccountScope.SYSTEM_ADMIN],
+                roleUuid: undefined,
+            },
+        });
+        expect(
+            mocks.projectModel.setServiceAccountProjectAccess,
+        ).toHaveBeenCalledWith('sa-1', []);
+    });
+
+    it('rejects both project access and an org role in the same edit', async () => {
         const mocks = buildMocks();
         mocks.serviceAccountModel.getTokenbyUuid.mockResolvedValue(
             projectScopedToken() as AnyType,
@@ -560,7 +613,10 @@ describe('ServiceAccountService.update', () => {
                 tokenUuid: 'sa-1',
                 update: {
                     description: 'name',
-                    scopes: [ServiceAccountScope.SYSTEM_ADMIN],
+                    roleUuid: CUSTOM_ROLE,
+                    projectAccess: [
+                        { projectUuid: PROJ_A, role: ProjectMemberRole.VIEWER },
+                    ],
                 },
             }),
         ).rejects.toBeInstanceOf(ParameterError);

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -390,6 +390,11 @@ export class ServiceAccountService extends BaseService {
         const hasOrgScopes =
             !!update.scopes && update.scopes.length > 0 && !scopesAreMember;
         const hasOrgPermission = hasOrgScopes || !!update.roleUuid;
+        // Project grants are written when targeting project mode (replace) or
+        // when switching an org permission onto a previously project-scoped SA
+        // (clear). Used for the audit entry below.
+        const projectAccessChanged =
+            targetIsProject || (hasOrgPermission && wasProjectScoped);
 
         let updated: ServiceAccount;
         if (targetIsProject) {
@@ -493,7 +498,7 @@ export class ServiceAccountService extends BaseService {
                                 scopes: updated.scopes,
                                 roleUuid: updated.roleUuid,
                             },
-                            projectAccessChanged: targetIsProject,
+                            projectAccessChanged,
                         },
                     },
                     {},

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -7,6 +7,7 @@ import {
     NotFoundError,
     ParameterError,
     ServiceAccount,
+    ServiceAccountProjectAccessInput,
     ServiceAccountProjectGrant,
     ServiceAccountScope,
     ServiceAccountWithProjectAccessCount,
@@ -65,6 +66,44 @@ export class ServiceAccountService extends BaseService {
         this.projectModel = projectModel;
     }
 
+    // Validates a batch of project-access grants: each must carry exactly one
+    // of `role` (system) or `roleUuid` (custom), and every custom role must
+    // belong to the org. Shared by create and the project-scoped edit path.
+    private async validateProjectAccessGrantsOrThrow(
+        projectAccess: ServiceAccountProjectAccessInput[],
+        organizationUuid: string,
+    ): Promise<void> {
+        // Each grant carries exactly one of `role` / `roleUuid`. The TS union
+        // covers compile-time callers, but request bodies arrive as JSON, so
+        // we double-check at the boundary.
+        for (const grant of projectAccess) {
+            const hasRole = grant.role !== undefined;
+            const hasRoleUuid = grant.roleUuid !== undefined;
+            if (hasRole === hasRoleUuid) {
+                throw new ParameterError(
+                    'Each projectAccess grant must specify exactly one of role or roleUuid',
+                );
+            }
+        }
+        // One bulk query for the whole batch (no per-grant N+1).
+        const customRoleUuids = projectAccess
+            .map((g) => g.roleUuid)
+            .filter((u): u is string => u !== undefined);
+        if (customRoleUuids.length > 0) {
+            const invalid = await this.projectModel.findInvalidCustomRoleUuids(
+                customRoleUuids,
+                organizationUuid,
+            );
+            if (invalid.length > 0) {
+                throw new ParameterError(
+                    `Unknown role uuid(s) for this organization: ${invalid.join(
+                        ', ',
+                    )}`,
+                );
+            }
+        }
+    }
+
     private throwForbiddenErrorOnNoPermission(user: SessionUser) {
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -103,39 +142,12 @@ export class ServiceAccountService extends BaseService {
                     'projectAccess can only be set when scopes = [system:member]',
                 );
             }
-            // Each grant carries exactly one of `role` (system) or
-            // `roleUuid` (custom). The TS discriminated union covers
-            // compile-time callers, but request bodies arrive as JSON, so
-            // we double-check at the boundary.
-            for (const grant of projectAccess) {
-                const hasRole = grant.role !== undefined;
-                const hasRoleUuid = grant.roleUuid !== undefined;
-                if (hasRole === hasRoleUuid) {
-                    throw new ParameterError(
-                        'Each projectAccess grant must specify exactly one of role or roleUuid',
-                    );
-                }
-            }
-            // Bulk-validate custom-role grants belong to the SA's org.
-            // Doing this before the SA insert avoids creating an SA that
-            // we'd then have to compensate-delete.
-            const customRoleUuids = projectAccess
-                .map((g) => g.roleUuid)
-                .filter((u): u is string => u !== undefined);
-            if (customRoleUuids.length > 0) {
-                const invalid =
-                    await this.projectModel.findInvalidCustomRoleUuids(
-                        customRoleUuids,
-                        tokenDetails.organizationUuid,
-                    );
-                if (invalid.length > 0) {
-                    throw new ParameterError(
-                        `Unknown role uuid(s) for this organization: ${invalid.join(
-                            ', ',
-                        )}`,
-                    );
-                }
-            }
+            // Validate grant shape + custom roles before the SA insert so we
+            // never create an SA we'd then have to compensate-delete.
+            await this.validateProjectAccessGrantsOrThrow(
+                projectAccess,
+                tokenDetails.organizationUuid,
+            );
         }
 
         try {
@@ -352,24 +364,70 @@ export class ServiceAccountService extends BaseService {
             throw new ForbiddenError("Token doesn't belong to organization");
         }
 
-        // Project-scope invariant: a `system:member` SA derives its access
-        // entirely from project grants, which this endpoint can't edit. So a
-        // permission change is refused on an SA that has grants (it would
-        // orphan them), and `system:member` can't be set here (it would leave
-        // the SA with no abilities and no grants). Mirrors `create`'s rule
-        // that `system:member` is only valid alongside `projectAccess`.
-        const isPermissionChange =
-            (!!update.scopes && update.scopes.length > 0) || !!update.roleUuid;
-        if (isPermissionChange) {
-            const grantCount =
-                (
-                    await this.projectModel.getProjectAccessCountsByServiceAccountUserUuids(
-                        [existingToken.userUuid],
-                    )
-                ).get(existingToken.userUuid) ?? 0;
-            if (grantCount > 0) {
+        // The SA's scope mode is fixed: a `system:member` SA is project-scoped
+        // (access comes from project grants), anything else is org-scoped. Each
+        // mode edits a disjoint set of fields; switching between them is not
+        // supported here (delete + recreate instead).
+        const isProjectScoped = existingToken.scopes.includes(
+            ServiceAccountScope.SYSTEM_MEMBER,
+        );
+
+        let updated: ServiceAccount;
+        if (isProjectScoped) {
+            // Project-scoped: only name + project grants are editable. Reject
+            // any attempt to give it an org role / non-member scopes.
+            if (update.roleUuid) {
                 throw new ParameterError(
-                    "Can't change the permissions of a project-scoped service account. Manage its project access instead.",
+                    "Can't assign an organization role to a project-scoped service account. Edit its project access instead.",
+                );
+            }
+            if (
+                update.scopes &&
+                !(
+                    update.scopes.length === 1 &&
+                    update.scopes[0] === ServiceAccountScope.SYSTEM_MEMBER
+                )
+            ) {
+                throw new ParameterError(
+                    "Can't change the scopes of a project-scoped service account. Edit its project access instead.",
+                );
+            }
+            if (update.projectAccess !== undefined) {
+                if (update.projectAccess.length === 0) {
+                    throw new ParameterError(
+                        'A project-scoped service account must keep at least one project. Delete it instead to remove all access.',
+                    );
+                }
+                await this.validateProjectAccessGrantsOrThrow(
+                    update.projectAccess,
+                    existingToken.organizationUuid,
+                );
+            }
+
+            // Replace grants first, then update the name. Grant replacement is
+            // the step that can fail (bad project / role), so doing it first
+            // means a failure leaves the SA fully unchanged. The scopes stay
+            // system:member and ≥1 grant is enforced, so the forbidden "member
+            // with no projects" state is never persisted. The two writes aren't
+            // wrapped in one transaction (they span two models); the worst case
+            // is a renamed SA whose grants are stale, never a corrupt one.
+            if (update.projectAccess !== undefined) {
+                await this.projectModel.setServiceAccountProjectAccess(
+                    tokenUuid,
+                    update.projectAccess,
+                );
+            }
+            updated = await this.serviceAccountModel.update({
+                serviceAccountUuid: tokenUuid,
+                data: { description: update.description },
+            });
+        } else {
+            // Org-scoped: name + org permission (scopes XOR roleUuid). Project
+            // access doesn't apply, and `system:member` would convert it to a
+            // project-scoped SA with no grants — both rejected.
+            if (update.projectAccess !== undefined) {
+                throw new ParameterError(
+                    'An organization-scoped service account has no project access. Use scopes or roleUuid instead.',
                 );
             }
             if (update.scopes?.includes(ServiceAccountScope.SYSTEM_MEMBER)) {
@@ -377,12 +435,15 @@ export class ServiceAccountService extends BaseService {
                     'system:member is only valid for project-scoped service accounts and cannot be set here',
                 );
             }
+            updated = await this.serviceAccountModel.update({
+                serviceAccountUuid: tokenUuid,
+                data: {
+                    description: update.description,
+                    scopes: update.scopes,
+                    roleUuid: update.roleUuid,
+                },
+            });
         }
-
-        const updated = await this.serviceAccountModel.update({
-            serviceAccountUuid: tokenUuid,
-            data: update,
-        });
 
         // Audit the change without writing any sensitive values (no token,
         // no scope contents) — just the org context, per PROD-8133.

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -18,6 +18,9 @@ import {
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../../config/parseConfig';
+import { createAuditLogEvent } from '../../../logging/auditLog';
+import { createActorFromUser } from '../../../logging/caslAuditWrapper';
+import { logAuditEvent } from '../../../logging/winston';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../../services/BaseService';
 import {
@@ -367,74 +370,75 @@ export class ServiceAccountService extends BaseService {
         // The SA's scope mode is fixed: a `system:member` SA is project-scoped
         // (access comes from project grants), anything else is org-scoped. Each
         // mode edits a disjoint set of fields; switching between them is not
-        // supported here (delete + recreate instead).
-        const isProjectScoped = existingToken.scopes.includes(
+        // supported (delete + recreate instead).
+        const wasProjectScoped = existingToken.scopes.includes(
             ServiceAccountScope.SYSTEM_MEMBER,
         );
 
-        let updated: ServiceAccount;
-        if (isProjectScoped) {
-            // Project-scoped: only name + project grants are editable. Reject
-            // any attempt to give it an org role / non-member scopes.
-            if (update.roleUuid) {
-                throw new ParameterError(
-                    "Can't assign an organization role to a project-scoped service account. Edit its project access instead.",
-                );
-            }
-            if (
-                update.scopes &&
-                !(
-                    update.scopes.length === 1 &&
-                    update.scopes[0] === ServiceAccountScope.SYSTEM_MEMBER
-                )
-            ) {
-                throw new ParameterError(
-                    "Can't change the scopes of a project-scoped service account. Edit its project access instead.",
-                );
-            }
-            if (update.projectAccess !== undefined) {
-                if (update.projectAccess.length === 0) {
-                    throw new ParameterError(
-                        'A project-scoped service account must keep at least one project. Delete it instead to remove all access.',
-                    );
-                }
-                await this.validateProjectAccessGrantsOrThrow(
-                    update.projectAccess,
-                    existingToken.organizationUuid,
-                );
-            }
+        // The request describes the SA's target shape:
+        //  - `projectAccess` present  → project-scoped (system:member + grants)
+        //  - org `scopes` / `roleUuid` → organization-scoped
+        //  - neither                  → rename only, preserve the current mode
+        const scopesAreMember =
+            !!update.scopes &&
+            update.scopes.length === 1 &&
+            update.scopes[0] === ServiceAccountScope.SYSTEM_MEMBER;
+        // `system:member` always means project-scoped — even without
+        // `projectAccess` it routes here, where the ≥1-grant check rejects it.
+        const targetIsProject =
+            update.projectAccess !== undefined || scopesAreMember;
+        const hasOrgScopes =
+            !!update.scopes && update.scopes.length > 0 && !scopesAreMember;
+        const hasOrgPermission = hasOrgScopes || !!update.roleUuid;
 
-            // Replace grants first, then update the name. Grant replacement is
-            // the step that can fail (bad project / role), so doing it first
-            // means a failure leaves the SA fully unchanged. The scopes stay
-            // system:member and ≥1 grant is enforced, so the forbidden "member
-            // with no projects" state is never persisted. The two writes aren't
-            // wrapped in one transaction (they span two models); the worst case
-            // is a renamed SA whose grants are stale, never a corrupt one.
-            if (update.projectAccess !== undefined) {
-                await this.projectModel.setServiceAccountProjectAccess(
-                    tokenUuid,
-                    update.projectAccess,
+        let updated: ServiceAccount;
+        if (targetIsProject) {
+            // Edit a project-scoped SA's grants, or switch an org-scoped SA to
+            // project-scoped. Either way the result is system:member + grants.
+            if (hasOrgPermission) {
+                throw new ParameterError(
+                    'Provide either project access or an organization role, not both',
                 );
             }
+            if (update.scopes && !scopesAreMember) {
+                throw new ParameterError(
+                    'A project-scoped service account must use scopes = [system:member]',
+                );
+            }
+            const grants = update.projectAccess ?? [];
+            if (grants.length === 0) {
+                throw new ParameterError(
+                    'A project-scoped service account must have at least one project. Delete it instead to remove all access.',
+                );
+            }
+            await this.validateProjectAccessGrantsOrThrow(
+                grants,
+                existingToken.organizationUuid,
+            );
+
+            // Replace grants first, then flip scopes to system:member. Grant
+            // replacement is the step that can fail, so doing it first means a
+            // failure leaves the SA unchanged. Because ≥1 grant exists before
+            // scopes become member, the forbidden "member with no projects"
+            // state is never persisted. The two writes span two models (not one
+            // transaction); the worst case is a renamed SA whose scopes lag its
+            // grants, never a corrupt one.
+            await this.projectModel.setServiceAccountProjectAccess(
+                tokenUuid,
+                grants,
+            );
             updated = await this.serviceAccountModel.update({
                 serviceAccountUuid: tokenUuid,
-                data: { description: update.description },
+                data: {
+                    description: update.description,
+                    scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+                },
             });
-        } else {
-            // Org-scoped: name + org permission (scopes XOR roleUuid). Project
-            // access doesn't apply, and `system:member` would convert it to a
-            // project-scoped SA with no grants — both rejected.
-            if (update.projectAccess !== undefined) {
-                throw new ParameterError(
-                    'An organization-scoped service account has no project access. Use scopes or roleUuid instead.',
-                );
-            }
-            if (update.scopes?.includes(ServiceAccountScope.SYSTEM_MEMBER)) {
-                throw new ParameterError(
-                    'system:member is only valid for project-scoped service accounts and cannot be set here',
-                );
-            }
+        } else if (hasOrgPermission) {
+            // Edit an org-scoped SA's role, or switch a project-scoped SA to
+            // organization-scoped. Set the org permission first (so it's no
+            // longer member), then drop any project grants — order that never
+            // leaves a "member with no projects" SA.
             updated = await this.serviceAccountModel.update({
                 serviceAccountUuid: tokenUuid,
                 data: {
@@ -443,10 +447,21 @@ export class ServiceAccountService extends BaseService {
                     roleUuid: update.roleUuid,
                 },
             });
+            if (wasProjectScoped) {
+                await this.projectModel.setServiceAccountProjectAccess(
+                    tokenUuid,
+                    [],
+                );
+            }
+        } else {
+            // Rename only — preserve the current scope mode and permission.
+            updated = await this.serviceAccountModel.update({
+                serviceAccountUuid: tokenUuid,
+                data: { description: update.description },
+            });
         }
 
-        // Audit the change without writing any sensitive values (no token,
-        // no scope contents) — just the org context, per PROD-8133.
+        // Product analytics (org context only, no sensitive values).
         this.analytics.track<ScimAccessTokenEvent>({
             event: 'scim_access_token.updated',
             userId: user.userUuid,
@@ -454,6 +469,50 @@ export class ServiceAccountService extends BaseService {
                 organizationId: existingToken.organizationUuid,
             },
         });
+
+        // Structured audit-log entry: record the before/after of the
+        // non-sensitive fields (name, scopes, role) so the change is
+        // attributable. The token is never included.
+        try {
+            logAuditEvent(
+                createAuditLogEvent(
+                    createActorFromUser(user),
+                    'update',
+                    {
+                        type: 'ServiceAccount',
+                        organizationUuid: existingToken.organizationUuid,
+                        metadata: {
+                            serviceAccountUuid: tokenUuid,
+                            before: {
+                                description: existingToken.description,
+                                scopes: existingToken.scopes,
+                                roleUuid: existingToken.roleUuid,
+                            },
+                            after: {
+                                description: updated.description,
+                                scopes: updated.scopes,
+                                roleUuid: updated.roleUuid,
+                            },
+                            projectAccessChanged: targetIsProject,
+                        },
+                    },
+                    {},
+                    'allowed',
+                ),
+            );
+        } catch (auditError) {
+            this.logger.warn(
+                'Failed to log service account update audit event',
+                {
+                    serviceAccountUuid: tokenUuid,
+                    error:
+                        auditError instanceof Error
+                            ? auditError.message
+                            : String(auditError),
+                },
+            );
+        }
+
         return updated;
     }
 

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -13,6 +13,7 @@ import {
     ServiceAccountWithToken,
     SessionUser,
     UnexpectedDatabaseError,
+    UpdateServiceAccount,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../../config/parseConfig';
@@ -324,6 +325,75 @@ export class ServiceAccountService extends BaseService {
             },
         });
         return newToken;
+    }
+
+    async update({
+        user,
+        tokenUuid,
+        update,
+    }: {
+        user: SessionUser;
+        tokenUuid: string;
+        update: UpdateServiceAccount;
+    }): Promise<ServiceAccount> {
+        this.throwForbiddenErrorOnNoPermission(user);
+
+        if (!update.description || update.description.trim() === '') {
+            throw new ParameterError('Description is required');
+        }
+
+        // Existence + cross-org guard before any write, mirroring delete/rotate.
+        const existingToken =
+            await this.serviceAccountModel.getTokenbyUuid(tokenUuid);
+        if (!existingToken) {
+            throw new NotFoundError(`Token with UUID ${tokenUuid} not found`);
+        }
+        if (existingToken.organizationUuid !== user.organizationUuid) {
+            throw new ForbiddenError("Token doesn't belong to organization");
+        }
+
+        // Project-scope invariant: a `system:member` SA derives its access
+        // entirely from project grants, which this endpoint can't edit. So a
+        // permission change is refused on an SA that has grants (it would
+        // orphan them), and `system:member` can't be set here (it would leave
+        // the SA with no abilities and no grants). Mirrors `create`'s rule
+        // that `system:member` is only valid alongside `projectAccess`.
+        const isPermissionChange =
+            (!!update.scopes && update.scopes.length > 0) || !!update.roleUuid;
+        if (isPermissionChange) {
+            const grantCount =
+                (
+                    await this.projectModel.getProjectAccessCountsByServiceAccountUserUuids(
+                        [existingToken.userUuid],
+                    )
+                ).get(existingToken.userUuid) ?? 0;
+            if (grantCount > 0) {
+                throw new ParameterError(
+                    "Can't change the permissions of a project-scoped service account. Manage its project access instead.",
+                );
+            }
+            if (update.scopes?.includes(ServiceAccountScope.SYSTEM_MEMBER)) {
+                throw new ParameterError(
+                    'system:member is only valid for project-scoped service accounts and cannot be set here',
+                );
+            }
+        }
+
+        const updated = await this.serviceAccountModel.update({
+            serviceAccountUuid: tokenUuid,
+            data: update,
+        });
+
+        // Audit the change without writing any sensitive values (no token,
+        // no scope contents) — just the org context, per PROD-8133.
+        this.analytics.track<ScimAccessTokenEvent>({
+            event: 'scim_access_token.updated',
+            userId: user.userUuid,
+            properties: {
+                organizationId: existingToken.organizationUuid,
+            },
+        });
+        return updated;
     }
 
     async get({

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -26658,6 +26658,108 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataTimezonePreviewNaive: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                rendered: { dataType: 'string', required: true },
+                readAs: { dataType: 'string', required: true },
+                raw: { dataType: 'string', required: true },
+                interpretedAs: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataTimezonePreviewAware: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                rendered: { dataType: 'string', required: true },
+                raw: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDataTimezonePreviewResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                aware: { ref: 'DataTimezonePreviewAware', required: true },
+                naive: { ref: 'DataTimezonePreviewNaive', required: true },
+                dataTimezoneApplies: { dataType: 'boolean', required: true },
+                projectTimezone: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDataTimezonePreview: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'ApiDataTimezonePreviewResults',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataTimezonePreviewRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        credentials: {
+                            ref: 'CreateWarehouseCredentials',
+                            required: true,
+                        },
+                        mode: {
+                            dataType: 'enum',
+                            enums: ['create'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dataTimezone: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        warehouseType: {
+                            ref: 'WarehouseTypes',
+                            required: true,
+                        },
+                        projectUuid: { dataType: 'string', required: true },
+                        mode: {
+                            dataType: 'enum',
+                            enums: ['edit'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UpdateProjectMember: {
         dataType: 'refAlias',
         type: {
@@ -58207,6 +58309,65 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'grantProjectAccessToUser',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_previewDataTimezone: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'DataTimezonePreviewRequest',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.post(
+        '/api/v1/projects/preview-data-timezone',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.previewDataTimezone,
+        ),
+
+        async function ProjectController_previewDataTimezone(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_previewDataTimezone,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'previewDataTimezone',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -439,6 +439,52 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_ServiceAccount.description_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                description: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateServiceAccount: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Pick_ServiceAccount.description_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        roleUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                        },
+                        scopes: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refEnum',
+                                ref: 'ServiceAccountScope',
+                            },
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateServiceAccountRequest: {
+        dataType: 'refAlias',
+        type: { ref: 'UpdateServiceAccount', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ServiceAccountWithToken: {
         dataType: 'refAlias',
         type: {
@@ -12635,17 +12681,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -12674,7 +12720,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12682,7 +12728,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12697,7 +12747,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12705,11 +12755,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12916,17 +12962,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -13105,40 +13151,6 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
-                                                                explore: {
-                                                                    dataType:
-                                                                        'nestedObjectLiteral',
-                                                                    nestedProperties:
-                                                                        {
-                                                                            joinedTables:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                    },
-                                                                                    required: true,
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                        },
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13195,6 +13207,29 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -13215,30 +13250,7 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -13249,18 +13261,52 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                name: {
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                explore: {
+                                                                    dataType:
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                        },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -13291,17 +13337,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -13415,6 +13461,10 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
+                                                href: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 warnings: {
                                                     dataType: 'array',
                                                     array: {
@@ -13422,17 +13472,13 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                href: {
-                                                    dataType: 'string',
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                                 slug: {
                                                     dataType: 'string',
-                                                    required: true,
-                                                },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                                 uuid: {
@@ -13543,6 +13589,13 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
                                                                                             'read',
                                                                                         ],
                                                                                     },
@@ -13551,13 +13604,6 @@ const models: TsoaRoute.Models = {
                                                                                             'enum',
                                                                                         enums: [
                                                                                             'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -13696,13 +13742,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                slug: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -13859,6 +13905,12 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
+                                                                                tableName:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -13870,12 +13922,6 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                tableName:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -26605,108 +26651,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DataTimezonePreviewNaive: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                rendered: { dataType: 'string', required: true },
-                readAs: { dataType: 'string', required: true },
-                raw: { dataType: 'string', required: true },
-                interpretedAs: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DataTimezonePreviewAware: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                rendered: { dataType: 'string', required: true },
-                raw: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiDataTimezonePreviewResults: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                aware: { ref: 'DataTimezonePreviewAware', required: true },
-                naive: { ref: 'DataTimezonePreviewNaive', required: true },
-                dataTimezoneApplies: { dataType: 'boolean', required: true },
-                projectTimezone: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiDataTimezonePreview: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    ref: 'ApiDataTimezonePreviewResults',
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DataTimezonePreviewRequest: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        credentials: {
-                            ref: 'CreateWarehouseCredentials',
-                            required: true,
-                        },
-                        mode: {
-                            dataType: 'enum',
-                            enums: ['create'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        dataTimezone: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                        warehouseType: {
-                            ref: 'WarehouseTypes',
-                            required: true,
-                        },
-                        projectUuid: { dataType: 'string', required: true },
-                        mode: {
-                            dataType: 'enum',
-                            enums: ['edit'],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UpdateProjectMember: {
         dataType: 'refAlias',
         type: {
@@ -27921,7 +27865,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27931,7 +27875,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -27941,7 +27885,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -27954,7 +27898,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -28609,7 +28553,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28619,7 +28563,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28629,7 +28573,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28642,7 +28586,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -37960,6 +37904,73 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsServiceAccountsController_updateServiceAccount: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        tokenUuid: {
+            in: 'path',
+            name: 'tokenUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiUpdateServiceAccountRequest',
+        },
+    };
+    app.patch(
+        '/api/v1/service-accounts/:tokenUuid',
+        ...fetchMiddlewares<RequestHandler>(ServiceAccountsController),
+        ...fetchMiddlewares<RequestHandler>(
+            ServiceAccountsController.prototype.updateServiceAccount,
+        ),
+
+        async function ServiceAccountsController_updateServiceAccount(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsServiceAccountsController_updateServiceAccount,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ServiceAccountsController>(
+                        ServiceAccountsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateServiceAccount',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);
@@ -58189,65 +58200,6 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'grantProjectAccessToUser',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsProjectController_previewDataTimezone: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'DataTimezonePreviewRequest',
-        },
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-    };
-    app.post(
-        '/api/v1/projects/preview-data-timezone',
-        ...fetchMiddlewares<RequestHandler>(ProjectController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectController.prototype.previewDataTimezone,
-        ),
-
-        async function ProjectController_previewDataTimezone(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsProjectController_previewDataTimezone,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<ProjectController>(ProjectController);
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'previewDataTimezone',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -459,6 +459,13 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        projectAccess: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'ServiceAccountProjectAccessInput',
+                            },
+                        },
                         roleUuid: {
                             dataType: 'union',
                             subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -295,6 +295,12 @@
                     },
                     {
                         "properties": {
+                            "projectAccess": {
+                                "items": {
+                                    "$ref": "#/components/schemas/ServiceAccountProjectAccessInput"
+                                },
+                                "type": "array"
+                            },
                             "roleUuid": {
                                 "type": "string",
                                 "nullable": true
@@ -309,7 +315,7 @@
                         "type": "object"
                     }
                 ],
-                "description": "In-place edit of a service account's name and Organization-scope permission,\nwithout rotating its token. `description` is always applied. The permission\nis optional: send exactly one of `scopes` (legacy/system preset) or\n`roleUuid` (custom org role) to change it, or neither to rename only. Sending\nboth is rejected. The token, expiry, and project grants are left untouched."
+                "description": "In-place edit of a service account's name, permissions, and project access,\nwithout rotating its token. `description` is always applied. The rest depends\non the SA's scope mode, which is fixed (no switching between the two):\n\n- Organization-scoped SA: send one of `scopes` (legacy/system preset) or\n  `roleUuid` (custom org role) to change its org permission, or neither to\n  rename only. `projectAccess` is rejected.\n- Project-scoped SA (`system:member`): send `projectAccess` (≥1 grant) to\n  replace its project grants, keeping `scopes = [system:member]`. `roleUuid`\n  and any non-member `scopes` are rejected.\n\nThe token and expiry are never touched."
             },
             "ApiUpdateServiceAccountRequest": {
                 "$ref": "#/components/schemas/UpdateServiceAccount"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -315,7 +315,7 @@
                         "type": "object"
                     }
                 ],
-                "description": "In-place edit of a service account's name, permissions, and project access,\nwithout rotating its token. `description` is always applied. The rest depends\non the SA's scope mode, which is fixed (no switching between the two):\n\n- Organization-scoped SA: send one of `scopes` (legacy/system preset) or\n  `roleUuid` (custom org role) to change its org permission, or neither to\n  rename only. `projectAccess` is rejected.\n- Project-scoped SA (`system:member`): send `projectAccess` (≥1 grant) to\n  replace its project grants, keeping `scopes = [system:member]`. `roleUuid`\n  and any non-member `scopes` are rejected.\n\nThe token and expiry are never touched."
+                "description": "In-place edit of a service account's name, permissions, and project access,\nwithout rotating its token. `description` is always applied. The rest is\ntarget-shaped — the payload describes what the SA should become, and the SA\ncan move between scope modes:\n\n- `projectAccess` (or `scopes = [system:member]`) → project-scoped: replace\n  its project grants (≥1 required), keeping `scopes = [system:member]`.\n  Sending an org `roleUuid` / non-member `scopes` alongside is rejected.\n- org `scopes` (preset) or `roleUuid` (custom role) → organization-scoped:\n  set the org permission and drop any project grants.\n- neither → rename only, preserving the current mode and permission.\n\nThe token and expiry are never touched."
             },
             "ApiUpdateServiceAccountRequest": {
                 "$ref": "#/components/schemas/UpdateServiceAccount"
@@ -27469,6 +27469,117 @@
                 "required": ["sendEmail", "role", "email"],
                 "type": "object"
             },
+            "DataTimezonePreviewNaive": {
+                "properties": {
+                    "rendered": {
+                        "type": "string"
+                    },
+                    "readAs": {
+                        "type": "string"
+                    },
+                    "raw": {
+                        "type": "string"
+                    },
+                    "interpretedAs": {
+                        "type": "string"
+                    }
+                },
+                "required": ["rendered", "readAs", "raw", "interpretedAs"],
+                "type": "object"
+            },
+            "DataTimezonePreviewAware": {
+                "properties": {
+                    "rendered": {
+                        "type": "string"
+                    },
+                    "raw": {
+                        "type": "string"
+                    }
+                },
+                "required": ["rendered", "raw"],
+                "type": "object"
+            },
+            "ApiDataTimezonePreviewResults": {
+                "properties": {
+                    "aware": {
+                        "$ref": "#/components/schemas/DataTimezonePreviewAware"
+                    },
+                    "naive": {
+                        "$ref": "#/components/schemas/DataTimezonePreviewNaive"
+                    },
+                    "dataTimezoneApplies": {
+                        "type": "boolean"
+                    },
+                    "projectTimezone": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "aware",
+                    "naive",
+                    "dataTimezoneApplies",
+                    "projectTimezone"
+                ],
+                "type": "object"
+            },
+            "ApiDataTimezonePreview": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ApiDataTimezonePreviewResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "DataTimezonePreviewRequest": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "credentials": {
+                                "$ref": "#/components/schemas/CreateWarehouseCredentials"
+                            },
+                            "mode": {
+                                "type": "string",
+                                "enum": ["create"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["credentials", "mode"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "dataTimezone": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "warehouseType": {
+                                "$ref": "#/components/schemas/WarehouseTypes"
+                            },
+                            "projectUuid": {
+                                "type": "string"
+                            },
+                            "mode": {
+                                "type": "string",
+                                "enum": ["edit"],
+                                "nullable": false
+                            }
+                        },
+                        "required": [
+                            "dataTimezone",
+                            "warehouseType",
+                            "projectUuid",
+                            "mode"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
             "UpdateProjectMember": {
                 "properties": {
                     "role": {
@@ -38148,7 +38259,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3119.0",
+        "version": "0.3120.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -51343,6 +51454,48 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/projects/preview-data-timezone": {
+            "post": {
+                "operationId": "PreviewDataTimezone",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDataTimezonePreview"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Preview how the warehouse disambiguates \"now\" under a data timezone",
+                "summary": "Preview data timezone",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DataTimezonePreviewRequest"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/projects/{projectUuid}/access/{userUuid}": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -278,6 +278,42 @@
                     }
                 ]
             },
+            "Pick_ServiceAccount.description_": {
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    }
+                },
+                "required": ["description"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "UpdateServiceAccount": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_ServiceAccount.description_"
+                    },
+                    {
+                        "properties": {
+                            "roleUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "scopes": {
+                                "items": {
+                                    "$ref": "#/components/schemas/ServiceAccountScope"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ],
+                "description": "In-place edit of a service account's name and Organization-scope permission,\nwithout rotating its token. `description` is always applied. The permission\nis optional: send exactly one of `scopes` (legacy/system preset) or\n`roleUuid` (custom org role) to change it, or neither to rename only. Sending\nboth is rejected. The token, expiry, and project grants are left untouched."
+            },
+            "ApiUpdateServiceAccountRequest": {
+                "$ref": "#/components/schemas/UpdateServiceAccount"
+            },
             "ServiceAccountWithToken": {
                 "allOf": [
                     {
@@ -14071,10 +14107,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -14083,8 +14119,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -14094,16 +14130,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -14196,10 +14232,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -14208,8 +14244,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -14304,32 +14340,6 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
-                                                                    "explore": {
-                                                                        "properties": {
-                                                                            "joinedTables": {
-                                                                                "items": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "type": "array"
-                                                                            },
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "label": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "name": {
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "joinedTables",
-                                                                            "baseTable",
-                                                                            "label",
-                                                                            "name"
-                                                                        ],
-                                                                        "type": "object"
-                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -14350,27 +14360,27 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "label": {
+                                                                                "name": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "name": {
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
@@ -14379,16 +14389,42 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "description",
                                                                                 "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
+                                                                                "description",
                                                                                 "label",
-                                                                                "name"
+                                                                                "fieldId",
+                                                                                "name",
+                                                                                "table"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
+                                                                    },
+                                                                    "explore": {
+                                                                        "properties": {
+                                                                            "baseTable": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "joinedTables": {
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "label": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "baseTable",
+                                                                            "joinedTables",
+                                                                            "label",
+                                                                            "name"
+                                                                        ],
+                                                                        "type": "object"
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -14400,8 +14436,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "explore",
                                                                     "fields",
+                                                                    "explore",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14414,10 +14450,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -14425,8 +14461,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "exploreLabel",
                                                                                 "reason",
+                                                                                "exploreLabel",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -14500,22 +14536,22 @@
                                                         ],
                                                         "type": "object"
                                                     },
+                                                    "href": {
+                                                        "type": "string"
+                                                    },
                                                     "warnings": {
                                                         "items": {
                                                             "type": "string"
                                                         },
                                                         "type": "array"
                                                     },
-                                                    "href": {
-                                                        "type": "string"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
                                                     },
                                                     "uuid": {
                                                         "type": "string"
@@ -14526,10 +14562,10 @@
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "warnings",
                                                     "href",
-                                                    "slug",
+                                                    "warnings",
                                                     "status",
+                                                    "slug",
                                                     "uuid",
                                                     "name"
                                                 ],
@@ -14543,9 +14579,9 @@
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
+                                                                        "search",
                                                                         "read",
                                                                         "edit",
-                                                                        "search",
                                                                         "compile",
                                                                         "stage"
                                                                     ]
@@ -14612,13 +14648,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -14626,8 +14662,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "slug",
                                                     "status",
+                                                    "slug",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -14664,13 +14700,13 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
+                                                                        "tableName": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -14678,9 +14714,9 @@
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "tableName",
                                                                         "fieldType",
                                                                         "label",
-                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -27427,117 +27463,6 @@
                 "required": ["sendEmail", "role", "email"],
                 "type": "object"
             },
-            "DataTimezonePreviewNaive": {
-                "properties": {
-                    "rendered": {
-                        "type": "string"
-                    },
-                    "readAs": {
-                        "type": "string"
-                    },
-                    "raw": {
-                        "type": "string"
-                    },
-                    "interpretedAs": {
-                        "type": "string"
-                    }
-                },
-                "required": ["rendered", "readAs", "raw", "interpretedAs"],
-                "type": "object"
-            },
-            "DataTimezonePreviewAware": {
-                "properties": {
-                    "rendered": {
-                        "type": "string"
-                    },
-                    "raw": {
-                        "type": "string"
-                    }
-                },
-                "required": ["rendered", "raw"],
-                "type": "object"
-            },
-            "ApiDataTimezonePreviewResults": {
-                "properties": {
-                    "aware": {
-                        "$ref": "#/components/schemas/DataTimezonePreviewAware"
-                    },
-                    "naive": {
-                        "$ref": "#/components/schemas/DataTimezonePreviewNaive"
-                    },
-                    "dataTimezoneApplies": {
-                        "type": "boolean"
-                    },
-                    "projectTimezone": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "aware",
-                    "naive",
-                    "dataTimezoneApplies",
-                    "projectTimezone"
-                ],
-                "type": "object"
-            },
-            "ApiDataTimezonePreview": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/ApiDataTimezonePreviewResults"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "DataTimezonePreviewRequest": {
-                "anyOf": [
-                    {
-                        "properties": {
-                            "credentials": {
-                                "$ref": "#/components/schemas/CreateWarehouseCredentials"
-                            },
-                            "mode": {
-                                "type": "string",
-                                "enum": ["create"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["credentials", "mode"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "dataTimezone": {
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "warehouseType": {
-                                "$ref": "#/components/schemas/WarehouseTypes"
-                            },
-                            "projectUuid": {
-                                "type": "string"
-                            },
-                            "mode": {
-                                "type": "string",
-                                "enum": ["edit"],
-                                "nullable": false
-                            }
-                        },
-                        "required": [
-                            "dataTimezone",
-                            "warehouseType",
-                            "projectUuid",
-                            "mode"
-                        ],
-                        "type": "object"
-                    }
-                ]
-            },
             "UpdateProjectMember": {
                 "properties": {
                     "role": {
@@ -28729,22 +28654,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -29304,22 +29229,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -38217,7 +38142,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3120.0",
+        "version": "0.3119.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -51412,48 +51337,6 @@
                         }
                     }
                 ]
-            }
-        },
-        "/api/v1/projects/preview-data-timezone": {
-            "post": {
-                "operationId": "PreviewDataTimezone",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDataTimezonePreview"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Preview how the warehouse disambiguates \"now\" under a data timezone",
-                "summary": "Preview data timezone",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/DataTimezonePreviewRequest"
-                            }
-                        }
-                    }
-                }
             }
         },
         "/api/v1/projects/{projectUuid}/access/{userUuid}": {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -10,6 +10,9 @@ import {
     ExploreType,
     FieldType,
     MetricType,
+    NotFoundError,
+    ParameterError,
+    ProjectMemberRole,
     SpaceMemberRole,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -19,6 +22,7 @@ import { FunctionQueryMatcher } from 'knex-mock-client/types/mock-client';
 import isEqual from 'lodash/isEqual';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { ProjectGroupAccessTableName } from '../../database/entities/projectGroupAccess';
+import { ProjectMembershipsTableName } from '../../database/entities/projectMemberships';
 import {
     CachedExploresTableName,
     CachedExploreTableName,
@@ -28,6 +32,7 @@ import {
     SpaceTableName,
     SpaceUserAccessTableName,
 } from '../../database/entities/spaces';
+import { ServiceAccountsTableName } from '../../ee/database/entities/serviceAccounts';
 import { ChangesetModel } from '../ChangesetModel';
 import { ProjectModel } from './ProjectModel';
 import {
@@ -548,6 +553,100 @@ describe('ProjectModel', () => {
                     role: 'editor',
                 },
             ]);
+        });
+    });
+
+    describe('setServiceAccountProjectAccess', () => {
+        const matchSql =
+            (table: string) =>
+            ({ sql }: RawQuery) =>
+                sql.includes(table);
+        const SA_UUID = 'sa-1';
+
+        test('throws NotFound when the service account does not exist', async () => {
+            tracker.on.select(matchSql(ServiceAccountsTableName)).response([]);
+            await expect(
+                model.setServiceAccountProjectAccess(SA_UUID, [
+                    { projectUuid: 'p-1', role: ProjectMemberRole.VIEWER },
+                ]),
+            ).rejects.toBeInstanceOf(NotFoundError);
+            expect(tracker.history.delete).toHaveLength(0);
+        });
+
+        test('rejects duplicate projects before any write', async () => {
+            tracker.on
+                .select(matchSql(ServiceAccountsTableName))
+                .response([{ user_id: 1, organization_uuid: 'org-1' }]);
+            await expect(
+                model.setServiceAccountProjectAccess(SA_UUID, [
+                    { projectUuid: 'p-1', role: ProjectMemberRole.VIEWER },
+                    { projectUuid: 'p-1', role: ProjectMemberRole.EDITOR },
+                ]),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(tracker.history.delete).toHaveLength(0);
+        });
+
+        test('throws NotFound when a project does not exist', async () => {
+            tracker.on
+                .select(matchSql(ServiceAccountsTableName))
+                .response([{ user_id: 1, organization_uuid: 'org-1' }]);
+            tracker.on.select(matchSql(ProjectTableName)).response([]);
+            await expect(
+                model.setServiceAccountProjectAccess(SA_UUID, [
+                    {
+                        projectUuid: 'p-missing',
+                        role: ProjectMemberRole.VIEWER,
+                    },
+                ]),
+            ).rejects.toBeInstanceOf(NotFoundError);
+            expect(tracker.history.delete).toHaveLength(0);
+        });
+
+        test('rejects a project from a different organization', async () => {
+            tracker.on
+                .select(matchSql(ServiceAccountsTableName))
+                .response([{ user_id: 1, organization_uuid: 'org-1' }]);
+            tracker.on
+                .select(matchSql(ProjectTableName))
+                .response([
+                    { project_uuid: 'p-1', project_id: 10, org_uuid: 'org-2' },
+                ]);
+            await expect(
+                model.setServiceAccountProjectAccess(SA_UUID, [
+                    { projectUuid: 'p-1', role: ProjectMemberRole.VIEWER },
+                ]),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(tracker.history.delete).toHaveLength(0);
+        });
+
+        test('replaces grants: deletes existing then inserts, with a Viewer placeholder for custom roles', async () => {
+            tracker.on
+                .select(matchSql(ServiceAccountsTableName))
+                .response([{ user_id: 1, organization_uuid: 'org-1' }]);
+            tracker.on.select(matchSql(ProjectTableName)).response([
+                { project_uuid: 'p-1', project_id: 10, org_uuid: 'org-1' },
+                { project_uuid: 'p-2', project_id: 20, org_uuid: 'org-1' },
+            ]);
+            tracker.on
+                .delete(matchSql(ProjectMembershipsTableName))
+                .response([]);
+            tracker.on
+                .insert(matchSql(ProjectMembershipsTableName))
+                .response([]);
+
+            await model.setServiceAccountProjectAccess(SA_UUID, [
+                { projectUuid: 'p-1', role: ProjectMemberRole.EDITOR },
+                { projectUuid: 'p-2', roleUuid: 'custom-role-1' },
+            ]);
+
+            expect(tracker.history.delete).toHaveLength(1);
+            expect(tracker.history.insert).toHaveLength(1);
+            const { bindings } = tracker.history.insert[0];
+            // System grant keeps its role; custom-role grant gets the Viewer
+            // placeholder plus the role_uuid.
+            expect(bindings).toContain(ProjectMemberRole.EDITOR);
+            expect(bindings).toContain(ProjectMemberRole.VIEWER);
+            expect(bindings).toContain('custom-role-1');
         });
     });
 });

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -35,6 +35,7 @@ import {
     ProjectType,
     sensitiveCredentialsFieldNames,
     sensitiveDbtCredentialsFieldNames,
+    ServiceAccountProjectAccessInput,
     ServiceAccountProjectGrant,
     SnowflakeAuthenticationType,
     SpaceMemberRole,
@@ -2121,6 +2122,104 @@ export class ProjectModel {
             }
             throw error;
         }
+    }
+
+    /**
+     * Replace a service account's entire set of project grants in one
+     * transaction. Used by the in-place SA edit path: delete every existing
+     * `project_memberships` row for the SA's dedicated user, then insert the
+     * new set. Wholesale replace (rather than a diff) keeps add / remove /
+     * role-change a single atomic operation.
+     *
+     * Each grant must carry exactly one of `role` (system) or `roleUuid`
+     * (custom); the service layer validates this and that custom roles belong
+     * to the org before calling. Projects are re-validated here to be in the
+     * SA's organization.
+     */
+    async setServiceAccountProjectAccess(
+        serviceAccountUuid: string,
+        grants: ServiceAccountProjectAccessInput[],
+    ): Promise<void> {
+        const [sa] = await this.database(ServiceAccountsTableName)
+            .leftJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${ServiceAccountsTableName}.service_account_user_uuid`,
+            )
+            .select<Array<{ user_id: number; organization_uuid: string }>>(
+                `${UserTableName}.user_id`,
+                `${ServiceAccountsTableName}.organization_uuid`,
+            )
+            .where(
+                `${ServiceAccountsTableName}.service_account_uuid`,
+                serviceAccountUuid,
+            );
+        if (!sa) {
+            throw new NotFoundError(
+                `Service account with uuid ${serviceAccountUuid} not found`,
+            );
+        }
+
+        // Resolve every project to its int id, validating same-org membership
+        // up front so the replace can't partially apply a cross-org grant.
+        const projectUuids = grants.map((g) => g.projectUuid);
+        if (new Set(projectUuids).size !== projectUuids.length) {
+            throw new ParameterError(
+                'A service account can have at most one grant per project',
+            );
+        }
+        const projects = await this.database(ProjectTableName)
+            .leftJoin(
+                OrganizationTableName,
+                `${ProjectTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .select<
+                { project_uuid: string; project_id: number; org_uuid: string }[]
+            >(
+                `${ProjectTableName}.project_uuid`,
+                `${ProjectTableName}.project_id`,
+                `${OrganizationTableName}.organization_uuid as org_uuid`,
+            )
+            .whereIn(`${ProjectTableName}.project_uuid`, projectUuids);
+        const projectByUuid = new Map(projects.map((p) => [p.project_uuid, p]));
+        for (const projectUuid of projectUuids) {
+            const project = projectByUuid.get(projectUuid);
+            if (!project) {
+                throw new NotFoundError(
+                    `Project with uuid ${projectUuid} not found`,
+                );
+            }
+            if (project.org_uuid !== sa.organization_uuid) {
+                throw new ParameterError(
+                    'Service account and project must be in the same organization',
+                );
+            }
+        }
+
+        await this.database.transaction(async (trx) => {
+            await trx(ProjectMembershipsTableName)
+                .where('user_id', sa.user_id)
+                .delete();
+            if (grants.length > 0) {
+                await trx(ProjectMembershipsTableName).insert(
+                    grants.map((grant) => {
+                        // Legacy `role` column is NOT NULL; when `role_uuid` is
+                        // set, runtime CASL prefers the custom role and `role`
+                        // is a Viewer placeholder (matches create's convention).
+                        const project = projectByUuid.get(grant.projectUuid)!;
+                        return {
+                            project_id: project.project_id,
+                            user_id: sa.user_id,
+                            role: grant.roleUuid
+                                ? ProjectMemberRole.VIEWER
+                                : (grant.role as ProjectMemberRole),
+                            role_uuid: grant.roleUuid ?? null,
+                        };
+                    }),
+                );
+            }
+        });
     }
 
     /**

--- a/packages/common/src/ee/serviceAccounts/types.ts
+++ b/packages/common/src/ee/serviceAccounts/types.ts
@@ -140,15 +140,23 @@ export type CreateServiceAccount = Pick<
 };
 
 /**
- * In-place edit of a service account's name and Organization-scope permission,
- * without rotating its token. `description` is always applied. The permission
- * is optional: send exactly one of `scopes` (legacy/system preset) or
- * `roleUuid` (custom org role) to change it, or neither to rename only. Sending
- * both is rejected. The token, expiry, and project grants are left untouched.
+ * In-place edit of a service account's name, permissions, and project access,
+ * without rotating its token. `description` is always applied. The rest depends
+ * on the SA's scope mode, which is fixed (no switching between the two):
+ *
+ * - Organization-scoped SA: send one of `scopes` (legacy/system preset) or
+ *   `roleUuid` (custom org role) to change its org permission, or neither to
+ *   rename only. `projectAccess` is rejected.
+ * - Project-scoped SA (`system:member`): send `projectAccess` (≥1 grant) to
+ *   replace its project grants, keeping `scopes = [system:member]`. `roleUuid`
+ *   and any non-member `scopes` are rejected.
+ *
+ * The token and expiry are never touched.
  */
 export type UpdateServiceAccount = Pick<ServiceAccount, 'description'> & {
     scopes?: ServiceAccountScope[];
     roleUuid?: string | null;
+    projectAccess?: ServiceAccountProjectAccessInput[];
 };
 
 export type ApiUpdateServiceAccountRequest = UpdateServiceAccount;

--- a/packages/common/src/ee/serviceAccounts/types.ts
+++ b/packages/common/src/ee/serviceAccounts/types.ts
@@ -138,3 +138,17 @@ export type CreateServiceAccount = Pick<
     roleUuid?: string | null;
     projectAccess?: ServiceAccountProjectAccessInput[];
 };
+
+/**
+ * In-place edit of a service account's name and Organization-scope permission,
+ * without rotating its token. `description` is always applied. The permission
+ * is optional: send exactly one of `scopes` (legacy/system preset) or
+ * `roleUuid` (custom org role) to change it, or neither to rename only. Sending
+ * both is rejected. The token, expiry, and project grants are left untouched.
+ */
+export type UpdateServiceAccount = Pick<ServiceAccount, 'description'> & {
+    scopes?: ServiceAccountScope[];
+    roleUuid?: string | null;
+};
+
+export type ApiUpdateServiceAccountRequest = UpdateServiceAccount;

--- a/packages/common/src/ee/serviceAccounts/types.ts
+++ b/packages/common/src/ee/serviceAccounts/types.ts
@@ -141,15 +141,16 @@ export type CreateServiceAccount = Pick<
 
 /**
  * In-place edit of a service account's name, permissions, and project access,
- * without rotating its token. `description` is always applied. The rest depends
- * on the SA's scope mode, which is fixed (no switching between the two):
+ * without rotating its token. `description` is always applied. The rest is
+ * target-shaped — the payload describes what the SA should become, and the SA
+ * can move between scope modes:
  *
- * - Organization-scoped SA: send one of `scopes` (legacy/system preset) or
- *   `roleUuid` (custom org role) to change its org permission, or neither to
- *   rename only. `projectAccess` is rejected.
- * - Project-scoped SA (`system:member`): send `projectAccess` (≥1 grant) to
- *   replace its project grants, keeping `scopes = [system:member]`. `roleUuid`
- *   and any non-member `scopes` are rejected.
+ * - `projectAccess` (or `scopes = [system:member]`) → project-scoped: replace
+ *   its project grants (≥1 required), keeping `scopes = [system:member]`.
+ *   Sending an org `roleUuid` / non-member `scopes` alongside is rejected.
+ * - org `scopes` (preset) or `roleUuid` (custom role) → organization-scoped:
+ *   set the org permission and drop any project grants.
+ * - neither → rename only, preserving the current mode and permission.
  *
  * The token and expiry are never touched.
  */

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountProjectRoles.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountProjectRoles.tsx
@@ -1,0 +1,146 @@
+import {
+    ActionIcon,
+    Button,
+    Group,
+    Select,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { type UseFormReturnType } from '@mantine/form';
+import { IconPlus, IconX } from '@tabler/icons-react';
+import { useMemo } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import {
+    DEFAULT_PROJECT_ROLE_SELECTION,
+    type ProjectRoleRow,
+} from './projectRoleOptions';
+import classes from './ServiceAccountsCreateModal.module.css';
+
+type RoleOptionGroups = {
+    group: string;
+    items: { value: string; label: string }[];
+}[];
+
+// Generic over both the form's value shape and its `transformValues` signature
+// so the create modal (which transforms `expiresAt`) and the edit modal (no
+// transform) can both pass their form in. The component only reads list state,
+// so the transform type is irrelevant to its behaviour.
+type Props<
+    T extends { projectRoles: ProjectRoleRow[] },
+    TransformValues extends (values: T) => unknown,
+> = {
+    form: UseFormReturnType<T, TransformValues>;
+    projects: { projectUuid: string; name: string }[];
+    projectRoleOptions: RoleOptionGroups;
+    rolesLoading: boolean;
+    disabled: boolean;
+};
+
+// Shared editor for a service account's per-project role rows, bound to a
+// Mantine form's `projectRoles` list field. Used by both the create and edit
+// modals so the project-access UI stays identical across them.
+export const ServiceAccountProjectRoles = <
+    T extends { projectRoles: ProjectRoleRow[] },
+    TransformValues extends (values: T) => unknown = (values: T) => T,
+>({
+    form,
+    projects,
+    projectRoleOptions,
+    rolesLoading,
+    disabled,
+}: Props<T, TransformValues>) => {
+    const projectOptions = useMemo(
+        () =>
+            projects.map((p) => ({
+                value: p.projectUuid,
+                label: p.name,
+            })),
+        [projects],
+    );
+
+    // Each row's project picker hides projects already picked in OTHER rows.
+    // The current row's value stays visible so the row renders the selected
+    // label, not a blank.
+    const projectOptionsForRow = (rowIdx: number) => {
+        const taken = new Set(
+            form.values.projectRoles
+                .filter((_, i) => i !== rowIdx)
+                .map((r) => r.projectUuid),
+        );
+        return projectOptions.filter((opt) => !taken.has(opt.value));
+    };
+
+    const addProjectRow = () => {
+        form.insertListItem('projectRoles', {
+            projectUuid: '',
+            roleSelection: DEFAULT_PROJECT_ROLE_SELECTION,
+        } satisfies ProjectRoleRow);
+    };
+
+    return (
+        <Stack gap="xs">
+            <Text size="sm" fw={500}>
+                Project access
+            </Text>
+            {form.values.projectRoles.length === 0 && (
+                <Text size="xs" c="dimmed">
+                    No projects added yet.
+                </Text>
+            )}
+            {form.values.projectRoles.map((_, idx) => (
+                <Group key={idx} gap="xs" wrap="nowrap">
+                    <Select
+                        flex={1}
+                        placeholder="Pick a project"
+                        data={projectOptionsForRow(idx)}
+                        searchable
+                        disabled={disabled}
+                        {...form.getInputProps(
+                            `projectRoles.${idx}.projectUuid`,
+                        )}
+                    />
+                    <Select
+                        w={200}
+                        data={projectRoleOptions}
+                        searchable
+                        disabled={disabled || rolesLoading}
+                        {...form.getInputProps(
+                            `projectRoles.${idx}.roleSelection`,
+                        )}
+                    />
+                    <Tooltip label="Remove">
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            disabled={disabled}
+                            onClick={() =>
+                                form.removeListItem('projectRoles', idx)
+                            }
+                        >
+                            <MantineIcon icon={IconX} />
+                        </ActionIcon>
+                    </Tooltip>
+                </Group>
+            ))}
+            {form.errors.projectRoles && (
+                <Text size="xs" c="red">
+                    {form.errors.projectRoles}
+                </Text>
+            )}
+            <Button
+                leftSection={<MantineIcon icon={IconPlus} />}
+                variant="subtle"
+                size="xs"
+                disabled={
+                    disabled ||
+                    form.values.projectRoles.length >= projects.length
+                }
+                onClick={addProjectRow}
+                className={classes.addProjectButton}
+            >
+                Add project
+            </Button>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
@@ -1,15 +1,13 @@
 import {
     CommercialFeatureFlags,
-    ProjectMemberRole,
-    ProjectMemberRoleLabels,
     ServiceAccountScope,
+    type ProjectMemberRole,
 } from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
     Button,
     CopyButton,
-    Group,
     SegmentedControl,
     Select,
     Stack,
@@ -18,13 +16,7 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
-import {
-    IconCheck,
-    IconCopy,
-    IconKey,
-    IconPlus,
-    IconX,
-} from '@tabler/icons-react';
+import { IconCheck, IconCopy, IconKey } from '@tabler/icons-react';
 import { addDays } from 'date-fns';
 import { useMemo, type FC } from 'react';
 import { Link } from 'react-router';
@@ -35,7 +27,11 @@ import { useProjects } from '../../../hooks/useProjects';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import { useCustomRoles } from '../customRoles/useCustomRoles';
-import classes from './ServiceAccountsCreateModal.module.css';
+import {
+    SYSTEM_PROJECT_ROLE_OPTIONS,
+    type ProjectRoleRow,
+} from './projectRoleOptions';
+import { ServiceAccountProjectRoles } from './ServiceAccountProjectRoles';
 
 // Organization-mode role options. `Member` is intentionally hidden — it's
 // the backend marker for "Project-scope SA" (see the SegmentedControl
@@ -54,24 +50,6 @@ const SYSTEM_ROLE_OPTIONS: { value: string; label: string }[] = [
     { value: `scope:${ServiceAccountScope.SYSTEM_ADMIN}`, label: 'Admin' },
 ];
 
-// Project-mode role options. Each row's role select offers stock
-// `ProjectMemberRole`s OR any of the org's custom roles (loaded at runtime).
-// Values are tagged so the submit handler can route them into the backend
-// contract: `system:<role>` → `{ projectUuid, role }`, `role:<uuid>` →
-// `{ projectUuid, roleUuid }`. Mirrors the org-mode `scope:` / `role:`
-// convention so the two pickers feel symmetric.
-const SYSTEM_PROJECT_ROLE_OPTIONS = [
-    ProjectMemberRole.VIEWER,
-    ProjectMemberRole.INTERACTIVE_VIEWER,
-    ProjectMemberRole.EDITOR,
-    ProjectMemberRole.DEVELOPER,
-    ProjectMemberRole.ADMIN,
-].map((role) => ({
-    value: `system:${role}`,
-    label: ProjectMemberRoleLabels[role],
-}));
-const DEFAULT_PROJECT_ROLE_SELECTION = `system:${ProjectMemberRole.VIEWER}`;
-
 const expireOptions = [
     { label: 'No expiration', value: '' },
     { label: '7 days', value: '7' },
@@ -83,13 +61,6 @@ const expireOptions = [
 ];
 
 type Scope = 'organization' | 'project';
-
-type ProjectRoleRow = {
-    projectUuid: string;
-    // Tagged selection: `system:<ProjectMemberRole>` or `role:<roleUuid>`.
-    // Parsed at submit time into either { role } or { roleUuid }.
-    roleSelection: string;
-};
 
 type Props = {
     isOpen: boolean;
@@ -205,34 +176,6 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
     const closeModal = () => {
         form.reset();
         onClose();
-    };
-
-    const projectOptions = useMemo(
-        () =>
-            projects.map((p) => ({
-                value: p.projectUuid,
-                label: p.name,
-            })),
-        [projects],
-    );
-
-    // Each row's project picker hides projects already picked in OTHER
-    // rows. The current row's value stays visible so the row renders the
-    // selected label, not a blank.
-    const projectOptionsForRow = (rowIdx: number) => {
-        const taken = new Set(
-            form.values.projectRoles
-                .filter((_, i) => i !== rowIdx)
-                .map((r) => r.projectUuid),
-        );
-        return projectOptions.filter((opt) => !taken.has(opt.value));
-    };
-
-    const addProjectRow = () => {
-        form.insertListItem('projectRoles', {
-            projectUuid: '',
-            roleSelection: DEFAULT_PROJECT_ROLE_SELECTION,
-        } satisfies ProjectRoleRow);
     };
 
     const handleOnSubmit = form.onSubmit(
@@ -374,77 +317,13 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
                                 {...form.getInputProps('roleSelection')}
                             />
                         ) : (
-                            <Stack gap="xs">
-                                <Text size="sm" fw={500}>
-                                    Project access
-                                </Text>
-                                {form.values.projectRoles.length === 0 && (
-                                    <Text size="xs" c="dimmed">
-                                        No projects added yet.
-                                    </Text>
-                                )}
-                                {form.values.projectRoles.map((_, idx) => (
-                                    <Group key={idx} gap="xs" wrap="nowrap">
-                                        <Select
-                                            flex={1}
-                                            placeholder="Pick a project"
-                                            data={projectOptionsForRow(idx)}
-                                            searchable
-                                            disabled={isWorking}
-                                            {...form.getInputProps(
-                                                `projectRoles.${idx}.projectUuid`,
-                                            )}
-                                        />
-                                        <Select
-                                            w={200}
-                                            data={projectRoleOptions}
-                                            searchable
-                                            disabled={
-                                                isWorking || listRoles.isLoading
-                                            }
-                                            {...form.getInputProps(
-                                                `projectRoles.${idx}.roleSelection`,
-                                            )}
-                                        />
-                                        <Tooltip label="Remove">
-                                            <ActionIcon
-                                                variant="subtle"
-                                                color="gray"
-                                                disabled={isWorking}
-                                                onClick={() =>
-                                                    form.removeListItem(
-                                                        'projectRoles',
-                                                        idx,
-                                                    )
-                                                }
-                                            >
-                                                <MantineIcon icon={IconX} />
-                                            </ActionIcon>
-                                        </Tooltip>
-                                    </Group>
-                                ))}
-                                {form.errors.projectRoles && (
-                                    <Text size="xs" c="red">
-                                        {form.errors.projectRoles}
-                                    </Text>
-                                )}
-                                <Button
-                                    leftSection={
-                                        <MantineIcon icon={IconPlus} />
-                                    }
-                                    variant="subtle"
-                                    size="xs"
-                                    disabled={
-                                        isWorking ||
-                                        form.values.projectRoles.length >=
-                                            projects.length
-                                    }
-                                    onClick={addProjectRow}
-                                    className={classes.addProjectButton}
-                                >
-                                    Add project
-                                </Button>
-                            </Stack>
+                            <ServiceAccountProjectRoles
+                                form={form}
+                                projects={projects}
+                                projectRoleOptions={projectRoleOptions}
+                                rolesLoading={listRoles.isLoading}
+                                disabled={isWorking}
+                            />
                         )}
                     </Stack>
                 </form>

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
@@ -1,0 +1,261 @@
+import {
+    ServiceAccountScope,
+    type ServiceAccountScope as ServiceAccountScopeType,
+    type ServiceAccountWithProjectAccessCount,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Button,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconPencil } from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineModal from '../../../components/common/MantineModal';
+import { useCustomRoles } from '../customRoles/useCustomRoles';
+import { useServiceAccounts } from './useServiceAccounts';
+
+const EDIT_FORM_ID = 'edit-service-account-form';
+
+// Organization-mode role options. Mirrors `ServiceAccountsCreateModal` —
+// `Member` is intentionally absent (it's the Project-scope marker, not a
+// user-selectable Organization role).
+const SYSTEM_ROLE_OPTIONS: { value: string; label: string }[] = [
+    { value: `scope:${ServiceAccountScope.SYSTEM_VIEWER}`, label: 'Viewer' },
+    {
+        value: `scope:${ServiceAccountScope.SYSTEM_INTERACTIVE_VIEWER}`,
+        label: 'Interactive viewer',
+    },
+    { value: `scope:${ServiceAccountScope.SYSTEM_EDITOR}`, label: 'Editor' },
+    {
+        value: `scope:${ServiceAccountScope.SYSTEM_DEVELOPER}`,
+        label: 'Developer',
+    },
+    { value: `scope:${ServiceAccountScope.SYSTEM_ADMIN}`, label: 'Admin' },
+];
+
+// Legacy `org:*` scopes predate the `system:*` aliases shown in the picker.
+// Map them so an SA minted on a legacy scope resolves to the matching option
+// instead of rendering a blank Select. Mirrors `getRoleForScopes` on the
+// backend.
+const LEGACY_SCOPE_TO_SYSTEM: Partial<
+    Record<ServiceAccountScopeType, ServiceAccountScopeType>
+> = {
+    [ServiceAccountScope.ORG_ADMIN]: ServiceAccountScope.SYSTEM_ADMIN,
+    [ServiceAccountScope.ORG_EDIT]: ServiceAccountScope.SYSTEM_EDITOR,
+    [ServiceAccountScope.ORG_READ]: ServiceAccountScope.SYSTEM_VIEWER,
+};
+
+// A project-scoped SA carries `system:member` + per-project grants. Editing its
+// org-wide permission would orphan those grants, so we only allow renaming it
+// here; project access is managed separately.
+const isProjectScoped = (sa: ServiceAccountWithProjectAccessCount) =>
+    sa.projectAccessCount > 0 ||
+    sa.scopes.includes(ServiceAccountScope.SYSTEM_MEMBER);
+
+// Resolve the role Select's initial value from the SA's current permission: a
+// custom role wins; otherwise a single org scope (legacy scopes mapped to their
+// system alias). Multi-scope / unmappable SAs start blank, forcing a pick.
+const getInitialRoleSelection = (
+    sa: ServiceAccountWithProjectAccessCount,
+): string => {
+    if (sa.roleUuid) {
+        return `role:${sa.roleUuid}`;
+    }
+    if (sa.scopes.length !== 1) {
+        return '';
+    }
+    const scope = LEGACY_SCOPE_TO_SYSTEM[sa.scopes[0]] ?? sa.scopes[0];
+    return scope === ServiceAccountScope.SYSTEM_MEMBER ? '' : `scope:${scope}`;
+};
+
+interface EditFormState {
+    isLoading: boolean;
+}
+
+const EditForm: FC<{
+    serviceAccount: ServiceAccountWithProjectAccessCount;
+    onStateChange: (state: EditFormState) => void;
+    onClose: () => void;
+}> = ({ serviceAccount, onStateChange, onClose }) => {
+    const { updateAccount } = useServiceAccounts();
+    const { mutateAsync, isLoading } = updateAccount;
+    const { listRoles } = useCustomRoles();
+
+    const projectScoped = isProjectScoped(serviceAccount);
+
+    // Edit always surfaces the org's custom roles (unlike create, which gates
+    // them behind the feature flag) so an SA already bound to a custom role
+    // keeps showing that role even if the flag is off.
+    const customRoleOptions = useMemo(
+        () =>
+            (listRoles.data ?? [])
+                .map((role) => ({
+                    value: `role:${role.roleUuid}`,
+                    label: role.name,
+                }))
+                .sort((a, b) =>
+                    a.label.localeCompare(b.label, undefined, {
+                        sensitivity: 'base',
+                    }),
+                ),
+        [listRoles.data],
+    );
+
+    const roleOptions = useMemo(() => {
+        const groups: {
+            group: string;
+            items: { value: string; label: string }[];
+        }[] = [
+            { group: 'Organization system roles', items: SYSTEM_ROLE_OPTIONS },
+        ];
+        if (customRoleOptions.length > 0) {
+            groups.push({ group: 'Custom roles', items: customRoleOptions });
+        }
+        return groups;
+    }, [customRoleOptions]);
+
+    const initialRoleSelection = getInitialRoleSelection(serviceAccount);
+
+    const form = useForm({
+        initialValues: {
+            description: serviceAccount.description,
+            roleSelection: initialRoleSelection,
+        },
+        validate: {
+            roleSelection: (value) =>
+                !projectScoped && value === ''
+                    ? 'Please select a permission set'
+                    : null,
+        },
+    });
+
+    const handleOnSubmit = form.onSubmit(
+        async ({ description, roleSelection }) => {
+            if (projectScoped) {
+                await mutateAsync({ uuid: serviceAccount.uuid, description });
+                onClose();
+                return;
+            }
+            // `scope:<service-account-scope>` → { scopes: [<scope>] }
+            // `role:<uuid>`                   → { roleUuid: <uuid> }
+            const sepIdx = roleSelection.indexOf(':');
+            const kind = roleSelection.slice(0, sepIdx) as 'scope' | 'role';
+            const value = roleSelection.slice(sepIdx + 1);
+            const payload =
+                kind === 'scope'
+                    ? { scopes: [value as ServiceAccountScopeType] }
+                    : { roleUuid: value };
+            await mutateAsync({
+                uuid: serviceAccount.uuid,
+                description,
+                ...payload,
+            });
+            onClose();
+        },
+    );
+
+    useEffect(() => {
+        onStateChange({ isLoading });
+    }, [isLoading, onStateChange]);
+
+    return (
+        <form id={EDIT_FORM_ID} onSubmit={handleOnSubmit}>
+            <Stack gap="md">
+                <TextInput
+                    label="Description"
+                    placeholder="What's this service account for?"
+                    required
+                    disabled={isLoading}
+                    {...form.getInputProps('description')}
+                />
+                {projectScoped ? (
+                    <Text size="xs" c="dimmed">
+                        This is a project-scoped service account. Its project
+                        access can't be edited here — only its name.
+                    </Text>
+                ) : (
+                    <Select
+                        label="Role"
+                        description={
+                            <>
+                                Pick a system role or a custom role you've
+                                created in{' '}
+                                <Anchor
+                                    component={Link}
+                                    to="/generalSettings/customRoles"
+                                    size="xs"
+                                >
+                                    custom roles
+                                </Anchor>
+                                . The token stays the same.
+                            </>
+                        }
+                        placeholder="Select a permission set"
+                        data={roleOptions}
+                        required
+                        searchable
+                        maxDropdownHeight={220}
+                        disabled={isLoading || listRoles.isLoading}
+                        {...form.getInputProps('roleSelection')}
+                    />
+                )}
+            </Stack>
+        </form>
+    );
+};
+
+type Props = {
+    isOpen: boolean;
+    onClose: () => void;
+    serviceAccount: ServiceAccountWithProjectAccessCount | undefined;
+};
+
+export const ServiceAccountsEditModal: FC<Props> = ({
+    isOpen,
+    onClose,
+    serviceAccount,
+}) => {
+    const [formState, setFormState] = useState<EditFormState>({
+        isLoading: false,
+    });
+
+    const handleClose = useCallback(() => {
+        onClose();
+        setFormState({ isLoading: false });
+    }, [onClose]);
+
+    return (
+        <MantineModal
+            opened={isOpen}
+            onClose={handleClose}
+            title="Edit service account"
+            icon={IconPencil}
+            size="md"
+            cancelLabel="Cancel"
+            cancelDisabled={formState.isLoading}
+            actions={
+                <Button
+                    type="submit"
+                    form={EDIT_FORM_ID}
+                    loading={formState.isLoading}
+                >
+                    Save changes
+                </Button>
+            }
+        >
+            {serviceAccount ? (
+                <EditForm
+                    key={serviceAccount.uuid}
+                    serviceAccount={serviceAccount}
+                    onStateChange={setFormState}
+                    onClose={handleClose}
+                />
+            ) : null}
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
@@ -4,6 +4,7 @@ import {
     type ServiceAccountProjectGrant,
     type ServiceAccountScope as ServiceAccountScopeType,
     type ServiceAccountWithProjectAccessCount,
+    type UpdateServiceAccount,
 } from '@lightdash/common';
 import {
     Anchor,
@@ -18,7 +19,7 @@ import {
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { IconPencil } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { useCallback, useMemo, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineModal from '../../../components/common/MantineModal';
 import { useProjects } from '../../../hooks/useProjects';
@@ -132,23 +133,16 @@ const useCustomRoleOptions = () => {
     return { options, isLoading: listRoles.isLoading };
 };
 
-interface EditFormState {
-    isLoading: boolean;
-    isReady: boolean;
-}
-
-const READY: EditFormState = { isLoading: false, isReady: true };
-
 // Unified edit form — mounts only once grants are loaded so `useForm` captures
-// them as initial values (per the no-effect-sync state pattern).
+// them as initial values (per the no-effect-sync state pattern). The mutation
+// and its loading state live in the parent, which derives them at render time
+// (no effects); this form just builds the payload and calls `onSubmit`.
 const EditForm: FC<{
     serviceAccount: ServiceAccountWithProjectAccessCount;
     grants: ServiceAccountProjectGrant[];
-    onStateChange: (state: EditFormState) => void;
-    onClose: () => void;
-}> = ({ serviceAccount, grants, onStateChange, onClose }) => {
-    const { updateAccount } = useServiceAccounts();
-    const { mutateAsync, isLoading } = updateAccount;
+    isSubmitting: boolean;
+    onSubmit: (payload: UpdateServiceAccount) => void;
+}> = ({ serviceAccount, grants, isSubmitting, onSubmit }) => {
     const { data: projects = [] } = useProjects();
     const { options: customRoleOptions, isLoading: rolesLoading } =
         useCustomRoleOptions();
@@ -207,10 +201,9 @@ const EditForm: FC<{
     });
 
     const handleOnSubmit = form.onSubmit(
-        async ({ description, scope, roleSelection, projectRoles }) => {
+        ({ description, scope, roleSelection, projectRoles }) => {
             if (scope === 'project') {
-                await mutateAsync({
-                    uuid: serviceAccount.uuid,
+                onSubmit({
                     description,
                     scopes: [ServiceAccountScope.SYSTEM_MEMBER],
                     projectAccess: projectRoles.map((r) => {
@@ -225,29 +218,20 @@ const EditForm: FC<{
                               };
                     }),
                 });
-                onClose();
                 return;
             }
             // Organization scope:
             //   scope:<service-account-scope> → { scopes: [<scope>] }
             //   role:<uuid>                   → { roleUuid: <uuid> }
             const { kind, value } = parseTaggedRole(roleSelection);
-            const payload =
-                kind === 'scope'
-                    ? { scopes: [value as ServiceAccountScopeType] }
-                    : { roleUuid: value };
-            await mutateAsync({
-                uuid: serviceAccount.uuid,
+            onSubmit({
                 description,
-                ...payload,
+                ...(kind === 'scope'
+                    ? { scopes: [value as ServiceAccountScopeType] }
+                    : { roleUuid: value }),
             });
-            onClose();
         },
     );
-
-    useEffect(() => {
-        onStateChange({ isLoading, isReady: true });
-    }, [isLoading, onStateChange]);
 
     // Switching scope mode is destructive — warn before save.
     const switchWarning =
@@ -264,7 +248,7 @@ const EditForm: FC<{
                     label="Description"
                     placeholder="What's this service account for?"
                     required
-                    disabled={isLoading}
+                    disabled={isSubmitting}
                     {...form.getInputProps('description')}
                 />
 
@@ -274,7 +258,7 @@ const EditForm: FC<{
                     </Text>
                     <SegmentedControl
                         fullWidth
-                        disabled={isLoading}
+                        disabled={isSubmitting}
                         data={[
                             { label: 'Organization', value: 'organization' },
                             { label: 'Project', value: 'project' },
@@ -310,7 +294,7 @@ const EditForm: FC<{
                         required
                         searchable
                         maxDropdownHeight={220}
-                        disabled={isLoading || rolesLoading}
+                        disabled={isSubmitting || rolesLoading}
                         {...form.getInputProps('roleSelection')}
                     />
                 ) : (
@@ -319,7 +303,7 @@ const EditForm: FC<{
                         projects={projects}
                         projectRoleOptions={projectRoleOptions}
                         rolesLoading={rolesLoading}
-                        disabled={isLoading}
+                        disabled={isSubmitting}
                     />
                 )}
             </Stack>
@@ -333,85 +317,80 @@ type Props = {
     serviceAccount: ServiceAccountWithProjectAccessCount | undefined;
 };
 
-// Fetches the SA's current grants up front so the form prefills project access
-// (and is ready if the user switches into Project mode), then mounts the form.
-const EditModalBody: FC<{
-    serviceAccount: ServiceAccountWithProjectAccessCount;
-    onStateChange: (state: EditFormState) => void;
-    onClose: () => void;
-}> = ({ serviceAccount, onStateChange, onClose }) => {
-    const grantsQuery = useServiceAccountProjectGrants(serviceAccount.uuid);
-
-    useEffect(() => {
-        if (grantsQuery.isLoading) {
-            onStateChange({ isLoading: false, isReady: false });
-        }
-    }, [grantsQuery.isLoading, onStateChange]);
-
-    if (grantsQuery.isLoading) {
-        return (
-            <Center mih={120}>
-                <Loader size="sm" />
-            </Center>
-        );
-    }
-    if (grantsQuery.isError || !grantsQuery.data) {
-        return (
-            <Text size="sm" c="red">
-                Failed to load this service account's project access.
-            </Text>
-        );
-    }
-
-    return (
-        <EditForm
-            serviceAccount={serviceAccount}
-            grants={grantsQuery.data}
-            onStateChange={onStateChange}
-            onClose={onClose}
-        />
-    );
-};
-
 export const ServiceAccountsEditModal: FC<Props> = ({
     isOpen,
     onClose,
     serviceAccount,
 }) => {
-    const [formState, setFormState] = useState<EditFormState>(READY);
+    const { updateAccount } = useServiceAccounts();
+    // Grants are fetched at the modal level so loading/ready state is derived
+    // here at render time (no effects) and the form prefills project access.
+    const grantsQuery = useServiceAccountProjectGrants(
+        serviceAccount?.uuid ?? '',
+    );
+    const isSubmitting = updateAccount.isLoading;
+    const grantsReady = !grantsQuery.isLoading && !!grantsQuery.data;
 
-    const handleClose = useCallback(() => {
-        onClose();
-        setFormState(READY);
-    }, [onClose]);
+    const handleSubmit = useCallback(
+        (payload: UpdateServiceAccount) => {
+            if (!serviceAccount) return;
+            // `mutate` (not `mutateAsync`): success closes the modal, failure
+            // surfaces the hook's onError toast and keeps it open.
+            updateAccount.mutate(
+                { uuid: serviceAccount.uuid, ...payload },
+                { onSuccess: () => onClose() },
+            );
+        },
+        [serviceAccount, updateAccount, onClose],
+    );
+
+    const renderBody = () => {
+        if (!serviceAccount) return null;
+        if (grantsQuery.isLoading) {
+            return (
+                <Center mih={120}>
+                    <Loader size="sm" />
+                </Center>
+            );
+        }
+        if (grantsQuery.isError || !grantsQuery.data) {
+            return (
+                <Text size="sm" c="red">
+                    Failed to load this service account's project access.
+                </Text>
+            );
+        }
+        return (
+            <EditForm
+                key={serviceAccount.uuid}
+                serviceAccount={serviceAccount}
+                grants={grantsQuery.data}
+                isSubmitting={isSubmitting}
+                onSubmit={handleSubmit}
+            />
+        );
+    };
 
     return (
         <MantineModal
             opened={isOpen}
-            onClose={handleClose}
+            onClose={onClose}
             title="Edit service account"
             icon={IconPencil}
             cancelLabel="Cancel"
-            cancelDisabled={formState.isLoading}
+            cancelDisabled={isSubmitting}
             actions={
                 <Button
                     type="submit"
                     form={EDIT_FORM_ID}
-                    loading={formState.isLoading}
-                    disabled={!formState.isReady}
+                    loading={isSubmitting}
+                    disabled={!grantsReady}
                 >
                     Save changes
                 </Button>
             }
         >
-            {serviceAccount ? (
-                <EditModalBody
-                    key={serviceAccount.uuid}
-                    serviceAccount={serviceAccount}
-                    onStateChange={setFormState}
-                    onClose={handleClose}
-                />
-            ) : null}
+            {renderBody()}
         </MantineModal>
     );
 };

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
@@ -365,7 +365,6 @@ const EditModalBody: FC<{
 
     return (
         <EditForm
-            key={serviceAccount.uuid}
             serviceAccount={serviceAccount}
             grants={grantsQuery.data}
             onStateChange={onStateChange}

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
@@ -1,11 +1,15 @@
 import {
     ServiceAccountScope,
+    type ProjectMemberRole,
+    type ServiceAccountProjectGrant,
     type ServiceAccountScope as ServiceAccountScopeType,
     type ServiceAccountWithProjectAccessCount,
 } from '@lightdash/common';
 import {
     Anchor,
     Button,
+    Center,
+    Loader,
     Select,
     Stack,
     Text,
@@ -16,7 +20,14 @@ import { IconPencil } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineModal from '../../../components/common/MantineModal';
+import { useProjects } from '../../../hooks/useProjects';
 import { useCustomRoles } from '../customRoles/useCustomRoles';
+import {
+    SYSTEM_PROJECT_ROLE_OPTIONS,
+    type ProjectRoleRow,
+} from './projectRoleOptions';
+import { ServiceAccountProjectRoles } from './ServiceAccountProjectRoles';
+import { useServiceAccountProjectGrants } from './useProjectAccess';
 import { useServiceAccounts } from './useServiceAccounts';
 
 const EDIT_FORM_ID = 'edit-service-account-form';
@@ -50,16 +61,14 @@ const LEGACY_SCOPE_TO_SYSTEM: Partial<
     [ServiceAccountScope.ORG_READ]: ServiceAccountScope.SYSTEM_VIEWER,
 };
 
-// A project-scoped SA carries `system:member` + per-project grants. Editing its
-// org-wide permission would orphan those grants, so we only allow renaming it
-// here; project access is managed separately.
+// A project-scoped SA carries `system:member` + per-project grants. Its mode is
+// fixed: this modal edits the project grants, never an org-wide role.
 const isProjectScoped = (sa: ServiceAccountWithProjectAccessCount) =>
-    sa.projectAccessCount > 0 ||
     sa.scopes.includes(ServiceAccountScope.SYSTEM_MEMBER);
 
-// Resolve the role Select's initial value from the SA's current permission: a
-// custom role wins; otherwise a single org scope (legacy scopes mapped to their
-// system alias). Multi-scope / unmappable SAs start blank, forcing a pick.
+// Resolve the org role Select's initial value: a custom role wins; otherwise a
+// single org scope (legacy scopes mapped to their system alias). Multi-scope /
+// unmappable SAs start blank, forcing a pick.
 const getInitialRoleSelection = (
     sa: ServiceAccountWithProjectAccessCount,
 ): string => {
@@ -73,25 +82,24 @@ const getInitialRoleSelection = (
     return scope === ServiceAccountScope.SYSTEM_MEMBER ? '' : `scope:${scope}`;
 };
 
-interface EditFormState {
-    isLoading: boolean;
-}
+// Parse a tagged role selection (`scope:x` / `role:uuid` / `system:role`) into
+// its kind + value. Mirrors the create modal's submit-time translator.
+const parseTaggedRole = (
+    selection: string,
+): { kind: string; value: string } => {
+    const sepIdx = selection.indexOf(':');
+    return {
+        kind: selection.slice(0, sepIdx),
+        value: selection.slice(sepIdx + 1),
+    };
+};
 
-const EditForm: FC<{
-    serviceAccount: ServiceAccountWithProjectAccessCount;
-    onStateChange: (state: EditFormState) => void;
-    onClose: () => void;
-}> = ({ serviceAccount, onStateChange, onClose }) => {
-    const { updateAccount } = useServiceAccounts();
-    const { mutateAsync, isLoading } = updateAccount;
+// Edit always surfaces the org's custom roles (unlike create, which gates them
+// behind the feature flag) so an SA already bound to a custom role keeps
+// showing that role even if the flag is off.
+const useCustomRoleOptions = () => {
     const { listRoles } = useCustomRoles();
-
-    const projectScoped = isProjectScoped(serviceAccount);
-
-    // Edit always surfaces the org's custom roles (unlike create, which gates
-    // them behind the feature flag) so an SA already bound to a custom role
-    // keeps showing that role even if the flag is off.
-    const customRoleOptions = useMemo(
+    const options = useMemo(
         () =>
             (listRoles.data ?? [])
                 .map((role) => ({
@@ -105,6 +113,26 @@ const EditForm: FC<{
                 ),
         [listRoles.data],
     );
+    return { options, isLoading: listRoles.isLoading };
+};
+
+interface EditFormState {
+    isLoading: boolean;
+    isReady: boolean;
+}
+
+const READY: EditFormState = { isLoading: false, isReady: true };
+
+// Organization-scoped SA: edit name + org role / scopes.
+const OrgEditForm: FC<{
+    serviceAccount: ServiceAccountWithProjectAccessCount;
+    onStateChange: (state: EditFormState) => void;
+    onClose: () => void;
+}> = ({ serviceAccount, onStateChange, onClose }) => {
+    const { updateAccount } = useServiceAccounts();
+    const { mutateAsync, isLoading } = updateAccount;
+    const { options: customRoleOptions, isLoading: rolesLoading } =
+        useCustomRoleOptions();
 
     const roleOptions = useMemo(() => {
         const groups: {
@@ -119,33 +147,22 @@ const EditForm: FC<{
         return groups;
     }, [customRoleOptions]);
 
-    const initialRoleSelection = getInitialRoleSelection(serviceAccount);
-
     const form = useForm({
         initialValues: {
             description: serviceAccount.description,
-            roleSelection: initialRoleSelection,
+            roleSelection: getInitialRoleSelection(serviceAccount),
         },
         validate: {
             roleSelection: (value) =>
-                !projectScoped && value === ''
-                    ? 'Please select a permission set'
-                    : null,
+                value === '' ? 'Please select a permission set' : null,
         },
     });
 
     const handleOnSubmit = form.onSubmit(
         async ({ description, roleSelection }) => {
-            if (projectScoped) {
-                await mutateAsync({ uuid: serviceAccount.uuid, description });
-                onClose();
-                return;
-            }
             // `scope:<service-account-scope>` → { scopes: [<scope>] }
             // `role:<uuid>`                   → { roleUuid: <uuid> }
-            const sepIdx = roleSelection.indexOf(':');
-            const kind = roleSelection.slice(0, sepIdx) as 'scope' | 'role';
-            const value = roleSelection.slice(sepIdx + 1);
+            const { kind, value } = parseTaggedRole(roleSelection);
             const payload =
                 kind === 'scope'
                     ? { scopes: [value as ServiceAccountScopeType] }
@@ -160,7 +177,7 @@ const EditForm: FC<{
     );
 
     useEffect(() => {
-        onStateChange({ isLoading });
+        onStateChange({ isLoading, isReady: true });
     }, [isLoading, onStateChange]);
 
     return (
@@ -173,39 +190,176 @@ const EditForm: FC<{
                     disabled={isLoading}
                     {...form.getInputProps('description')}
                 />
-                {projectScoped ? (
-                    <Text size="xs" c="dimmed">
-                        This is a project-scoped service account. Its project
-                        access can't be edited here — only its name.
-                    </Text>
-                ) : (
-                    <Select
-                        label="Role"
-                        description={
-                            <>
-                                Pick a system role or a custom role you've
-                                created in{' '}
-                                <Anchor
-                                    component={Link}
-                                    to="/generalSettings/customRoles"
-                                    size="xs"
-                                >
-                                    custom roles
-                                </Anchor>
-                                . The token stays the same.
-                            </>
-                        }
-                        placeholder="Select a permission set"
-                        data={roleOptions}
-                        required
-                        searchable
-                        maxDropdownHeight={220}
-                        disabled={isLoading || listRoles.isLoading}
-                        {...form.getInputProps('roleSelection')}
-                    />
-                )}
+                <Select
+                    label="Role"
+                    description={
+                        <>
+                            Pick a system role or a custom role you've created
+                            in{' '}
+                            <Anchor
+                                component={Link}
+                                to="/generalSettings/customRoles"
+                                size="xs"
+                            >
+                                custom roles
+                            </Anchor>
+                            . The token stays the same.
+                        </>
+                    }
+                    placeholder="Select a permission set"
+                    data={roleOptions}
+                    required
+                    searchable
+                    maxDropdownHeight={220}
+                    disabled={isLoading || rolesLoading}
+                    {...form.getInputProps('roleSelection')}
+                />
             </Stack>
         </form>
+    );
+};
+
+// Convert the SA's current grants into the form's tagged project rows.
+const grantsToRows = (grants: ServiceAccountProjectGrant[]): ProjectRoleRow[] =>
+    grants.map((g) =>
+        g.roleUuid
+            ? {
+                  projectUuid: g.projectUuid,
+                  roleSelection: `role:${g.roleUuid}`,
+              }
+            : {
+                  projectUuid: g.projectUuid,
+                  roleSelection: `system:${g.role}`,
+              },
+    );
+
+// Inner project form — mounts only once grants are loaded so `useForm` captures
+// them as initial values (per the no-effect-sync state pattern).
+const ProjectEditFormInner: FC<{
+    serviceAccount: ServiceAccountWithProjectAccessCount;
+    grants: ServiceAccountProjectGrant[];
+    onStateChange: (state: EditFormState) => void;
+    onClose: () => void;
+}> = ({ serviceAccount, grants, onStateChange, onClose }) => {
+    const { updateAccount } = useServiceAccounts();
+    const { mutateAsync, isLoading } = updateAccount;
+    const { data: projects = [] } = useProjects();
+    const { options: customRoleOptions, isLoading: rolesLoading } =
+        useCustomRoleOptions();
+
+    const projectRoleOptions = useMemo(() => {
+        const groups: {
+            group: string;
+            items: { value: string; label: string }[];
+        }[] = [{ group: 'System roles', items: SYSTEM_PROJECT_ROLE_OPTIONS }];
+        if (customRoleOptions.length > 0) {
+            groups.push({ group: 'Custom roles', items: customRoleOptions });
+        }
+        return groups;
+    }, [customRoleOptions]);
+
+    const form = useForm({
+        initialValues: {
+            description: serviceAccount.description,
+            projectRoles: grantsToRows(grants),
+        },
+        validate: {
+            projectRoles: (rows) => {
+                if (rows.length === 0) return 'Add at least one project';
+                if (rows.some((r) => !r.projectUuid))
+                    return 'Pick a project for each row';
+                const uniques = new Set(rows.map((r) => r.projectUuid));
+                if (uniques.size !== rows.length)
+                    return 'Each project can only be added once';
+                return null;
+            },
+        },
+    });
+
+    const handleOnSubmit = form.onSubmit(
+        async ({ description, projectRoles }) => {
+            const projectAccess = projectRoles.map((r) => {
+                const { kind, value } = parseTaggedRole(r.roleSelection);
+                return kind === 'role'
+                    ? { projectUuid: r.projectUuid, roleUuid: value }
+                    : {
+                          projectUuid: r.projectUuid,
+                          role: value as ProjectMemberRole,
+                      };
+            });
+            await mutateAsync({
+                uuid: serviceAccount.uuid,
+                description,
+                scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+                projectAccess,
+            });
+            onClose();
+        },
+    );
+
+    useEffect(() => {
+        onStateChange({ isLoading, isReady: true });
+    }, [isLoading, onStateChange]);
+
+    return (
+        <form id={EDIT_FORM_ID} onSubmit={handleOnSubmit}>
+            <Stack gap="md">
+                <TextInput
+                    label="Description"
+                    placeholder="What's this service account for?"
+                    required
+                    disabled={isLoading}
+                    {...form.getInputProps('description')}
+                />
+                <ServiceAccountProjectRoles
+                    form={form}
+                    projects={projects}
+                    projectRoleOptions={projectRoleOptions}
+                    rolesLoading={rolesLoading}
+                    disabled={isLoading}
+                />
+            </Stack>
+        </form>
+    );
+};
+
+// Project-scoped SA: fetch its current grants, then render the inner form.
+const ProjectEditForm: FC<{
+    serviceAccount: ServiceAccountWithProjectAccessCount;
+    onStateChange: (state: EditFormState) => void;
+    onClose: () => void;
+}> = ({ serviceAccount, onStateChange, onClose }) => {
+    const grantsQuery = useServiceAccountProjectGrants(serviceAccount.uuid);
+
+    useEffect(() => {
+        if (grantsQuery.isLoading) {
+            onStateChange({ isLoading: false, isReady: false });
+        }
+    }, [grantsQuery.isLoading, onStateChange]);
+
+    if (grantsQuery.isLoading) {
+        return (
+            <Center mih={120}>
+                <Loader size="sm" />
+            </Center>
+        );
+    }
+    if (grantsQuery.isError || !grantsQuery.data) {
+        return (
+            <Text size="sm" c="red">
+                Failed to load this service account's project access.
+            </Text>
+        );
+    }
+
+    return (
+        <ProjectEditFormInner
+            key={serviceAccount.uuid}
+            serviceAccount={serviceAccount}
+            grants={grantsQuery.data}
+            onStateChange={onStateChange}
+            onClose={onClose}
+        />
     );
 };
 
@@ -220,14 +374,16 @@ export const ServiceAccountsEditModal: FC<Props> = ({
     onClose,
     serviceAccount,
 }) => {
-    const [formState, setFormState] = useState<EditFormState>({
-        isLoading: false,
-    });
+    const [formState, setFormState] = useState<EditFormState>(READY);
 
     const handleClose = useCallback(() => {
         onClose();
-        setFormState({ isLoading: false });
+        setFormState(READY);
     }, [onClose]);
+
+    const projectScoped = serviceAccount
+        ? isProjectScoped(serviceAccount)
+        : false;
 
     return (
         <MantineModal
@@ -243,18 +399,28 @@ export const ServiceAccountsEditModal: FC<Props> = ({
                     type="submit"
                     form={EDIT_FORM_ID}
                     loading={formState.isLoading}
+                    disabled={!formState.isReady}
                 >
                     Save changes
                 </Button>
             }
         >
             {serviceAccount ? (
-                <EditForm
-                    key={serviceAccount.uuid}
-                    serviceAccount={serviceAccount}
-                    onStateChange={setFormState}
-                    onClose={handleClose}
-                />
+                projectScoped ? (
+                    <ProjectEditForm
+                        key={serviceAccount.uuid}
+                        serviceAccount={serviceAccount}
+                        onStateChange={setFormState}
+                        onClose={handleClose}
+                    />
+                ) : (
+                    <OrgEditForm
+                        key={serviceAccount.uuid}
+                        serviceAccount={serviceAccount}
+                        onStateChange={setFormState}
+                        onClose={handleClose}
+                    />
+                )
             ) : null}
         </MantineModal>
     );

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
@@ -302,7 +302,7 @@ const EditForm: FC<{
                                 >
                                     custom roles
                                 </Anchor>
-                                . The token stays the same.
+                                .
                             </>
                         }
                         placeholder="Select a permission set"
@@ -392,7 +392,6 @@ export const ServiceAccountsEditModal: FC<Props> = ({
             onClose={handleClose}
             title="Edit service account"
             icon={IconPencil}
-            size="md"
             cancelLabel="Cancel"
             cancelDisabled={formState.isLoading}
             actions={

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
@@ -10,6 +10,7 @@ import {
     Button,
     Center,
     Loader,
+    SegmentedControl,
     Select,
     Stack,
     Text,
@@ -31,6 +32,8 @@ import { useServiceAccountProjectGrants } from './useProjectAccess';
 import { useServiceAccounts } from './useServiceAccounts';
 
 const EDIT_FORM_ID = 'edit-service-account-form';
+
+type ScopeMode = 'organization' | 'project';
 
 // Organization-mode role options. Mirrors `ServiceAccountsCreateModal` —
 // `Member` is intentionally absent (it's the Project-scope marker, not a
@@ -61,14 +64,13 @@ const LEGACY_SCOPE_TO_SYSTEM: Partial<
     [ServiceAccountScope.ORG_READ]: ServiceAccountScope.SYSTEM_VIEWER,
 };
 
-// A project-scoped SA carries `system:member` + per-project grants. Its mode is
-// fixed: this modal edits the project grants, never an org-wide role.
+// A project-scoped SA carries `system:member` + per-project grants.
 const isProjectScoped = (sa: ServiceAccountWithProjectAccessCount) =>
     sa.scopes.includes(ServiceAccountScope.SYSTEM_MEMBER);
 
 // Resolve the org role Select's initial value: a custom role wins; otherwise a
 // single org scope (legacy scopes mapped to their system alias). Multi-scope /
-// unmappable SAs start blank, forcing a pick.
+// member / unmappable SAs start blank, forcing a pick.
 const getInitialRoleSelection = (
     sa: ServiceAccountWithProjectAccessCount,
 ): string => {
@@ -93,6 +95,20 @@ const parseTaggedRole = (
         value: selection.slice(sepIdx + 1),
     };
 };
+
+// Convert the SA's current grants into the form's tagged project rows.
+const grantsToRows = (grants: ServiceAccountProjectGrant[]): ProjectRoleRow[] =>
+    grants.map((g) =>
+        g.roleUuid
+            ? {
+                  projectUuid: g.projectUuid,
+                  roleSelection: `role:${g.roleUuid}`,
+              }
+            : {
+                  projectUuid: g.projectUuid,
+                  roleSelection: `system:${g.role}`,
+              },
+    );
 
 // Edit always surfaces the org's custom roles (unlike create, which gates them
 // behind the feature flag) so an SA already bound to a custom role keeps
@@ -123,16 +139,23 @@ interface EditFormState {
 
 const READY: EditFormState = { isLoading: false, isReady: true };
 
-// Organization-scoped SA: edit name + org role / scopes.
-const OrgEditForm: FC<{
+// Unified edit form — mounts only once grants are loaded so `useForm` captures
+// them as initial values (per the no-effect-sync state pattern).
+const EditForm: FC<{
     serviceAccount: ServiceAccountWithProjectAccessCount;
+    grants: ServiceAccountProjectGrant[];
     onStateChange: (state: EditFormState) => void;
     onClose: () => void;
-}> = ({ serviceAccount, onStateChange, onClose }) => {
+}> = ({ serviceAccount, grants, onStateChange, onClose }) => {
     const { updateAccount } = useServiceAccounts();
     const { mutateAsync, isLoading } = updateAccount;
+    const { data: projects = [] } = useProjects();
     const { options: customRoleOptions, isLoading: rolesLoading } =
         useCustomRoleOptions();
+
+    const initialScope: ScopeMode = isProjectScoped(serviceAccount)
+        ? 'project'
+        : 'organization';
 
     const roleOptions = useMemo(() => {
         const groups: {
@@ -147,21 +170,67 @@ const OrgEditForm: FC<{
         return groups;
     }, [customRoleOptions]);
 
+    const projectRoleOptions = useMemo(() => {
+        const groups: {
+            group: string;
+            items: { value: string; label: string }[];
+        }[] = [{ group: 'System roles', items: SYSTEM_PROJECT_ROLE_OPTIONS }];
+        if (customRoleOptions.length > 0) {
+            groups.push({ group: 'Custom roles', items: customRoleOptions });
+        }
+        return groups;
+    }, [customRoleOptions]);
+
     const form = useForm({
         initialValues: {
             description: serviceAccount.description,
+            scope: initialScope,
             roleSelection: getInitialRoleSelection(serviceAccount),
+            projectRoles: grantsToRows(grants),
         },
         validate: {
-            roleSelection: (value) =>
-                value === '' ? 'Please select a permission set' : null,
+            roleSelection: (value, values) =>
+                values.scope === 'organization' && value === ''
+                    ? 'Please select a permission set'
+                    : null,
+            projectRoles: (rows, values) => {
+                if (values.scope !== 'project') return null;
+                if (rows.length === 0) return 'Add at least one project';
+                if (rows.some((r) => !r.projectUuid))
+                    return 'Pick a project for each row';
+                const uniques = new Set(rows.map((r) => r.projectUuid));
+                if (uniques.size !== rows.length)
+                    return 'Each project can only be added once';
+                return null;
+            },
         },
     });
 
     const handleOnSubmit = form.onSubmit(
-        async ({ description, roleSelection }) => {
-            // `scope:<service-account-scope>` → { scopes: [<scope>] }
-            // `role:<uuid>`                   → { roleUuid: <uuid> }
+        async ({ description, scope, roleSelection, projectRoles }) => {
+            if (scope === 'project') {
+                await mutateAsync({
+                    uuid: serviceAccount.uuid,
+                    description,
+                    scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+                    projectAccess: projectRoles.map((r) => {
+                        const { kind, value } = parseTaggedRole(
+                            r.roleSelection,
+                        );
+                        return kind === 'role'
+                            ? { projectUuid: r.projectUuid, roleUuid: value }
+                            : {
+                                  projectUuid: r.projectUuid,
+                                  role: value as ProjectMemberRole,
+                              };
+                    }),
+                });
+                onClose();
+                return;
+            }
+            // Organization scope:
+            //   scope:<service-account-scope> → { scopes: [<scope>] }
+            //   role:<uuid>                   → { roleUuid: <uuid> }
             const { kind, value } = parseTaggedRole(roleSelection);
             const payload =
                 kind === 'scope'
@@ -180,6 +249,14 @@ const OrgEditForm: FC<{
         onStateChange({ isLoading, isReady: true });
     }, [isLoading, onStateChange]);
 
+    // Switching scope mode is destructive — warn before save.
+    const switchWarning =
+        form.values.scope === initialScope
+            ? null
+            : form.values.scope === 'organization'
+              ? 'Switching to Organization removes all project access from this service account.'
+              : 'Switching to Project replaces the organization role with per-project access.';
+
     return (
         <form id={EDIT_FORM_ID} onSubmit={handleOnSubmit}>
             <Stack gap="md">
@@ -190,141 +267,75 @@ const OrgEditForm: FC<{
                     disabled={isLoading}
                     {...form.getInputProps('description')}
                 />
-                <Select
-                    label="Role"
-                    description={
-                        <>
-                            Pick a system role or a custom role you've created
-                            in{' '}
-                            <Anchor
-                                component={Link}
-                                to="/generalSettings/customRoles"
-                                size="xs"
-                            >
-                                custom roles
-                            </Anchor>
-                            . The token stays the same.
-                        </>
-                    }
-                    placeholder="Select a permission set"
-                    data={roleOptions}
-                    required
-                    searchable
-                    maxDropdownHeight={220}
-                    disabled={isLoading || rolesLoading}
-                    {...form.getInputProps('roleSelection')}
-                />
+
+                <Stack gap="xs">
+                    <Text size="sm" fw={500}>
+                        Scope
+                    </Text>
+                    <SegmentedControl
+                        fullWidth
+                        disabled={isLoading}
+                        data={[
+                            { label: 'Organization', value: 'organization' },
+                            { label: 'Project', value: 'project' },
+                        ]}
+                        {...form.getInputProps('scope')}
+                    />
+                    {switchWarning && (
+                        <Text size="xs" c="orange">
+                            {switchWarning}
+                        </Text>
+                    )}
+                </Stack>
+
+                {form.values.scope === 'organization' ? (
+                    <Select
+                        label="Role"
+                        description={
+                            <>
+                                Pick a system role or a custom role you've
+                                created in{' '}
+                                <Anchor
+                                    component={Link}
+                                    to="/generalSettings/customRoles"
+                                    size="xs"
+                                >
+                                    custom roles
+                                </Anchor>
+                                . The token stays the same.
+                            </>
+                        }
+                        placeholder="Select a permission set"
+                        data={roleOptions}
+                        required
+                        searchable
+                        maxDropdownHeight={220}
+                        disabled={isLoading || rolesLoading}
+                        {...form.getInputProps('roleSelection')}
+                    />
+                ) : (
+                    <ServiceAccountProjectRoles
+                        form={form}
+                        projects={projects}
+                        projectRoleOptions={projectRoleOptions}
+                        rolesLoading={rolesLoading}
+                        disabled={isLoading}
+                    />
+                )}
             </Stack>
         </form>
     );
 };
 
-// Convert the SA's current grants into the form's tagged project rows.
-const grantsToRows = (grants: ServiceAccountProjectGrant[]): ProjectRoleRow[] =>
-    grants.map((g) =>
-        g.roleUuid
-            ? {
-                  projectUuid: g.projectUuid,
-                  roleSelection: `role:${g.roleUuid}`,
-              }
-            : {
-                  projectUuid: g.projectUuid,
-                  roleSelection: `system:${g.role}`,
-              },
-    );
-
-// Inner project form — mounts only once grants are loaded so `useForm` captures
-// them as initial values (per the no-effect-sync state pattern).
-const ProjectEditFormInner: FC<{
-    serviceAccount: ServiceAccountWithProjectAccessCount;
-    grants: ServiceAccountProjectGrant[];
-    onStateChange: (state: EditFormState) => void;
+type Props = {
+    isOpen: boolean;
     onClose: () => void;
-}> = ({ serviceAccount, grants, onStateChange, onClose }) => {
-    const { updateAccount } = useServiceAccounts();
-    const { mutateAsync, isLoading } = updateAccount;
-    const { data: projects = [] } = useProjects();
-    const { options: customRoleOptions, isLoading: rolesLoading } =
-        useCustomRoleOptions();
-
-    const projectRoleOptions = useMemo(() => {
-        const groups: {
-            group: string;
-            items: { value: string; label: string }[];
-        }[] = [{ group: 'System roles', items: SYSTEM_PROJECT_ROLE_OPTIONS }];
-        if (customRoleOptions.length > 0) {
-            groups.push({ group: 'Custom roles', items: customRoleOptions });
-        }
-        return groups;
-    }, [customRoleOptions]);
-
-    const form = useForm({
-        initialValues: {
-            description: serviceAccount.description,
-            projectRoles: grantsToRows(grants),
-        },
-        validate: {
-            projectRoles: (rows) => {
-                if (rows.length === 0) return 'Add at least one project';
-                if (rows.some((r) => !r.projectUuid))
-                    return 'Pick a project for each row';
-                const uniques = new Set(rows.map((r) => r.projectUuid));
-                if (uniques.size !== rows.length)
-                    return 'Each project can only be added once';
-                return null;
-            },
-        },
-    });
-
-    const handleOnSubmit = form.onSubmit(
-        async ({ description, projectRoles }) => {
-            const projectAccess = projectRoles.map((r) => {
-                const { kind, value } = parseTaggedRole(r.roleSelection);
-                return kind === 'role'
-                    ? { projectUuid: r.projectUuid, roleUuid: value }
-                    : {
-                          projectUuid: r.projectUuid,
-                          role: value as ProjectMemberRole,
-                      };
-            });
-            await mutateAsync({
-                uuid: serviceAccount.uuid,
-                description,
-                scopes: [ServiceAccountScope.SYSTEM_MEMBER],
-                projectAccess,
-            });
-            onClose();
-        },
-    );
-
-    useEffect(() => {
-        onStateChange({ isLoading, isReady: true });
-    }, [isLoading, onStateChange]);
-
-    return (
-        <form id={EDIT_FORM_ID} onSubmit={handleOnSubmit}>
-            <Stack gap="md">
-                <TextInput
-                    label="Description"
-                    placeholder="What's this service account for?"
-                    required
-                    disabled={isLoading}
-                    {...form.getInputProps('description')}
-                />
-                <ServiceAccountProjectRoles
-                    form={form}
-                    projects={projects}
-                    projectRoleOptions={projectRoleOptions}
-                    rolesLoading={rolesLoading}
-                    disabled={isLoading}
-                />
-            </Stack>
-        </form>
-    );
+    serviceAccount: ServiceAccountWithProjectAccessCount | undefined;
 };
 
-// Project-scoped SA: fetch its current grants, then render the inner form.
-const ProjectEditForm: FC<{
+// Fetches the SA's current grants up front so the form prefills project access
+// (and is ready if the user switches into Project mode), then mounts the form.
+const EditModalBody: FC<{
     serviceAccount: ServiceAccountWithProjectAccessCount;
     onStateChange: (state: EditFormState) => void;
     onClose: () => void;
@@ -353,7 +364,7 @@ const ProjectEditForm: FC<{
     }
 
     return (
-        <ProjectEditFormInner
+        <EditForm
             key={serviceAccount.uuid}
             serviceAccount={serviceAccount}
             grants={grantsQuery.data}
@@ -361,12 +372,6 @@ const ProjectEditForm: FC<{
             onClose={onClose}
         />
     );
-};
-
-type Props = {
-    isOpen: boolean;
-    onClose: () => void;
-    serviceAccount: ServiceAccountWithProjectAccessCount | undefined;
 };
 
 export const ServiceAccountsEditModal: FC<Props> = ({
@@ -380,10 +385,6 @@ export const ServiceAccountsEditModal: FC<Props> = ({
         onClose();
         setFormState(READY);
     }, [onClose]);
-
-    const projectScoped = serviceAccount
-        ? isProjectScoped(serviceAccount)
-        : false;
 
     return (
         <MantineModal
@@ -406,21 +407,12 @@ export const ServiceAccountsEditModal: FC<Props> = ({
             }
         >
             {serviceAccount ? (
-                projectScoped ? (
-                    <ProjectEditForm
-                        key={serviceAccount.uuid}
-                        serviceAccount={serviceAccount}
-                        onStateChange={setFormState}
-                        onClose={handleClose}
-                    />
-                ) : (
-                    <OrgEditForm
-                        key={serviceAccount.uuid}
-                        serviceAccount={serviceAccount}
-                        onStateChange={setFormState}
-                        onClose={handleClose}
-                    />
-                )
+                <EditModalBody
+                    key={serviceAccount.uuid}
+                    serviceAccount={serviceAccount}
+                    onStateChange={setFormState}
+                    onClose={handleClose}
+                />
             ) : null}
         </MantineModal>
     );

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -32,6 +32,7 @@ import {
     IconDots,
     IconFilter,
     IconInfoCircle,
+    IconPencil,
     IconRefresh,
     IconSearch,
     IconShieldLock,
@@ -51,6 +52,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { useCustomRoles } from '../customRoles/useCustomRoles';
 import { ProjectsHoverCard } from './ProjectsHoverCard';
 import { ServiceAccountsDeleteModal } from './ServiceAccountsDeleteModal';
+import { ServiceAccountsEditModal } from './ServiceAccountsEditModal';
 import { ServiceAccountsRotateModal } from './ServiceAccountsRotateModal';
 import classes from './ServiceAccountsToolbar.module.css';
 import { isServiceAccountStale, STALE_THRESHOLD_DAYS } from './staleness';
@@ -153,6 +155,8 @@ export const ServiceAccountsTable: FC<Props> = ({
     const [opened, { open, close }] = useDisclosure(false);
     const [rotateOpened, { open: openRotate, close: closeRotate }] =
         useDisclosure(false);
+    const [editOpened, { open: openEdit, close: closeEdit }] =
+        useDisclosure(false);
 
     const [search, setSearch] = useState('');
     const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
@@ -212,6 +216,9 @@ export const ServiceAccountsTable: FC<Props> = ({
     const [serviceAccountToRotate, setServiceAccountToRotate] = useState<
         ServiceAccount | undefined
     >();
+    const [serviceAccountToEdit, setServiceAccountToEdit] = useState<
+        ServiceAccountWithProjectAccessCount | undefined
+    >();
 
     const handleOpenDelete = useCallback(
         (sa: ServiceAccount) => {
@@ -244,6 +251,19 @@ export const ServiceAccountsTable: FC<Props> = ({
         setServiceAccountToRotate(undefined);
         closeRotate();
     }, [closeRotate]);
+
+    const handleOpenEdit = useCallback(
+        (sa: ServiceAccountWithProjectAccessCount) => {
+            setServiceAccountToEdit(sa);
+            openEdit();
+        },
+        [openEdit],
+    );
+
+    const handleCloseEdit = useCallback(() => {
+        setServiceAccountToEdit(undefined);
+        closeEdit();
+    }, [closeEdit]);
 
     const columns: ContentTableColumnDef<ServiceAccountWithProjectAccessCount>[] =
         useMemo(
@@ -576,6 +596,14 @@ export const ServiceAccountsTable: FC<Props> = ({
                                     </ActionIcon>
                                 </Menu.Target>
                                 <Menu.Dropdown>
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon icon={IconPencil} />
+                                        }
+                                        onClick={() => handleOpenEdit(sa)}
+                                    >
+                                        Edit
+                                    </Menu.Item>
                                     {sa.roleUuid && (
                                         <Menu.Item
                                             component={Link}
@@ -619,7 +647,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                     },
                 },
             ],
-            [rolesByUuid, handleOpenRotate, handleOpenDelete],
+            [rolesByUuid, handleOpenEdit, handleOpenRotate, handleOpenDelete],
         );
 
     const handleStatusFilterChange = useCallback((value: string) => {
@@ -897,6 +925,12 @@ export const ServiceAccountsTable: FC<Props> = ({
                 isOpen={rotateOpened}
                 onClose={handleCloseRotate}
                 serviceAccount={serviceAccountToRotate}
+            />
+
+            <ServiceAccountsEditModal
+                isOpen={editOpened}
+                onClose={handleCloseEdit}
+                serviceAccount={serviceAccountToEdit}
             />
         </>
     );

--- a/packages/frontend/src/ee/features/serviceAccounts/projectRoleOptions.ts
+++ b/packages/frontend/src/ee/features/serviceAccounts/projectRoleOptions.ts
@@ -1,0 +1,23 @@
+import { ProjectMemberRole, ProjectMemberRoleLabels } from '@lightdash/common';
+
+// One project-access row. The role is a tagged selection parsed at submit time:
+// `system:<ProjectMemberRole>` → { role } or `role:<roleUuid>` → { roleUuid }.
+export type ProjectRoleRow = {
+    projectUuid: string;
+    roleSelection: string;
+};
+
+// Project-mode system role options. Mirrors the org-mode `scope:` / `role:`
+// convention so the two pickers feel symmetric.
+export const SYSTEM_PROJECT_ROLE_OPTIONS = [
+    ProjectMemberRole.VIEWER,
+    ProjectMemberRole.INTERACTIVE_VIEWER,
+    ProjectMemberRole.EDITOR,
+    ProjectMemberRole.DEVELOPER,
+    ProjectMemberRole.ADMIN,
+].map((role) => ({
+    value: `system:${role}`,
+    label: ProjectMemberRoleLabels[role],
+}));
+
+export const DEFAULT_PROJECT_ROLE_SELECTION = `system:${ProjectMemberRole.VIEWER}`;

--- a/packages/frontend/src/ee/features/serviceAccounts/useProjectAccess.ts
+++ b/packages/frontend/src/ee/features/serviceAccounts/useProjectAccess.ts
@@ -5,10 +5,9 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
-// SAs are immutable after creation, so the only client-side need is reading
-// the per-SA grants list (for the table's hover preview). Mutation hooks
-// have been intentionally removed along with the underlying backend
-// endpoints — grants are set once via the SA create payload.
+// Reads the per-SA project-grants list — used by the table's hover preview and
+// by the edit modal to pre-fill the project-access rows. Grants are written via
+// the SA create and update payloads, not a dedicated grants endpoint.
 const SA_GRANTS_KEY = 'service-account-project-grants';
 
 const fetchGrantsForServiceAccount = (serviceAccountUuid: string) =>

--- a/packages/frontend/src/ee/features/serviceAccounts/useServiceAccounts.ts
+++ b/packages/frontend/src/ee/features/serviceAccounts/useServiceAccounts.ts
@@ -85,6 +85,11 @@ export const useServiceAccounts = () => {
             }),
         onSuccess: async () => {
             await queryClient.invalidateQueries([CACHE_KEY]);
+            // Project-scoped edits change the grants list; refresh it so a
+            // re-open of the edit modal shows the new project access.
+            await queryClient.invalidateQueries([
+                'service-account-project-grants',
+            ]);
             showToastSuccess({
                 title: `Service account updated`,
             });

--- a/packages/frontend/src/ee/features/serviceAccounts/useServiceAccounts.ts
+++ b/packages/frontend/src/ee/features/serviceAccounts/useServiceAccounts.ts
@@ -2,6 +2,7 @@ import {
     type ApiError,
     type ServiceAccount,
     type ServiceAccountWithProjectAccessCount,
+    type UpdateServiceAccount,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
@@ -71,6 +72,31 @@ export const useServiceAccounts = () => {
         },
     });
 
+    const updateAccount = useMutation<
+        ServiceAccount,
+        ApiError,
+        { uuid: string } & UpdateServiceAccount
+    >({
+        mutationFn: ({ uuid, ...body }) =>
+            lightdashApi<ServiceAccount>({
+                method: 'PATCH',
+                url: `/service-accounts/${uuid}`,
+                body: JSON.stringify(body),
+            }),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries([CACHE_KEY]);
+            showToastSuccess({
+                title: `Service account updated`,
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: `Failed to update service account`,
+                apiError: error,
+            });
+        },
+    });
+
     const rotateAccount = useMutation<
         CreateServiceAccountResult,
         ApiError,
@@ -101,8 +127,15 @@ export const useServiceAccounts = () => {
         return {
             listAccounts,
             createAccount,
+            updateAccount,
             deleteAccount,
             rotateAccount,
         };
-    }, [listAccounts, createAccount, deleteAccount, rotateAccount]);
+    }, [
+        listAccounts,
+        createAccount,
+        updateAccount,
+        deleteAccount,
+        rotateAccount,
+    ]);
 };


### PR DESCRIPTION
## Summary

Editing a service account's role, permission scopes, or project access used to require deleting and recreating it — which issues a new token and breaks every CI/CD integration wired to the old one. This PR makes those edits in place, keeping the token valid. Closes PROD-8133 (#23908).

The token, expiry, and hash are never touched: editing only rewrites the SA's `description`, its org permission (`scopes`/`roleUuid`), or its project grants. Permissions take effect on the SA's next request (runtime CASL is scope-derived).

## How it works

The edit modal mirrors create: an **Organization | Project** scope toggle, then either an org role picker or a per-project grants editor. An SA can be edited within its mode **or switched between modes** in place.

### Backend

- `PATCH /api/v1/service-accounts/{tokenUuid}` (`serviceAccountsController.ts`) — new route, same middleware as rotate (`allowApiKeyAuthentication`, `isAuthenticated`, `unauthorisedInDemo`). Body is `UpdateServiceAccount`.
- `ServiceAccountService.update` — org-admin gate + cross-org guard (as delete/rotate), then **target-shaped**:
  - `projectAccess` (or `scopes:[system:member]`) → project-scoped: validate (≥1 grant, role XOR per grant, custom roles in-org), replace grants, set `system:member`.
  - org `scopes`/`roleUuid` → org-scoped: set the permission, then clear any project grants.
  - neither → rename only, preserve mode.
  - Cross-model writes are ordered so a `member`-with-zero-projects state is never persisted (grants-before-member-scope; org-scope-before-clear-grants).
- `ServiceAccountModel.update` — one transaction across `service_accounts`, the backing user's `first_name`, and `organization_memberships`.
- `ProjectModel.setServiceAccountProjectAccess` — transactional replace-all of the SA user's `project_memberships` (same-org projects, rejects duplicates).
- **Audit:** the org-admin authorization decision is recorded by the audited ability automatically; the change emits a structured `logAuditEvent` (action `update`, resource `ServiceAccount`, before/after of name/scopes/role — no token) **and** the `scim_access_token.updated` analytics event (`organizationId` only).

### Frontend

- `useServiceAccounts.updateAccount` mutation; invalidates the SA list and the project-grants cache.
- "Edit" row action → `ServiceAccountsEditModal`: prefetches the SA's grants, then a unified form with the scope toggle, org role select, and the shared `ServiceAccountProjectRoles` editor (extracted from the create modal). Warns before a destructive scope switch.

## Regression analysis

| Group | Effect |
|---|---|
| Existing service accounts | No change until edited. Token never rotates on edit. |
| Org admins | Edit name, role/scopes, project access, or switch scope mode in place. |
| Non-admins | No access — same `manage Organization` gate as create/delete/rotate. |
| Other orgs | Rejected (org-ownership guard + per-grant project/role org validation). |
| Create flow | Refactored to share the project-rows component + grant-validation helper; behaviour preserved. |

The large `generated/routes.ts` + `swagger.json` diff is mostly **pre-existing drift**: regenerating untouched `main` already produces ~300 lines of churn (an earlier merge skipped `generate-api`). Only the `UpdateServiceAccount` schema + route are mine.

## Migration

None — no schema change.

## Test plan

- [x] `pnpm -F common build && pnpm -F backend typecheck:fast && pnpm -F frontend typecheck:fast` — clean
- [x] `pnpm -F backend lint && oxlint serviceAccounts/` — clean
- [x] `npx jest ServiceAccountService` — 22/22 (org edit, project edit, both switch directions, all negatives)
- [x] Manual (org SA): rename, change `viewer→admin`, custom role — token_hash unchanged, membership role tracks scope, user `first_name` synced
- [x] Manual (project SA): change a project role, add/remove projects (replace-all), rename-only — token_hash unchanged
- [x] Manual (switch): org `viewer/0 projects` → project `member/1`; back to `admin/0` (grants cleared) — token_hash unchanged across both
- [x] Manual: structured audit-log line emitted per edit (actor, before/after, `projectAccessChanged`); negatives (both-fields → 400, empty/whitespace desc → 400, missing uuid → 404, `projectAccess:[]` → 400, bogus project → 404 with grants rolled back)

## Example payloads

Switch an org SA to project-scoped, `PATCH /api/v1/service-accounts/{uuid}`:
```json
{
  "description": "ci-uploader",
  "scopes": ["system:member"],
  "projectAccess": [
    { "projectUuid": "p-1", "role": "editor" },
    { "projectUuid": "p-2", "roleUuid": "custom-role-uuid" }
  ]
}
```

Structured audit event (no token/secrets):
```json
{
  "action": "update",
  "resource": { "type": "ServiceAccount", "metadata": {
    "serviceAccountUuid": "sa-uuid",
    "before": { "scopes": ["system:viewer"], "roleUuid": null },
    "after":  { "scopes": ["system:member"], "roleUuid": null },
    "projectAccessChanged": true
  }},
  "status": "allowed"
}
```

## Token immutability

```
Before:  edit perms → delete SA → new token → update every integration
After:   edit perms → PATCH /{uuid} → same token keeps working
           service_accounts.token_hash: unchanged (verified across edits + scope switches)
```

## Follow-ups (separate PRs)

- `ServiceAccountModel.delete` leaves the backing user's `project_memberships` behind (dormant — the token is gone, so they can't be exercised). Pre-existing; worth cleaning up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
