### PR TITLE
chore(ai): unify skill tool definitions and service

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -41,6 +41,7 @@ import { enhanceExploresForPreAggregates } from './preAggregates/enhanceExplores
 import { preAggregatePostProcessor } from './preAggregates/postProcessor';
 import { CommercialSchedulerClient } from './scheduler/SchedulerClient';
 import { CommercialSchedulerWorker } from './scheduler/SchedulerWorker';
+import { BuiltInSkills } from './services/ai/skills/builtInSkills';
 import { AiAgentContentValidation } from './services/ai/utils/AiAgentContentValidation';
 import { AiAgentAdminService } from './services/AiAgentAdminService';
 import { AiAgentDocumentService } from './services/AiAgentDocumentService';
@@ -197,6 +198,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 }),
             aiAgentToolsService: ({ models, repository, context }) =>
                 new AiAgentToolsService({
+                    builtInSkills: BuiltInSkills,
                     lightdashConfig: context.lightdashConfig,
                     projectModel: models.getProjectModel(),
                     projectService: repository.getProjectService(),

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -210,7 +210,6 @@ import { matchesPreset } from '../ai/models/presets';
 import { runRepoShellCommand } from '../ai/repoFs/bashShell';
 import { createGithubRepoSource } from '../ai/repoFs/githubRepoSource';
 import { RepoFs } from '../ai/repoFs/RepoFs';
-import { BuiltInSkills } from '../ai/skills/builtInSkills';
 import { markSlackThreadAutoApproved } from '../ai/tools/sqlApprovals';
 import { AiAgentArgs, AiAgentDependencies } from '../ai/types/aiAgent';
 import {
@@ -5102,6 +5101,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             repoShell,
             listProjects: toolsRuntime.listProjects,
             getProjectInfo: toolsRuntime.getProjectInfo,
+            loadSkill: toolsRuntime.loadSkill,
         };
     }
 
@@ -5418,7 +5418,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 }),
             );
         const availableSkills = canUseContentTools
