### PR TITLE
fix(mcp): isolate built-in skill loading failures

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -2726,7 +2726,7 @@ export class McpService extends BaseService {
 
         // Skill resources load asynchronously; register them directly on the
         // new server so no server swap spans the await.
-        await McpService.setupSkillResourceHandlers(newServer);
+        await this.setupSkillResourceHandlers(newServer);
 
         return newServer;
     }
@@ -2832,58 +2832,68 @@ export class McpService extends BaseService {
         );
     }
 
-    private static async setupSkillResourceHandlers(
+    private async setupSkillResourceHandlers(
         mcpServer: McpServer,
     ): Promise<void> {
-        const resources = await BuiltInSkills.listMcpResources();
+        // Built-in skills are optional context, not core MCP functionality.
+        // This runs per request (createServer is per-request), so a skill load
+        // or registration failure must never reject and 500 the whole endpoint
+        // — log it and serve the server without skill resources.
+        try {
+            const resources = await BuiltInSkills.listMcpResources();
 
-        resources.forEach((resource) => {
-            mcpServer.registerResource(
-                resource.name,
-                resource.uri,
-                {
-                    title: resource.title,
-                    description: resource.description,
-                    mimeType: resource.mimeType,
-                    size: resource.size,
-                },
-                async () => {
-                    const text = await BuiltInSkills.getMcpResourceBody(
-                        resource.uri,
-                    );
-                    if (text === undefined) {
-                        throw new NotFoundError(
-                            `Resource "${resource.uri}" was not found`,
+            resources.forEach((resource) => {
+                mcpServer.registerResource(
+                    resource.name,
+                    resource.uri,
+                    {
+                        title: resource.title,
+                        description: resource.description,
+                        mimeType: resource.mimeType,
+                        size: resource.size,
+                    },
+                    async () => {
+                        const text = await BuiltInSkills.getMcpResourceBody(
+                            resource.uri,
                         );
-                    }
-                    return {
-                        contents: [
-                            {
-                                uri: resource.uri,
-                                mimeType: resource.mimeType,
-                                text,
-                            },
-                        ],
-                    };
-                },
-            );
-        });
+                        if (text === undefined) {
+                            throw new NotFoundError(
+                                `Resource "${resource.uri}" was not found`,
+                            );
+                        }
+                        return {
+                            contents: [
+                                {
+                                    uri: resource.uri,
+                                    mimeType: resource.mimeType,
+                                    text,
+                                },
+                            ],
+                        };
+                    },
+                );
+            });
 
-        // The SDK auto-advertises `resources.listChanged: true` when
-        // registerResource is called, but we never emit list_changed
-        // notifications. We also declare the skills extension so clients can
-        // detect built-in skill support.
-        mcpServer.server.registerCapabilities({
-            resources: { subscribe: false, listChanged: false },
-            // Advertise under both: `extensions` per the final SEP, and
-            // `experimental` for draft-era clients (the de-facto wild form).
-            experimental: {
-                [MCP_SKILLS_EXTENSION_NAME]: {},
-            },
-            extensions: {
-                [MCP_SKILLS_EXTENSION_NAME]: {},
-            },
-        });
+            // The SDK auto-advertises `resources.listChanged: true` when
+            // registerResource is called, but we never emit list_changed
+            // notifications. We also declare the skills extension so clients can
+            // detect built-in skill support.
+            mcpServer.server.registerCapabilities({
+                resources: { subscribe: false, listChanged: false },
+                // Advertise under both: `extensions` per the final SEP, and
+                // `experimental` for draft-era clients (the de-facto wild form).
+                experimental: {
+                    [MCP_SKILLS_EXTENSION_NAME]: {},
+                },
+                extensions: {
+                    [MCP_SKILLS_EXTENSION_NAME]: {},
+                },
+            });
+        } catch (error) {
+            this.logger.warn('Failed to register built-in skill resources', {
+                error,
+            });
+        }
     }
 
     static getAccount(context: McpProtocolContext) {

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
@@ -1,8 +1,9 @@
-import { ParameterError } from '@lightdash/common';
+import { getErrorMessage, ParameterError } from '@lightdash/common';
 import crypto from 'crypto';
 import * as fs from 'fs/promises';
 import matter from 'gray-matter';
 import * as path from 'path';
+import Logger from '../../../../logging/logger';
 import {
     AiAgentSkill,
     AiAgentSkillReference,
@@ -189,11 +190,40 @@ export class BuiltInSkills {
         this.loadedPromise = (async () => {
             try {
                 const skillNames = await this.getSkillNames();
-                const loaded = await Promise.all(
+                // A single malformed or duplicate skill directory must not take
+                // down every skill (and, in the MCP path, the whole server), so
+                // load each independently and skip the ones that fail.
+                const settled = await Promise.allSettled(
                     skillNames.map((skillName) =>
                         this.loadSkillDirectory(skillName),
                     ),
                 );
+
+                const loaded: LoadedBuiltInSkill[] = [];
+                const seenNames = new Set<string>();
+                settled.forEach((result, index) => {
+                    if (result.status === 'rejected') {
+                        Logger.warn(
+                            `Skipping built-in skill "${
+                                skillNames[index]
+                            }": ${getErrorMessage(result.reason)}`,
+                        );
+                        return;
+                    }
+                    // The skill name is the final skill:// path segment, so
+                    // duplicates would mint colliding URIs and break
+                    // registerResource. Keep the first, skip the rest.
+                    const nameKey = result.value.name.toLowerCase();
+                    if (seenNames.has(nameKey)) {
+                        Logger.warn(
+                            `Skipping built-in skill "${skillNames[index]}": duplicate skill name "${result.value.name}"`,
+                        );
+                        return;
+                    }
+                    seenNames.add(nameKey);
+                    loaded.push(result.value);
+                });
+
                 this.loaded = loaded;
                 return loaded;
             } catch (error) {

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -173,7 +173,8 @@ mcpRouter.all(
                 // Dark launch: the run_ai_writeback tool is only registered
                 // (and thus only listed/invocable) when the AiWriteback flag is
                 // enabled for this caller. Resolved here because tool
-                // registration in createServer/setupHandlers is synchronous.
+                // registration in setupHandlers is synchronous (createServer
+                // only awaits to register skill resources afterwards).
                 const aiWritebackEnabled =
                     await mcpService.isAiWritebackEnabled(req.user!);
                 const mcpServer = await mcpService.createServer({


### PR DESCRIPTION
Stacked on #24009 (`chore(mcp)/sep-2640-conventions`).

`createServer` registers built-in skill resources per request. A single malformed skill directory (missing/invalid `SKILL.md` frontmatter) or two skills sharing a frontmatter name previously rejected the whole `load()` (`Promise.all`) — and because that runs inside the per-request `createServer`, it 500'd **every** MCP request, not just skills. Failed loads aren't cached, so it re-read the filesystem and re-threw on each subsequent request.

This makes built-in skill loading fault-isolated:

- `load()` uses `Promise.allSettled` — a directory that fails to parse is logged and skipped; the rest still load.
- Duplicate frontmatter names are deduped before they mint clashing `skill://` URIs (which would throw in `registerResource`). First wins; duplicates are logged and skipped. Per SEP-2640 a `skill-md` entry name must equal its final path segment, so duplicates were also a spec violation.
- Skill resource registration is now best-effort (try/catch + warn), so a skill failure can never take down the MCP endpoint — the server is served without skill resources if registration fails.

Relates: ZAP-421