### PR TITLE
feat(ai): extend find content spaces

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -60,6 +60,9 @@ import {
     DescribeWarehouseTableFn,
     EditContentFn,
     FindContentFn,
+    FindContentResult,
+    FindContentSpaceBreadcrumb,
+    FindContentSpaceMetadata,
     FindExploresFn,
     FindFieldFn,
     GetDashboardChartsFn,
@@ -90,6 +93,7 @@ import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewD
 
 type AgentListContentResult = Awaited<ReturnType<ListContentFn>>;
 type AgentListContentItem = AgentListContentResult['items'][number];
+type ProjectSpace = Awaited<ReturnType<ProjectService['getSpaces']>>[number];
 
 export type AiAgentToolsSource = 'ai_agent' | 'mcp';
 
@@ -645,6 +649,79 @@ export class AiAgentToolsService extends BaseService {
         );
     }
 
+    private static getSpaceMetadata(
+        space: ProjectSpace,
+        spacesByPath: Map<string, ProjectSpace>,
+    ): FindContentSpaceMetadata {
+        const pathParts = space.path.split('.');
+        const breadcrumbs = pathParts.reduce<FindContentSpaceBreadcrumb[]>(
+            (acc, _pathPart, index) => {
+                const path = pathParts.slice(0, index + 1).join('.');
+                const breadcrumbSpace = spacesByPath.get(path);
+                if (!breadcrumbSpace) {
+                    return acc;
+                }
+
+                acc.push({
+                    uuid: breadcrumbSpace.uuid,
+                    name: breadcrumbSpace.name,
+                    slug: getContentAsCodePathFromLtreePath(
+                        breadcrumbSpace.path,
+                    ),
+                });
+                return acc;
+            },
+            [],
+        );
+
+        return {
+            uuid: space.uuid,
+            name: space.name,
+            slug: getContentAsCodePathFromLtreePath(space.path),
+            breadcrumbs,
+        };
+    }
+
+    private async getFindContentSpaceScope(
+        context: AiAgentToolsRuntimeContext,
+        spaceSlug: string | null,
+    ): Promise<{
+        spaces: ProjectSpace[];
+        scopedSpaceUuids: Set<string> | null;
+    }> {
+        const spaces = (
+            await this.projectService.getSpaces(
+                context.user,
+                context.projectUuid,
+            )
+        ).filter((space) =>
+            AiAgentToolsService.hasAgentSpaceAccess(
+                context.spaceAccess,
+                space.uuid,
+            ),
+        );
+
+        if (spaceSlug === null) {
+            return { spaces, scopedSpaceUuids: null };
+        }
+
+        const ltreePath = getLtreePathFromContentAsCodePath(spaceSlug);
+        const scopedSpaces = spaces.filter(
+            (space) =>
+                space.path === ltreePath ||
+                space.path.startsWith(`${ltreePath}.`),
+        );
+
+        if (scopedSpaces.length === 0) {
+            throw new NotFoundError(`Space "${spaceSlug}" was not found`);
+        }
+
+        return {
+            spaces,
+            scopedSpaceUuids: new Set(scopedSpaces.map((space) => space.uuid)),
+        };
+    }
+
     private findContent(
         context: AiAgentToolsRuntimeContext,
         args: Parameters<FindContentFn>[0],
@@ -653,49 +730,107 @@ export class AiAgentToolsService extends BaseService {
             `${AiAgentToolsService.transactionPrefix(context)}.findContent`,
             args,
             async () => {
-                if (context.source === 'ai_agent') {
-                    const { content } = await this.searchService.findContent(
-                        context.user,
-                        context.projectUuid,
-                        args.searchQuery.label,
+                const { spaces, scopedSpaceUuids } =
+                    await this.getFindContentSpaceScope(
+                        context,
+                        args.spaceSlug ?? null,
                     );
-                    return {
-                        content: content.filter(({ spaceUuid }) =>
-                            AiAgentToolsService.hasAgentSpaceAccess(
+                const spacesByUuid = new Map<string, ProjectSpace>(
+                    spaces.map((space) => [space.uuid, space]),
+                );
+                const spacesByPath = new Map<string, ProjectSpace>(
+                    spaces.map((space) => [space.path, space]),
+                );
+                const searchQuery = args.searchQuery.label.toLowerCase();
+                const { content } = await this.searchService.findContent(
+                    context.user,
+                    context.projectUuid,
+                    args.searchQuery.label,
+                );
+
+                const contentResults = content.flatMap(
+                    (item): FindContentResult[] => {
+                        if (
+                            !AiAgentToolsService.hasAgentSpaceAccess(
                                 context.spaceAccess,
-                                spaceUuid,
+                                item.spaceUuid,
+                            ) ||
+                            (scopedSpaceUuids !== null &&
+                                !scopedSpaceUuids.has(item.spaceUuid))
+                        ) {
+                            return [];
+                        }
+
+                        const space = spacesByUuid.get(item.spaceUuid);
+                        if (!space) {
+                            return [];
+                        }
+
+                        const spaceMetadata =
+                            AiAgentToolsService.getSpaceMetadata(
+                                space,
+                                spacesByPath,
+                            );
+                        if ('charts' in item) {
+                            return [
+                                {
+                                    ...item,
+                                    contentType: 'dashboard',
+                                    space: spaceMetadata,
+                                },
+                            ];
+                        }
+
+                        return [
+                            {
+                                ...item,
+                                contentType: 'chart',
+                                space: spaceMetadata,
+                            },
+                        ];
+                    },
+                );
+
+                const spaceResults = spaces
+                    .filter(
+                        (space) =>
+                            scopedSpaceUuids === null ||
+                            scopedSpaceUuids.has(space.uuid),
+                    )
+                    .filter((space) => {
+                        const slug = getContentAsCodePathFromLtreePath(
+                            space.path,
+                        ).toLowerCase();
+                        return (
+                            space.name.toLowerCase().includes(searchQuery) ||
+                            slug.includes(searchQuery)
+                        );
+                    })
+                    .map(
+                        (space): FindContentResult => ({
+                            contentType: 'space',
+                            uuid: space.uuid,
+                            name: space.name,
+                            slug: getContentAsCodePathFromLtreePath(space.path),
+                            search_rank:
+                                space.name.toLowerCase() === searchQuery
+                                    ? 1
+                                    : 0,
+                            chartCount: space.chartCount,
+                            dashboardCount: space.dashboardCount,
+                            childSpaceCount: space.childSpaceCount,
+                            appCount: space.appCount,
+                            directAccess:
+                                space.userAccess?.hasDirectAccess === true,
+                            space: AiAgentToolsService.getSpaceMetadata(
+                                space,
+                                spacesByPath,
                             ),
-                        ),
-                    };
-                }
-
-                const dashboardSearchResults =
-                    await this.searchModel.searchDashboards(
-                        context.projectUuid,
-                        args.searchQuery.label,
-                        undefined,
-                        'OR',
+                            verification: null,
+                        }),
                     );
-                const chartSearchResults =
-                    await this.searchModel.searchAllCharts(
-                        context.projectUuid,
-                        args.searchQuery.label,
-                        'OR',
-                    );
-                const filteredResults =
-                    await this.spaceService.filterBySpaceAccess(context.user, [
-                        ...dashboardSearchResults,
-                        ...chartSearchResults,
-                    ]);
 
-                return {
-                    content: filteredResults.filter(({ spaceUuid }) =>
-                        AiAgentToolsService.hasAgentSpaceAccess(
-                            context.spaceAccess,
-                            spaceUuid,
-                        ),
-                    ),
-                };
+                return { content: [...spaceResults, ...contentResults] };
             },
         );
     }

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -48,6 +48,25 @@ const queryUuid = '11111111-1111-4111-8111-111111111111';
 const allowedSpaceUuid = 'allowed-space-uuid';
 const blockedSpaceUuid = 'blocked-space-uuid';
 
+const makeSpaceMetadata = (spaceUuid: string) => ({
+    uuid: spaceUuid,
+    name: spaceUuid === allowedSpaceUuid ? 'Allowed Space' : 'Blocked Space',
+    slug: spaceUuid === allowedSpaceUuid ? 'allowed-space' : 'blocked-space',
+    breadcrumbs: [
+        {
+            uuid: spaceUuid,
+            name:
+                spaceUuid === allowedSpaceUuid
+                    ? 'Allowed Space'
+                    : 'Blocked Space',
+            slug:
+                spaceUuid === allowedSpaceUuid
+                    ? 'allowed-space'
+                    : 'blocked-space',
+        },
+    ],
+});
+
 const account = {
     isRegisteredUser: () => true,
     isServiceAccount: () => false,
@@ -196,8 +215,10 @@ const makeMcpService = ({
         spaceAccess: string[];
     } | null;
     explores?: Record<string, ReturnType<typeof makeExplore>>;
-    dashboardSearchResults?: Record<string, unknown>[];
-    chartSearchResults?: Record<string, unknown>[];
+    dashboardSearchResults?: (Record<string, unknown> & {
+        spaceUuid: string;
+    })[];
+    chartSearchResults?: ReturnType<typeof makeChartSearchResult>[];
     verifiedContent?: Record<string, unknown>[];
 } = {}) => {
     const asyncQueryService = {
@@ -354,15 +375,21 @@ const makeMcpService = ({
             findFields: jest.fn(async () => ({ fields: [], pagination: {} })),
             findContent: jest.fn(async () => ({
                 content: [
-                    ...dashboardSearchResults,
-                    ...chartSearchResults,
+                    ...dashboardSearchResults.map((dashboard) => ({
+                        ...dashboard,
+                        contentType: 'dashboard',
+                        space: makeSpaceMetadata(dashboard.spaceUuid),
+                    })),
+                    ...chartSearchResults.map((chart) => ({
+                        ...chart,
+                        contentType: 'chart',
+                        space: makeSpaceMetadata(chart.spaceUuid),
+                    })),
                 ].filter(
                     ({ spaceUuid }) =>
                         !runtimeContext.spaceAccess ||
                         runtimeContext.spaceAccess.length === 0 ||
-                        runtimeContext.spaceAccess.includes(
-                            spaceUuid as string,
-                        ),
+                        runtimeContext.spaceAccess.includes(spaceUuid),
                 ),
             })),
             searchFieldValues: jest.fn(async (args) => {

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -205,15 +205,16 @@ Usage tips:
       "agentName": null,
       "description": "Tool: "findContent"
 Purpose:
-Finds charts or dashboards by name or description within a project, returning detailed information about each.
+Finds spaces, charts, or dashboards by name or description within a project, returning detailed information about each.
 
 Usage tips:
 - IMPORTANT: Pass the user's full query or relevant portion directly (e.g., "revenue based on campaigns" instead of just "campaigns").
 - The search engine understands natural language and context — more descriptive queries yield better results.
 - You can provide multiple search queries to look for different topics simultaneously (e.g., ["monthly revenue", "user acquisition trends"]).
+- Pass spaceSlug to search only inside that space and its descendants.
 - If results aren't relevant, retry with the full user query or more specific terms.
 - Dashboards with validation errors will be deprioritized.
-- Returns chart and dashboard URLs when available.
+- Returns space breadcrumb/path metadata and chart/dashboard URLs when available.
 - Dashboards show a preview of the first 5 charts and the total chart count. Use "getDashboardCharts" to see all charts for a specific dashboard.
 - It doesn't provide summaries for dashboards yet, so don't suggest this capability.",
       "inputSchema": {
@@ -235,6 +236,10 @@ Usage tips:
               "type": "object",
             },
             "type": "array",
+          },
+          "spaceSlug": {
+            "description": "Optional space slug/path. Use null to search the whole project. When set, only content in this space and descendants is returned., ",
+            "type": "string",
           },
         },
         "required": [

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -760,15 +760,16 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
   {
     "description": "Tool: "findContent"
 Purpose:
-Finds charts or dashboards by name or description within a project, returning detailed information about each.
+Finds spaces, charts, or dashboards by name or description within a project, returning detailed information about each.
 
 Usage tips:
 - IMPORTANT: Pass the user's full query or relevant portion directly (e.g., "revenue based on campaigns" instead of just "campaigns").
 - The search engine understands natural language and context — more descriptive queries yield better results.
 - You can provide multiple search queries to look for different topics simultaneously (e.g., ["monthly revenue", "user acquisition trends"]).
+- Pass spaceSlug to search only inside that space and its descendants.
 - If results aren't relevant, retry with the full user query or more specific terms.
 - Dashboards with validation errors will be deprioritized.
-- Returns chart and dashboard URLs when available.
+- Returns space breadcrumb/path metadata and chart/dashboard URLs when available.
 - Dashboards show a preview of the first 5 charts and the total chart count. Use "getDashboardCharts" to see all charts for a specific dashboard.
 - It doesn't provide summaries for dashboards yet, so don't suggest this capability.",
     "inputSchema": {
@@ -791,9 +792,17 @@ Usage tips:
           },
           "type": "array",
         },
+        "spaceSlug": {
+          "description": "Optional space slug/path. Use null to search the whole project. When set, only content in this space and descendants is returned.",
+          "type": [
+            "string",
+            "null",
+          ],
+        },
       },
       "required": [
         "searchQueries",
+        "spaceSlug",
       ],
       "type": "object",
     },

--- a/packages/backend/src/ee/services/ai/tools/findContent.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/findContent.test.ts
@@ -5,6 +5,10 @@ import {
     type ToolFindContentOutput,
     type ToolGetDashboardChartsOutput,
 } from '@lightdash/common';
+import type {
+    FindContentDashboardResult,
+    FindContentResult,
+} from '../types/aiAgentDependencies';
 import { DASHBOARD_CHARTS_PREVIEW_COUNT } from '../utils/truncation';
 import { getFindContent } from './findContent';
 import { getGetDashboardCharts } from './getDashboardCharts';
@@ -36,8 +40,8 @@ const makeMockChart = (
 
 const makeMockDashboard = (
     chartCount: number,
-    overrides: Partial<DashboardSearchResult> = {},
-): DashboardSearchResult => ({
+    overrides: Partial<FindContentDashboardResult> = {},
+): FindContentDashboardResult => ({
     uuid: 'dash-uuid-1',
     name: 'Test Dashboard',
     slug: 'test-dashboard',
@@ -57,6 +61,19 @@ const makeMockDashboard = (
     validationErrors: [],
     charts: Array.from({ length: chartCount }, (_, i) => makeMockChart(i)),
     verification: null,
+    contentType: 'dashboard',
+    space: {
+        uuid: 'space-uuid-1',
+        name: 'Marketing',
+        slug: 'marketing',
+        breadcrumbs: [
+            {
+                uuid: 'space-uuid-1',
+                name: 'Marketing',
+                slug: 'marketing',
+            },
+        ],
+    },
     ...overrides,
 });
 
@@ -81,9 +98,35 @@ const executeGetDashboardCharts = (
         toolCallId: 'test',
     }) as Promise<ToolGetDashboardChartsOutput>;
 
+const makeMockSpace = (): FindContentResult => ({
+    contentType: 'space',
+    uuid: 'space-uuid-1',
+    name: 'Marketing',
+    slug: 'marketing',
+    search_rank: 1,
+    chartCount: 2,
+    dashboardCount: 1,
+    childSpaceCount: 1,
+    appCount: 0,
+    directAccess: true,
+    verification: null,
+    space: {
+        uuid: 'space-uuid-1',
+        name: 'Marketing',
+        slug: 'marketing',
+        breadcrumbs: [
+            {
+                uuid: 'space-uuid-1',
+                name: 'Marketing',
+                slug: 'marketing',
+            },
+        ],
+    },
+});
+
 describe('getFindContent', () => {
     const createTool = (
-        content: DashboardSearchResult[],
+        content: FindContentResult[],
         trackCoverage: jest.Mock = jest.fn(),
     ) => {
         const mockFindContent = jest.fn().mockResolvedValue({ content });
@@ -93,17 +136,35 @@ describe('getFindContent', () => {
                 siteUrl: '',
                 trackCoverage,
             }),
+            mockFindContent,
             trackCoverage,
         };
     };
-    const toolOf = (content: DashboardSearchResult[]) =>
-        createTool(content).tool;
+    const toolOf = (content: FindContentResult[]) => createTool(content).tool;
+
+    it('renders spaces and forwards the space filter', async () => {
+        const { tool, mockFindContent } = createTool([makeMockSpace()]);
+        const output = await executeFindContent(tool, {
+            searchQueries: [{ label: 'marketing' }],
+            spaceSlug: 'company/marketing',
+        });
+
+        expect(output.metadata.status).toBe('success');
+        expect(output.result).toContain('<spaceResult');
+        expect(output.result).toContain('slug="marketing"');
+        expect(output.result).toContain('breadcrumb="Marketing"');
+        expect(mockFindContent).toHaveBeenCalledWith({
+            searchQuery: { label: 'marketing' },
+            spaceSlug: 'company/marketing',
+        });
+    });
 
     it('renders all charts when dashboard has fewer than the preview limit', async () => {
         const underLimit = DASHBOARD_CHARTS_PREVIEW_COUNT - 1;
         const tool = toolOf([makeMockDashboard(underLimit)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
+            spaceSlug: null,
         });
 
         expect(output.metadata.status).toBe('success');
@@ -119,6 +180,7 @@ describe('getFindContent', () => {
         ]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
+            spaceSlug: null,
         });
 
         expect(output.result).toContain(
@@ -133,6 +195,7 @@ describe('getFindContent', () => {
         const tool = toolOf([makeMockDashboard(100)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
+            spaceSlug: null,
         });
 
         expect(output.result).toContain('<charts count="100">');
@@ -145,6 +208,7 @@ describe('getFindContent', () => {
         const tool = toolOf([makeMockDashboard(1)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
+            spaceSlug: null,
         });
 
         expect(output.result).toContain('<charts count="1">');
@@ -157,6 +221,7 @@ describe('getFindContent', () => {
         const tool = toolOf([makeMockDashboard(200)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
+            spaceSlug: null,
         });
 
         expect(output.result.length).toBeLessThan(10_000);
@@ -181,6 +246,7 @@ describe('getFindContent', () => {
         const tool = toolOf([unverified, verified]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
+            spaceSlug: null,
         });
 
         const verifiedIdx = output.result.indexOf('dash-verified');
@@ -197,6 +263,7 @@ describe('getFindContent', () => {
         const tool = toolOf([verified]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
+            spaceSlug: null,
         });
 
         expect(output.result).toMatch(/<verified[^>]*by="Alex Doe"/);
@@ -207,6 +274,7 @@ describe('getFindContent', () => {
         const tool = toolOf([makeMockDashboard(0)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
+            spaceSlug: null,
         });
         expect(output.result).not.toContain('<verified');
     });
@@ -222,6 +290,7 @@ describe('getFindContent', () => {
         const tool = toolOf([dashboard]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
+            spaceSlug: null,
         });
 
         expect(output.result).toMatch(/<verified[^>]*by="Inner Verifier"/);
@@ -237,6 +306,7 @@ describe('getFindContent', () => {
         const { tool } = createTool([verified, unverified], trackCoverage);
         await executeFindContent(tool, {
             searchQueries: [{ label: 'revenue dashboards' }],
+            spaceSlug: null,
         });
 
         expect(trackCoverage).toHaveBeenCalledTimes(1);
@@ -253,6 +323,7 @@ describe('getFindContent', () => {
         const { tool } = createTool([makeMockDashboard(0)], trackCoverage);
         await executeFindContent(tool, {
             searchQueries: [{ label: 'q' }],
+            spaceSlug: null,
         });
 
         expect(trackCoverage).toHaveBeenCalledWith({

--- a/packages/backend/src/ee/services/ai/tools/findContent.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findContent.tsx
@@ -3,13 +3,19 @@ import {
     ContentVerificationInfo,
     DashboardSearchResult,
     findContentToolDefinition,
-    isDashboardSearchResult,
     isSavedChartSearchResult,
     isSqlChartSearchResult,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import moment from 'moment';
-import type { FindContentFn } from '../types/aiAgentDependencies';
+import type {
+    FindContentChartResult,
+    FindContentDashboardResult,
+    FindContentFn,
+    FindContentResult,
+    FindContentSpaceMetadata,
+    FindContentSpaceResult,
+} from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import {
@@ -40,7 +46,35 @@ type Dependencies = {
 
 const toolDefinition = findContentToolDefinition.for('agent');
 
-const renderChart = (chart: AllChartsSearchResult, siteUrl: string) => {
+const renderSpaceMetadata = (space: FindContentSpaceMetadata) => (
+    <space
+        uuid={space.uuid}
+        name={space.name}
+        slug={space.slug}
+        breadcrumb={space.breadcrumbs.map((item) => item.name).join(' / ')}
+    />
+);
+
+const renderSpace = (space: FindContentSpaceResult) => (
+    <spaceResult
+        spaceUuid={space.uuid}
+        slug={space.slug}
+        searchRank={space.search_rank}
+        chartCount={space.chartCount}
+        dashboardCount={space.dashboardCount}
+        childSpaceCount={space.childSpaceCount}
+        appCount={space.appCount}
+        directAccess={space.directAccess}
+    >
+        <name>{space.name}</name>
+        {renderSpaceMetadata(space.space)}
+    </spaceResult>
+);
+
+const renderChart = (
+    chart: AllChartsSearchResult & Pick<FindContentChartResult, 'space'>,
+    siteUrl: string,
+) => {
     const isSavedChart = isSavedChartSearchResult(chart);
     const isSqlChart = isSqlChartSearchResult(chart);
 
@@ -63,6 +97,7 @@ const renderChart = (chart: AllChartsSearchResult, siteUrl: string) => {
             href={chartUrl}
         >
             <name>{chart.name}</name>
+            {renderSpaceMetadata(chart.space)}
             {chart.description && (
                 <description>
                     {truncate(chart.description, CONTENT_DESCRIPTION_MAX_CHARS)}
@@ -93,7 +128,11 @@ const renderChart = (chart: AllChartsSearchResult, siteUrl: string) => {
     );
 };
 
-const renderDashboard = (dashboard: DashboardSearchResult, siteUrl: string) => (
+const renderDashboard = (
+    dashboard: DashboardSearchResult &
+        Pick<FindContentDashboardResult, 'space'>,
+    siteUrl: string,
+) => (
     <dashboard
         dashboardUuid={dashboard.uuid}
         slug={dashboard.slug}
@@ -103,6 +142,7 @@ const renderDashboard = (dashboard: DashboardSearchResult, siteUrl: string) => (
     >
         <name>{dashboard.name}</name>
         <searchrank>{dashboard.search_rank}</searchrank>
+        {renderSpaceMetadata(dashboard.space)}
 
         {dashboard.description && (
             <description>
@@ -161,6 +201,14 @@ const renderDashboard = (dashboard: DashboardSearchResult, siteUrl: string) => (
     </dashboard>
 );
 
+const isDashboardResult = (
+    content: FindContentResult,
+): content is FindContentDashboardResult => content.contentType === 'dashboard';
+
+const isSpaceResult = (
+    content: FindContentResult,
+): content is FindContentSpaceResult => content.contentType === 'space';
+
 const renderContent = (
     args: Awaited<ReturnType<FindContentFn>> & { searchQuery: string },
     siteUrl: string,
@@ -171,11 +219,14 @@ const renderContent = (
     );
     return (
         <searchresult searchQuery={args.searchQuery}>
-            {sortedContent.map((content) =>
-                isDashboardSearchResult(content)
+            {sortedContent.map((content) => {
+                if (isSpaceResult(content)) {
+                    return renderSpace(content);
+                }
+                return isDashboardResult(content)
                     ? renderDashboard(content, siteUrl)
-                    : renderChart(content, siteUrl),
-            )}
+                    : renderChart(content, siteUrl);
+            })}
         </searchresult>
     );
 };
@@ -194,6 +245,7 @@ export const getFindContent = ({
                         searchQuery: searchQuery.label,
                         ...(await findContent({
                             searchQuery,
+                            spaceSlug: args.spaceSlug ?? null,
                         })),
                     })),
                 );

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -102,10 +102,54 @@ export type SearchSemanticLayerFn = (args: {
 
 export type GetExploreFn = (args: { table: string }) => Promise<Explore>;
 
+export type FindContentSpaceBreadcrumb = {
+    uuid: string;
+    name: string;
+    slug: string;
+};
+
+export type FindContentSpaceMetadata = {
+    uuid: string;
+    name: string;
+    slug: string;
+    breadcrumbs: FindContentSpaceBreadcrumb[];
+};
+
+export type FindContentChartResult = AllChartsSearchResult & {
+    contentType: 'chart';
+    space: FindContentSpaceMetadata;
+};
+
+export type FindContentDashboardResult = DashboardSearchResult & {
+    contentType: 'dashboard';
+    space: FindContentSpaceMetadata;
+};
+
+export type FindContentSpaceResult = {
+    contentType: 'space';
+    uuid: string;
+    name: string;
+    slug: string;
+    search_rank: number;
+    chartCount: number;
+    dashboardCount: number;
+    childSpaceCount: number;
+    appCount: number;
+    directAccess: boolean;
+    space: FindContentSpaceMetadata;
+    verification: null;
+};
+
+export type FindContentResult =
+    | FindContentChartResult
+    | FindContentDashboardResult
+    | FindContentSpaceResult;
+
 export type FindContentFn = (args: {
     searchQuery: ToolFindContentArgs['searchQueries'][number];
+    spaceSlug: ToolFindContentArgs['spaceSlug'];
 }) => Promise<{
-    content: (AllChartsSearchResult | DashboardSearchResult)[];
+    content: FindContentResult[];
 }>;
 
 export type ListContentFn = (args: {

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindContentArgs.ts
@@ -4,15 +4,16 @@ import { createToolSchema } from '../toolSchemaBuilder';
 
 export const TOOL_FIND_CONTENT_DESCRIPTION = `Tool: "findContent"
 Purpose:
-Finds charts or dashboards by name or description within a project, returning detailed information about each.
+Finds spaces, charts, or dashboards by name or description within a project, returning detailed information about each.
 
 Usage tips:
 - IMPORTANT: Pass the user's full query or relevant portion directly (e.g., "revenue based on campaigns" instead of just "campaigns").
 - The search engine understands natural language and context — more descriptive queries yield better results.
 - You can provide multiple search queries to look for different topics simultaneously (e.g., ["monthly revenue", "user acquisition trends"]).
+- Pass spaceSlug to search only inside that space and its descendants.
 - If results aren't relevant, retry with the full user query or more specific terms.
 - Dashboards with validation errors will be deprioritized.
-- Returns chart and dashboard URLs when available.
+- Returns space breadcrumb/path metadata and chart/dashboard URLs when available.
 - Dashboards show a preview of the first 5 charts and the total chart count. Use "getDashboardCharts" to see all charts for a specific dashboard.
 - It doesn't provide summaries for dashboards yet, so don't suggest this capability.`;
 
@@ -27,6 +28,12 @@ export const toolFindContentArgsSchema = createToolSchema()
                     ),
             }),
         ),
+        spaceSlug: z
+            .string()
+            .nullable()
+            .describe(
+                'Optional space slug/path. Use null to search the whole project. When set, only content in this space and descendants is returned.',
+            ),
     })
     .build();
 


### PR DESCRIPTION
Closes ZAP-391
Related ZAP-384

Based on #24099.

## Summary
- extend shared `find_content` runtime for AI agents and MCP
- include spaces in `find_content` results
- add space metadata and breadcrumbs to chart/dashboard/space results
- add optional `spaceSlug` filtering for a space and descendants

## Testing
- `pnpm -F common build`
- `pnpm -F common typecheck:fast`
- `pnpm -F backend typecheck:fast`
- `pnpm -F backend lint`
- `pnpm -F backend exec jest --config jest.config.js --runTestsByPath src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts src/ee/services/ai/tools/findContent.test.ts src/ee/services/McpService/mcpToolContracts.snapshot.test.ts src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts src/ee/services/McpService/McpService.queryPolling.test.ts --runInBand`