### PR TITLE
feat: per-org CORS settings with dynamic allow-list

### DIFF
--- a/examples/api/cors.http
+++ b/examples/api/cors.http
@@ -1,0 +1,8 @@
+### Test cors 
+// 1. Save new allowed origin on settings/embed/cors 
+// 2. Run this request from a different origin 
+// 3. Confirm it appears the domain under `Access-Control-Allow-Origin` header in the response
+GET http://localhost:3000/api/v1/health
+Content-Type: application/json
+Origin: https://example.com
+

--- a/packages/api-tests/tests/cors.test.ts
+++ b/packages/api-tests/tests/cors.test.ts
@@ -1,0 +1,107 @@
+import {
+    type ApiOrganizationSettingsResponse,
+    type UpdateOrganizationSettings,
+} from '@lightdash/common';
+import { SITE_URL } from '../helpers/api-client';
+import { login } from '../helpers/auth';
+
+const getCorsResponse = async (origin: string): Promise<Response> =>
+    fetch(`${SITE_URL}/api/v1/health`, {
+        headers: { Origin: origin },
+    });
+
+describe('CORS policy', () => {
+    let admin: Awaited<ReturnType<typeof login>>;
+    let originalCorsAllowedDomains: string[] = [];
+
+    beforeAll(async () => {
+        admin = await login();
+        const originalSettings =
+            await admin.get<ApiOrganizationSettingsResponse>(
+                '/api/v1/org/settings',
+            );
+        expect(originalSettings.status).toBe(200);
+        originalCorsAllowedDomains =
+            originalSettings.body.results.corsAllowedDomains ?? [];
+    });
+
+    afterAll(async () => {
+        if (!admin) {
+            return;
+        }
+
+        await admin.patch<ApiOrganizationSettingsResponse>(
+            '/api/v1/org/settings',
+            {
+                corsAllowedDomains: originalCorsAllowedDomains,
+            } satisfies UpdateOrganizationSettings,
+        );
+    });
+
+    it('uses updated org CORS settings immediately after invalidating the cache', async () => {
+        const runId = Date.now();
+        const exactOrigin = `https://cors-exact-${runId}.example.com`;
+        const regexOrigin = `https://app.cors-regex-${runId}.example.com`;
+        const unknownOrigin = `https://unknown-cors-${runId}.example.com`;
+        const regexPattern = `/^https:\\/\\/.*\\.cors-regex-${runId}\\.example\\.com$/`;
+
+        const warmCacheResponse = await getCorsResponse(exactOrigin);
+        expect(warmCacheResponse.status).toBe(200);
+        expect(
+            warmCacheResponse.headers.get('access-control-allow-origin'),
+        ).toBeNull();
+
+        const updateSettings =
+            await admin.patch<ApiOrganizationSettingsResponse>(
+                '/api/v1/org/settings',
+                {
+                    corsAllowedDomains: [exactOrigin, regexPattern],
+                } satisfies UpdateOrganizationSettings,
+            );
+        expect(updateSettings.status).toBe(200);
+        expect(updateSettings.body.results.corsAllowedDomains).toEqual([
+            exactOrigin,
+            regexPattern,
+        ]);
+
+        const exactResponse = await getCorsResponse(exactOrigin);
+        expect(exactResponse.status).toBe(200);
+        expect(exactResponse.headers.get('access-control-allow-origin')).toBe(
+            exactOrigin,
+        );
+
+        const regexResponse = await getCorsResponse(regexOrigin);
+        expect(regexResponse.status).toBe(200);
+        expect(regexResponse.headers.get('access-control-allow-origin')).toBe(
+            regexOrigin,
+        );
+
+        const unknownResponse = await getCorsResponse(unknownOrigin);
+        expect(unknownResponse.status).toBe(200);
+        expect(
+            unknownResponse.headers.get('access-control-allow-origin'),
+        ).toBeNull();
+
+        const secondExactResponse = await getCorsResponse(exactOrigin);
+        expect(secondExactResponse.status).toBe(200);
+        expect(
+            secondExactResponse.headers.get('access-control-allow-origin'),
+        ).toBe(exactOrigin);
+
+        const removeSettings =
+            await admin.patch<ApiOrganizationSettingsResponse>(
+                '/api/v1/org/settings',
+                {
+                    corsAllowedDomains: [],
+                } satisfies UpdateOrganizationSettings,
+            );
+        expect(removeSettings.status).toBe(200);
+        expect(removeSettings.body.results.corsAllowedDomains).toEqual([]);
+
+        const removedExactResponse = await getCorsResponse(exactOrigin);
+        expect(removedExactResponse.status).toBe(200);
+        expect(
+            removedExactResponse.headers.get('access-control-allow-origin'),
+        ).toBeNull();
+    });
+});

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -72,6 +72,7 @@ import { SchedulerWorker } from './scheduler/SchedulerWorker';
 import { SchedulerWorkerHealth } from './scheduler/SchedulerWorkerHealth';
 import { createOrganizationNameResolver } from './sentry/organizationNameResolver';
 import { InstanceConfigurationService } from './services/InstanceConfigurationService/InstanceConfigurationService';
