### PR TITLE
feat(metrics): Prometheus counter for repo VFS GitHub requests

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5053,6 +5053,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                                                 event.outcome,
                                             );
                                         }
+                                        // Track GitHub request volume per org/app
+                                        // installation to watch rate-limit usage.
+                                        this.prometheusMetrics?.incrementRepoFsGithubRequest(
+                                            {
+                                                organizationUuid,
+                                                installationId:
+                                                    access.installationId,
+                                                kind: event.kind,
+                                                outcome: event.outcome,
+                                            },
+                                        );
                                     },
                                 }),
                             ),

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -200,6 +200,7 @@ export class AiWritebackService extends BaseService {
         branch: string;
         token: string;
         subPath: string;
+        installationId: string;
     }> {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
@@ -257,6 +258,9 @@ export class AiWritebackService extends BaseService {
             // can't expose secrets/other files elsewhere in the repo. '.' (repo
             // root) means no scoping.
             subPath: connection.projectSubPath,
+            // Surfaced so callers can segment GitHub request metrics by the
+            // app installation whose rate-limit budget the reads consume.
+            installationId: installation.installationId,
         };
     }
 

--- a/packages/backend/src/ee/services/ai/repoFs/githubRepoSource.test.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/githubRepoSource.test.ts
@@ -1,5 +1,5 @@
 import { NotFoundError, UnexpectedGitError } from '@lightdash/common';
-import { getFileContent } from '../../../../clients/github/Github';
+import { getFileContent, getRepoTree } from '../../../../clients/github/Github';
 import {
     createGithubRepoSource,
     type RepoFsTimingCallback,
@@ -10,6 +10,8 @@ jest.mock('../../../../clients/github/Github');
 const mockGetFileContent = getFileContent as jest.MockedFunction<
     typeof getFileContent
 >;
+
+const mockGetRepoTree = getRepoTree as jest.MockedFunction<typeof getRepoTree>;
 
 const source = (onTiming?: RepoFsTimingCallback) =>
     createGithubRepoSource({
@@ -98,6 +100,26 @@ describe('githubRepoSource onTiming (metrics hook)', () => {
         ).rejects.toThrow();
         expect(onTiming).toHaveBeenCalledWith(
             expect.objectContaining({ kind: 'file', outcome: 'error' }),
+        );
+    });
+
+    it('reports tree outcome=success for a listed repo', async () => {
+        const onTiming = jest.fn();
+        mockGetRepoTree.mockResolvedValue({ files: [], truncated: false });
+        await source(onTiming).listAllPaths();
+        expect(onTiming).toHaveBeenCalledWith(
+            expect.objectContaining({ kind: 'tree', outcome: 'success' }),
+        );
+    });
+
+    it('reports tree outcome=error and re-throws on a failed tree fetch', async () => {
+        const onTiming = jest.fn();
+        mockGetRepoTree.mockRejectedValue(
+            new UnexpectedGitError('API rate limit exceeded'),
+        );
+        await expect(source(onTiming).listAllPaths()).rejects.toThrow();
+        expect(onTiming).toHaveBeenCalledWith(
+            expect.objectContaining({ kind: 'tree', outcome: 'error' }),
         );
     });
 });

--- a/packages/backend/src/ee/services/ai/repoFs/githubRepoSource.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/githubRepoSource.ts
@@ -8,7 +8,7 @@ import { RepoSource } from './RepoFs';
  * service) can record metrics without coupling this layer to Prometheus.
  */
 export type RepoFsTimingEvent =
