### PR TITLE
feat(ai-writeback): add per-stage duration Prometheus histogram

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -517,6 +517,10 @@ export class AiWritebackService extends BaseService {
                 nextStage: stage,
                 durationMs: now - stageStartedAt,
             });
+            this.prometheusMetrics?.observeAiWritebackStageDuration(
+                failureStage,
+                now - stageStartedAt,
+            );
             failureStage = stage;
             stageStartedAt = now;
             // Stages can opt out of progress reporting by returning null

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -108,6 +108,9 @@ export default class PrometheusMetrics {
     public aiWritebackRunDurationHistogram: prometheus.Histogram<'status'> | null =
         null;
 
+    public aiWritebackStageDurationHistogram: prometheus.Histogram<'stage'> | null =
+        null;
+
     // Pre-aggregate metrics
     public preAggregateMatchCounter: prometheus.Counter<string> | null = null;
 
@@ -448,6 +451,22 @@ export default class PrometheusMetrics {
                         ...rest,
                     },
                 );
+
+                // Per-stage latency budget for a writeback run. The 'agent'
+                // stage is the time the in-sandbox agent spends working on the
+                // problem; the others (install/sandbox/clone/commit/push/
+                // pull_request) account for the surrounding pipeline.
+                this.aiWritebackStageDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'ai_writeback_stage_duration_ms',
+                        help: 'AI writeback per-stage duration in ms (install, sandbox, clone, agent, commit, push, pull_request)',
+                        labelNames: ['stage'],
+                        buckets: [
+                            100, 250, 500, 1000, 2500, 5000, 10000, 30000,
+                            60000, 120000, 240000, 480000, 900000,
+                        ],
+                        ...rest,
+                    });
 
                 // Initialize pre-aggregate metrics
                 this.preAggregateMatchCounter = new prometheus.Counter({
@@ -1124,6 +1143,10 @@ export default class PrometheusMetrics {
         status: 'success' | 'error',
     ) {
         this.aiWritebackRunDurationHistogram?.observe({ status }, durationMs);
+    }
+
+    public observeAiWritebackStageDuration(stage: string, durationMs: number) {
+        this.aiWritebackStageDurationHistogram?.observe({ stage }, durationMs);
     }
 
     public monitorEventMetrics(eventEmitter: EventEmitter) {


### PR DESCRIPTION
## What

Adds a new Prometheus histogram **`ai_writeback_stage_duration_ms{stage}`** that records the duration of each stage in the AI writeback pipeline:

```
install → sandbox → clone → agent → commit → push → pull_request
```

The `stage="agent"` series is the time the in-sandbox agent spends actually working on the problem; the others give a full per-stage latency budget for the run.

## Why

These per-stage durations were already computed in `setStage` and emitted to structured logs (`ai_writeback.run.stage`), but nothing reached Prometheus. As a result, the agent's working time — the single biggest contributor to writeback latency — wasn't visible in Prometheus / Cloud Monitoring, only in logs. The existing writeback metrics cover sandbox-create, per-compile, and end-to-end run, but not the stage breakdown.

This makes it possible to chart, e.g., a stacked p95-by-stage latency budget and immediately see whether a slow writeback is the agent thinking, the clone, or the compile-heavy agent stage.

## How

- `PrometheusMetrics.ts`: new `aiWritebackStageDurationHistogram` (labelled `stage`) + `observeAiWritebackStageDuration()`, mirroring the existing `ai_writeback_run_duration_ms` pattern.
- `AiWritebackService.ts`: one `observe()` call inside `setStage`, next to the existing stage-complete log. It reuses the duration already computed for the log line, so there is no additional measurement overhead.

## Testing

- `pnpm --filter backend typecheck` passes.
- No behavioural change — purely additive instrumentation gated on `prometheusMetrics` being present (no-op when metrics are disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)