+import { createCorsOptionsDelegate } from './services/OrganizationSettingsService/CorsPolicy';
 import {
     OperationContext,
     ServiceProviderMap,
@@ -334,37 +335,15 @@ export default class App {
         // Cross-Origin Resource Sharing policy (CORS)
         // WARNING: this middleware should be mounted before the helmet middleware
         // (ideally at the top of the middleware stack)
-        if (
-            this.lightdashConfig.security.crossOriginResourceSharingPolicy
-                .enabled &&
-            this.lightdashConfig.security.crossOriginResourceSharingPolicy
-                .allowedDomains.length > 0
-        ) {
-            const allowedOrigins: Array<string | RegExp> = [
-                this.lightdashConfig.siteUrl,
-            ];
-
-            for (const allowedDomain of this.lightdashConfig.security
-                .crossOriginResourceSharingPolicy.allowedDomains) {
-                if (
-                    allowedDomain.startsWith('/') &&
-                    allowedDomain.endsWith('/')
-                ) {
-                    allowedOrigins.push(new RegExp(allowedDomain.slice(1, -1)));
-                } else {
-                    allowedOrigins.push(allowedDomain);
-                }
-            }
-
-            expressApp.use(
-                cors({
-                    methods: 'OPTIONS, GET, HEAD, PUT, PATCH, POST, DELETE',
-                    allowedHeaders: '*',
-                    credentials: false,
-                    origin: allowedOrigins,
+        expressApp.use(
+            cors(
+                createCorsOptionsDelegate({
+                    lightdashConfig: this.lightdashConfig,
+                    organizationSettingsModel:
+                        this.models.getOrganizationSettingsModel(),
                 }),
-            );
-        }
+            ),
+        );
 
         const KnexSessionStore = connectSessionKnex(expressSession);
 

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -264,7 +264,7 @@ export const lightdashConfigMock: LightdashConfig = {
             frameAncestors: [],
         },
         crossOriginResourceSharingPolicy: {
-            enabled: false,
+            enabled: true,
             allowedDomains: [],
         },
     },

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -797,6 +797,35 @@ describe('getUpdateSetupConfig userAttributes', () => {
     });
 });
 
+describe('process.env.LIGHTDASH_CORS_ENABLED', () => {
+    test('defaults CORS to enabled when not set', () => {
+        process.env.LIGHTDASH_CORS_ALLOWED_DOMAINS = 'https://example.com';
+
+        const config = parseConfig();
+
+        expect(config.security.crossOriginResourceSharingPolicy.enabled).toBe(
+            true,
+        );
+        expect(
+            config.security.crossOriginResourceSharingPolicy.allowedDomains,
+        ).toEqual(['https://example.com']);
+    });
+
+    test('disables CORS only when explicitly false', () => {
+        process.env.LIGHTDASH_CORS_ENABLED = 'false';
+        process.env.LIGHTDASH_CORS_ALLOWED_DOMAINS = 'https://example.com';
+
+        const config = parseConfig();
+
+        expect(config.security.crossOriginResourceSharingPolicy.enabled).toBe(
+            false,
+        );
+        expect(
+            config.security.crossOriginResourceSharingPolicy.allowedDomains,
+        ).toEqual([]);
+    });
+});
+
 describe('parseAndSanitizeSchedulerTasks', () => {
     beforeEach(() => {
         // Clear scheduler environment variables before each test

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1789,7 +1789,7 @@ export const parseConfig = (): LightdashConfig => {
         'LIGHTDASH_CORS_ALLOWED_DOMAINS',
     );
     const iframeEmbeddingEnabled = iframeAllowedDomains.length > 0;
-    const corsEnabled = process.env.LIGHTDASH_CORS_ENABLED === 'true';
+    const corsEnabled = process.env.LIGHTDASH_CORS_ENABLED !== 'false';
     const secureCookies = process.env.SECURE_COOKIES === 'true';
     const useSecureBrowser = process.env.USE_SECURE_BROWSER === 'true';
     const browserProtocol = useSecureBrowser ? 'wss' : 'ws';

--- a/packages/backend/src/database/entities/organizationSettings.ts
+++ b/packages/backend/src/database/entities/organizationSettings.ts
@@ -28,6 +28,8 @@ export type DbOrganizationSettings = {
     // (LIGHTDASH_QUERY_MAX_LIMIT / LIGHTDASH_CSV_CELLS_LIMIT).
     query_limit: number | null;
     csv_cells_limit: number | null;
+    // Per-org CORS entries. NULL/absent resolves to no org domains.
+    cors_allowed_domains: string[] | null;
     created_at: Date;
     updated_at: Date;
 };

--- a/packages/backend/src/database/migrations/20260610120000_add_cors_settings_to_organization_settings.ts
+++ b/packages/backend/src/database/migrations/20260610120000_add_cors_settings_to_organization_settings.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+const ORGANIZATION_SETTINGS_TABLE = 'organization_settings';
+const CORS_ALLOWED_DOMAINS_COLUMN = 'cors_allowed_domains';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ORGANIZATION_SETTINGS_TABLE, (table) => {
+        table.specificType(CORS_ALLOWED_DOMAINS_COLUMN, 'text[]').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ORGANIZATION_SETTINGS_TABLE, (table) => {
+        table.dropColumn(CORS_ALLOWED_DOMAINS_COLUMN);
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12702,17 +12702,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -12741,7 +12741,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12749,7 +12749,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12764,7 +12768,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12772,11 +12776,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12828,11 +12828,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12983,17 +12983,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -13172,40 +13172,6 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
-                                                                explore: {
-                                                                    dataType:
-                                                                        'nestedObjectLiteral',
-                                                                    nestedProperties:
-                                                                        {
-                                                                            joinedTables:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                    },
-                                                                                    required: true,
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                        },
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13214,6 +13180,26 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
                                                                                 isFromJoinedTable:
                                                                                     {
                                                                                         dataType:
@@ -13250,36 +13236,16 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                                 fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                description:
+                                                                                fieldValueType:
                                                                                     {
                                                                                         dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
+                                                                                            'string',
                                                                                         required: true,
                                                                                     },
                                                                                 fieldType:
@@ -13292,14 +13258,14 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'metric',
+                                                                                                        'dimension',
                                                                                                     ],
                                                                                                 },
                                                                                                 {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'dimension',
+                                                                                                        'metric',
                                                                                                     ],
                                                                                                 },
                                                                                             ],
@@ -13330,6 +13296,40 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
+                                                                explore: {
+                                                                    dataType:
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                        },
+                                                                    required: true,
+                                                                },
                                                                 status: {
                                                                     dataType:
                                                                         'enum',
@@ -13358,17 +13358,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -13482,15 +13482,15 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
+                                                href: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 warnings: {
                                                     dataType: 'array',
                                                     array: {
                                                         dataType: 'string',
                                                     },
-                                                    required: true,
-                                                },
-                                                href: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 slug: {
@@ -13502,31 +13502,12 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 name: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                    ],
+                                                uuid: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -13591,27 +13572,25 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
-                                                prAction: {
+                                                status: {
                                                     dataType: 'union',
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['opened'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['updated'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
+                                                            enums: ['success'],
                                                         },
                                                     ],
+                                                    required: true,
                                                 },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
                                                 steps: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13672,6 +13651,27 @@ const models: TsoaRoute.Models = {
                                                                         },
                                                                     },
                                                             },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
+                                                prAction: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['opened'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['updated'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13872,25 +13872,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13951,6 +13932,11 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
@@ -13962,13 +13948,27 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -13980,14 +13980,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
@@ -14013,11 +14013,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -28119,7 +28119,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28129,7 +28129,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28139,7 +28139,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28152,7 +28152,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -28807,7 +28807,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28817,7 +28817,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28827,7 +28827,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28840,7 +28840,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -30400,6 +30400,14 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                corsAllowedDomains: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 csvCellsLimit: {
                     dataType: 'union',
                     subSchemas: [
@@ -30578,6 +30586,14 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                corsAllowedDomains: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'enum', enums: [null] },
                         { dataType: 'undefined' },
                     ],

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14122,10 +14122,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -14134,8 +14134,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -14145,16 +14145,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -14184,8 +14184,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -14247,10 +14247,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -14259,8 +14259,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -14355,6 +14355,66 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "description",
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldFilterType",
+                                                                                "fieldValueType",
+                                                                                "fieldType",
+                                                                                "table",
+                                                                                "fieldId",
+                                                                                "label",
+                                                                                "name"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "joinedTables": {
@@ -14381,66 +14441,6 @@
                                                                         ],
                                                                         "type": "object"
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
-                                                                                "fieldValueType",
-                                                                                "fieldFilterType",
-                                                                                "description",
-                                                                                "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
-                                                                                "label",
-                                                                                "name"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -14451,8 +14451,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "explore",
                                                                     "fields",
+                                                                    "explore",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14465,10 +14465,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -14476,8 +14476,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "exploreLabel",
                                                                                 "reason",
+                                                                                "exploreLabel",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -14551,14 +14551,14 @@
                                                         ],
                                                         "type": "object"
                                                     },
+                                                    "href": {
+                                                        "type": "string"
+                                                    },
                                                     "warnings": {
                                                         "items": {
                                                             "type": "string"
                                                         },
                                                         "type": "array"
-                                                    },
-                                                    "href": {
-                                                        "type": "string"
                                                     },
                                                     "slug": {
                                                         "type": "string"
@@ -14568,35 +14568,26 @@
                                                         "enum": ["success"],
                                                         "nullable": false
                                                     },
-                                                    "uuid": {
+                                                    "name": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
+                                                    "uuid": {
                                                         "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "warnings",
                                                     "href",
+                                                    "warnings",
                                                     "slug",
                                                     "status",
-                                                    "uuid",
-                                                    "name"
+                                                    "name",
+                                                    "uuid"
                                                 ],
                                                 "type": "object"
                                             },
                                             {
                                                 "properties": {
-                                                    "prAction": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "opened",
-                                                            "updated",
-                                                            null
-                                                        ],
-                                                        "nullable": true
-                                                    },
                                                     "steps": {
                                                         "items": {
                                                             "properties": {
@@ -14621,6 +14612,15 @@
                                                             "type": "object"
                                                         },
                                                         "type": "array",
+                                                        "nullable": true
+                                                    },
+                                                    "prAction": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "opened",
+                                                            "updated",
+                                                            null
+                                                        ],
                                                         "nullable": true
                                                     },
                                                     "prUrl": {
@@ -14702,10 +14702,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -14722,39 +14718,43 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
                                                                             "type": "string"
-                                                                        },
-                                                                        "name": {
-                                                                            "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
+                                                                        "name",
                                                                         "tableName",
-                                                                        "label",
-                                                                        "name"
+                                                                        "label"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": "array"
                                                             },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
+                                                            "searchQuery",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -14762,8 +14762,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -28904,22 +28904,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -29479,22 +29479,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -30968,6 +30968,14 @@
             },
             "OrganizationSettings": {
                 "properties": {
+                    "corsAllowedDomains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true,
+                        "description": "Exact origins, wildcard subdomain origins, and regex patterns this org\ncontributes to the instance CORS allow-list. Regex entries use `/.../`\nsyntax."
+                    },
                     "csvCellsLimit": {
                         "type": "number",
                         "format": "double",
@@ -31027,6 +31035,7 @@
                     }
                 },
                 "required": [
+                    "corsAllowedDomains",
                     "csvCellsLimit",
                     "queryLimit",
                     "scheduledDeliveryExpirationSecondsGoogleChat",
@@ -31113,6 +31122,14 @@
                         "format": "double",
                         "nullable": true,
                         "description": "Max number of cells (rows × columns) a CSV/Excel export may contain for\nthis org. Inherits `LIGHTDASH_CSV_CELLS_LIMIT` and is capped by\n`LIGHTDASH_CSV_MAX_LIMIT` (the ceiling); `null` inherits the\ndefault. Always resolved to an effective number in API responses."
+                    },
+                    "corsAllowedDomains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true,
+                        "description": "Exact origins, wildcard subdomain origins, and regex patterns this org\ncontributes to the instance CORS allow-list. Regex entries use `/.../`\nsyntax."
                     }
                 },
                 "type": "object",
@@ -38392,7 +38409,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3126.2",
+        "version": "0.3128.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/OrganizationSettingsModel.test.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.test.ts
@@ -51,6 +51,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
                 queryLimit: null,
                 csvCellsLimit: null,
+                corsAllowedDomains: null,
             });
         });
 
@@ -74,6 +75,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
                 queryLimit: null,
                 csvCellsLimit: null,
+                corsAllowedDomains: null,
             });
         });
 
@@ -94,6 +96,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
                 queryLimit: null,
                 csvCellsLimit: null,
+                corsAllowedDomains: null,
             });
         });
 
@@ -116,7 +119,65 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
                 queryLimit: null,
                 csvCellsLimit: null,
+                corsAllowedDomains: null,
             });