-    | { kind: 'tree'; durationMs: number }
+    | { kind: 'tree'; durationMs: number; outcome: 'success' | 'error' }
     | {
           kind: 'file';
           durationMs: number;
@@ -52,12 +52,25 @@ export const createGithubRepoSource = ({
         label: `${owner}/${repo}@${branch}${root ? `/${root}` : ''}`,
         listAllPaths: async () => {
             const start = Date.now();
-            const { files, truncated } = await getRepoTree({
-                owner,
-                repo,
-                branch,
-                token,
-            });
+            let treeResult;
+            try {
+                treeResult = await getRepoTree({
+                    owner,
+                    repo,
+                    branch,
+                    token,
+                });
+            } catch (error) {
+                // Count the request even when it fails (e.g. rate limit) so the
+                // GitHub request metric reflects every round-trip, then rethrow.
+                onTiming?.({
+                    kind: 'tree',
+                    durationMs: Date.now() - start,
+                    outcome: 'error',
+                });
+                throw error;
+            }
+            const { files, truncated } = treeResult;
             const durationMs = Date.now() - start;
             Logger.info(
                 `[repoShell] github tree fetched in ${durationMs}ms (${
@@ -72,7 +85,7 @@ export const createGithubRepoSource = ({
                     durationMs,
                 },
             );
-            onTiming?.({ kind: 'tree', durationMs });
+            onTiming?.({ kind: 'tree', durationMs, outcome: 'success' });
             if (!root) return { files, truncated };
             const scoped = files
                 .filter((f) => f.path.startsWith(prefix))

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -98,6 +98,12 @@ export default class PrometheusMetrics {
     public repoFsGithubFileDurationHistogram: prometheus.Histogram<'outcome'> | null =
         null;
 
+    // repoShell GitHub API request volume, segmented by org/app installation so
+    // GitHub rate-limit consumption (per-installation budget) can be monitored.
+    public repoFsGithubRequestCounter: prometheus.Counter<
+        'organization_uuid' | 'installation_id' | 'kind' | 'outcome'
+    > | null = null;
+
     // AI writeback (E2B sandbox) latency
     public aiWritebackSandboxCreateDurationHistogram: prometheus.Histogram | null =
         null;
@@ -414,6 +420,18 @@ export default class PrometheusMetrics {
                         buckets: githubRequestBuckets,
                         ...rest,
                     });
+
+                this.repoFsGithubRequestCounter = new prometheus.Counter({
+                    name: 'ai_repofs_github_requests_total',
+                    help: 'Total repoShell (AI repo virtual filesystem) requests to the GitHub API, segmented by organization and app installation, to monitor rate-limit consumption',
+                    labelNames: [
+                        'organization_uuid',
+                        'installation_id',
+                        'kind',
+                        'outcome',
+                    ],
+                    ...rest,
+                });
 
                 // AI writeback (E2B sandbox) latency
                 this.aiWritebackSandboxCreateDurationHistogram =
@@ -1122,6 +1140,20 @@ export default class PrometheusMetrics {
             { outcome },
             durationMs,
         );
+    }
+
+    public incrementRepoFsGithubRequest(args: {
+        organizationUuid: string;
+        installationId: string;
+        kind: 'tree' | 'file';
+        outcome: string;
+    }) {
+        this.repoFsGithubRequestCounter?.inc({
+            organization_uuid: args.organizationUuid,
+            installation_id: args.installationId,
+            kind: args.kind,
+            outcome: args.outcome,
+        });
     }
 
     public observeAiWritebackSandboxCreateDuration(durationMs: number) {


### PR DESCRIPTION
## What & why

The AI repo virtual filesystem (`repoShell`) reads dbt source straight from GitHub via the Contents and Git Trees APIs using a GitHub **App installation** token. GitHub rate limits are scoped per installation, so a busy org's AI runs can quietly burn through the budget. Today we have latency histograms for those calls but no way to see **how many** requests we're making, segmented by which installation/org is consuming the budget.

This adds a Prometheus counter so we can keep an eye on rate-limit consumption.

## Changes

- **New metric** `ai_repofs_github_requests_total` (`PrometheusMetrics`) — a counter of GitHub API requests made by the repo VFS, with labels:
  - `organization_uuid` — the org driving the requests
  - `installation_id` — the GitHub App installation whose rate-limit budget is consumed
  - `kind` — `tree` (repo listing) or `file` (per-file read)
  - `outcome` — `success` / `found` / `missing` / `error` (so rate-limit `403`s show up as `outcome="error"`)
- Surface `installationId` from `AiWritebackService.getRepoReadAccess` so the call site can label by installation.
- Increment the counter from the existing `repoShell` `onTiming` hook in `AiAgentService` — no new plumbing through the generic GitHub client.
- Count the **tree** fetch even when it fails (previously `onTiming` only fired on success), so the metric reflects every round-trip including throttled ones.

## Example PromQL

```promql
# Request rate per installation (compare against the per-installation limit)
sum by (installation_id) (rate(ai_repofs_github_requests_total[5m]))

# Throttled / failed requests
sum by (organization_uuid) (rate(ai_repofs_github_requests_total{outcome="error"}[5m]))
```

## Testing

- `pnpm -F backend typecheck:fast` ✅
- Lint (with `--rulesdir eslint-rules`) ✅
- `githubRepoSource.test.ts` (added tree success/error cases) and `PrometheusMetrics.test.ts` ✅

---

Slack thread: https://lightdash.slack.com/archives/D0ACU3A32JZ/p1781047717924389?thread_ts=1780346683.189249&cid=D0ACU3A32JZ

https://claude.ai/code/session_01TAuG681Q7G89WA8jFYwj9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAuG681Q7G89WA8jFYwj9u)_