### PR TITLE
feat: support aws bedrock for data apps

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -77,6 +77,11 @@ import type { SpacePermissionService } from '../../../services/SpaceService/Spac
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { getAnthropicModel } from '../ai/models/anthropic-claude';
 import { getModelPreset } from '../ai/models/presets';
+import {
+    buildClaudeCodeEnv,
+    claudeCodeAllowedHosts,
+    describeClaudeCodeEnv,
+} from './claudeCodeEnv';
 import { ClaudeStreamProcessor } from './ClaudeStreamProcessor';
 import {
     copyDesignIntoSandbox,
@@ -305,6 +310,18 @@ export class AppGenerateService extends BaseService {
             );
         }
         return key;
+    }
+
+    /**
+     * Resolves the env vars passed to the `claude` CLI in the sandbox: the
+     * Bedrock block (reusing the copilot's BEDROCK_* config) when configured,
+     * otherwise the Anthropic API key. Throws MissingConfigError when neither
+     * is set.
+     */
+    private getClaudeCodeEnv(): Record<string, string> {
+        return buildClaudeCodeEnv(this.lightdashConfig.ai.copilot, () =>
+            this.getAnthropicApiKey(),
+        );
     }
 
     private getE2bApiKey(): string {
@@ -833,7 +850,9 @@ export class AppGenerateService extends BaseService {
             apiKey: e2bApiKey,
             lifecycle: { onTimeout: 'pause' },
             network: {
-                allowOut: ['api.anthropic.com'],
+                allowOut: claudeCodeAllowedHosts(
+                    this.lightdashConfig.ai.copilot,
+                ),
                 denyOut: [ALL_TRAFFIC],
             },
         });
