### PR TITLE
feat(mcp): add content-as-code tools

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -10,7 +10,9 @@ import {
     CommercialFeatureFlags,
     convertAiTableCalcsSchemaToTableCalcs,
     convertFieldRefToFieldId,
+    createContentToolDefinition,
     createToolRunSqlArgsSchema,
+    editContentToolDefinition,
     Explore,
     FeatureFlags,
     findContentToolDefinition,
@@ -42,6 +44,7 @@ import {
     ParameterError,
     QueryExecutionContext,
     QueryHistoryStatus,
+    readContentToolDefinition,
     readSkillResourceToolDefinition,
     readSkillToolDefinition,
     renderChartToolDefinition,
@@ -105,11 +108,14 @@ import {
     getMcpAnalystPromptWithContext,
     MCP_ANALYST_PROMPT,
 } from '../ai/prompts/mcpAnalyst';
+import { getCreateContent } from '../ai/tools/createContent';
+import { getEditContent } from '../ai/tools/editContent';
 import { getFindContent } from '../ai/tools/findContent';
 import { getFindExplores } from '../ai/tools/findExplores';
 import { getFindFields } from '../ai/tools/findFields';
 import { getListContent } from '../ai/tools/listContent';
 import { getMcpListExplores } from '../ai/tools/mcpListExplores';
+import { getReadContent } from '../ai/tools/readContent';
 import { validateRunQueryTool } from '../ai/tools/runQuery';
 import { getSearchFieldValues } from '../ai/tools/searchFieldValues';
 import { getPivotedResults } from '../ai/utils/getPivotedResults';
@@ -139,6 +145,9 @@ export enum McpToolName {
     FIND_FIELDS = 'find_fields',
     FIND_CONTENT = 'find_content',
     LIST_CONTENT = 'list_content',
+    READ_CONTENT = 'read_content',
+    CREATE_CONTENT = 'create_content',
+    EDIT_CONTENT = 'edit_content',
     LIST_PROJECTS = 'list_projects',
     SET_PROJECT = 'set_project',
     GET_CURRENT_PROJECT = 'get_current_project',
@@ -168,6 +177,9 @@ const mcpFindExploresTool = findExploresToolDefinition.for('mcp');
 const mcpFindFieldsTool = findFieldsToolDefinition.for('mcp');
 const mcpFindContentTool = findContentToolDefinition.for('mcp');
 const mcpListContentTool = listContentToolDefinition.for('mcp');
+const mcpReadContentTool = readContentToolDefinition.for('mcp');
+const mcpCreateContentTool = createContentToolDefinition.for('mcp');
+const mcpEditContentTool = editContentToolDefinition.for('mcp');
 const mcpListProjectsTool = mcpListProjectsToolDefinition.for('mcp');
 const mcpSetProjectTool = setProjectToolDefinition.for('mcp');
 const mcpGetCurrentProjectTool = getCurrentProjectToolDefinition.for('mcp');
@@ -1320,6 +1332,130 @@ export class McpService extends BaseService {
                     listContent: toolsRuntime.listContent,
                 });
                 const result = await listContentTool.execute!(argsWithProject, {
+                    toolCallId: '',
+                    messages: [],
+                });
+
+                return this.buildScopedResponse(
+                    ctx,
+                    await McpService.streamToolResult(result),
+                    undefined,
+                    projectUuid,
+                );
+            },
+        );
+
+        this.mcpServer.registerTool(
+            mcpReadContentTool.name,
+            {
+                title: mcpReadContentTool.title,
+                description: mcpReadContentTool.description,
+                inputSchema: this.getMcpCompatibleSchema(
+                    mcpReadContentTool.inputSchema,
+                ),
+                annotations: mcpReadContentTool.annotations,
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+                const projectUuid = await this.resolveProjectUuid(ctx);
+                const argsWithProject = { ...args, projectUuid };
+
+                this.trackToolCall(ctx, McpToolName.READ_CONTENT, projectUuid);
+
+                const toolsRuntime = await this.getToolsRuntime(
+                    ctx,
+                    projectUuid,
+                );
+
+                const readContentTool = getReadContent({
+                    readContent: toolsRuntime.readContent,
+                });
+                const result = await readContentTool.execute!(argsWithProject, {
+                    toolCallId: '',
+                    messages: [],
+                });
+
+                return this.buildScopedResponse(
+                    ctx,
+                    await McpService.streamToolResult(result),
+                    undefined,
+                    projectUuid,
+                );
+            },
+        );
+
+        this.mcpServer.registerTool(
+            mcpCreateContentTool.name,
+            {
+                title: mcpCreateContentTool.title,
+                description: mcpCreateContentTool.description,
+                inputSchema: this.getMcpCompatibleSchema(
+                    mcpCreateContentTool.inputSchema,
+                ),
+                annotations: mcpCreateContentTool.annotations,
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+                const projectUuid = await this.resolveProjectUuid(ctx);
+                const argsWithProject = { ...args, projectUuid };
+
+                this.trackToolCall(
+                    ctx,
+                    McpToolName.CREATE_CONTENT,
+                    projectUuid,
+                );
+
+                const toolsRuntime = await this.getToolsRuntime(
+                    ctx,
+                    projectUuid,
+                );
+
+                const createContentTool = getCreateContent({
+                    createContent: toolsRuntime.createContent,
+                });
+                const result = await createContentTool.execute!(
+                    argsWithProject,
+                    {
+                        toolCallId: '',
+                        messages: [],
+                    },
+                );
+
+                return this.buildScopedResponse(
+                    ctx,
+                    await McpService.streamToolResult(result),
+                    undefined,
+                    projectUuid,
+                );
+            },
+        );
+
+        this.mcpServer.registerTool(
+            mcpEditContentTool.name,
+            {
+                title: mcpEditContentTool.title,
+                description: mcpEditContentTool.description,
+                inputSchema: this.getMcpCompatibleSchema(
+                    mcpEditContentTool.inputSchema,
+                ),
+                annotations: mcpEditContentTool.annotations,
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+                const projectUuid = await this.resolveProjectUuid(ctx);
+                const argsWithProject = { ...args, projectUuid };
+
+                this.trackToolCall(ctx, McpToolName.EDIT_CONTENT, projectUuid);
+
+                const toolsRuntime = await this.getToolsRuntime(
+                    ctx,
+                    projectUuid,
+                );
+
+                const editContentTool = getEditContent({
+                    editContent: toolsRuntime.editContent,
+                });
+                const result = await editContentTool.execute!(argsWithProject, {
                     toolCallId: '',
                     messages: [],
                 });

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -277,6 +277,248 @@ Usage tips:
     },
     {
       "agentName": null,
+      "description": "Read a dashboard or chart as JSON using its slug. Call this before editing.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "slug": {
+            "description": "Slug of the dashboard or chart to read.",
+            "minLength": 1,
+            "type": "string",
+          },
+          "type": {
+            "description": "Type of Lightdash content to read.",
+            "enum": [
+              "dashboard",
+              "chart",
+            ],
+            "type": "string",
+          },
+        },
+        "required": [
+          "slug",
+          "type",
+        ],
+        "type": "object",
+      },
+      "name": "read_content",
+      "title": "Read content",
+    },
+    {
+      "agentName": null,
+      "description": "Create a new dashboard or chart, consult the skills for the required fields. Returns the created content with the final persisted slug.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "description": "Full Dashboard JSON to create.",
+                "properties": {
+                  "config": {},
+                  "contentType": {
+                    "type": "string",
+                  },
+                  "description": {
+                    "description": ", ",
+                    "type": "string",
+                  },
+                  "downloadedAt": {},
+                  "filters": {},
+                  "name": {
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "parameters": {},
+                  "slug": {
+                    "description": "Requested slug. Lightdash may append a suffix if this slug already exists.",
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "spaceSlug": {
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "tabs": {
+                    "items": {},
+                    "type": "array",
+                  },
+                  "tiles": {
+                    "items": {},
+                    "type": "array",
+                  },
+                  "updatedAt": {},
+                  "verification": {},
+                  "verified": {
+                    "type": "boolean",
+                  },
+                  "version": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "slug",
+                  "name",
+                  "spaceSlug",
+                  "version",
+                  "contentType",
+                  "verified",
+                  "tiles",
+                  "tabs",
+                ],
+                "type": "object",
+              },
+              {
+                "additionalProperties": true,
+                "description": "Full Chart JSON to create.",
+                "properties": {
+                  "chartConfig": {},
+                  "contentType": {
+                    "type": "string",
+                  },
+                  "dashboardSlug": {
+                    "type": "string",
+                  },
+                  "description": {
+                    "description": ", ",
+                    "type": "string",
+                  },
+                  "downloadedAt": {},
+                  "metricQuery": {
+                    "additionalProperties": true,
+                    "description": "Chart-as-code metricQuery object. Required fields: exploreName, dimensions, metrics, filters, sorts, limit, tableCalculations. Optional passthrough fields: additionalMetrics, customDimensions, metricOverrides, dimensionOverrides, timezone, pivotDimensions, metadata. Every dimension in dimensions must appear in exactly one of: layout.xField, layout.yField, or pivotConfig.columns.",
+                    "properties": {
+                      "dimensions": {
+                        "items": {},
+                        "type": "array",
+                      },
+                      "exploreName": {},
+                      "filters": {},
+                      "limit": {},
+                      "metrics": {
+                        "items": {},
+                        "type": "array",
+                      },
+                      "sorts": {
+                        "items": {},
+                        "type": "array",
+                      },
+                      "tableCalculations": {
+                        "items": {},
+                        "type": "array",
+                      },
+                    },
+                    "required": [
+                      "dimensions",
+                      "metrics",
+                      "sorts",
+                      "tableCalculations",
+                    ],
+                    "type": "object",
+                  },
+                  "name": {
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "parameters": {},
+                  "pivotConfig": {},
+                  "slug": {
+                    "description": "Requested slug. Lightdash may append a suffix if this slug already exists.",
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "spaceSlug": {
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "tableConfig": {},
+                  "tableName": {
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "updatedAt": {},
+                  "verification": {},
+                  "verified": {
+                    "type": "boolean",
+                  },
+                  "version": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "slug",
+                  "name",
+                  "spaceSlug",
+                  "version",
+                  "contentType",
+                  "verified",
+                  "tableName",
+                  "metricQuery",
+                  "dashboardSlug",
+                ],
+                "type": "object",
+              },
+            ],
+          },
+          "type": {
+            "description": "Type of Lightdash content to create.",
+            "enum": [
+              "dashboard",
+              "chart",
+            ],
+            "type": "string",
+          },
+        },
+        "required": [
+          "type",
+          "content",
+        ],
+        "type": "object",
+      },
+      "name": "create_content",
+      "title": "Create content",
+    },
+    {
+      "agentName": null,
+      "description": "Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "patch": {
+            "description": "RFC6902 Patch objects array to apply to the current dashboard or chart JSON",
+            "items": {},
+            "type": "array",
+          },
+          "slug": {
+            "description": "Slug of the dashboard or chart to edit",
+            "minLength": 1,
+            "type": "string",
+          },
+          "type": {
+            "description": "Type of Lightdash content to edit",
+            "enum": [
+              "dashboard",
+              "chart",
+            ],
+            "type": "string",
+          },
+        },
+        "required": [
+          "slug",
+          "type",
+          "patch",
+        ],
+        "type": "object",
+      },
+      "name": "edit_content",
+      "title": "Edit content",
+    },
+    {
+      "agentName": null,
       "description": "List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -7829,6 +8071,9 @@ exports[`MCP tool contracts matches the shared MCP tool definition names snapsho
   "run_sql",
   "get_query_result",
   "render_chart",
+  "read_content",
+  "edit_content",
+  "create_content",
   "list_content",
   "get_lightdash_version",
   "list_explores",

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -440,27 +440,39 @@ export const readContentToolDefinition = defineTool({
     name: 'readContent',
     title: 'Read content',
     description: TOOL_READ_CONTENT_DESCRIPTION,
-    availability: ['agent'],
+    availability: ['agent', 'mcp'],
     inputSchema: toolReadContentArgsSchema,
     agent: { outputSchema: toolReadContentOutputSchema },
+    mcp: {
+        name: 'read_content',
+        annotations: readOnlyAnnotations,
+    },
 });
 
 export const editContentToolDefinition = defineTool({
     name: 'editContent',
     title: 'Edit content',
     description: TOOL_EDIT_CONTENT_DESCRIPTION,
-    availability: ['agent'],
+    availability: ['agent', 'mcp'],
     inputSchema: toolEditContentArgsSchema,
     agent: { outputSchema: toolEditContentOutputSchema },
+    mcp: {
+        name: 'edit_content',
+        annotations: writeAnnotations,
+    },
 });
 
 export const createContentToolDefinition = defineTool({
     name: 'createContent',
     title: 'Create content',
     description: TOOL_CREATE_CONTENT_DESCRIPTION,
-    availability: ['agent'],
+    availability: ['agent', 'mcp'],
     inputSchema: toolCreateContentArgsSchema,
     agent: { outputSchema: toolCreateContentOutputSchema },
+    mcp: {
+        name: 'create_content',
+        annotations: writeAnnotations,
+    },
 });
 
 export const runContentQueryToolDefinition = defineTool({


### PR DESCRIPTION
Stacked on [#23907](https://github.com/lightdash/lightdash/pull/23907).

Related ZAP-384
Closes ZAP-422
Closes #23307

## Summary
- Add MCP `read_content`, `create_content`, and `edit_content` tools for chart/dashboard content-as-code workflows.
- Accept the existing chart/dashboard-as-code payloads so agents can create or modify full Lightdash content instead of narrow chart schemas.
- Reuse `AiAgentToolsService` runtime so MCP shares AI-agent validation, CoderService permissions, active project context, and content URLs.

## Testing
- `pnpm -F common build`
- `pnpm -F backend typecheck:fast`
- `pnpm -F common typecheck:fast`
- `pnpm -F backend exec jest --config jest.config.js --runTestsByPath src/ee/services/McpService/mcpToolContracts.snapshot.test.ts`
