### PR TITLE
fix(ai): harden repoShell — surface partial-failure stderr, drop symlinks from the VFS tree

### DIFF
--- a/packages/backend/src/clients/github/Github.test.ts
+++ b/packages/backend/src/clients/github/Github.test.ts
@@ -1,4 +1,12 @@
-import { isGithubRateLimitError } from './Github';
+import { Octokit } from '@octokit/rest';
+import { getRepoTree, isGithubRateLimitError } from './Github';
+
+jest.mock('@octokit/rest');
+
+const mockGetTree = jest.fn();
+(Octokit as unknown as jest.Mock).mockImplementation(() => ({
+    rest: { git: { getTree: mockGetTree } },
+}));
 
 const octokitError = (
     status: number,
@@ -60,5 +68,45 @@ describe('isGithubRateLimitError', () => {
         expect(isGithubRateLimitError(new Error('socket hang up'))).toBe(false);
         expect(isGithubRateLimitError(null)).toBe(false);
         expect(isGithubRateLimitError(undefined)).toBe(false);
+    });
+});
+
+describe('getRepoTree', () => {
+    beforeEach(() => {
+        mockGetTree.mockReset();
+    });
+
+    const args = { owner: 'acme', repo: 'jaffle', branch: 'main', token: 't' };
+
+    it('excludes symlink blobs (mode 120000) so the Contents API cannot follow them out of scope', async () => {
+        // Security invariant: a symlink blob (mode 120000) must never enter the
+        // VFS index. The GitHub Contents API follows symlinks server-side, so
+        // including one would let a path like `dbt/escape -> ../../secrets`
+        // escape a scoped subPath and return out-of-scope file content.
+        mockGetTree.mockResolvedValue({
+            data: {
+                truncated: false,
+                tree: [
+                    {
+                        path: 'models/orders.sql',
+                        type: 'blob',
+                        mode: '100644',
+                        size: 42,
+                    },
+                    {
+                        path: 'escape',
+                        type: 'blob',
+                        mode: '120000',
+                        size: 20,
+                    },
+                ],
+            },
+        });
+
+        const { files } = await getRepoTree(args);
+        const paths = files.map((f) => f.path);
+
+        expect(paths).toContain('models/orders.sql'); // regular files are unaffected
+        expect(paths).not.toContain('escape'); // the symlink must be excluded
     });
 });

--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -311,7 +311,17 @@ export const getRepoTree = async ({
             headers,
         });
         const files = response.data.tree