+        });
+
+        test('maps the CORS columns', async () => {
+            const { model } = createModel({
+                cors_allowed_domains: [
+                    'https://app.example.com',
+                    '/^https:\\/\\/.*\\.example\\.com$/',
+                ],
+            });
+            expect(await model.get(ORG)).toEqual({
+                oidcLinkingEnabled: null,
+                oidcToEmailLinkingEnabled: null,
+                supportImpersonationEnabled: null,
+                scheduledDeliveryExpirationSeconds: null,
+                scheduledDeliveryExpirationSecondsEmail: null,
+                scheduledDeliveryExpirationSecondsSlack: null,
+                scheduledDeliveryExpirationSecondsMsTeams: null,
+                scheduledDeliveryExpirationSecondsGoogleChat: null,
+                queryLimit: null,
+                csvCellsLimit: null,
+                corsAllowedDomains: [
+                    'https://app.example.com',
+                    '/^https:\\/\\/.*\\.example\\.com$/',
+                ],
+            });
+        });
+    });
+
+    describe('getAllEnabledCorsAllowedDomains', () => {
+        test('returns a flattened list of domains from org rows with CORS entries', async () => {
+            const rows = [
+                {
+                    cors_allowed_domains: [
+                        'https://app.example.com',
+                        '/^https:\\/\\/.*\\.example\\.com$/',
+                    ],
+                },
+                { cors_allowed_domains: ['https://embed.example.com'] },
+            ];
+            const builder: Record<string, jest.Mock> = {};
+            Object.assign(builder, {
+                select: jest.fn(() => builder),
+                whereNotNull: jest.fn(async () => rows),
+            });
+            const database = jest.fn(() => builder) as unknown as Knex;
+            const model = new OrganizationSettingsModel({ database });
+
+            await expect(
+                model.getAllEnabledCorsAllowedDomains(),
+            ).resolves.toEqual([
+                'https://app.example.com',
+                '/^https:\\/\\/.*\\.example\\.com$/',
+                'https://embed.example.com',
+            ]);
+            expect(builder.whereNotNull).toHaveBeenCalledWith(
+                'cors_allowed_domains',
+            );
         });
     });
 
@@ -158,6 +219,7 @@ describe('OrganizationSettingsModel', () => {
                 scheduledDeliveryExpirationSecondsGoogleChat: null,
                 queryLimit: null,
                 csvCellsLimit: null,
+                corsAllowedDomains: null,
             });
         });
 
@@ -206,6 +268,37 @@ describe('OrganizationSettingsModel', () => {
             expect(captured.merge).not.toHaveProperty('oidc_linking_enabled');
         });
 