@@ -1373,7 +1392,7 @@ export class AppGenerateService extends BaseService {
         appUuid: string,
         version: number,
         continueSession: boolean,
-        anthropicApiKey: string,
+        claudeCodeEnv: Record<string, string>,
         claudeModel: DataAppClaudeModel,
     ): Promise<{
         durationMs: number;
@@ -1415,7 +1434,7 @@ export class AppGenerateService extends BaseService {
                     {
                         cwd: '/app',
                         timeoutMs: 55 * 60 * 1000,
-                        envs: { ANTHROPIC_API_KEY: anthropicApiKey },
+                        envs: claudeCodeEnv,
                         onStdout: (chunk) => {
                             for (const event of processor.feedChunk(chunk)) {
                                 sessionEstablished = true;
@@ -1560,7 +1579,7 @@ export class AppGenerateService extends BaseService {
         sandbox: Sandbox,
         appUuid: string,
         version: number,
-        anthropicApiKey: string,
+        claudeCodeEnv: Record<string, string>,
         claudeModel: DataAppClaudeModel,
     ): Promise<{
         name: string;
@@ -1584,7 +1603,7 @@ export class AppGenerateService extends BaseService {
             appUuid,
             version,
             true, // --continue: Claude remembers what it just built
-            anthropicApiKey,
+            claudeCodeEnv,
             claudeModel,
         );
 
@@ -1705,7 +1724,7 @@ export class AppGenerateService extends BaseService {
         sandbox: Sandbox,
         appUuid: string,
         version: number,
-        anthropicApiKey: string,
+        claudeCodeEnv: Record<string, string>,
         claudeModel: DataAppClaudeModel,
     ): Promise<{
         buildMs: number;
@@ -1792,7 +1811,7 @@ export class AppGenerateService extends BaseService {
                 appUuid,
                 version,
                 true, // --continue: keep conversation context from generation
-                anthropicApiKey,
+                claudeCodeEnv,
                 claudeModel,
             );
             fixGenerationMs += generation.durationMs;
@@ -2028,12 +2047,12 @@ export class AppGenerateService extends BaseService {
             return;
         }
 
-        let anthropicApiKey: string;
+        let claudeCodeEnv: Record<string, string>;
         let e2bApiKey: string;
         let s3Client: S3Client;
         let bucket: string;
         try {
-            anthropicApiKey = this.getAnthropicApiKey();
+            claudeCodeEnv = this.getClaudeCodeEnv();
             e2bApiKey = this.getE2bApiKey();
             ({ client: s3Client, bucket } = this.getS3Client());
         } catch (error) {
@@ -2055,7 +2074,7 @@ export class AppGenerateService extends BaseService {
         this.logger.info(
             `App ${appUuid}: pipeline started (version=${version}, status=${currentStatus}, isIteration=${isIteration}, model=${
                 payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL
-            })`,
+            }, llm=${describeClaudeCodeEnv(claudeCodeEnv)})`,
         );
 
         // --- Stage: sandbox ---
@@ -2195,7 +2214,7 @@ export class AppGenerateService extends BaseService {
                 overallStart,
                 currentStatus,
                 wasResumed,
-                anthropicApiKey,
+                claudeCodeEnv,
                 imageIds,
                 chartReferences,
             );
@@ -2214,7 +2233,7 @@ export class AppGenerateService extends BaseService {
         overallStart: number,
         currentStatus: AppVersionStatus,
         wasResumed: boolean,
-        anthropicApiKey: string,
+        claudeCodeEnv: Record<string, string>,
         imageIds: string[] | undefined,
         chartReferences: ChartReference[] | undefined,
     ): Promise<void> {
@@ -2335,7 +2354,7 @@ export class AppGenerateService extends BaseService {
                     appUuid,
                     version,
                     continueSession,
-                    anthropicApiKey,
+                    claudeCodeEnv,
                     claudeModel,
                 );
                 durations.generateMs = generation.durationMs;
@@ -2382,7 +2401,7 @@ export class AppGenerateService extends BaseService {
                     sandbox,
                     appUuid,
                     version,
-                    anthropicApiKey,
+                    claudeCodeEnv,
                     claudeModel,
                 );
                 durations.buildMs = buildResult.buildMs;
@@ -2424,7 +2443,7 @@ export class AppGenerateService extends BaseService {
                     sandbox,
                     appUuid,
                     version,
-                    anthropicApiKey,
+                    claudeCodeEnv,
                     claudeModel,
                 );
                 if (metadata) {
@@ -3704,9 +3723,9 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         appUuid: string,
         sourceVersion: number,
     ): Promise<void> {
-        let anthropicApiKey: string;
+        let claudeCodeEnv: Record<string, string>;
         try {
-            anthropicApiKey = this.getAnthropicApiKey();
+            claudeCodeEnv = this.getClaudeCodeEnv();
         } catch (error) {
             this.logger.warn(
                 `App ${appUuid}: skipping restore FYI — ${getErrorMessage(error)}`,
@@ -3732,7 +3751,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 {
                     cwd: '/app',
                     timeoutMs: 60_000,
-                    envs: { ANTHROPIC_API_KEY: anthropicApiKey },
+                    envs: claudeCodeEnv,
                 },
             );
             if (result.exitCode !== 0) {

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.test.ts
@@ -1,0 +1,178 @@
+import {
+    buildClaudeCodeEnv,
+    claudeCodeAllowedHosts,
+    describeClaudeCodeEnv,
+} from './claudeCodeEnv';
+
+describe('buildClaudeCodeEnv', () => {
+    const bedrockApiKey = { apiKey: 'bedrock-key', region: 'us-east-1' };
+
+    test('uses the Bedrock API-key env when defaultProvider is bedrock', () => {
+        const env = buildClaudeCodeEnv(
+            {
+                defaultProvider: 'bedrock',
+                providers: { bedrock: bedrockApiKey },
+            },
+            () => {
+                throw new Error('should not resolve the Anthropic key');
+            },
+        );
+
+        expect(env).toEqual({
+            CLAUDE_CODE_USE_BEDROCK: '1',
+            AWS_REGION: 'us-east-1',
+            AWS_BEARER_TOKEN_BEDROCK: 'bedrock-key',
+        });
+    });
+
+    test('uses the Bedrock IAM env with a session token when defaultProvider is bedrock', () => {
+        const env = buildClaudeCodeEnv(
+            {
+                defaultProvider: 'bedrock',
+                providers: {
+                    bedrock: {
+                        region: 'eu-west-1',
+                        accessKeyId: 'AKIAEXAMPLE',
+                        secretAccessKey: 'secret',
+                        sessionToken: 'session',
+                    },
+                },
+            },
+            () => {
+                throw new Error('should not resolve the Anthropic key');
+            },
+        );
+
+        expect(env).toEqual({
+            CLAUDE_CODE_USE_BEDROCK: '1',
+            AWS_REGION: 'eu-west-1',
+            AWS_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+            AWS_SECRET_ACCESS_KEY: 'secret',
+            AWS_SESSION_TOKEN: 'session',
+        });
+    });
+
+    test('omits AWS_SESSION_TOKEN when the IAM session token is absent', () => {
+        const env = buildClaudeCodeEnv(
+            {
+                defaultProvider: 'bedrock',
+                providers: {
+                    bedrock: {
+                        region: 'eu-west-1',
+                        accessKeyId: 'AKIAEXAMPLE',
+                        secretAccessKey: 'secret',
+                    },
+                },
+            },
+            () => 'unused',
+        );
+
+        expect(env).not.toHaveProperty('AWS_SESSION_TOKEN');
+        expect(env).toEqual({
+            CLAUDE_CODE_USE_BEDROCK: '1',
+            AWS_REGION: 'eu-west-1',
+            AWS_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+            AWS_SECRET_ACCESS_KEY: 'secret',
+        });
+    });
+
+    test('uses the Anthropic key when defaultProvider is not bedrock, even if Bedrock creds exist', () => {
+        const env = buildClaudeCodeEnv(
+            {
+                defaultProvider: 'openai',
+                providers: { bedrock: bedrockApiKey },
+            },
+            () => 'anthropic-key',
+        );
+
+        expect(env).toEqual({ ANTHROPIC_API_KEY: 'anthropic-key' });
+    });
+
+    test('uses the Anthropic key when defaultProvider is bedrock but no Bedrock creds are configured', () => {
+        const env = buildClaudeCodeEnv(
+            { defaultProvider: 'bedrock', providers: {} },
+            () => 'anthropic-key',
+        );
+
+        expect(env).toEqual({ ANTHROPIC_API_KEY: 'anthropic-key' });
+    });
+});
+
+describe('describeClaudeCodeEnv', () => {
+    test('describes Bedrock API-key mode with region (no secrets)', () => {
+        expect(
+            describeClaudeCodeEnv({
+                CLAUDE_CODE_USE_BEDROCK: '1',
+                AWS_REGION: 'us-east-1',
+                AWS_BEARER_TOKEN_BEDROCK: 'super-secret',
+            }),
+        ).toBe('Bedrock (API key, region=us-east-1)');
+    });
+
+    test('describes Bedrock IAM mode with region (no secrets)', () => {
+        expect(
+            describeClaudeCodeEnv({
+                CLAUDE_CODE_USE_BEDROCK: '1',
+                AWS_REGION: 'eu-west-1',
+                AWS_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+                AWS_SECRET_ACCESS_KEY: 'super-secret',
+            }),
+        ).toBe('Bedrock (IAM, region=eu-west-1)');
+    });
+
+    test('describes the Anthropic API mode', () => {
+        expect(
+            describeClaudeCodeEnv({ ANTHROPIC_API_KEY: 'super-secret' }),
+        ).toBe('Anthropic API');
+    });
+});
+
+describe('claudeCodeAllowedHosts', () => {
+    test('allows only api.anthropic.com when not using Bedrock', () => {
+        expect(
+            claudeCodeAllowedHosts({
+                defaultProvider: 'openai',
+                providers: {},
+            }),
+        ).toEqual(['api.anthropic.com']);
+    });
+
+    test('allows the Bedrock endpoints for the region (API key)', () => {
+        expect(
+            claudeCodeAllowedHosts({
+                defaultProvider: 'bedrock',
+                providers: { bedrock: { apiKey: 'k', region: 'us-east-1' } },
+            }),
+        ).toEqual([
+            'bedrock-runtime.us-east-1.amazonaws.com',
+            'bedrock.us-east-1.amazonaws.com',
+        ]);
+    });
+
+    test('allows the Bedrock endpoints for the region (IAM)', () => {
+        expect(
+            claudeCodeAllowedHosts({
+                defaultProvider: 'bedrock',
+                providers: {
+                    bedrock: {
+                        region: 'eu-west-1',
+                        accessKeyId: 'a',
+                        secretAccessKey: 's',
+                    },
+                },
+            }),
+        ).toEqual([
+            'bedrock-runtime.eu-west-1.amazonaws.com',
+            'bedrock.eu-west-1.amazonaws.com',
+        ]);
+    });
+
+    test('falls back to api.anthropic.com when Bedrock is selected but unconfigured', () => {
+        expect(
+            claudeCodeAllowedHosts({
+                defaultProvider: 'bedrock',
+                providers: {},
+            }),
+        ).toEqual(['api.anthropic.com']);
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts
@@ -1,0 +1,102 @@
+/**
+ * The subset of the Bedrock provider config the `claude` CLI needs: a region
+ * plus either a bearer token (API key) or static IAM credentials. This is
+ * structurally a subset of `lightdashConfig.ai.copilot.providers.bedrock`, so
+ * that config can be passed straight through without remapping.
+ */
+export type ClaudeCodeBedrockConfig =
+    | { region: string; apiKey: string }
+    | {
+          region: string;
+          accessKeyId: string;
+          secretAccessKey: string;
+          sessionToken?: string;
+      };
+
+/**
+ * The slice of the AI copilot config the Claude CLI env depends on: the active
+ * provider switch (`AI_DEFAULT_PROVIDER`) and the Bedrock credentials.
+ * Structurally a subset of `lightdashConfig.ai.copilot`, so it can be passed
+ * straight through.
+ */
+export type ClaudeCodeProviderConfig = {
+    defaultProvider: string;
+    providers: { bedrock?: ClaudeCodeBedrockConfig };
+};
+
+/**
+ * Builds the environment variables passed to the `claude` CLI inside the E2B
+ * sandbox. Data apps follow the same provider switch as the AI copilot: when
+ * `AI_DEFAULT_PROVIDER` is `bedrock` they route through Bedrock (bearer token or
+ * IAM credentials); for any other provider they use the Anthropic API, since
+ * Claude Code only supports Anthropic and Bedrock.
+ *
+ * `resolveAnthropicApiKey` is a thunk so the Anthropic key is only resolved
+ * (and validated) when we actually need it — in Bedrock mode it is never called.
+ */
+export const buildClaudeCodeEnv = (
+    copilot: ClaudeCodeProviderConfig,
+    resolveAnthropicApiKey: () => string,
+): Record<string, string> => {
+    const bedrock =
+        copilot.defaultProvider === 'bedrock'
+            ? copilot.providers.bedrock
+            : undefined;
+
+    if (!bedrock) {
+        return { ANTHROPIC_API_KEY: resolveAnthropicApiKey() };
+    }
+
+    const base: Record<string, string> = {
+        CLAUDE_CODE_USE_BEDROCK: '1',
+        AWS_REGION: bedrock.region,
+    };
+
+    if ('apiKey' in bedrock) {
+        return { ...base, AWS_BEARER_TOKEN_BEDROCK: bedrock.apiKey };
+    }
+
+    return {
+        ...base,
+        AWS_ACCESS_KEY_ID: bedrock.accessKeyId,
+        AWS_SECRET_ACCESS_KEY: bedrock.secretAccessKey,
+        ...(bedrock.sessionToken
+            ? { AWS_SESSION_TOKEN: bedrock.sessionToken }
+            : {}),
+    };
+};
+
+/**
+ * A non-secret, human-readable summary of the env from `buildClaudeCodeEnv`,
+ * for logging which provider the sandbox launched with. Never includes the
+ * credential values — only the mode and (for Bedrock) the auth method + region.
+ */
+export const describeClaudeCodeEnv = (env: Record<string, string>): string => {
+    if (env.CLAUDE_CODE_USE_BEDROCK !== '1') {
+        return 'Anthropic API';
+    }
+    const method = 'AWS_BEARER_TOKEN_BEDROCK' in env ? 'API key' : 'IAM';
+    return `Bedrock (${method}, region=${env.AWS_REGION})`;
+};
+
+/**
+ * The egress allowlist for the E2B sandbox firewall. Data apps deny all
+ * outbound traffic except the LLM endpoint, so this must follow the same
+ * provider switch as the env: the Bedrock runtime + control-plane hosts for
+ * the region in Bedrock mode, otherwise the Anthropic API host.
+ */
+export const claudeCodeAllowedHosts = (
+    copilot: ClaudeCodeProviderConfig,
+): string[] => {
+    const bedrock =
+        copilot.defaultProvider === 'bedrock'
+            ? copilot.providers.bedrock
+            : undefined;
+    if (!bedrock) {
+        return ['api.anthropic.com'];
+    }
+    return [
+        `bedrock-runtime.${bedrock.region}.amazonaws.com`,
+        `bedrock.${bedrock.region}.amazonaws.com`,
+    ];
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #23093 

### Description:

Adds support for creating data apps using AWS Bedrock. To use Bedrock

These must be set
```
AI_DEFAULT_PROVIDER=bedrock
# Region — REQUIRED; use one where Claude Sonnet is access-enabled
BEDROCK_REGION=us-east-1
```

And either the API or IAM keys must be set
```
# Credentials — pick ONE method:
#  (a) Bedrock API key — simplest
BEDROCK_API_KEY=

#  (b) OR IAM keys
# BEDROCK_ACCESS_KEY_ID=<...>
# BEDROCK_SECRET_ACCESS_KEY=<...>
# BEDROCK_SESSION_TOKEN=<...>
```