-            ? await BuiltInSkills.getAiAgentSkills()
+            ? await this.aiAgentToolsService.listAgentSkills()
             : [];
         const modelProperties = getModel(this.lightdashConfig.ai.copilot, {
             enableReasoning: prompt.modelConfig?.reasoning,
@@ -5571,7 +5571,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     decision,
                     decidedByUserUuid,
                 ),
-            loadSkill: async (name) => BuiltInSkills.getAiAgentSkill(name),
+            loadSkill: async (name) =>
+                this.aiAgentToolsService.loadAgentSkill(name),
 
             perf: {
                 measureGenerateResponseTime: (durationMs) => {

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -75,6 +75,15 @@ const makeService = ({
     searchFieldUniqueValues?: jest.Mock;
 } = {}) =>
     new AiAgentToolsService({
+        builtInSkills: {
+            getAiAgentSkills: jest.fn(),
+            getAiAgentSkill: jest.fn(),
+            listSkillToolReferences: jest.fn(),
+            readSkillTool: jest.fn(),
+            readSkillToolResource: jest.fn(),
+            listMcpResources: jest.fn(),
+            getMcpResourceBody: jest.fn(),
+        },
         lightdashConfig: {
             siteUrl: 'https://lightdash.example',
             ai: { copilot: { maxQueryLimit: 500 } },

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -54,6 +54,7 @@ import {
 import { wrapSentryTransaction } from '../../../utils';
 import { AiAgentDocumentModel } from '../../models/AiAgentDocumentModel';
 import { ProjectContextModel } from '../../models/ProjectContextModel';
+import type { BuiltInSkills } from '../ai/skills/builtInSkills';
 import {
     CreateContentFn,
     DescribeWarehouseTableFn,
@@ -70,6 +71,7 @@ import {
     ListKnowledgeDocumentsFn,
     ListProjectsFn,
     ListWarehouseTablesFn,
+    LoadAgentSkillFn,
     ReadContentFn,
     RunAsyncQueryFn,
     RunSavedChartQueryFn,
@@ -134,9 +136,22 @@ export type AiAgentToolsRuntime = {
     setupPreviewDeploy: SetupPreviewDeployFn;
     listProjects: ListProjectsFn;
     getProjectInfo: GetProjectInfoFn;
+    loadSkill: LoadAgentSkillFn;
 };
 
+type BuiltInSkillsClient = Pick<
+    typeof BuiltInSkills,
+    | 'getAiAgentSkills'
+    | 'getAiAgentSkill'
+    | 'listSkillToolReferences'
+    | 'readSkillTool'
+    | 'readSkillToolResource'
+    | 'listMcpResources'
+    | 'getMcpResourceBody'
+>;
+
 type AiAgentToolsServiceDependencies = {
+    builtInSkills: BuiltInSkillsClient;
     projectModel: ProjectModel;
     projectService: ProjectService;
     userAttributesModel: UserAttributesModel;
@@ -203,7 +218,41 @@ export class AiAgentToolsService extends BaseService {
 
     private readonly lightdashConfig: AiAgentToolsServiceDependencies['lightdashConfig'];
 
+    private readonly builtInSkills: BuiltInSkillsClient;
+
+    listAgentSkills() {
+        return this.builtInSkills.getAiAgentSkills();
+    }
+
+    loadAgentSkill(name: string) {
+        return this.builtInSkills.getAiAgentSkill(name);
+    }
+
+    listMcpSkills() {
+        return this.builtInSkills.listSkillToolReferences();
+    }
+
+    loadMcpSkill(name: string) {
+        return this.builtInSkills.readSkillTool(name);
+    }
+
+    loadMcpSkillResource(args: { name: string; path: string }) {
+        return this.builtInSkills.readSkillToolResource({
+            name: args.name,
+            resourcePath: args.path,
+        });
+    }
+
+    listMcpSkillResources() {
+        return this.builtInSkills.listMcpResources();
+    }
+
+    getMcpSkillResourceBody(uri: string) {
+        return this.builtInSkills.getMcpResourceBody(uri);
+    }
+
     constructor({
+        builtInSkills,
         projectModel,
         projectService,
         userAttributesModel,
@@ -225,6 +274,7 @@ export class AiAgentToolsService extends BaseService {
         lightdashConfig,
     }: AiAgentToolsServiceDependencies) {
         super();
+        this.builtInSkills = builtInSkills;
         this.projectModel = projectModel;
         this.projectService = projectService;
         this.userAttributesModel = userAttributesModel;
@@ -376,6 +426,7 @@ export class AiAgentToolsService extends BaseService {
             setupPreviewDeploy: () => this.setupPreviewDeploy(context),
             listProjects: () => this.listProjects(context),
             getProjectInfo: () => this.getProjectInfo(context),
+            loadSkill: (name) => this.loadAgentSkill(name),
         };
     }
 

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -29,6 +29,7 @@ import {
     ItemsMap,
     listAgentsToolDefinition,
     listExploresToolDefinition,
+    listSkillsToolDefinition,
     listVerifiedContentToolDefinition,
     MCP_QUERY_POLL_INTERVAL_MS,
     MCP_QUERY_SYNC_WAIT_MS,
@@ -40,6 +41,8 @@ import {
     ParameterError,
     QueryExecutionContext,
     QueryHistoryStatus,
+    readSkillResourceToolDefinition,
+    readSkillToolDefinition,
     renderChartToolDefinition,
     runAiWritebackToolDefinition,
     runQueryToolDefinition,
@@ -101,7 +104,6 @@ import {
     getMcpAnalystPromptWithContext,
     MCP_ANALYST_PROMPT,
 } from '../ai/prompts/mcpAnalyst';
-import { BuiltInSkills } from '../ai/skills/builtInSkills';
 import { getFindContent } from '../ai/tools/findContent';
 import { getFindExplores } from '../ai/tools/findExplores';
 import { getFindFields } from '../ai/tools/findFields';
@@ -156,27 +158,6 @@ export enum McpToolName {
 // Skills-over-MCP extension identifier (SEP-2640).
 const MCP_SKILLS_EXTENSION_NAME = 'io.modelcontextprotocol/skills';
 
-const listSkillsToolSchema = z.object({});
-const readSkillToolSchema = z.object({
-    name: z
-        .string()
-        .describe(
-            'Skill name from list_skills, for example developing-in-lightdash',
-        ),
-});
-const readSkillResourceToolSchema = z.object({
-    name: z
-        .string()
-        .describe(
-            'Skill name from list_skills, for example developing-in-lightdash',
-        ),
-    path: z
-        .string()
-        .describe(
-            'Resource path from list_skills, for example resources/dashboard-reference.md',
-        ),
-});
-
 const mcpRunAiWritebackTool = runAiWritebackToolDefinition.for('mcp');
 const mcpGetLightdashVersionTool = getLightdashVersionToolDefinition.for('mcp');
 const mcpListExploresTool = listExploresToolDefinition.for('mcp');
@@ -196,6 +177,9 @@ const mcpSearchFieldValuesTool = searchFieldValuesToolDefinition.for('mcp');
 const mcpRunSqlTool = runSqlToolDefinition.for('mcp');
 const mcpGetQueryResultTool = getQueryResultToolDefinition.for('mcp');
 const mcpListVerifiedContentTool = listVerifiedContentToolDefinition.for('mcp');
+const mcpListSkillsTool = listSkillsToolDefinition.for('mcp');
+const mcpReadSkillTool = readSkillToolDefinition.for('mcp');
+const mcpReadSkillResourceTool = readSkillResourceToolDefinition.for('mcp');
 
 type McpServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -2733,45 +2717,46 @@ export class McpService extends BaseService {
 
     private registerSkillToolHandlers(): void {
         this.mcpServer.registerTool(
-            McpToolName.LIST_SKILLS,
+            mcpListSkillsTool.name,
             {
-                title: 'List Skills',
-                description:
-                    'List Lightdash built-in skills available to this MCP server. Use this when the client does not expose MCP resources directly.',
-                inputSchema: this.getMcpCompatibleSchema(listSkillsToolSchema),
-                annotations: { readOnlyHint: true },
+                title: mcpListSkillsTool.title,
+                description: mcpListSkillsTool.description,
+                inputSchema: this.getMcpCompatibleSchema(
+                    mcpListSkillsTool.inputSchema,
+                ),
+                outputSchema: mcpListSkillsTool.outputSchema.shape,
+                annotations: mcpListSkillsTool.annotations,
             },
             async (_args, extra) => {
                 const ctx = getMcpContext(extra);
                 this.trackToolCall(ctx, McpToolName.LIST_SKILLS);
 
-                const skills = await BuiltInSkills.listSkillToolReferences();
-                return {
-                    content: [
-                        {
-                            type: 'text' as const,
-                            text: JSON.stringify({ skills }, null, 2),
-                        },
-                    ],
-                    structuredContent: { skills },
-                };
+                const skills = await this.aiAgentToolsService.listMcpSkills();
+                return mcpListSkillsTool.result.structured(
+                    JSON.stringify({ skills }, null, 2),
+                    { skills },
+                );
             },
         );
 
         this.mcpServer.registerTool(
-            McpToolName.READ_SKILL,
+            mcpReadSkillTool.name,
             {
-                title: 'Read Skill',
-                description:
-                    'Read the main SKILL.md instructions for a Lightdash built-in skill. Call list_skills first to discover available skill names.',
-                inputSchema: this.getMcpCompatibleSchema(readSkillToolSchema),
-                annotations: { readOnlyHint: true },
+                title: mcpReadSkillTool.title,
+                description: mcpReadSkillTool.description,
+                inputSchema: this.getMcpCompatibleSchema(
+                    mcpReadSkillTool.inputSchema,
+                ),
+                outputSchema: mcpReadSkillTool.outputSchema.shape,
+                annotations: mcpReadSkillTool.annotations,
             },
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
                 this.trackToolCall(ctx, McpToolName.READ_SKILL);
 
-                const result = await BuiltInSkills.readSkillTool(args.name);
+                const result = await this.aiAgentToolsService.loadMcpSkill(
+                    args.name,
+                );
                 if (!result) {
                     throw new NotFoundError(
                         `Skill "${args.name}" was not found`,
@@ -2779,55 +2764,41 @@ export class McpService extends BaseService {
                 }
                 const { skill, body } = result;
 
-                return {
-                    content: [{ type: 'text' as const, text: body }],
-                    structuredContent: {
-                        skill: {
-                            name: skill.name,
-                            uri: skill.uri,
-                            title: skill.title,
-                            description: skill.description,
-                            mimeType: skill.mimeType,
-                            size: skill.size,
-                            digest: skill.digest,
-                        },
-                    },
-                };
+                return mcpReadSkillTool.result.structured(body, {
+                    skill,
+                    body,
+                });
             },
         );
 
         this.mcpServer.registerTool(
-            McpToolName.READ_SKILL_RESOURCE,
+            mcpReadSkillResourceTool.name,
             {
-                title: 'Read Skill Resource',
-                description:
-                    'Read a supporting resource file for a Lightdash built-in skill. Use the resource path returned by list_skills.',
+                title: mcpReadSkillResourceTool.title,
+                description: mcpReadSkillResourceTool.description,
                 inputSchema: this.getMcpCompatibleSchema(
-                    readSkillResourceToolSchema,
+                    mcpReadSkillResourceTool.inputSchema,
                 ),
-                annotations: { readOnlyHint: true },
+                outputSchema: mcpReadSkillResourceTool.outputSchema.shape,
+                annotations: mcpReadSkillResourceTool.annotations,
             },
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
                 this.trackToolCall(ctx, McpToolName.READ_SKILL_RESOURCE);
 
-                const result = await BuiltInSkills.readSkillToolResource({
-                    name: args.name,
-                    resourcePath: args.path,
-                });
+                const result =
+                    await this.aiAgentToolsService.loadMcpSkillResource(args);
                 if (!result) {
                     throw new NotFoundError(
                         `Skill resource "${args.path}" was not found for skill "${args.name}"`,
                     );
                 }
 
-                return {
-                    content: [{ type: 'text' as const, text: result.body }],
-                    structuredContent: {
-                        skill: { name: result.skillName },
-                        resource: result.resource,
-                    },
-                };
+                return mcpReadSkillResourceTool.result.structured(result.body, {
+                    skill: result.skill,
+                    resource: result.resource,
+                    body: result.body,
+                });
             },
         );
     }
@@ -2840,7 +2811,8 @@ export class McpService extends BaseService {
         // or registration failure must never reject and 500 the whole endpoint
         // — log it and serve the server without skill resources.
         try {
-            const resources = await BuiltInSkills.listMcpResources();
+            const resources =
+                await this.aiAgentToolsService.listMcpSkillResources();
 
             resources.forEach((resource) => {
                 mcpServer.registerResource(
@@ -2853,9 +2825,10 @@ export class McpService extends BaseService {
                         size: resource.size,
                     },
                     async () => {
-                        const text = await BuiltInSkills.getMcpResourceBody(
-                            resource.uri,
-                        );
+                        const text =
+                            await this.aiAgentToolsService.getMcpSkillResourceBody(
+                                resource.uri,
+                            );
                         if (text === undefined) {
                             throw new NotFoundError(
                                 `Resource "${resource.uri}" was not found`,

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -7375,6 +7375,99 @@ Notes:
         "type": "object",
       },
       "name": "list_skills",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "skills": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "type": "string",
+                },
+                "digest": {
+                  "type": "string",
+                },
+                "mimeType": {
+                  "type": "string",
+                },
+                "name": {
+                  "type": "string",
+                },
+                "resources": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                      },
+                      "digest": {
+                        "type": "string",
+                      },
+                      "mimeType": {
+                        "type": "string",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                      "path": {
+                        "type": "string",
+                      },
+                      "size": {
+                        "type": "number",
+                      },
+                      "title": {
+                        "type": "string",
+                      },
+                      "uri": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "path",
+                      "uri",
+                      "name",
+                      "title",
+                      "description",
+                      "mimeType",
+                      "size",
+                      "digest",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "size": {
+                  "type": "number",
+                },
+                "title": {
+                  "type": "string",
+                },
+                "uri": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "name",
+                "uri",
+                "title",
+                "description",
+                "mimeType",
+                "size",
+                "digest",
+                "resources",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "skills",
+        ],
+        "type": "object",
+      },
       "title": "List Skills",
     },
     {
@@ -7395,6 +7488,100 @@ Notes:
         "type": "object",
       },
       "name": "read_skill",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "type": "string",
+          },
+          "skill": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string",
+              },
+              "digest": {
+                "type": "string",
+              },
+              "mimeType": {
+                "type": "string",
+              },
+              "name": {
+                "type": "string",
+              },
+              "resources": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "type": "string",
+                    },
+                    "digest": {
+                      "type": "string",
+                    },
+                    "mimeType": {
+                      "type": "string",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "path": {
+                      "type": "string",
+                    },
+                    "size": {
+                      "type": "number",
+                    },
+                    "title": {
+                      "type": "string",
+                    },
+                    "uri": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "path",
+                    "uri",
+                    "name",
+                    "title",
+                    "description",
+                    "mimeType",
+                    "size",
+                    "digest",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "size": {
+                "type": "number",
+              },
+              "title": {
+                "type": "string",
+              },
+              "uri": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "name",
+              "uri",
+              "title",
+              "description",
+              "mimeType",
+              "size",
+              "digest",
+              "resources",
+            ],
+            "type": "object",
+          },
+        },
+        "required": [
+          "skill",
+          "body",
+        ],
+        "type": "object",
+      },
       "title": "Read Skill",
     },
     {
@@ -7420,6 +7607,104 @@ Notes:
         "type": "object",
       },
       "name": "read_skill_resource",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "type": "string",
+          },
+          "resource": {
+            "$ref": "#/properties/skill/properties/resources/items",
+          },
+          "skill": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string",
+              },
+              "digest": {
+                "type": "string",
+              },
+              "mimeType": {
+                "type": "string",
+              },
+              "name": {
+                "type": "string",
+              },
+              "resources": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "type": "string",
+                    },
+                    "digest": {
+                      "type": "string",
+                    },
+                    "mimeType": {
+                      "type": "string",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "path": {
+                      "type": "string",
+                    },
+                    "size": {
+                      "type": "number",
+                    },
+                    "title": {
+                      "type": "string",
+                    },
+                    "uri": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "path",
+                    "uri",
+                    "name",
+                    "title",
+                    "description",
+                    "mimeType",
+                    "size",
+                    "digest",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "size": {
+                "type": "number",
+              },
+              "title": {
+                "type": "string",
+              },
+              "uri": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "name",
+              "uri",
+              "title",
+              "description",
+              "mimeType",
+              "size",
+              "digest",
+              "resources",
+            ],
+            "type": "object",
+          },
+        },
+        "required": [
+          "skill",
+          "resource",
+          "body",
+        ],
+        "type": "object",
+      },
       "title": "Read Skill Resource",
     },
     {
@@ -7515,6 +7800,9 @@ exports[`MCP tool contracts matches the shared MCP tool definition names snapsho
   "render_chart",
   "get_lightdash_version",
   "list_explores",
+  "list_skills",
+  "read_skill",
+  "read_skill_resource",
   "list_projects",
   "set_project",
   "get_current_project",

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
@@ -457,7 +457,7 @@ export class BuiltInSkills {
         resourcePath: string;
     }): Promise<
         | {
-              skillName: string;
+              skill: BuiltInSkillToolReference;
               resource: BuiltInSkillToolResource;
               body: string;
           }
@@ -480,6 +480,6 @@ export class BuiltInSkills {
         if (body === undefined) {
             return undefined;
         }
-        return { skillName: skill.name, resource, body };
+        return { skill, resource, body };
     }
 }

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -130,6 +130,9 @@ describe('defineTool', () => {
 
         expect(structuredMcpToolNames).toEqual([
             'get_query_result',
+            'list_skills',
+            'read_skill',
+            'read_skill_resource',
             'render_chart',
             'run_ai_writeback',
             'run_metric_query',

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -1,4 +1,5 @@
 export * from './toolDefinitions';
+export * from './toolBuiltInSkillArgs';
 export * from './toolQueryResultSchemas';
 export * from './toolDiscoverFieldsArgs';
 export * from './toolEditContentArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolBuiltInSkillArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolBuiltInSkillArgs.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+export const TOOL_LIST_SKILLS_DESCRIPTION =
+    'List Lightdash built-in skills available to this MCP server. Use this when the client does not expose MCP resources directly.';
+
+export const TOOL_LOAD_SKILL_DESCRIPTION_MCP =
+    'Read the main SKILL.md instructions for a Lightdash built-in skill. Call list_skills first to discover available skill names.';
+
+export const TOOL_LOAD_SKILL_RESOURCE_DESCRIPTION =
+    'Read a supporting resource file for a Lightdash built-in skill. Use the resource path returned by list_skills.';
+
+export const toolListSkillsArgsSchema = z.object({});
+
+export const toolLoadSkillMcpArgsSchema = z.object({
+    name: z
+        .string()
+        .describe(
+            'Skill name from list_skills, for example developing-in-lightdash',
+        ),
+});
+
+export const toolLoadSkillResourceArgsSchema = z.object({
+    name: z
+        .string()
+        .describe(
+            'Skill name from list_skills, for example developing-in-lightdash',
+        ),
+    path: z
+        .string()
+        .describe(
+            'Resource path from list_skills, for example resources/dashboard-reference.md',
+        ),
+});
+
+export const skillToolResourceSchema = z.object({
+    path: z.string(),
+    uri: z.string(),
+    name: z.string(),
+    title: z.string(),
+    description: z.string(),
+    mimeType: z.string(),
+    size: z.number(),
+    digest: z.string(),
+});
+
+export const skillToolReferenceSchema = z.object({
+    name: z.string(),
+    uri: z.string(),
+    title: z.string(),
+    description: z.string(),
+    mimeType: z.string(),
+    size: z.number(),
+    digest: z.string(),
+    resources: z.array(skillToolResourceSchema),
+});
+
+export const toolListSkillsOutputSchema = z.object({
+    skills: z.array(skillToolReferenceSchema),
+});
+
+export const toolLoadSkillOutputSchemaMcp = z.object({
+    skill: skillToolReferenceSchema,
+    body: z.string(),
+});
+
+export const toolLoadSkillResourceOutputSchema = z.object({
+    skill: skillToolReferenceSchema,
+    resource: skillToolResourceSchema,
+    body: z.string(),
+});
+
+export type ToolListSkillsArgs = z.infer<typeof toolListSkillsArgsSchema>;
+export type ToolLoadSkillMcpArgs = z.infer<typeof toolLoadSkillMcpArgsSchema>;
+export type ToolLoadSkillResourceArgs = z.infer<
+    typeof toolLoadSkillResourceArgsSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -15,6 +15,17 @@ import {
     mcpToolListExploresArgsSchema,
 } from './mcpToolListExploresArgs';
 import {
+    TOOL_LIST_SKILLS_DESCRIPTION,
+    TOOL_LOAD_SKILL_DESCRIPTION_MCP,
+    TOOL_LOAD_SKILL_RESOURCE_DESCRIPTION,
+    toolListSkillsArgsSchema,
+    toolListSkillsOutputSchema,
+    toolLoadSkillMcpArgsSchema,
+    toolLoadSkillOutputSchemaMcp,
+    toolLoadSkillResourceArgsSchema,
+    toolLoadSkillResourceOutputSchema,
+} from './toolBuiltInSkillArgs';
+import {
     TOOL_CREATE_CONTENT_DESCRIPTION,
     toolCreateContentArgsSchema,
     toolCreateContentOutputSchema,
@@ -667,6 +678,42 @@ export const listExploresToolDefinition = defineTool({
     mcp: { annotations: readOnlyAnnotations },
 });
 
+export const listSkillsToolDefinition = defineTool({
+    name: 'listSkills',
+    title: 'List Skills',
+    description: TOOL_LIST_SKILLS_DESCRIPTION,
+    availability: ['mcp'],
+    inputSchema: toolListSkillsArgsSchema,
+    mcp: {
+        annotations: readOnlyAnnotations,
+        structuredContentSchema: toolListSkillsOutputSchema,
+    },
+});
+
+export const readSkillToolDefinition = defineTool({
+    name: 'readSkill',
+    title: 'Read Skill',
+    description: TOOL_LOAD_SKILL_DESCRIPTION_MCP,
+    availability: ['mcp'],
+    inputSchema: toolLoadSkillMcpArgsSchema,
+    mcp: {
+        annotations: readOnlyAnnotations,
+        structuredContentSchema: toolLoadSkillOutputSchemaMcp,
+    },
+});
+
+export const readSkillResourceToolDefinition = defineTool({
+    name: 'readSkillResource',
+    title: 'Read Skill Resource',
+    description: TOOL_LOAD_SKILL_RESOURCE_DESCRIPTION,
+    availability: ['mcp'],
+    inputSchema: toolLoadSkillResourceArgsSchema,
+    mcp: {
+        annotations: readOnlyAnnotations,
+        structuredContentSchema: toolLoadSkillResourceOutputSchema,
+    },
+});
+
 export const mcpListProjectsToolDefinition = defineTool({
     name: 'listProjects',
     title: 'List projects',
@@ -886,6 +933,9 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     generateTimeSeriesVizConfigToolDefinition,
     getLightdashVersionToolDefinition,
     listExploresToolDefinition,
+    listSkillsToolDefinition,
+    readSkillToolDefinition,
+    readSkillResourceToolDefinition,
     listProjectsToolDefinition,
     mcpListProjectsToolDefinition,
     getProjectInfoToolDefinition,


### PR DESCRIPTION
Stacked on #24090 (`fix(mcp)/skill-load-resilience`).

Moves the built-in skill MCP fallback tool contracts (`list_skills`, `read_skill`, `read_skill_resource`) into the shared `defineTool` registry and routes both MCP + AI agent skill loading through `AiAgentToolsService`.

Relates: ZAP-421