+        test('writes the CORS columns when provided', async () => {
+            const { model, captured } = createModel({
+                cors_allowed_domains: [
+                    'https://app.example.com',
+                    '/^https:\\/\\/.*\\.example\\.com$/',
+                ],
+            });
+
+            await model.update(ORG, {
+                corsAllowedDomains: [
+                    'https://app.example.com',
+                    '/^https:\\/\\/.*\\.example\\.com$/',
+                ],
+            });
+
+            expect(captured.insert).toEqual({
+                organization_uuid: ORG,
+                cors_allowed_domains: [
+                    'https://app.example.com',
+                    '/^https:\\/\\/.*\\.example\\.com$/',
+                ],
+            });
+            expect(captured.merge).toMatchObject({
+                cors_allowed_domains: [
+                    'https://app.example.com',
+                    '/^https:\\/\\/.*\\.example\\.com$/',
+                ],
+            });
+            expect(captured.merge).not.toHaveProperty('oidc_linking_enabled');
+        });
+
         test('updating multiple settings writes all provided columns', async () => {
             const { model, captured } = createModel({
                 oidc_linking_enabled: true,
@@ -244,6 +337,7 @@ describe('OrganizationSettingsModel', () => {
             expect(captured.merge).not.toHaveProperty(
                 'scheduled_delivery_expiration_seconds_slack',
             );
+            expect(captured.merge).not.toHaveProperty('cors_allowed_domains');
             expect(captured.merge?.updated_at).toBeInstanceOf(Date);
             expect(captured.insert).toEqual({ organization_uuid: ORG });
         });

--- a/packages/backend/src/models/OrganizationSettingsModel.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.ts
@@ -58,7 +58,16 @@ export class OrganizationSettingsModel {
                 row?.scheduled_delivery_expiration_seconds_googlechat ?? null,
             queryLimit: row?.query_limit ?? null,
             csvCellsLimit: row?.csv_cells_limit ?? null,
+            corsAllowedDomains: row?.cors_allowed_domains ?? null,
         };
+    }
+
+    async getAllEnabledCorsAllowedDomains(): Promise<string[]> {
+        const rows = await this.database(OrganizationSettingsTableName)
+            .select('cors_allowed_domains')
+            .whereNotNull('cors_allowed_domains');
+
+        return rows.flatMap((row) => row.cors_allowed_domains ?? []);
     }
 
     /**
@@ -86,6 +95,7 @@ export class OrganizationSettingsModel {
                 patch.scheduledDeliveryExpirationSecondsGoogleChat,
             query_limit: patch.queryLimit,
             csv_cells_limit: patch.csvCellsLimit,
+            cors_allowed_domains: patch.corsAllowedDomains,
         };
         const toWrite = omitBy(
             columns,

--- a/packages/backend/src/services/OrganizationSettingsService/CorsPolicy.test.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/CorsPolicy.test.ts
@@ -1,0 +1,266 @@
+import cors from 'cors';
+import { type Request, type Response } from 'express';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { type OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
+import {
+    createCorsOptionsDelegate,
+    invalidateCorsPolicyCache,
+} from './CorsPolicy';
+
+const getCorsHeaders = async ({
+    origin,
+    method = 'GET',
+    dbAllowedDomains,
+    dbError,
+    envAllowedDomains = [],
+    envEnabled = true,
+}: {
+    origin?: string;
+    method?: string;
+    dbAllowedDomains: string[];
+    dbError?: Error;
+    envAllowedDomains?: string[];
+    envEnabled?: boolean;
+}) => {
+    invalidateCorsPolicyCache();
+    const organizationSettingsModel = {
+        getAllEnabledCorsAllowedDomains: jest.fn(async () => {
+            if (dbError) {
+                throw dbError;
+            }
+            return dbAllowedDomains;
+        }),
+    } as unknown as OrganizationSettingsModel;
+    const lightdashConfig = {
+        ...lightdashConfigMock,
+        siteUrl: 'https://lightdash.example.com',
+        security: {
+            ...lightdashConfigMock.security,
+            crossOriginResourceSharingPolicy: {
+                enabled: envEnabled,
+                allowedDomains: envAllowedDomains,
+            },
+        },
+    };
+
+    const headers = new Map<string, string>();
+    const req = {
+        method,
+        headers: {
+            ...(origin ? { origin } : {}),
+            'access-control-request-method': 'GET',
+        },
+    } as unknown as Request;
+    const next = jest.fn();
+
+    let res!: Response;
+    await new Promise<void>((resolve, reject) => {
+        res = {
+            getHeader: jest.fn((key: string) => headers.get(key)),
+            setHeader: jest.fn((key: string, value: string) => {
+                headers.set(key, value);
+            }),
+            end: jest.fn(() => resolve()),
+        } as unknown as Response;
+
+        cors(
+            createCorsOptionsDelegate({
+                lightdashConfig,
+                organizationSettingsModel,
+            }),
+        )(req, res, (error?: unknown) => {
+            if (error) reject(error);
+            next(error);
+            resolve();
+        });
+    });
+
+    return { headers, res, next, organizationSettingsModel };
+};
+
+describe('CorsPolicy', () => {
+    afterEach(() => {
+        invalidateCorsPolicyCache();
+    });
+
+    test('allows exact origins from enabled org CORS settings', async () => {
+        const { headers } = await getCorsHeaders({
+            origin: 'https://app.example.com',
+            dbAllowedDomains: ['https://app.example.com'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBe(
+            'https://app.example.com',
+        );
+    });
+
+    test('does not load org CORS settings when request has no origin header', async () => {
+        const { headers, organizationSettingsModel } = await getCorsHeaders({
+            dbAllowedDomains: ['https://app.example.com'],
+            envAllowedDomains: ['https://env.example.com'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBeUndefined();
+        expect(
+            organizationSettingsModel.getAllEnabledCorsAllowedDomains,
+        ).not.toHaveBeenCalled();
+    });
+
+    test('allows regex origins from enabled org CORS settings', async () => {
+        const { headers } = await getCorsHeaders({
+            origin: 'https://embed.example.com',
+            dbAllowedDomains: ['/^https:\\/\\/.*\\.example\\.com$/'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBe(
+            'https://embed.example.com',
+        );
+    });
+
+    test('allows wildcard subdomain origins from enabled org CORS settings', async () => {
+        const { headers } = await getCorsHeaders({
+            origin: 'https://embed.example.com',
+            dbAllowedDomains: ['*.example.com'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBe(
+            'https://embed.example.com',
+        );
+    });
+
+    test('wildcard origins do not include the apex domain or a different protocol', async () => {
+        const { headers: apexHeaders } = await getCorsHeaders({
+            origin: 'https://example.com',
+            dbAllowedDomains: ['*.example.com'],
+        });
+        expect(apexHeaders.get('Access-Control-Allow-Origin')).toBeUndefined();
+
+        const { headers: protocolHeaders } = await getCorsHeaders({
+            origin: 'http://embed.example.com',
+            dbAllowedDomains: ['*.example.com'],
+        });
+        expect(
+            protocolHeaders.get('Access-Control-Allow-Origin'),
+        ).toBeUndefined();
+    });
+
+    test('wildcard origins can specify http and a port', async () => {
+        const { headers } = await getCorsHeaders({
+            origin: 'http://embed.example.com:3000',
+            dbAllowedDomains: ['http://*.example.com:3000'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBe(
+            'http://embed.example.com:3000',
+        );
+    });
+
+    test('allows env configured origins when env CORS is enabled', async () => {
+        const { headers } = await getCorsHeaders({
+            origin: 'https://env.example.com',
+            dbAllowedDomains: [],
+            envEnabled: true,
+            envAllowedDomains: ['https://env.example.com'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBe(
+            'https://env.example.com',
+        );
+    });
+
+    test('falls back to env configured origins when org CORS settings cannot be loaded', async () => {
+        const { headers } = await getCorsHeaders({
+            origin: 'https://env.example.com',
+            dbAllowedDomains: ['https://app.example.com'],
+            dbError: new Error('column "cors_allowed_domains" does not exist'),
+            envAllowedDomains: ['https://env.example.com'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBe(
+            'https://env.example.com',
+        );
+
+        const { headers: orgOnlyHeaders } = await getCorsHeaders({
+            origin: 'https://app.example.com',
+            dbAllowedDomains: ['https://app.example.com'],
+            dbError: new Error('column "cors_allowed_domains" does not exist'),
+            envAllowedDomains: ['https://env.example.com'],
+        });
+        expect(
+            orgOnlyHeaders.get('Access-Control-Allow-Origin'),
+        ).toBeUndefined();
+    });
+
+    test('skips org CORS entries that cannot be compiled without dropping other origins', async () => {
+        const { headers } = await getCorsHeaders({
+            origin: 'https://env.example.com',
+            dbAllowedDomains: [
+                undefined,
+                'https://app.example.com',
+            ] as unknown as string[],
+            envAllowedDomains: ['https://env.example.com'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBe(
+            'https://env.example.com',
+        );
+
+        const { headers: orgHeaders } = await getCorsHeaders({
+            origin: 'https://app.example.com',
+            dbAllowedDomains: [
+                undefined,
+                'https://app.example.com',
+            ] as unknown as string[],
+            envAllowedDomains: ['https://env.example.com'],
+        });
+        expect(orgHeaders.get('Access-Control-Allow-Origin')).toBe(
+            'https://app.example.com',
+        );
+    });
+
+    test('falls back to env configured origins when the dynamic policy fails unexpectedly', async () => {
+        const now = jest.spyOn(Date, 'now').mockImplementation(() => {
+            throw new Error('clock failed');
+        });
+
+        try {
+            const { headers } = await getCorsHeaders({
+                origin: 'https://env.example.com',
+                dbAllowedDomains: ['https://app.example.com'],
+                envAllowedDomains: ['https://env.example.com'],
+            });
+            expect(headers.get('Access-Control-Allow-Origin')).toBe(
+                'https://env.example.com',
+            );
+        } finally {
+            now.mockRestore();
+        }
+    });
+
+    test('does not allow org or env origins when global CORS is disabled', async () => {
+        const { headers, organizationSettingsModel } = await getCorsHeaders({
+            origin: 'https://app.example.com',
+            dbAllowedDomains: ['https://app.example.com'],
+            envEnabled: false,
+            envAllowedDomains: ['https://app.example.com'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBeUndefined();
+        expect(
+            organizationSettingsModel.getAllEnabledCorsAllowedDomains,
+        ).not.toHaveBeenCalled();
+    });
+
+    test('does not allow unknown origins', async () => {
+        const { headers } = await getCorsHeaders({
+            origin: 'https://unknown.example.com',
+            dbAllowedDomains: ['https://app.example.com'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBeUndefined();
+    });
+
+    test('OPTIONS preflight still short-circuits for denied origins', async () => {
+        const { headers, res, next } = await getCorsHeaders({
+            origin: 'https://unknown.example.com',
+            method: 'OPTIONS',
+            dbAllowedDomains: ['https://app.example.com'],
+        });
+        expect(headers.get('Access-Control-Allow-Origin')).toBeUndefined();
+        expect(headers.get('Access-Control-Allow-Methods')).toBe(
+            'OPTIONS, GET, HEAD, PUT, PATCH, POST, DELETE',
+        );
+        expect(res.end).toHaveBeenCalled();
+        expect(next).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/OrganizationSettingsService/CorsPolicy.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/CorsPolicy.ts
@@ -1,0 +1,190 @@
+import {
+    getCorsWildcardOriginRegexSource,
+    isCorsWildcardOrigin,
+} from '@lightdash/common';
+import { Request } from 'express';
+import { type LightdashConfig } from '../../config/parseConfig';
+import Logger from '../../logging/logger';
+import { type OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
+
+const CORS_POLICY_CACHE_TTL_MS = 60_000;
+
+type CorsOptions = {
+    methods: string;
+    allowedHeaders: string;
+    credentials: boolean;
+    origin: Array<string | RegExp> | false;
+};
+
+const createCorsOptions = (origin: CorsOptions['origin']): CorsOptions => ({
+    methods: 'OPTIONS, GET, HEAD, PUT, PATCH, POST, DELETE',
+    allowedHeaders: '*',
+    credentials: false,
+    origin,
+});
+
+type CorsOptionsDelegate = (
+    req: Request,
+    callback: (err: Error | null, options?: CorsOptions) => void,
+) => void;
+
+let cachedAllowedOrigins: Array<string | RegExp> | undefined;
+let cachedUntil = 0;
+let refreshPromise: Promise<Array<string | RegExp>> | undefined;
+
+export const invalidateCorsPolicyCache = () => {
+    cachedAllowedOrigins = undefined;
+    cachedUntil = 0;
+    refreshPromise = undefined;
+};
+
+export const compileCorsAllowedDomain = (
+    allowedDomain: string,
+): string | RegExp | undefined => {
+    if (allowedDomain.startsWith('/') && allowedDomain.endsWith('/')) {
+        try {
+            return new RegExp(allowedDomain.slice(1, -1));
+        } catch (error) {
+            Logger.warn('Ignoring invalid CORS regex pattern', {
+                allowedDomain,
+                error,
+            });
+            return undefined;
+        }
+    }
+    if (isCorsWildcardOrigin(allowedDomain)) {
+        const regexSource = getCorsWildcardOriginRegexSource(allowedDomain);
+        return regexSource ? new RegExp(regexSource) : undefined;
+    }
+    return allowedDomain;
+};
+
+const dedupeOrigins = (
+    origins: Array<string | RegExp>,
+): Array<string | RegExp> => {
+    const seen = new Set<string>();
+    return origins.filter((origin) => {
+        const key =
+            typeof origin === 'string'
+                ? `string:${origin}`
+                : `regex:${origin.toString()}`;
+        if (seen.has(key)) {
+            return false;
+        }
+        seen.add(key);
+        return true;
+    });
+};
+
+const compileAllowedDomains = (
+    allowedDomains: string[],
+    source: 'instance' | 'organization',
+): Array<string | RegExp> =>
+    allowedDomains.flatMap((allowedDomain) => {
+        try {
+            const compiled = compileCorsAllowedDomain(allowedDomain);
+            return compiled ? [compiled] : [];
+        } catch (error) {
+            Logger.warn('Ignoring invalid CORS allowed domain', {
+                allowedDomain,
+                source,
+                error,
+            });
+            return [];
+        }
+    });
+
+const buildInstanceAllowedOrigins = (
+    lightdashConfig: LightdashConfig,
+): Array<string | RegExp> => {
+    if (!lightdashConfig.security.crossOriginResourceSharingPolicy.enabled) {
+        return [];
+    }
+
+    return dedupeOrigins(
+        compileAllowedDomains(
+            [
+                lightdashConfig.siteUrl,
+                ...lightdashConfig.security.crossOriginResourceSharingPolicy
+                    .allowedDomains,
+            ],
+            'instance',
+        ),
+    );
+};
+
+const buildAllowedOrigins = async ({
+    lightdashConfig,
+    organizationSettingsModel,
+}: {
+    lightdashConfig: LightdashConfig;
+    organizationSettingsModel: OrganizationSettingsModel;
+}): Promise<Array<string | RegExp>> => {
+    if (!lightdashConfig.security.crossOriginResourceSharingPolicy.enabled) {
+        return [];
+    }
+
+    const instanceAllowedOrigins = buildInstanceAllowedOrigins(lightdashConfig);
+
+    let dbAllowedDomains: string[] = [];
+    try {
+        dbAllowedDomains =
+            await organizationSettingsModel.getAllEnabledCorsAllowedDomains();
+    } catch (error) {
+        Logger.warn(
+            'Could not load organization CORS settings; using instance CORS settings only',
+            { error },
+        );
+        return instanceAllowedOrigins;
+    }
+
+    return dedupeOrigins([
+        ...instanceAllowedOrigins,
+        ...compileAllowedDomains(dbAllowedDomains, 'organization'),
+    ]);
+};
+
+const getAllowedOrigins = async (args: {
+    lightdashConfig: LightdashConfig;
+    organizationSettingsModel: OrganizationSettingsModel;
+}): Promise<Array<string | RegExp>> => {
+    const now = Date.now();
+    if (cachedAllowedOrigins && cachedUntil > now) {
+        return cachedAllowedOrigins;
+    }
+
+    refreshPromise ??= buildAllowedOrigins(args);
+    cachedAllowedOrigins = await refreshPromise;
+    cachedUntil = now + CORS_POLICY_CACHE_TTL_MS;
+    refreshPromise = undefined;
+    return cachedAllowedOrigins;
+};
+
+export const createCorsOptionsDelegate =
+    (args: {
+        lightdashConfig: LightdashConfig;
+        organizationSettingsModel: OrganizationSettingsModel;
+    }): CorsOptionsDelegate =>
+    (req, callback) => {
+        if (!req.headers.origin) {
+            callback(null, createCorsOptions(false));
+            return;
+        }
+
+        getAllowedOrigins(args)
+            .then((allowedOrigins) => {
+                callback(null, createCorsOptions(allowedOrigins));
+            })
+            .catch((error) => {
+                Logger.warn(
+                    'Could not build CORS policy; using instance CORS settings only',
+                    { error },
+                );
+                callback(
+                    null,
+                    createCorsOptions(
+                        buildInstanceAllowedOrigins(args.lightdashConfig),
+                    ),
+                );
+            });
+    };

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.test.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.test.ts
@@ -2,6 +2,7 @@ import { Ability } from '@casl/ability';
 import {
     FeatureFlags,
     ForbiddenError,
+    ParameterError,
     type PossibleAbilities,
     type RegisteredAccount,
 } from '@lightdash/common';
@@ -79,5 +80,54 @@ describe('OrganizationSettingsService — pro-limits gate', () => {
             csvCellsLimit: 50,
         });
         expect(organizationSettingsModel.update).toHaveBeenCalled();
+    });
+
+    it('allows valid CORS settings when pro-limits is disabled', async () => {
+        const { service, organizationSettingsModel } = buildService(false);
+        await service.updateOrganizationSettings(account, {
+            corsAllowedDomains: [
+                'https://app.example.com',
+                '/^https:\\/\\/.*\\.example\\.com$/',
+            ],
+        });
+        expect(organizationSettingsModel.update).toHaveBeenCalledWith(
+            'org-uuid',
+            {
+                corsAllowedDomains: [
+                    'https://app.example.com',
+                    '/^https:\\/\\/.*\\.example\\.com$/',
+                ],
+            },
+        );
+    });
+
+    it('rejects invalid CORS regex patterns', async () => {
+        const { service, organizationSettingsModel } = buildService(false);
+        await expect(
+            service.updateOrganizationSettings(account, {
+                corsAllowedDomains: ['/unterminated[/'],
+            }),
+        ).rejects.toThrow(ParameterError);
+        expect(organizationSettingsModel.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects broad CORS regex patterns', async () => {
+        const { service, organizationSettingsModel } = buildService(false);
+        await expect(
+            service.updateOrganizationSettings(account, {
+                corsAllowedDomains: ['/^https?:\\/\\/.*$/'],
+            }),
+        ).rejects.toThrow(ParameterError);
+        expect(organizationSettingsModel.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid CORS origins', async () => {
+        const { service, organizationSettingsModel } = buildService(false);
+        await expect(
+            service.updateOrganizationSettings(account, {
+                corsAllowedDomains: ['https://app.example.com/path'],
+            }),
+        ).rejects.toThrow(ParameterError);
+        expect(organizationSettingsModel.update).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -7,12 +7,14 @@ import {
     POSTGRES_INTEGER_MAX,
     resolveEffectiveOrganizationSettings,
     UpdateOrganizationSettings,
+    validateCorsAllowedDomains,
     type RegisteredAccount,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import { BaseService } from '../BaseService';
+import { invalidateCorsPolicyCache } from './CorsPolicy';
 import { getOrganizationSettingsInstanceDefaults } from './getInstanceDefaults';
 
 type OrganizationSettingsServiceArguments = {
@@ -110,7 +112,7 @@ export class OrganizationSettingsService extends BaseService {
         ];
         // Bounded by the integer column ceiling — above it the DB insert throws
         // an out-of-range error (a 500) instead of a clean validation failure.
-        const isInvalid = (value: number | boolean | null | undefined) =>
+        const isInvalid = (value: unknown) =>
             value !== undefined &&
             value !== null &&
             (typeof value !== 'number' ||
@@ -150,6 +152,14 @@ export class OrganizationSettingsService extends BaseService {
                 `Maximum query rows cannot exceed ${queryLimitCap}.`,
             );
         }
+        if (data.corsAllowedDomains !== undefined) {
+            const corsError = validateCorsAllowedDomains(
+                data.corsAllowedDomains ?? [],
+            );
+            if (corsError) {
+                throw new ParameterError(corsError);
+            }
+        }
     }
 
     async getOrganizationSettings(
@@ -174,6 +184,9 @@ export class OrganizationSettingsService extends BaseService {
             organizationUuid,
             data,
         );
+        if (data.corsAllowedDomains !== undefined) {
+            invalidateCorsPolicyCache();
+        }
         return resolveEffectiveOrganizationSettings(
             raw,
             getOrganizationSettingsInstanceDefaults(this.lightdashConfig),

--- a/packages/common/src/types/organizationSettings.test.ts
+++ b/packages/common/src/types/organizationSettings.test.ts
@@ -1,5 +1,6 @@
 import {
     resolveEffectiveOrganizationSettings,
+    validateCorsAllowedDomains,
     type OrganizationSettingsInstanceDefaults,
 } from './organizationSettings';
 
@@ -26,6 +27,7 @@ describe('resolveEffectiveOrganizationSettings', () => {
             scheduledDeliveryExpirationSecondsGoogleChat: null,
             queryLimit: 5000,
             csvCellsLimit: 100000,
+            corsAllowedDomains: [],
         });
     });
 
@@ -77,5 +79,81 @@ describe('resolveEffectiveOrganizationSettings', () => {
             resolveEffectiveOrganizationSettings({}, INSTANCE_DEFAULTS)
                 .supportImpersonationEnabled,
         ).toBe(false);
+    });
+
+    test('CORS settings default to no org domains, without env inheritance', () => {
+        const inherited = resolveEffectiveOrganizationSettings(
+            {},
+            INSTANCE_DEFAULTS,
+        );
+        expect(inherited.corsAllowedDomains).toEqual([]);
+
+        const overridden = resolveEffectiveOrganizationSettings(
+            {
+                corsAllowedDomains: [
+                    'https://app.example.com',
+                    '/^https:\\/\\/.*\\.example\\.com$/',
+                ],
+            },
+            INSTANCE_DEFAULTS,
+        );
+        expect(overridden.corsAllowedDomains).toEqual([
+            'https://app.example.com',
+            '/^https:\\/\\/.*\\.example\\.com$/',
+        ]);
+    });
+});
+
+describe('validateCorsAllowedDomains', () => {
+    test('accepts exact origins and anchored subdomain regex patterns', () => {
+        expect(
+            validateCorsAllowedDomains([
+                'https://app.example.com',
+                '/^https:\\/\\/.*\\.example\\.com$/',
+                '/^http:\\/\\/.*\\.example\\.com$/',
+            ]),
+        ).toBeNull();
+    });
+
+    test('accepts leading wildcard subdomain origins', () => {
+        expect(
+            validateCorsAllowedDomains([
+                '*.example.com',
+                'https://*.lightdash.example.com',
+                'http://*.example.com:3000',
+            ]),
+        ).toBeNull();
+    });
+
+    test('rejects broad or misplaced wildcard origins', () => {
+        expect(validateCorsAllowedDomains(['*.com'])).toContain(
+            'leading subdomain wildcard',
+        );
+        expect(validateCorsAllowedDomains(['*'])).toContain(
+            'leading subdomain wildcard',
+        );
+        expect(validateCorsAllowedDomains(['https://foo.*.com'])).toContain(
+            'leading subdomain wildcard',
+        );
+    });
+
+    test('rejects invalid regex patterns', () => {
+        expect(validateCorsAllowedDomains(['/unterminated[/'])).toBeTruthy();
+    });
+
+    test('rejects unanchored regex patterns', () => {
+        expect(validateCorsAllowedDomains(['/example\\.com/'])).toContain(
+            'anchored origins',
+        );
+    });
+
+    test('rejects regex patterns that allow arbitrary external origins', () => {
+        expect(validateCorsAllowedDomains(['/.*/'])).toBeTruthy();
+        expect(validateCorsAllowedDomains(['/^https?:\\/\\/.*$/'])).toContain(
+            'arbitrary external origins',
+        );
+        expect(
+            validateCorsAllowedDomains(['/^https:\\/\\/.*\\.com$/']),
+        ).toContain('arbitrary external origins');
     });
 });

