### PR TITLE
feat(common): consolidate the calendar-value predicate (GLITCH-450)

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -10,6 +10,7 @@ import {
     NumberSeparator,
     type CustomFormat,
     type Dimension,
+    type Metric,
 } from '../types/field';
 import { TimeFrames } from '../types/timeFrames';
 import {
@@ -25,6 +26,7 @@ import {
     formatValueWithExpression,
     getCustomFormatFromLegacy,
     getEffectiveSeparator,
+    isCalendarValueDimension,
     isMomentInput,
     shouldShiftItemTimezone,
     toIsoWithProjectOffset,
@@ -730,6 +732,84 @@ describe('Formatting', () => {
         });
     });
 
+    describe('isCalendarValueDimension', () => {
+        const dateBaseColumn: Dimension = {
+            ...dimension,
+            type: DimensionType.DATE,
+        };
+        const dateOverDateDay: Dimension = {
+            ...dimension,
+            type: DimensionType.DATE,
+            timeInterval: TimeFrames.DAY,
+            timeIntervalBaseDimensionType: DimensionType.DATE,
+        };
+        const dateOverDateWeek: Dimension = {
+            ...dimension,
+            type: DimensionType.DATE,
+            timeInterval: TimeFrames.WEEK,
+            timeIntervalBaseDimensionType: DimensionType.DATE,
+        };
+        const dateOverTimestampDay: Dimension = {
+            ...dimension,
+            type: DimensionType.DATE,
+            timeInterval: TimeFrames.DAY,
+            timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+        };
+        const timestampRaw: Dimension = {
+            ...dimension,
+            type: DimensionType.TIMESTAMP,
+        };
+        const timestampHour: Dimension = {
+            ...dimension,
+            type: DimensionType.TIMESTAMP,
+            timeInterval: TimeFrames.HOUR,
+            timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+        };
+        const dateMetric: Metric = {
+            ...metric,
+            type: MetricType.DATE,
+        };
+
+        test('treats wall-clock DATE values as calendar values', () => {
+            // plain DATE column (no interval, base undefined)
+            expect(isCalendarValueDimension(dateBaseColumn)).toBe(true);
+            // DATE truncated from a DATE base — any grain
+            expect(isCalendarValueDimension(dateOverDateDay)).toBe(true);
+            expect(isCalendarValueDimension(dateOverDateWeek)).toBe(true);
+            // A date-typed metric (MetricType.DATE) — not a Dimension, still calendar
+            expect(isCalendarValueDimension(dateMetric)).toBe(true);
+        });
+
+        test('treats real instants as non-calendar values', () => {
+            // DATE truncated from a TIMESTAMP base is a bucketed instant
+            expect(isCalendarValueDimension(dateOverTimestampDay)).toBe(false);
+            // plain + sub-day TIMESTAMP
+            expect(isCalendarValueDimension(timestampRaw)).toBe(false);
+            expect(isCalendarValueDimension(timestampHour)).toBe(false);
+        });
+
+        test('skipTimezoneConversion does not make a TIMESTAMP a calendar value', () => {
+            // The trap: convert_timezone:false is TZ-immune but still an instant.
+            const timestampRawOptOut: Dimension = {
+                ...timestampRaw,
+                skipTimezoneConversion: true,
+            };
+            // A DATE stays a calendar value regardless of the marker
+            const dateOptOut: Dimension = {
+                ...dateOverDateDay,
+                skipTimezoneConversion: true,
+            };
+            expect(isCalendarValueDimension(timestampRawOptOut)).toBe(false);
+            expect(isCalendarValueDimension(dateOptOut)).toBe(true);
+        });
+
+        test('non-temporal items and undefined are not calendar values', () => {
+            expect(isCalendarValueDimension(undefined)).toBe(false);
+            expect(isCalendarValueDimension(dimension)).toBe(false); // STRING
+            expect(isCalendarValueDimension(metric)).toBe(false); // COUNT
+        });
+    });
+
     describe('formatItemValue', () => {
         test('formatItemValue should return the right format when field is undefined', () => {
             expect(formatItemValue(undefined, undefined)).toEqual('-');
@@ -827,6 +907,31 @@ describe('Formatting', () => {
                     'Pacific/Pago_Pago',
                 ),
             ).toEqual('2026-03-02');
+        });
+
+        test('formatItemValue DATE ignores display timezone for plain DATE columns and DATE metrics', () => {
+            const value = new Date('2026-03-03T00:00:00.000Z');
+            // Plain DATE column (no interval, base undefined) is a calendar
+            // value — a negative-offset zone must NOT roll the day back.
+            expect(
+                formatItemValue(
+                    { ...dimension, type: DimensionType.DATE },
+                    value,
+                    false,
+                    undefined,
+                    'Pacific/Pago_Pago',
+                ),
+            ).toEqual('2026-03-03');
+            // A date-typed metric (MetricType.DATE) is likewise a calendar value.
+            expect(
+                formatItemValue(
+                    { ...metric, type: MetricType.DATE },
+                    value,
+                    false,
+                    undefined,
+                    'Pacific/Pago_Pago',
+                ),
+            ).toEqual('2026-03-03');
         });
 
         test('formatItemValue ignores display timezone when skipTimezoneConversion is set', () => {
@@ -2042,8 +2147,9 @@ describe('Formatting', () => {
                 ).toContain('(-11:00)');
             });
 
-            test('DATE DAY shifts into project TZ (positive offset canary)', () => {
-                // Tokyo midnight Jan 14 = UTC Jan 13 15:00
+            test('DATE DAY over TIMESTAMP base shifts into project TZ (positive offset canary)', () => {
+                // A day-grain truncation of a TIMESTAMP column is a midnight
+                // instant, so it still shifts. Tokyo midnight Jan 14 = UTC Jan 13 15:00
                 const value = new Date('2024-01-13T15:00:00.000Z');
                 expect(
                     formatItemValue(
@@ -2051,6 +2157,8 @@ describe('Formatting', () => {
                             ...dimension,
                             type: DimensionType.DATE,
                             timeInterval: TimeFrames.DAY,
+                            timeIntervalBaseDimensionType:
+                                DimensionType.TIMESTAMP,
                         },
                         value,
                         false,

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -232,6 +232,23 @@ export const shouldShiftItemTimezone = (item: Item | undefined): boolean => {
     );
 };
 
+// A calendar value is a bare wall-clock date (year/month/day, no instant) that
+// must never be timezone-shifted or anchored. True for plain DATE columns,
+// DATE-base truncations and DATE metrics; false for any TIMESTAMP (including
+// `skipTimezoneConversion` ones — those are TZ-immune but still real instants)
+// and for a DATE truncated from a TIMESTAMP base, which is a bucketed instant
+// that still anchors and shifts.
+export const isCalendarValueDimension = (
+    item: Item | AdditionalMetric | undefined,
+): boolean => {
+    if (!isField(item)) return false;
+    if (item.type !== DimensionType.DATE) return false;
+    return !(
+        isDimension(item) &&
+        item.timeIntervalBaseDimensionType === DimensionType.TIMESTAMP
+    );
+};
+
 // Renders a temporal cell as the wall-clock string Excel and Google Sheets
 // auto-detect as a date. TIMESTAMP → `YYYY-MM-DD HH:mm:ss.SSS`, DATE →
 // `YYYY-MM-DD`. Shifts into the project tz when the item is timezone-
@@ -1069,15 +1086,12 @@ export function formatItemValue(
                 case DimensionType.DATE:
                 case MetricType.DATE:
                 case TableCalculationType.DATE: {
-                    // Truncated dimensions whose base column is DATE have no
-                    // time component — applying a display timezone would
-                    // shift the calendar day (off-by-one in negative offsets).
-                    const dateTimezone =
-                        isDimension(item) &&
-                        item.timeIntervalBaseDimensionType ===
-                            DimensionType.DATE
-                            ? undefined
-                            : effectiveTimezone;
+                    // Calendar values (wall-clock dates) have no time component
+                    // — applying a display timezone would shift the calendar
+                    // day (off-by-one in negative offsets).
+                    const dateTimezone = isCalendarValueDimension(item)
+                        ? undefined
+                        : effectiveTimezone;
                     return isMomentInput(value)
                         ? formatDate(
                               value,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -757,6 +757,34 @@ describe('getCategoryDateAxisConfig', () => {
                     '2024-03-01T00:00:00Z',
                 ]);
             });
+
+            // Complement of the above: TIMESTAMP-base dims are bucketed
+            // instants, so they DO shift with the resolved timezone.
+            test('TIMESTAMP-base dim honors resolvedTimezone and snaps in project tz', () => {
+                const tz = 'America/Los_Angeles';
+                const months: Array<[number, number]> = [
+                    [2024, 4],
+                    [2024, 5],
+                    [2024, 6],
+                ];
+                const tsBaseField = {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.MONTH,
+                    timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                    name: 'created_at_month',
+                    table: 'orders',
+                } as unknown as Dimension;
+                const result = getCategoryDateAxisConfig(
+                    axisId,
+                    tsBaseField,
+                    monthlyRowsFor(tz, months),
+                    'category',
+                    undefined,
+                    tz,
+                );
+                expect(result.data).toEqual(expectedMonthlyRange(tz, months));
+            });
         });
 
         describe('YEAR', () => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -37,6 +37,7 @@ import {
     getValueLabelStyle,
     hashFieldReference,
     hasValidFormatExpression,
+    isCalendarValueDimension,
     isCustomBinDimension,
     isCustomDimension,
     isCustomSqlDimension,
@@ -1534,12 +1535,11 @@ export const getCategoryDateAxisConfig = (
     );
     const boundaryGap = hasBarSeries;
 
-    // DATE-base intervals are raw calendar values — snap in UTC to match.
-    const isDateBaseInterval =
-        isDimension(axisField) &&
-        axisField.timeIntervalBaseDimensionType === DimensionType.DATE;
+    // Calendar values (wall-clock dates) are raw — snap in UTC to match.
     const tz =
-        isDateBaseInterval || !resolvedTimezone ? 'UTC' : resolvedTimezone;
+        isCalendarValueDimension(axisField) || !resolvedTimezone
+            ? 'UTC'
+            : resolvedTimezone;
     // Skip dayjs.tz for UTC: .add() chains drift sub-ms vs fresh .tz() objects
     // and break .isBefore at the boundary.
     const inTz = (v: string | number) =>


### PR DESCRIPTION
Closes: GLITCH-450

### Description:

Consolidates the duplicated "is this a calendar value?" check into a single predicate, `isCalendarValueDimension` (`packages/common/src/utils/formatting.ts`), and routes the two remaining inlined `timeIntervalBaseDimensionType === DimensionType.DATE` sites through it:

- the `formatItemValue` DATE timezone gate, and
- the ECharts category-date axis snap (`getCategoryDateAxisConfig`).

Closes design principle 18 (`gap-calendar-predicate`) and unblocks the Phase 2 cast-to-DATE work (GLITCH-452): with one predicate keyed on the **base** type, Phase 2 can change warehouse output types without re-deciding the rule at each site.

### Behavior change (principle 15 — acceptance criterion #5)

The predicate is intentionally **wider** than the old inlined checks: it treats **plain DATE columns** and **DATE metrics** as calendar values, not only DATE-base truncations.

- **`formatItemValue` (real, intended change):** a plain DATE value or DATE metric is no longer timezone-shifted under a non-UTC display timezone. This is the contract-correct fix — it removes a negative-offset off-by-one for wall-clock dates. ("DATE metric" here means an explicit `MetricType.DATE` metric; MIN/MAX date metrics render via a separate `formatTimestamp` path and are unaffected.)
- **ECharts axis (no behavior change):** behavior-preserving for every shape the compiler actually produces — the snap only runs for `WEEK/MONTH/QUARTER/YEAR`, those dims always carry a base type, and plain DATE columns have no coarse interval (they early-return). Migrated for single-source-of-truth only.

### Tests

- New unit matrix for `isCalendarValueDimension` (DATE/TIMESTAMP × grains, plain DATE base, DATE metric, `skipTimezoneConversion`).
- New `formatItemValue` test for the widened plain-DATE / DATE-metric no-shift behavior.
- New ECharts characterization test (TIMESTAMP-base dim shifts — the complement of the existing DATE-base UTC test).
- Corrected one pre-existing canary fixture that asserted a DATE-DAY shift but omitted `timeIntervalBaseDimensionType` (a shape the compiler never emits); given the TIMESTAMP base it represents, it still asserts the shift.
- Full common suite (2216 tests) + ECharts suite green; `typecheck:fast` and lint clean.