-            .filter((entry) => entry.type === 'blob' && Boolean(entry.path))
+            // Symlinks are blobs with mode 120000. The Contents API follows an
+            // in-repo symlink server-side and returns the *target's* content, so
+            // a symlink committed inside a scoped dbt subPath would let a read
+            // escape that scope. Exclude them — the repo VFS exposes real files
+            // only (and reports isSymbolicLink: false everywhere).
+            .filter(
+                (entry) =>
+                    entry.type === 'blob' &&
+                    entry.mode !== '120000' &&
+                    Boolean(entry.path),
+            )
             .map((entry) => ({
                 path: entry.path as string,
                 size: entry.size ?? 0,

--- a/packages/backend/src/ee/services/ai/repoFs/RepoFs.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/RepoFs.ts
@@ -304,7 +304,11 @@ export class RepoFs {
         // the file genuinely doesn't exist — skip the wasted Contents API call.
         // When it's truncated, the file may exist despite being absent from the
         // capped listing, so ask the source directly (it can fetch an explicit
-        // path) instead of falsely reporting "No such file".
+        // path) instead of falsely reporting "No such file". Caveat: symlinks
+        // are stripped from the tree (see getRepoTree) so a complete listing
+        // can't resolve one, but this truncated read-through bypasses the index
+        // and could still follow a symlink in a >100k-entry repo — a narrow
+        // residual we accept rather than break reads of files the cap omitted.
         if (!index.files.has(normalized) && !index.truncated) {
             this.cacheWrite(normalized, null);
             return null;

--- a/packages/backend/src/ee/services/ai/repoFs/bashShell.test.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/bashShell.test.ts
@@ -190,4 +190,23 @@ describe('runRepoShellCommand (just-bash)', () => {
             expect(out).toContain('GitHub truncated');
         });
     });
+
+    describe('partial failure (stderr must not be swallowed)', () => {
+        it('surfaces the missing-file diagnostic alongside the file that was read', async () => {
+            // Regression: `cat good missing` prints the existing file (stdout)
+            // AND errors on the missing one (stderr, exit 1). Previously stdout
+            // won unconditionally and the diagnostic was dropped, so the agent
+            // saw a partial result as if it were complete. Both must surface.
+            const out = await run('cat dbt_project.yml nope.sql');
+            expect(out).toContain('name: jaffle');
+            expect(out).toContain('nope.sql');
+            expect(out).toContain('No such file');
+        });
+
+        it('does not throw — the partial output is still returned to the agent', async () => {
+            await expect(
+                run('cat dbt_project.yml nope.sql'),
+            ).resolves.toContain('name: jaffle');
+        });
+    });
 });

--- a/packages/backend/src/ee/services/ai/repoFs/bashShell.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/bashShell.ts
@@ -180,12 +180,19 @@ export const runRepoShellCommand = async (
     // Real output wins regardless of exit code — a `grep` with matches exits 0,
     // a `grep` with none exits 1 with empty output (not an error).
     if (stdout.length > 0) {
-        const note =
+        const truncationNote =
             ['find', 'grep', 'rg', 'ls'].includes(leadingCommand(command)) &&
             (await repoFs.isTruncated())
                 ? '\n… note: this repository is large and GitHub truncated its file listing, so find/grep/ls results may be incomplete — narrow to a subdirectory.'
                 : '';
-        return clamp(stdout + note);
+        // A non-zero exit alongside real output is a partial failure — e.g.
+        // `cat good.sql missing.sql` prints the first file but errors on the
+        // second. Surface the stderr diagnostic so the agent sees what failed
+        // instead of treating the partial result as complete. Clamp the stdout
+        // first so the error note is never the part that gets truncated away.
+        const errorNote =
+            result.exitCode !== 0 && stderr.length > 0 ? `\n${stderr}` : '';
+        return clamp(stdout) + errorNote + truncationNote;
     }
 
     // No stdout: a non-zero exit with a diagnostic is an expected agent mistake


### PR DESCRIPTION
## Summary

Two follow-up hardening fixes for the read-only repo virtual filesystem (`repoShell`) shipped in #24041 / #24079, found while auditing the VFS and verified against the running app via the live AI agent.

### 1. Surface stderr on partial failures (correctness)

`runRepoShellCommand` returned stdout unconditionally whenever it was non-empty, discarding stderr and reporting `status: success`. So a command that partially failed — e.g. `cat dbt_project.yml missing.yml`, which prints the first file and errors on the second — handed the agent a partial result with **no signal** that anything was missing.

Verified live: driving the agent through the UI, `cat dbt_project.yml zzz_does_not_exist.yml` returned the full first file with no error and `metadata: {"status":"success"}`. The agent presented the partial output as complete.

Fix: append the stderr diagnostic when the command exits non-zero, clamping stdout first so the error note can't be the part that gets truncated away. Fully-failed commands (no stdout) still throw `ShellError`; `grep`-no-match (exit 1, empty stderr) still returns cleanly.

### 2. Exclude symlinks from the VFS tree (security hardening)

Git stores a symlink as a blob with mode `120000`. `getRepoTree` kept all blobs and discarded the mode, so a symlink entered the index as an ordinary file. The GitHub Contents API **follows** an in-repo symlink server-side and returns the *target's* content — so a symlink committed inside a scoped dbt `subPath` could be read to escape that scope and expose other parts of the same repo, downstream of every path guard in the VFS.

Fix: filter out mode-`120000` entries in `getRepoTree`. The git tree is the only layer that can still distinguish a symlink from a file (the Contents API response, once it has followed the link, cannot). A narrow residual remains on truncated (>100k-entry) repos, where the read-through bypasses the index — documented in a comment rather than left silent.

Scope notes: this is a confinement bypass, not a host compromise — the Contents API only follows symlinks to normal files **within the same repo**, and the App token already has whole-repo read access. It is also moot when `subPath` is `.` (no scope to escape).

## Testing

- New regression tests in `bashShell.test.ts` (partial-failure stderr) and `Github.test.ts` (`getRepoTree` symlink filter). Each was confirmed to fail without its fix and pass with it.
- Full sweep green: `github` + `repoFs` + `repoShell` suites (46 tests).

Relates to PROD-8175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)