### PR TITLE
feat(sankey): node layout option 

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -201,6 +201,13 @@ export type GaugeChart = {
     customPercentageLabel?: string;
 };
 
+/**
+ * How nodes are laid out:
+ * - `multi-step`: depth-unrolled journeys (default)
+ * - `merged`: one node per label, journeys preserved (acyclic flows only)
+ */
+export type SankeyNodeLayout = 'multi-step' | 'merged';
+
 export type SankeyChart = {
     /** Field ID for the source node dimension */
     sourceFieldId?: string;
@@ -212,6 +219,8 @@ export type SankeyChart = {
     nodeAlign?: 'left' | 'right' | 'justify';
     /** Orientation of the diagram */
     orient?: 'horizontal' | 'vertical';
+    /** How nodes are laid out across steps */
+    nodeLayout?: SankeyNodeLayout;
 };
 
 export enum MapChartLocation {

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
@@ -6,6 +6,7 @@ import {
     type CustomDimension,
     type Dimension,
     type Metric,
+    type SankeyNodeLayout,
     type TableCalculation,
 } from '@lightdash/common';
 import {
@@ -13,6 +14,7 @@ import {
     SegmentedControl,
     Stack,
     Tabs,
+    Text,
     useMantineColorScheme,
 } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
@@ -90,7 +92,14 @@ export const ConfigTabs: FC = memo(() => {
         onNodeAlignChange,
         orient,
         onOrientChange,
+        nodeLayout,
+        onNodeLayoutChange,
+        data,
     } = visualizationConfig.chartConfig;
+
+    // Merging needs an acyclic graph, so cyclic data falls back to multi-step
+    const effectiveLayout: SankeyNodeLayout =
+        nodeLayout === 'merged' && data.hasCycle ? 'multi-step' : nodeLayout;
 
     return (
         <MantineProvider inherit theme={themeOverride}>
@@ -240,6 +249,36 @@ export const ConfigTabs: FC = memo(() => {
                                         )
                                     }
                                 />
+                            </Config.Section>
+                        </Config>
+                        <Config>
+                            <Config.Section>
+                                <Config.Heading>Node layout</Config.Heading>
+                                <SegmentedControl
+                                    value={effectiveLayout}
+                                    data={[
+                                        {
+                                            value: 'multi-step',
+                                            label: 'Multi-step',
+                                        },
+                                        {
+                                            value: 'merged',
+                                            label: 'Merged',
+                                            disabled: data.hasCycle,
+                                        },
+                                    ]}
+                                    onChange={(value) =>
+                                        onNodeLayoutChange(
+                                            value as SankeyNodeLayout,
+                                        )
+                                    }
+                                />
+                                {data.hasCycle && (
+                                    <Text size="xs" c="dimmed" mt="xs">
+                                        Merging isn't available for flows that
+                                        loop back on themselves.
+                                    </Text>
+                                )}
                             </Config.Section>
                         </Config>
                     </Stack>

--- a/packages/frontend/src/hooks/sankeyTransform.test.ts
+++ b/packages/frontend/src/hooks/sankeyTransform.test.ts
@@ -1,0 +1,108 @@
+import { type ResultRow } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { transformSankeyData } from './sankeyTransform';
+
+const cell = (formatted: string, raw: unknown = formatted) => ({
+    value: { raw, formatted },
+});
+
+const row = (source: string, target: string, weight: number): ResultRow => ({
+    src: cell(source),
+    tgt: cell(target),
+    val: cell(String(weight), weight),
+});
+
+const FIELDS = {
+    sourceFieldId: 'src',
+    targetFieldId: 'tgt',
+    metricFieldId: 'val',
+};
+
+type Data = ReturnType<typeof transformSankeyData>;
+
+const nodeIds = (data: Data) => data.nodes.map((n) => n.name).sort();
+const sourceTargets = (data: Data) =>
+    data.links.map((l) => `${l.source}→${l.target}`).sort();
+
+describe('transformSankeyData', () => {
+    it('returns empty for no rows', () => {
+        expect(
+            transformSankeyData([], FIELDS, { nodeLayout: 'multi-step' }),
+        ).toEqual({ nodes: [], links: [], maxDepth: 0, hasCycle: false });
+    });
+
+    it('sums the metric across rows sharing a source→target pair', () => {
+        const data = transformSankeyData(
+            [row('A', 'B', 3), row('A', 'B', 4)],
+            FIELDS,
+            { nodeLayout: 'merged' },
+        );
+
+        expect(data.links).toHaveLength(1);
+        expect(data.links[0].value).toBe(7);
+        expect(data.links[0].meta.rows).toHaveLength(2);
+    });
+
+    it('skips rows with a non-positive or non-numeric metric', () => {
+        const data = transformSankeyData(
+            [row('A', 'B', 0), row('A', 'C', -5), row('A', 'D', 2)],
+            FIELDS,
+            { nodeLayout: 'merged' },
+        );
+
+        expect(sourceTargets(data)).toEqual(['A→D']);
+    });
+
+    // C is reached at two depths (A→C and A→B→C), so it lands at two depths.
+    const diamond = [row('A', 'B', 1), row('A', 'C', 1), row('B', 'C', 1)];
+
+    describe('multi-step', () => {
+        it('splits a multi-depth label into "Step N" nodes', () => {
+            const data = transformSankeyData(diamond, FIELDS, {
+                nodeLayout: 'multi-step',
+            });
+
+            expect(data.hasCycle).toBe(false);
+            expect(nodeIds(data)).toEqual([
+                'A',
+                'B',
+                'C - Step 1',
+                'C - Step 2',
+            ]);
+        });
+    });
+
+    describe('merged', () => {
+        it('collapses same-label nodes into one for acyclic data', () => {
+            const data = transformSankeyData(diamond, FIELDS, {
+                nodeLayout: 'merged',
+            });
+
+            expect(data.hasCycle).toBe(false);
+            expect(nodeIds(data)).toEqual(['A', 'B', 'C']);
+            expect(sourceTargets(data)).toEqual(['A→B', 'A→C', 'B→C']);
+            expect(data.maxDepth).toBe(2);
+        });
+
+        it('falls back to multi-step (and reports a cycle) for cyclic data', () => {
+            const data = transformSankeyData(
+                [row('A', 'B', 1), row('B', 'A', 1)],
+                FIELDS,
+                { nodeLayout: 'merged' },
+            );
+
+            expect(data.hasCycle).toBe(true);
+            expect(data.nodes.some((n) => / - Step \d+$/.test(n.name))).toBe(
+                true,
+            );
+        });
+    });
+
+    it('treats a self-loop as a cycle', () => {
+        const data = transformSankeyData([row('A', 'A', 1)], FIELDS, {
+            nodeLayout: 'merged',
+        });
+
+        expect(data.hasCycle).toBe(true);
+    });
+});

--- a/packages/frontend/src/hooks/sankeyTransform.ts
+++ b/packages/frontend/src/hooks/sankeyTransform.ts
@@ -1,0 +1,282 @@
+import {
+    type ResultRow,
+    type ResultValue,
+    type SankeyNodeLayout,
+} from '@lightdash/common';
+
+export type SankeySeriesDataPoint = {
+    nodes: { name: string }[];
+    links: {
+        source: string;
+        target: string;
+        value: number;
+        meta: {
+            value: ResultValue;
+            rows: ResultRow[];
+        };
+    }[];
+    /** Deepest layer in the flow, used to size the per-depth colour palette */
+    maxDepth: number;
+    /** True when the graph has a cycle, which makes node merging impossible. */
+    hasCycle: boolean;
+};
+
+type SankeyBuild = Omit<SankeySeriesDataPoint, 'hasCycle'>;
+
+type AggregatedLink = {
+    source: string;
+    target: string;
+    value: number;
+    meta: { value: ResultValue; rows: ResultRow[] };
+};
+
+type SankeyFields = {
+    sourceFieldId: string;
+    targetFieldId: string;
+    metricFieldId: string;
+};
+
+const EMPTY: SankeySeriesDataPoint = {
+    nodes: [],
+    links: [],
+    maxDepth: 0,
+    hasCycle: false,
+};
+
+const linkKey = (source: string, target: string) => `${source}→${target}`;
+
+// One link per source→target pair, summing the metric across rows.
+const aggregateLinks = (
+    rows: ResultRow[],
+    { sourceFieldId, targetFieldId, metricFieldId }: SankeyFields,
+): Map<string, AggregatedLink> => {
+    const aggregated = new Map<string, AggregatedLink>();
+
+    for (const row of rows) {
+        const sourceCell = row[sourceFieldId];
+        const targetCell = row[targetFieldId];
+        const metricCell = row[metricFieldId];
+        if (!sourceCell || !targetCell || !metricCell) continue;
+
+        const source = String(sourceCell.value.formatted);
+        const target = String(targetCell.value.formatted);
+        const value = Number(metricCell.value.raw);
+        if (isNaN(value) || value <= 0) continue;
+
+        const key = linkKey(source, target);
+        const existing = aggregated.get(key);
+        if (existing) {
+            existing.value += value;
+            existing.meta.rows.push(row);
+        } else {
+            aggregated.set(key, {
+                source,
+                target,
+                value,
+                meta: { value: metricCell.value, rows: [row] },
+            });
+        }
+    }
+
+    return aggregated;
+};
+
+// Kahn's algorithm: detects a cycle and returns the longest-path depth.
+const analyzeFlowGraph = (
+    aggregated: Map<string, AggregatedLink>,
+): { hasCycle: boolean; maxDepth: number } => {
+    const nodes = new Set<string>();
+    const adjacency = new Map<string, string[]>();
+    const inDegree = new Map<string, number>();
+
+    for (const { source, target } of aggregated.values()) {
+        nodes.add(source);
+        nodes.add(target);
+        if (!adjacency.has(source)) adjacency.set(source, []);
+        adjacency.get(source)!.push(target);
+        inDegree.set(target, (inDegree.get(target) ?? 0) + 1);
+        if (!inDegree.has(source)) inDegree.set(source, 0);
+    }
+
+    const depthByNode = new Map<string, number>();
+    const queue: string[] = [];
+    for (const node of nodes) {
+        if ((inDegree.get(node) ?? 0) === 0) {
+            queue.push(node);
+            depthByNode.set(node, 0);
+        }
+    }
+
+    let processed = 0;
+    let maxDepth = 0;
+    while (queue.length > 0) {
+        const node = queue.shift()!;
+        processed += 1;
+        const depth = depthByNode.get(node) ?? 0;
+        for (const target of adjacency.get(node) ?? []) {
+            const nextDepth = Math.max(depthByNode.get(target) ?? 0, depth + 1);
+            depthByNode.set(target, nextDepth);
+            if (nextDepth > maxDepth) maxDepth = nextDepth;
+            const remaining = (inDegree.get(target) ?? 0) - 1;
+            inDegree.set(target, remaining);
+            if (remaining === 0) queue.push(target);
+        }
+    }
+
+    return { hasCycle: processed < nodes.size, maxDepth };
+};
+
+// One node per unique label: the aggregated links, unchanged. Acyclic only.
+const buildMergedSankey = (
+    aggregated: Map<string, AggregatedLink>,
+    maxDepth: number,
+): SankeyBuild => {
+    const names = new Set<string>();
+    const links: SankeyBuild['links'] = [];
+
+    for (const link of aggregated.values()) {
+        names.add(link.source);
+        names.add(link.target);
+        links.push({
+            source: link.source,
+            target: link.target,
+            value: link.value,
+            meta: link.meta,
+        });
+    }
+
+    return {
+        nodes: Array.from(names).map((name) => ({ name })),
+        links,
+        maxDepth,
+    };
+};
+
+// Unroll into depth layers via BFS so cyclic flows can render as a DAG: a label
+// seen at multiple depths splits into "Label - Step N" nodes.
+const buildSteppedSankey = (
+    aggregated: Map<string, AggregatedLink>,
+): SankeyBuild => {
+    const outgoing = new Map<string, Set<string>>();
+    for (const link of aggregated.values()) {
+        if (!outgoing.has(link.source)) outgoing.set(link.source, new Set());
+        outgoing.get(link.source)!.add(link.target);
+    }
+
+    const allTargets = new Set(
+        Array.from(aggregated.values()).map((l) => l.target),
+    );
+    const allSources = new Set(
+        Array.from(aggregated.values()).map((l) => l.source),
+    );
+    let roots = [...allSources].filter((s) => !allTargets.has(s));
+    if (roots.length === 0) roots = [...allSources].slice(0, 1); // pure cycle: pick any source
+
+    const MAX_DEPTH = 50;
+    const nodeDepthMap = new Map<string, Set<number>>();
+    const edgeInstances: {
+        source: string;
+        sourceDepth: number;
+        target: string;
+        targetDepth: number;
+    }[] = [];
+    const placedOriginalEdges = new Set<string>();
+
+    type BFSItem = { name: string; depth: number };
+    const queue: BFSItem[] = roots.map((n) => ({ name: n, depth: 0 }));
+    const visited = new Set<string>(); // "name:depth"
+    let maxDepth = 0;
+
+    while (queue.length > 0) {
+        const { name, depth } = queue.shift()!;
+        if (depth > MAX_DEPTH) continue;
+
+        const key = `${name}:${depth}`;
+        if (visited.has(key)) continue;
+        visited.add(key);
+
+        if (!nodeDepthMap.has(name)) nodeDepthMap.set(name, new Set());
+        nodeDepthMap.get(name)!.add(depth);
+        if (depth > maxDepth) maxDepth = depth;
+
+        const targets = outgoing.get(name);
+        if (!targets) continue;
+
+        for (const target of targets) {
+            const originalEdgeKey = linkKey(name, target);
+            if (placedOriginalEdges.has(originalEdgeKey)) continue;
+            placedOriginalEdges.add(originalEdgeKey);
+
+            const targetDepth = depth + 1;
+            edgeInstances.push({
+                source: name,
+                sourceDepth: depth,
+                target,
+                targetDepth,
+            });
+            queue.push({ name: target, depth: targetDepth });
+        }
+    }
+
+    const multiDepthNodes = new Set<string>();
+    for (const [name, depths] of nodeDepthMap) {
+        if (depths.size > 1) multiDepthNodes.add(name);
+    }
+    const getLabel = (name: string, depth: number) =>
+        multiDepthNodes.has(name) ? `${name} - Step ${depth}` : name;
+
+    const nodeSet = new Set<string>();
+    const links: SankeyBuild['links'] = [];
+    const placedLinks = new Set<string>();
+
+    for (const edge of edgeInstances) {
+        const sourceLabel = getLabel(edge.source, edge.sourceDepth);
+        const targetLabel = getLabel(edge.target, edge.targetDepth);
+
+        nodeSet.add(sourceLabel);
+        nodeSet.add(targetLabel);
+
+        const key = linkKey(sourceLabel, targetLabel);
+        if (placedLinks.has(key)) continue;
+        placedLinks.add(key);
+
+        const aggLink = aggregated.get(linkKey(edge.source, edge.target));
+        if (!aggLink) continue;
+
+        links.push({
+            source: sourceLabel,
+            target: targetLabel,
+            value: aggLink.value,
+            meta: aggLink.meta,
+        });
+    }
+
+    return {
+        nodes: Array.from(nodeSet).map((name) => ({ name })),
+        links,
+        maxDepth,
+    };
+};
+
+/**
+ * Build Sankey nodes & links according to the chosen layout:
+ * - `merged`: one node per label (acyclic only; falls back to multi-step)
+ * - `multi-step`: depth-unrolled journeys with "Step N" instances
+ */
+export const transformSankeyData = (
+    rows: ResultRow[],
+    fields: SankeyFields,
+    { nodeLayout }: { nodeLayout: SankeyNodeLayout },
+): SankeySeriesDataPoint => {
+    const aggregated = aggregateLinks(rows, fields);
+    if (aggregated.size === 0) return EMPTY;
+
+    const { hasCycle, maxDepth } = analyzeFlowGraph(aggregated);
+
+    const build: SankeyBuild =
+        nodeLayout === 'merged' && !hasCycle
+            ? buildMergedSankey(aggregated, maxDepth)
+            : buildSteppedSankey(aggregated);
+
+    return { ...build, hasCycle };
+};

--- a/packages/frontend/src/hooks/useSankeyChartConfig.ts
+++ b/packages/frontend/src/hooks/useSankeyChartConfig.ts
@@ -3,29 +3,16 @@ import {
     type Dimension,
     type ItemsMap,
     type Metric,
-    type ResultRow,
-    type ResultValue,
     type SankeyChart,
     type TableCalculation,
     type TableCalculationMetadata,
 } from '@lightdash/common';
 import { useEffect, useMemo, useState } from 'react';
+import {
+    transformSankeyData,
+    type SankeySeriesDataPoint,
+} from './sankeyTransform';
 import { type InfiniteQueryResults } from './useQueryResults';
-
-export type SankeySeriesDataPoint = {
-    nodes: { name: string }[];
-    links: {
-        source: string;
-        target: string;
-        value: number;
-        meta: {
-            value: ResultValue;
-            rows: ResultRow[];
-        };
-    }[];
-    /** Maximum depth level discovered during BFS traversal */
-    maxDepth: number;
-};
 
 type SankeyChartConfig = {
     validConfig: SankeyChart;
@@ -43,6 +30,11 @@ type SankeyChartConfig = {
 
     orient: NonNullable<SankeyChart['orient']>;
     onOrientChange: (orient: NonNullable<SankeyChart['orient']>) => void;
+
+    nodeLayout: NonNullable<SankeyChart['nodeLayout']>;
+    onNodeLayoutChange: (
+        nodeLayout: NonNullable<SankeyChart['nodeLayout']>,
+    ) => void;
 
     data: SankeySeriesDataPoint;
 };
@@ -81,6 +73,9 @@ const useSankeyChartConfig: SankeyChartConfigFn = (
     const [orient, setOrient] = useState<NonNullable<SankeyChart['orient']>>(
         sankeyChartConfig?.orient ?? 'horizontal',
     );
+    const [nodeLayout, setNodeLayout] = useState<
+        NonNullable<SankeyChart['nodeLayout']>
+    >(sankeyChartConfig?.nodeLayout ?? 'multi-step');
 
     const dimensionIds = useMemo(() => Object.keys(dimensions), [dimensions]);
     const numericFieldIds = useMemo(
@@ -153,175 +148,21 @@ const useSankeyChartConfig: SankeyChartConfigFn = (
         }
     }, [numericFieldIds, metricFieldId, isLoading, tableCalculationsMetadata]);
 
-    // Transform results into Sankey nodes & links using BFS-based depth assignment.
-    // This handles cyclical flows by creating depth-specific node instances
-    // (e.g., "Conversion - Step 2" and "Conversion - Step 4").
     const data: SankeySeriesDataPoint = useMemo(() => {
         if (
             !resultsData ||
             !sourceFieldId ||
             !targetFieldId ||
-            !metricFieldId ||
-            resultsData.rows.length === 0
+            !metricFieldId
         ) {
-            return { nodes: [], links: [], maxDepth: 0 };
+            return { nodes: [], links: [], maxDepth: 0, hasCycle: false };
         }
-
-        // Step 1: Aggregate raw rows into source→target links
-        const aggregated = new Map<
-            string,
-            {
-                source: string;
-                target: string;
-                value: number;
-                meta: { value: ResultValue; rows: ResultRow[] };
-            }
-        >();
-
-        for (const row of resultsData.rows) {
-            const sourceCell = row[sourceFieldId];
-            const targetCell = row[targetFieldId];
-            const metricCell = row[metricFieldId];
-            if (!sourceCell || !targetCell || !metricCell) continue;
-
-            const sourceName = String(sourceCell.value.formatted);
-            const targetName = String(targetCell.value.formatted);
-            const metricValue = Number(metricCell.value.raw);
-            if (isNaN(metricValue) || metricValue <= 0) continue;
-
-            const key = `${sourceName}→${targetName}`;
-            const existing = aggregated.get(key);
-            if (existing) {
-                existing.value += metricValue;
-                existing.meta.rows.push(row);
-            } else {
-                aggregated.set(key, {
-                    source: sourceName,
-                    target: targetName,
-                    value: metricValue,
-                    meta: { value: metricCell.value, rows: [row] },
-                });
-            }
-        }
-
-        // Step 2: Build adjacency list (source → set of targets)
-        const outgoing = new Map<string, Set<string>>();
-        for (const link of aggregated.values()) {
-            if (!outgoing.has(link.source))
-                outgoing.set(link.source, new Set());
-            outgoing.get(link.source)!.add(link.target);
-        }
-
-        // Step 3: Find root nodes (sources that never appear as targets)
-        const allTargets = new Set(
-            Array.from(aggregated.values()).map((l) => l.target),
+        return transformSankeyData(
+            resultsData.rows,
+            { sourceFieldId, targetFieldId, metricFieldId },
+            { nodeLayout },
         );
-        const allSources = new Set(
-            Array.from(aggregated.values()).map((l) => l.source),
-        );
-        let roots = [...allSources].filter((s) => !allTargets.has(s));
-        if (roots.length === 0) roots = [...allSources].slice(0, 1); // fallback for pure cycles
-
-        // Step 4: BFS to discover node depths and edges.
-        // Each original edge (e.g., "Conversion→Retargeting") is placed exactly
-        // once. This prevents cycles from creating infinite depth expansion.
-        const MAX_DEPTH = 50;
-
-        // Track all depths each node appears at
-        const nodeDepthMap = new Map<string, Set<number>>();
-        // Track edges with depth info
-        const edgeInstances: {
-            source: string;
-            sourceDepth: number;
-            target: string;
-            targetDepth: number;
-        }[] = [];
-        // Track which original edges have been placed (stop BFS when all placed)
-        const placedOriginalEdges = new Set<string>();
-
-        type BFSItem = { name: string; depth: number };
-        const queue: BFSItem[] = roots.map((n) => ({ name: n, depth: 0 }));
-        const visited = new Set<string>(); // "name:depth"
-        let maxDepth = 0;
-
-        while (queue.length > 0) {
-            const { name, depth } = queue.shift()!;
-            if (depth > MAX_DEPTH) continue;
-
-            const key = `${name}:${depth}`;
-            if (visited.has(key)) continue;
-            visited.add(key);
-
-            if (!nodeDepthMap.has(name)) nodeDepthMap.set(name, new Set());
-            nodeDepthMap.get(name)!.add(depth);
-            if (depth > maxDepth) maxDepth = depth;
-
-            const targets = outgoing.get(name);
-            if (!targets) continue;
-
-            for (const target of targets) {
-                const originalEdgeKey = `${name}→${target}`;
-                // Each original edge is placed only once to prevent
-                // cycles from expanding infinitely
-                if (placedOriginalEdges.has(originalEdgeKey)) continue;
-                placedOriginalEdges.add(originalEdgeKey);
-
-                const targetDepth = depth + 1;
-                edgeInstances.push({
-                    source: name,
-                    sourceDepth: depth,
-                    target,
-                    targetDepth,
-                });
-                queue.push({ name: target, depth: targetDepth });
-            }
-        }
-
-        // Step 5: Determine which nodes need step suffixes (appear at multiple depths)
-        const multiDepthNodes = new Set<string>();
-        for (const [name, depths] of nodeDepthMap) {
-            if (depths.size > 1) multiDepthNodes.add(name);
-        }
-
-        const getLabel = (name: string, depth: number) => {
-            if (multiDepthNodes.has(name)) return `${name} - Step ${depth}`;
-            return name;
-        };
-
-        // Step 6: Build final nodes and links
-        const nodeSet = new Set<string>();
-        const finalLinks: SankeySeriesDataPoint['links'] = [];
-        const placedLinks = new Set<string>();
-
-        for (const edge of edgeInstances) {
-            const sourceLabel = getLabel(edge.source, edge.sourceDepth);
-            const targetLabel = getLabel(edge.target, edge.targetDepth);
-
-            nodeSet.add(sourceLabel);
-            nodeSet.add(targetLabel);
-
-            const linkKey = `${sourceLabel}→${targetLabel}`;
-            if (placedLinks.has(linkKey)) continue;
-            placedLinks.add(linkKey);
-
-            const aggKey = `${edge.source}→${edge.target}`;
-            const aggLink = aggregated.get(aggKey);
-            if (!aggLink) continue;
-
-            finalLinks.push({
-                source: sourceLabel,
-                target: targetLabel,
-                value: aggLink.value,
-                meta: aggLink.meta,
-            });
-        }
-
-        return {
-            nodes: Array.from(nodeSet).map((name) => ({ name })),
-            links: finalLinks,
-            maxDepth,
-        };
-    }, [resultsData, sourceFieldId, targetFieldId, metricFieldId]);
+    }, [resultsData, sourceFieldId, targetFieldId, metricFieldId, nodeLayout]);
 
     const validConfig: SankeyChart = useMemo(
         () => ({
@@ -330,8 +171,16 @@ const useSankeyChartConfig: SankeyChartConfigFn = (
             metricFieldId: metricFieldId ?? undefined,
             nodeAlign,
             orient,
+            nodeLayout,
         }),
-        [sourceFieldId, targetFieldId, metricFieldId, nodeAlign, orient],
+        [
+            sourceFieldId,
+            targetFieldId,
+            metricFieldId,
+            nodeAlign,
+            orient,
+            nodeLayout,
+        ],
     );
 
     return {
@@ -346,6 +195,8 @@ const useSankeyChartConfig: SankeyChartConfigFn = (
         onNodeAlignChange: setNodeAlign,
         orient,
         onOrientChange: setOrient,
+        nodeLayout,
+        onNodeLayoutChange: setNodeLayout,
         data,
     };
 };


### PR DESCRIPTION
Closes: PROD-7963
Closes: #23563

> First of a two-PR stack. This PR adds the **Multi-step** and **Merged** layouts; a follow-up stacked PR adds a **Direct** layout (PROD-7057 / #22175).

### Description

Adds a **Node layout** option to the Sankey chart config, replacing the implicit per-depth node splitting with an explicit choice:

- **Multi-step** (default) — depth-unrolled journeys; a label reached at several depths is split into "Step N" instances. Unchanged from today's behaviour.
- **Merged** — collapses nodes that share a label into a single node, so flows converge while the multi-step journey is preserved.

The option is opt-in and defaults to **Multi-step**, so existing charts are unaffected.

#### Cycles

Merging requires an acyclic graph (ECharts renders a Sankey as a DAG). When the data contains a loop, the **Merged** segment is disabled with a short hint, and the chart falls back to multi-step rendering.

### Implementation notes

- New `nodeLayout?: 'multi-step' | 'merged'` on the `SankeyChart` config (optional, defaults to multi-step — no migration needed).
- The Sankey data transform lives in a pure, unit-tested module (`sankeyTransform.ts`); the config hook is just state plus one call.
- Node **ids** and display **labels** are now separate fields, which removes the `" - Step N"` string-parsing that previously lived in the ECharts layer.
- Cycle detection uses Kahn's algorithm, which also yields the max depth for the colour levels.

### Testing

- Unit tests in `sankeyTransform.test.ts` cover aggregation, both layouts, the cyclic-merge fallback, and self-loops.
- Verified manually with the `sankey_demo` model.