### PR TITLE
chore(ai): finish proposeWriteback → editDbtProject rename leftovers

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
+++ b/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
@@ -69,7 +69,7 @@ export const getEditDbtProject = ({ editDbtProject }: Dependencies) =>
                 const prVerb = prAction === 'updated' ? 'Updated' : 'Opened';
                 const base = prUrl
                     ? `${prVerb} a pull request against ${target}. A "View pull request" button is shown to the user, so do NOT include the pull request URL or number in your reply — just summarise the change and which project/repository it targeted.\n\nAgent summary:\n${output}`
-                    : `The writeback agent ran against ${target} but made no file changes, so no pull request was opened.\n\nAgent summary:\n${output}`;
+                    : `Ran against ${target} but made no file changes, so no pull request was opened.\n\nAgent summary:\n${output}`;
 
                 // Deterministic offer: when the repo has no Lightdash
                 // preview-deploy GitHub Actions, instruct the assistant to

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -46,7 +46,7 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     listProjects: 'list_projects',
     getProjectInfo: 'get_project_info',
     proposeChange: 'propose_change',
-    editDbtProject: 'propose_writeback',
+    editDbtProject: 'edit_dbt_project',
     repoShell: 'repo_shell',
     setupPreviewDeploy: 'setup_preview_deploy',
 } satisfies Record<ToolName, string>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -537,7 +537,7 @@ export const proposeChangeToolDefinition = defineTool({
 
 export const editDbtProjectToolDefinition = defineTool({
     name: 'editDbtProject',
-    title: 'Propose writeback',
+    title: 'Edit dbt project',
     description: TOOL_EDIT_DBT_PROJECT_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolEditDbtProjectArgsSchema,


### PR DESCRIPTION
## Summary

Follow-up to #24095, which renamed the `proposeWriteback` tool to `editDbtProject` and reframed it as first-person. A post-merge review found three strings the rename missed:

- **Tool definition title** (`toolDefinitions.ts`) was still `'Propose writeback'` → now `'Edit dbt project'`, matching the sibling definitions' name/title pairing. The title is currently latent (the tool is `availability: ['agent']` only), so no runtime surface changes.
- **LLM-judge tool-name map** (`llmAsJudgeForTools.ts`) still listed `propose_writeback` in the judge's "[Available Tools]" prompt while recorded tool calls render the raw name — the judge saw an available tool that could never appear in the call log, skewing "expected tool not used" judgments. Now `edit_dbt_project`, consistent with its `repo_shell`/`setup_preview_deploy` neighbours.
- **No-changes tool result** (`editDbtProject.ts`) still narrated *"The writeback agent ran against …"* in the third person — exactly the personified framing #24095 set out to remove, in the one branch it missed. Now subject-less ("Ran against …"), matching the success branch's "Opened a pull request against …" style.

## Verification

- `common` and `backend` typecheck clean
- Tool-contract snapshot tests pass unchanged (the title/description contracts don't include these strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)