--- a/packages/common/src/types/organizationSettings.ts
+++ b/packages/common/src/types/organizationSettings.ts
@@ -76,6 +76,12 @@ export type OrganizationSettings = {
      * default. Always resolved to an effective number in API responses.
      */
     csvCellsLimit: number | null;
+    /**
+     * Exact origins, wildcard subdomain origins, and regex patterns this org
+     * contributes to the instance CORS allow-list. Regex entries use `/.../`
+     * syntax.
+     */
+    corsAllowedDomains: string[] | null;
 };
 
 /**
@@ -97,6 +103,141 @@ export type UpdateOrganizationSettings = Partial<OrganizationSettings>;
 export type ApiOrganizationSettingsResponse = {
     status: 'ok';
     results: OrganizationSettings;
+};
+
+export const isCorsRegexPattern = (value: string): boolean =>
+    value.length > 2 && value.startsWith('/') && value.endsWith('/');
+
+export type CorsWildcardOriginParts = {
+    protocol: 'http' | 'https';
+    hostname: string;
+    port: string | null;
+};
+
+const CORS_HOST_LABEL_PATTERN = '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?';
+const CORS_WILDCARD_ORIGIN_PATTERN = new RegExp(
+    `^(?:(https?):\\/\\/)?\\*\\.(${CORS_HOST_LABEL_PATTERN}(?:\\.${CORS_HOST_LABEL_PATTERN})+)(?::([0-9]{1,5}))?$`,
+);
+
+const escapeRegexPart = (value: string): string =>
+    value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const getCorsWildcardOriginParts = (
+    value: string,
+): CorsWildcardOriginParts | null => {
+    const match = value.trim().match(CORS_WILDCARD_ORIGIN_PATTERN);
+    if (!match) {
+        return null;
+    }
+
+    const [, protocol = 'https', hostname, port = null] = match;
+    if (port !== null && Number(port) > 65535) {
+        return null;
+    }
+
+    return {
+        protocol: protocol as 'http' | 'https',
+        hostname,
+        port,
+    };
+};
+
+export const isCorsWildcardOrigin = (value: string): boolean =>
+    getCorsWildcardOriginParts(value) !== null;
+
+export const getCorsWildcardOriginRegexSource = (
+    value: string,
+): string | null => {
+    const parts = getCorsWildcardOriginParts(value);
+    if (!parts) {
+        return null;
+    }
+
+    const subdomainSource = '.*';
+    const portSource = parts.port ? `:${parts.port}` : '';
+    return `^${parts.protocol}:\\/\\/${subdomainSource}\\.${escapeRegexPart(
+        parts.hostname,
+    )}${portSource}$`;
+};
+
+const BROAD_CORS_REGEX_SAMPLE_ORIGINS = [
+    'https://malicious.com',
+    'http://malicious.com',
+    'https://attacker.invalid',
+    'https://anything.bad-example.com',
+];
+
+export const validateCorsAllowedDomain = (value: string): string | null => {
+    const trimmedValue = value.trim();
+    if (trimmedValue.length === 0) {
+        return 'CORS allowed origins cannot be empty.';
+    }
+
+    if (isCorsRegexPattern(trimmedValue)) {
+        try {
+            const pattern = trimmedValue.slice(1, -1);
+            if (pattern.length > 256) {
+                return 'CORS regex patterns must be 256 characters or fewer.';
+            }
+            const regex = new RegExp(pattern);
+            regex.test('');
+            const { source } = regex;
+            const startsWithOriginProtocol =
+                source.startsWith('^https:\\/\\/') ||
+                source.startsWith('^http:\\/\\/') ||
+                source.startsWith('^https?:\\/\\/');
+            if (!startsWithOriginProtocol || !source.endsWith('$')) {
+                return 'CORS regex patterns must be anchored origins, for example /^https:\\/\\/.*\\.example\\.com$/.';
+            }
+            if (
+                BROAD_CORS_REGEX_SAMPLE_ORIGINS.some((origin) =>
+                    regex.test(origin),
+                )
+            ) {
+                return 'CORS regex patterns cannot match arbitrary external origins.';
+            }
+            return null;
+        } catch {
+            return 'CORS regex patterns must be valid JavaScript regular expressions.';
+        }
+    }
+
+    if (isCorsWildcardOrigin(trimmedValue)) {
+        return null;
+    }
+
+    if (trimmedValue.includes('*')) {
+        return 'CORS wildcard origins must use a leading subdomain wildcard, for example *.example.com or https://*.example.com.';
+    }
+
+    try {
+        const url = new URL(trimmedValue);
+        if (!['http:', 'https:'].includes(url.protocol)) {
+            return 'CORS origins must use http or https.';
+        }
+        if (url.origin !== trimmedValue) {
+            return 'CORS origins must not include a path, query string, hash, or trailing slash.';
+        }
+        return null;
+    } catch {
+        return 'CORS entries must be exact origins like https://app.example.com, wildcard subdomains like *.example.com, or regex patterns like /^https:\\/\\/.*\\.example\\.com$/.';
+    }
+};
+
+export const validateCorsAllowedDomains = (values: string[]): string | null => {
+    const seen = new Set<string>();
+    for (const value of values) {
+        const trimmedValue = value.trim();
+        const error = validateCorsAllowedDomain(trimmedValue);
+        if (error) {
+            return error;
+        }
+        if (seen.has(trimmedValue)) {
+            return 'CORS allowed origins must be unique.';
+        }
+        seen.add(trimmedValue);
+    }
+    return null;
 };
 
 /**
@@ -150,4 +291,5 @@ export const resolveEffectiveOrganizationSettings = (
     // Limits resolve to an effective number (fall back to the env default).
     queryLimit: raw.queryLimit ?? instanceDefaults.queryLimit,
     csvCellsLimit: raw.csvCellsLimit ?? instanceDefaults.csvCellsLimit,
+    corsAllowedDomains: raw.corsAllowedDomains ?? [],
 });

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mantine-8/core';
+import { Anchor, Stack, Text, Title } from '@mantine-8/core';
 import { useMemo, type FC } from 'react';
 import { Navigate, useParams, useRoutes, type RouteObject } from 'react-router';
 import SettingsEmbed from '../../ee/features/embed/SettingsEmbed';
@@ -10,6 +10,7 @@ import useApp from '../../providers/App/useApp';
 import { DocumentTitle } from '../common/DocumentTitle';
 import ErrorState from '../common/ErrorState';
 import PageBreadcrumbs from '../common/PageBreadcrumbs';
+import { SettingsGridCard } from '../common/Settings/SettingsCard';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import CompilationHistory from '../CompilationHistory';
 import { DataOps } from '../DataOps';
@@ -27,6 +28,7 @@ import SettingsQueryTimezone from '../SettingsQueryTimezone';
 import SettingsScheduler from '../SettingsScheduler';
 import SettingsUsageAnalytics from '../SettingsUsageAnalytics';
 import { SettingsValidator } from '../SettingsValidator';
+import CorsSettingsPanel from '../UserSettings/CorsSettingsPanel';
 import VerifiedContentPanel from '../VerifiedContent/VerifiedContentPanel';
 
 const ProjectSettings: FC = () => {
@@ -34,7 +36,7 @@ const ProjectSettings: FC = () => {
         projectUuid: string;
     }>();
 
-    const { health } = useApp();
+    const { health, user } = useApp();
     const { isInitialLoading, data: project, error } = useProject(projectUuid);
 
     const isSoftDeleteEnabled = health.data?.softDelete?.enabled ?? false;
@@ -165,8 +167,48 @@ const ProjectSettings: FC = () => {
                 path: '/embed', // commercial route
                 element: <SettingsEmbed projectUuid={projectUuid} />,
             },
+            ...(user.data?.ability.can('manage', 'Organization')
+                ? [
+                      {
+                          path: '/embed/cors',
+                          element: (
+                              <Stack gap="xl">
+                                  <SettingsGridCard>
+                                      <Stack gap="xs">
+                                          <Title order={4}>CORS</Title>
+                                          <Text c="ldGray.6" fz="xs">
+                                              CORS controls which external
+                                              browser origins can call the
+                                              Lightdash API. Add exact origins
+                                              like https://app.example.com or
+                                              wildcard subdomains like
+                                              *.example.com. Use regex only for
+                                              advanced patterns.
+                                          </Text>
+                                          <Text c="ldGray.6" fz="xs">
+                                              This is commonly needed for
+                                              embedding Lightdash in another
+                                              application.{' '}
+                                              <Anchor
+                                                  inherit
+                                                  href="https://docs.lightdash.com/guides/embedding/how-to-embed-content#cors"
+                                                  target="_blank"
+                                                  rel="noreferrer"
+                                              >
+                                                  Read the embedding docs
+                                              </Anchor>
+                                              .
+                                          </Text>
+                                      </Stack>
+                                      <CorsSettingsPanel />
+                                  </SettingsGridCard>
+                              </Stack>
+                          ),
+                      },
+                  ]
+                : []),
         ];
-    }, [projectUuid, isSoftDeleteEnabled, isGitProject]);
+    }, [projectUuid, isSoftDeleteEnabled, isGitProject, user.data?.ability]);
     const routesElements = useRoutes(routes);
 
     if (error) {

--- a/packages/frontend/src/components/UserSettings/CorsSettingsPanel/index.test.ts
+++ b/packages/frontend/src/components/UserSettings/CorsSettingsPanel/index.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'vitest';
+import {
+    getInitialCorsAllowedDomainsInput,
+    getRegexPatternInput,
+    normalizeCorsAllowedDomainsInput,
+    validateCorsAllowedDomainsInput,
+} from './utils';
+
+describe('CorsSettingsPanel helpers', () => {
+    test('uses one empty input when there are no saved domains', () => {
+        expect(getInitialCorsAllowedDomainsInput([])).toEqual([
+            { type: 'origin', value: '' },
+        ]);
+    });
+
+    test('uses saved domains as one input per entry', () => {
+        expect(
+            getInitialCorsAllowedDomainsInput([
+                'https://app.example.com',
+                '/^https:\\/\\/.*\\.example\\.com$/',
+            ]),
+        ).toEqual([
+            { type: 'origin', value: 'https://app.example.com' },
+            { type: 'regex', value: 'https:\\/\\/.*\\.example\\.com' },
+        ]);
+    });
+
+    test('normalizes inputs into trimmed API allowed domains', () => {
+        expect(
+            normalizeCorsAllowedDomainsInput([
+                { type: 'origin', value: ' https://app.example.com ' },
+                { type: 'origin', value: ' *.example.com ' },
+                { type: 'origin', value: ' http://*.test.com ' },
+                { type: 'origin', value: '' },
+                {
+                    type: 'regex',
+                    value: ' https:\\/\\/.*\\.example\\.com ',
+                },
+            ]),
+        ).toEqual([
+            'https://app.example.com',
+            '/^https:\\/\\/.*\\.example\\.com$/',
+            '/^http:\\/\\/.*\\.test\\.com$/',
+            '/^https:\\/\\/.*\\.example\\.com$/',
+        ]);
+    });
+
+    test('strips regex delimiters and anchors from pasted regex values', () => {
+        expect(getRegexPatternInput('/^https:\\/\\/.*\\.example\\.com$/')).toBe(
+            'https:\\/\\/.*\\.example\\.com',
+        );
+    });
+
+    test('accepts exact origins, wildcard origins, and regex patterns', () => {
+        expect(
+            validateCorsAllowedDomainsInput([
+                { type: 'origin', value: 'https://app.example.com' },
+                { type: 'origin', value: '*.example.com' },
+                { type: 'origin', value: 'http://*.test.com' },
+                {
+                    type: 'regex',
+                    value: 'https:\\/\\/.*\\.lightdash\\.com',
+                },
+            ]),
+        ).toEqual({});
+    });
+
+    test('rejects invalid regex patterns', () => {
+        expect(
+            validateCorsAllowedDomainsInput([
+                { type: 'origin', value: 'https://app.example.com' },
+                { type: 'regex', value: 'unterminated[' },
+            ]),
+        ).toEqual({
+            'corsAllowedDomains.1.value':
+                'CORS regex patterns must be valid JavaScript regular expressions.',
+        });
+    });
+
+    test('rejects broad regex patterns', () => {
+        expect(
+            validateCorsAllowedDomainsInput([
+                { type: 'regex', value: 'https?:\\/\\/.*' },
+            ]),
+        ).toEqual({
+            'corsAllowedDomains.0.value':
+                'CORS regex patterns cannot match arbitrary external origins.',
+        });
+    });
+
+    test('rejects exact origins in regex mode', () => {
+        expect(
+            validateCorsAllowedDomainsInput([
+                { type: 'regex', value: 'https://lightdash.com' },
+            ]),
+        ).toEqual({
+            'corsAllowedDomains.0.value':
+                'Use origin mode for exact origins, or escape regex dots like https:\\/\\/lightdash\\.com.',
+        });
+    });
+
+    test('rejects origins with paths', () => {
+        expect(
+            validateCorsAllowedDomainsInput([
+                { type: 'origin', value: 'https://app.example.com' },
+                { type: 'origin', value: 'https://app.example.com/path' },
+            ]),
+        ).toEqual({
+            'corsAllowedDomains.1.value':
+                'CORS origins must not include a path, query string, hash, or trailing slash.',
+        });
+    });
+
+    test('rejects duplicate origins on the duplicated row', () => {
+        expect(
+            validateCorsAllowedDomainsInput([
+                { type: 'origin', value: 'https://app.example.com' },
+                { type: 'origin', value: 'https://app.example.com' },
+            ]),
+        ).toEqual({
+            'corsAllowedDomains.1.value':
+                'CORS allowed origins must be unique.',
+        });
+    });
+});

--- a/packages/frontend/src/components/UserSettings/CorsSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/CorsSettingsPanel/index.tsx
@@ -1,0 +1,238 @@
+import {
+    type OrganizationSettings,
+    type UpdateOrganizationSettings,
+    getCorsWildcardOriginRegexSource,
+    isCorsWildcardOrigin,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Button,
+    Group,
+    Loader,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconPlus, IconTrash } from '@tabler/icons-react';
+import isEqual from 'lodash/isEqual';
+import { type FC } from 'react';
+import {
+    useOrganizationSettings,
+    useUpdateOrganizationSettings,
+} from '../../../hooks/organization/useOrganizationSettings';
+import {
+    type CorsAllowedDomainInput,
+    type CorsAllowedDomainInputType,
+    getInitialCorsAllowedDomainsInput,
+    getRegexPatternInput,
+    normalizeCorsAllowedDomainsInput,
+    validateCorsAllowedDomainsInput,
+} from './utils';
+
+type FormValues = {
+    corsAllowedDomains: CorsAllowedDomainInput[];
+};
+
+const newCorsAllowedDomainInput = (
+    type: CorsAllowedDomainInputType = 'origin',
+): CorsAllowedDomainInput => ({
+    type,
+    value: '',
+});
+
+const getNextInputValue = (
+    input: CorsAllowedDomainInput,
+    type: CorsAllowedDomainInputType,
+) => {
+    if (type === 'regex' && isCorsWildcardOrigin(input.value)) {
+        const regexSource = getCorsWildcardOriginRegexSource(input.value);
+        return regexSource
+            ? getRegexPatternInput(`/${regexSource}/`)
+            : input.value;
+    }
+
+    return input.value;
+};
+
+const CorsSettingsForm: FC<{ settings: OrganizationSettings }> = ({
+    settings,
+}) => {
+    const update = useUpdateOrganizationSettings();
+
+    const initial = {
+        corsAllowedDomains: getInitialCorsAllowedDomainsInput(
+            settings.corsAllowedDomains ?? [],
+        ),
+    };
+    const initialAllowedDomains = normalizeCorsAllowedDomainsInput(
+        initial.corsAllowedDomains,
+    );
+
+    const form = useForm<FormValues>({
+        initialValues: initial,
+        validate: (values) =>
+            validateCorsAllowedDomainsInput(values.corsAllowedDomains),
+    });
+
+    const currentAllowedDomains = normalizeCorsAllowedDomainsInput(
+        form.values.corsAllowedDomains,
+    );
+    const isUnchanged = isEqual(currentAllowedDomains, initialAllowedDomains);
+
+    const handleSubmit = form.onSubmit((values) => {
+        const patch: UpdateOrganizationSettings = {
+            corsAllowedDomains: normalizeCorsAllowedDomainsInput(
+                values.corsAllowedDomains,
+            ),
+        };
+        update.mutate(patch);
+    });
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <Stack gap="lg">
+                <Stack gap="xs">
+                    {form.values.corsAllowedDomains.map((input, index) => {
+                        const fieldPath = `corsAllowedDomains.${index}.value`;
+                        const isRegex = input.type === 'regex';
+                        return (
+                            <Group
+                                key={index}
+                                gap="xs"
+                                align="flex-end"
+                                wrap="nowrap"
+                            >
+                                <TextInput
+                                    w="100%"
+                                    label={
+                                        index === 0 ? 'Allowed origins' : null
+                                    }
+                                    description={
+                                        index === 0
+                                            ? 'Origin mode accepts exact origins or *.example.com. Regex mode (.*) accepts a pattern and matches the whole origin automatically.'
+                                            : null
+                                    }
+                                    placeholder={
+                                        isRegex
+                                            ? 'https:\\/\\/.*\\.example\\.com'
+                                            : 'https://app.example.com or *.example.com'
+                                    }
+                                    rightSectionWidth={44}
+                                    rightSection={
+                                        <Tooltip
+                                            withinPortal
+                                            label={
+                                                isRegex
+                                                    ? 'Switch to origin mode'
+                                                    : 'Switch to regex mode'
+                                            }
+                                        >
+                                            <ActionIcon
+                                                type="button"
+                                                size="sm"
+                                                variant={
+                                                    isRegex ? 'light' : 'subtle'
+                                                }
+                                                color={
+                                                    isRegex ? 'blue' : 'gray'
+                                                }
+                                                aria-label={
+                                                    isRegex
+                                                        ? 'Switch to origin mode'
+                                                        : 'Switch to regex mode'
+                                                }
+                                                onClick={() => {
+                                                    const type: CorsAllowedDomainInputType =
+                                                        isRegex
+                                                            ? 'origin'
+                                                            : 'regex';
+                                                    form.setFieldValue(
+                                                        `corsAllowedDomains.${index}`,
+                                                        {
+                                                            ...input,
+                                                            type,
+                                                            value: getNextInputValue(
+                                                                input,
+                                                                type,
+                                                            ),
+                                                        },
+                                                    );
+                                                }}
+                                            >
+                                                {isRegex ? '.*' : 'Aa'}
+                                            </ActionIcon>
+                                        </Tooltip>
+                                    }
+                                    {...form.getInputProps(fieldPath)}
+                                />
+                                <ActionIcon
+                                    type="button"
+                                    variant="subtle"
+                                    color="red"
+                                    mb={form.errors[fieldPath] ? 'xl' : 0}
+                                    aria-label="Remove CORS origin"
+                                    onClick={() =>
+                                        form.removeListItem(
+                                            'corsAllowedDomains',
+                                            index,
+                                        )
+                                    }
+                                >
+                                    <IconTrash size={16} />
+                                </ActionIcon>
+                            </Group>
+                        );
+                    })}
+                    {form.values.corsAllowedDomains.length === 0 && (
+                        <Text c="ldGray.6" fz="sm">
+                            No CORS origins configured.
+                        </Text>
+                    )}
+                    <Group justify="flex-start">
+                        <Button
+                            type="button"
+                            variant="subtle"
+                            leftSection={<IconPlus size={16} />}
+                            onClick={() =>
+                                form.insertListItem(
+                                    'corsAllowedDomains',
+                                    newCorsAllowedDomainInput(),
+                                )
+                            }
+                        >
+                            Add origin
+                        </Button>
+                    </Group>
+                </Stack>
+                <Group justify="flex-end">
+                    <Button
+                        type="submit"
+                        loading={update.isLoading}
+                        disabled={isUnchanged}
+                    >
+                        Save
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    );
+};
+
+const CorsSettingsPanel: FC = () => {
+    const { data, isInitialLoading } = useOrganizationSettings();
+
+    if (isInitialLoading || !data) {
+        return <Loader />;
+    }
+
+    return (
+        <CorsSettingsForm
+            key={(data.corsAllowedDomains ?? []).join(',')}
+            settings={data}
+        />
+    );
+};
+
+export default CorsSettingsPanel;

--- a/packages/frontend/src/components/UserSettings/CorsSettingsPanel/utils.ts
+++ b/packages/frontend/src/components/UserSettings/CorsSettingsPanel/utils.ts
@@ -1,0 +1,109 @@
+import {
+    getCorsWildcardOriginRegexSource,
+    isCorsRegexPattern,
+    isCorsWildcardOrigin,
+    validateCorsAllowedDomain,
+} from '@lightdash/common';
+import { type FormErrors } from '@mantine/form';
+
+export type CorsAllowedDomainInputType = 'origin' | 'regex';
+
+export type CorsAllowedDomainInput = {
+    type: CorsAllowedDomainInputType;
+    value: string;
+};
+
+export const getRegexPatternInput = (value: string): string => {
+    const trimmedValue = value.trim();
+    const pattern = isCorsRegexPattern(trimmedValue)
+        ? trimmedValue.slice(1, -1)
+        : trimmedValue;
+    return pattern.replace(/^\^/, '').replace(/\$$/, '');
+};
+
+const isExactOrigin = (value: string): boolean => {
+    try {
+        const url = new URL(value);
+        return (
+            ['http:', 'https:'].includes(url.protocol) && url.origin === value
+        );
+    } catch {
+        return false;
+    }
+};
+
+const serializeCorsAllowedDomainInput = ({
+    type,
+    value,
+}: CorsAllowedDomainInput): string | null => {
+    const trimmedValue = value.trim();
+    if (trimmedValue.length === 0) {
+        return null;
+    }
+
+    if (type === 'regex') {
+        return `/^${getRegexPatternInput(trimmedValue)}$/`;
+    }
+
+    if (isCorsWildcardOrigin(trimmedValue)) {
+        const regexSource = getCorsWildcardOriginRegexSource(trimmedValue);
+        return regexSource ? `/${regexSource}/` : trimmedValue;
+    }
+
+    return trimmedValue;
+};
+
+export const normalizeCorsAllowedDomainsInput = (
+    values: CorsAllowedDomainInput[],
+): string[] =>
+    values
+        .map(serializeCorsAllowedDomainInput)
+        .filter((value): value is string => value !== null);
+
+export const getInitialCorsAllowedDomainsInput = (
+    values: string[],
+): CorsAllowedDomainInput[] =>
+    values.length > 0
+        ? values.map((value) => ({
+              type: isCorsRegexPattern(value.trim()) ? 'regex' : 'origin',
+              value: isCorsRegexPattern(value.trim())
+                  ? getRegexPatternInput(value)
+                  : value,
+          }))
+        : [{ type: 'origin', value: '' }];
+
+export const validateCorsAllowedDomainsInput = (
+    values: CorsAllowedDomainInput[],
+): FormErrors => {
+    const errors: FormErrors = {};
+    const seen = new Set<string>();
+
+    values.forEach((input, index) => {
+        const serializedValue = serializeCorsAllowedDomainInput(input);
+        if (serializedValue === null) {
+            return;
+        }
+
+        const fieldPath = `corsAllowedDomains.${index}.value`;
+        if (input.type === 'regex' && isExactOrigin(input.value.trim())) {
+            errors[fieldPath] =
+                'Use origin mode for exact origins, or escape regex dots like https:\\/\\/lightdash\\.com.';
+            return;
+        }
+
+        const error = validateCorsAllowedDomain(serializedValue);
+        if (error) {
+            errors[fieldPath] = error;
+            return;
+        }
+
+        if (seen.has(serializedValue)) {
+            errors[fieldPath] = 'CORS allowed origins must be unique.';
+            return;
+        }
+
+        seen.add(serializedValue);
+    });
+
+    return errors;
+};

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -38,6 +38,7 @@ import {
     IconUsers,
     IconUserShield,
     IconVariable,
+    IconWorldCog,
     IconWorldCheck,
 } from '@tabler/icons-react';
 import { useMemo } from 'react';
@@ -628,13 +629,34 @@ export const useSettingsNavigation = (
                 ) &&
                 isEmbeddingEnabled
             ) {
+                const embedChildren: SettingsNavigationItem[] = [
+                    {
+                        label: 'General',
+                        to: `${base}/embed`,
+                        icon: IconBrowser,
+                        keywords: ['embed', 'iframe', 'public'],
+                        children: [],
+                        exact: true,
+                    },
+                ];
+
+                if (ability?.can('manage', 'Organization')) {
+                    embedChildren.push({
+                        label: 'CORS',
+                        to: `${base}/embed/cors`,
+                        icon: IconWorldCog,
+                        keywords: ['cors', 'origins', 'domains', 'embed'],
+                        children: [],
+                        exact: true,
+                    });
+                }
+
                 projectItems.push({
                     label: 'Embed configuration',
                     to: `${base}/embed`,
                     icon: IconBrowser,
                     keywords: ['embed', 'iframe', 'public'],
-                    children: [],
-                    exact: true,
+                    children: embedChildren,
                 });
             }
 


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-7554/admin-panel-cors-allowed-domains-configuration](https://linear.app/lightdash/issue/PROD-7554/admin-panel-cors-allowed-domains-configuration)

![CleanShot 2026-06-10 at 13.12.09.png](https://app.graphite.com/user-attachments/assets/05d7a7eb-01d4-4b75-b846-bcb560ab10dd.png)





### Description:

Adds per-organization CORS configuration, allowing admins to define allowed origins and regex patterns that are merged into the instance-wide CORS allow-list at runtime.

**Backend changes:**

- CORS is now always mounted as Express middleware using a new `createCorsOptionsDelegate` that resolves allowed origins dynamically, replacing the previous static conditional setup.
- The `LIGHTDASH_CORS_ENABLED` environment variable now defaults to `true` (opt-out via `=false`) rather than requiring explicit opt-in.
- A new `getAllEnabledCorsAllowedDomains` method on `OrganizationSettingsModel` queries all organizations with CORS enabled (or `null`, which defaults to enabled) and returns their configured domains.
- Allowed origins are built by merging the site URL, env-configured domains, and per-org DB domains, then cached for 60 seconds. The cache is invalidated whenever an organization updates its CORS settings.
- `corsEnabled` and `corsAllowedDomains` columns are added to the `organization_settings` table via a new migration.
- Validation rejects invalid regex patterns, origins with paths/query strings, and non-HTTP(S) schemes.

**Common/shared changes:**

- `OrganizationSettings` type gains `corsEnabled` and `corsAllowedDomains` fields.
- `validateCorsAllowedDomain` and `validateCorsAllowedDomains` helpers are exported for use in both backend validation and frontend form validation.
- `resolveEffectiveOrganizationSettings` defaults `corsEnabled` to `true` and `corsAllowedDomains` to `[]`.

**Frontend changes:**

- A new **CORS** settings panel is added under the **Embed configuration** section in project settings, visible to users with `manage Organization` ability.
- The panel provides a toggle to enable/disable CORS for the org and a textarea for entering one origin or `/regex/` pattern per line.