### PR TITLE
feat(sankey): add direct (two-column) node layout

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -205,8 +205,9 @@ export type GaugeChart = {
  * How nodes are laid out:
  * - `multi-step`: depth-unrolled journeys (default)
  * - `merged`: one node per label, journeys preserved (acyclic flows only)
+ * - `direct`: two-column source→target pairs, no chaining
  */
-export type SankeyNodeLayout = 'multi-step' | 'merged';
+export type SankeyNodeLayout = 'multi-step' | 'merged' | 'direct';
 
 export type SankeyChart = {
     /** Field ID for the source node dimension */

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
@@ -217,42 +217,6 @@ export const ConfigTabs: FC = memo(() => {
                         </Config>
                         <Config>
                             <Config.Section>
-                                <Config.Heading>Node alignment</Config.Heading>
-                                <SegmentedControl
-                                    value={nodeAlign}
-                                    data={[
-                                        {
-                                            value: 'left',
-                                            label:
-                                                orient === 'vertical'
-                                                    ? 'Top'
-                                                    : 'Left',
-                                        },
-                                        {
-                                            value: 'right',
-                                            label:
-                                                orient === 'vertical'
-                                                    ? 'Bottom'
-                                                    : 'Right',
-                                        },
-                                        {
-                                            value: 'justify',
-                                            label: 'Justify',
-                                        },
-                                    ]}
-                                    onChange={(value) =>
-                                        onNodeAlignChange(
-                                            value as
-                                                | 'left'
-                                                | 'right'
-                                                | 'justify',
-                                        )
-                                    }
-                                />
-                            </Config.Section>
-                        </Config>
-                        <Config>
-                            <Config.Section>
                                 <Config.Heading>Node layout</Config.Heading>
                                 <SegmentedControl
                                     value={effectiveLayout}
@@ -265,6 +229,10 @@ export const ConfigTabs: FC = memo(() => {
                                             value: 'merged',
                                             label: 'Merged',
                                             disabled: data.hasCycle,
+                                        },
+                                        {
+                                            value: 'direct',
+                                            label: 'Direct',
                                         },
                                     ]}
                                     onChange={(value) =>
@@ -281,6 +249,46 @@ export const ConfigTabs: FC = memo(() => {
                                 )}
                             </Config.Section>
                         </Config>
+                        {effectiveLayout !== 'direct' && (
+                            <Config>
+                                <Config.Section>
+                                    <Config.Heading>
+                                        Node alignment
+                                    </Config.Heading>
+                                    <SegmentedControl
+                                        value={nodeAlign}
+                                        data={[
+                                            {
+                                                value: 'left',
+                                                label:
+                                                    orient === 'vertical'
+                                                        ? 'Top'
+                                                        : 'Left',
+                                            },
+                                            {
+                                                value: 'right',
+                                                label:
+                                                    orient === 'vertical'
+                                                        ? 'Bottom'
+                                                        : 'Right',
+                                            },
+                                            {
+                                                value: 'justify',
+                                                label: 'Justify',
+                                            },
+                                        ]}
+                                        onChange={(value) =>
+                                            onNodeAlignChange(
+                                                value as
+                                                    | 'left'
+                                                    | 'right'
+                                                    | 'justify',
+                                            )
+                                        }
+                                    />
+                                </Config.Section>
+                            </Config>
+                        )}
                     </Stack>
                 </Tabs.Panel>
             </Tabs>

--- a/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
@@ -9,13 +9,10 @@ import {
 } from '@lightdash/common';
 import { useMantineTheme } from '@mantine/core';
 import { type EChartsOption, type SankeySeriesOption } from 'echarts';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { isSankeyVisualizationConfig } from '../../components/LightdashVisualization/types';
 import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
 import { sanitizeEchartsFontFamily } from '../../utils/sanitizeEchartsFontFamily';
-
-/** Strip " - Step N" suffix from node names for display */
-const stripStepSuffix = (name: string) => name.replace(/ - Step \d+$/, '');
 
 const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
     const {
@@ -33,6 +30,22 @@ const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
         if (!isSankeyVisualizationConfig(visualizationConfig)) return;
         return visualizationConfig.chartConfig;
     }, [visualizationConfig]);
+
+    // Node names are opaque ids; map them to their display labels.
+    const labelByName = useMemo(
+        () =>
+            new Map(
+                (chartConfig?.data.nodes ?? []).map((node) => [
+                    node.name,
+                    node.label,
+                ]),
+            ),
+        [chartConfig],
+    );
+    const displayName = useCallback(
+        (name: string) => labelByName.get(name) ?? name,
+        [labelByName],
+    );
 
     const sankeySeriesOption: SankeySeriesOption | undefined = useMemo(() => {
         if (!chartConfig) return;
@@ -89,12 +102,11 @@ const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
                 show: true,
                 color: theme.colors.foreground?.[0],
                 position: isVertical ? 'bottom' : 'right',
-                // Display clean names without step suffix
                 formatter: (params: { name?: string }) =>
-                    stripStepSuffix(params.name ?? ''),
+                    displayName(params.name ?? ''),
             },
         };
-    }, [chartConfig, theme.colors.foreground, colorPalette]);
+    }, [chartConfig, theme.colors.foreground, colorPalette, displayName]);
 
     const eChartsOptions: EChartsOption | undefined = useMemo(() => {
         if (!chartConfig || !sankeySeriesOption) return;
@@ -129,8 +141,8 @@ const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
                             parameters,
                             resolvedTimezone,
                         );
-                        const source = stripStepSuffix(params.data.source);
-                        const target = stripStepSuffix(params.data.target);
+                        const source = displayName(params.data.source);
+                        const target = displayName(params.data.target);
                         const colorIndicator = formatColorIndicator(
                             typeof params.color === 'string'
                                 ? params.color
@@ -148,7 +160,7 @@ const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
                     );
                     return formatTooltipRow(
                         colorIndicator,
-                        stripStepSuffix(params.name),
+                        displayName(params.name),
                         '',
                     );
                 },
@@ -166,6 +178,7 @@ const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
         visualizationConfig,
         parameters,
         resolvedTimezone,
+        displayName,
     ]);
 
     if (!eChartsOptions) return;

--- a/packages/frontend/src/hooks/sankeyTransform.test.ts
+++ b/packages/frontend/src/hooks/sankeyTransform.test.ts
@@ -21,6 +21,7 @@ const FIELDS = {
 type Data = ReturnType<typeof transformSankeyData>;
 
 const nodeIds = (data: Data) => data.nodes.map((n) => n.name).sort();
+const nodeLabels = (data: Data) => data.nodes.map((n) => n.label).sort();
 const sourceTargets = (data: Data) =>
     data.links.map((l) => `${l.source}→${l.target}`).sort();
 
@@ -69,6 +70,8 @@ describe('transformSankeyData', () => {
                 'C - Step 1',
                 'C - Step 2',
             ]);
+            // both "Step" instances still display as plain "C"
+            expect(nodeLabels(data)).toEqual(['A', 'B', 'C', 'C']);
         });
     });
 
@@ -94,6 +97,39 @@ describe('transformSankeyData', () => {
             expect(data.hasCycle).toBe(true);
             expect(data.nodes.some((n) => / - Step \d+$/.test(n.name))).toBe(
                 true,
+            );
+        });
+    });
+
+    describe('direct', () => {
+        it('renders a bipartite source→target view with no chaining', () => {
+            const data = transformSankeyData(diamond, FIELDS, {
+                nodeLayout: 'direct',
+            });
+
+            expect(data.maxDepth).toBe(1);
+            expect(data.links).toHaveLength(3);
+
+            // no node is both a link source and a link target (strict 2 columns)
+            const sources = new Set(data.links.map((l) => l.source));
+            const targets = new Set(data.links.map((l) => l.target));
+            expect([...sources].some((s) => targets.has(s))).toBe(false);
+
+            // "B" is both a source and a target, so it appears on both sides
+            expect(nodeLabels(data)).toEqual(['A', 'B', 'B', 'C']);
+        });
+
+        it('handles cyclic data without error', () => {
+            const data = transformSankeyData(
+                [row('A', 'B', 1), row('B', 'A', 1)],
+                FIELDS,
+                { nodeLayout: 'direct' },
+            );
+
+            expect(data.hasCycle).toBe(true);
+            expect(data.links).toHaveLength(2);
+            expect(data.nodes.some((n) => / - Step \d+$/.test(n.name))).toBe(
+                false,
             );
         });
     });

--- a/packages/frontend/src/hooks/sankeyTransform.ts
+++ b/packages/frontend/src/hooks/sankeyTransform.ts
@@ -1,11 +1,13 @@
 import {
+    assertUnreachable,
     type ResultRow,
     type ResultValue,
     type SankeyNodeLayout,
 } from '@lightdash/common';
 
 export type SankeySeriesDataPoint = {
-    nodes: { name: string }[];
+    /** `name` is the unique node id (links reference it); `label` is what's shown */
+    nodes: { name: string; label: string }[];
     links: {
         source: string;
         target: string;
@@ -146,14 +148,44 @@ const buildMergedSankey = (
     }
 
     return {
-        nodes: Array.from(names).map((name) => ({ name })),
+        nodes: Array.from(names).map((name) => ({ name, label: name })),
         links,
         maxDepth,
     };
 };
 
+// Direct flows only: a strict two-column source→target view. Source and target
+// identities are kept separate so ECharts never chains them into extra steps,
+// which also means cyclic data renders fine (the bipartite output is acyclic).
+const buildDirectSankey = (
+    aggregated: Map<string, AggregatedLink>,
+): SankeyBuild => {
+    const nodes = new Map<string, string>(); // node id -> label
+    const links: SankeyBuild['links'] = [];
+
+    for (const link of aggregated.values()) {
+        const sourceId = `source:${link.source}`;
+        const targetId = `target:${link.target}`;
+        nodes.set(sourceId, link.source);
+        nodes.set(targetId, link.target);
+        links.push({
+            source: sourceId,
+            target: targetId,
+            value: link.value,
+            meta: link.meta,
+        });
+    }
+
+    return {
+        nodes: Array.from(nodes, ([name, label]) => ({ name, label })),
+        links,
+        maxDepth: 1,
+    };
+};
+
 // Unroll into depth layers via BFS so cyclic flows can render as a DAG: a label
-// seen at multiple depths splits into "Label - Step N" nodes.
+// seen at multiple depths splits into "Label - Step N" nodes (the node id),
+// while its label stays the base name.
 const buildSteppedSankey = (
     aggregated: Map<string, AggregatedLink>,
 ): SankeyBuild => {
@@ -222,21 +254,21 @@ const buildSteppedSankey = (
     for (const [name, depths] of nodeDepthMap) {
         if (depths.size > 1) multiDepthNodes.add(name);
     }
-    const getLabel = (name: string, depth: number) =>
+    const getNodeId = (name: string, depth: number) =>
         multiDepthNodes.has(name) ? `${name} - Step ${depth}` : name;
 
-    const nodeSet = new Set<string>();
+    const nodes = new Map<string, string>(); // node id -> label
     const links: SankeyBuild['links'] = [];
     const placedLinks = new Set<string>();
 
     for (const edge of edgeInstances) {
-        const sourceLabel = getLabel(edge.source, edge.sourceDepth);
-        const targetLabel = getLabel(edge.target, edge.targetDepth);
+        const sourceId = getNodeId(edge.source, edge.sourceDepth);
+        const targetId = getNodeId(edge.target, edge.targetDepth);
 
-        nodeSet.add(sourceLabel);
-        nodeSet.add(targetLabel);
+        nodes.set(sourceId, edge.source);
+        nodes.set(targetId, edge.target);
 
-        const key = linkKey(sourceLabel, targetLabel);
+        const key = linkKey(sourceId, targetId);
         if (placedLinks.has(key)) continue;
         placedLinks.add(key);
 
@@ -244,15 +276,15 @@ const buildSteppedSankey = (
         if (!aggLink) continue;
 
         links.push({
-            source: sourceLabel,
-            target: targetLabel,
+            source: sourceId,
+            target: targetId,
             value: aggLink.value,
             meta: aggLink.meta,
         });
     }
 
     return {
-        nodes: Array.from(nodeSet).map((name) => ({ name })),
+        nodes: Array.from(nodes, ([name, label]) => ({ name, label })),
         links,
         maxDepth,
     };
@@ -260,6 +292,7 @@ const buildSteppedSankey = (
 
 /**
  * Build Sankey nodes & links according to the chosen layout:
+ * - `direct`: two-column source→target pairs (no chaining)
  * - `merged`: one node per label (acyclic only; falls back to multi-step)
  * - `multi-step`: depth-unrolled journeys with "Step N" instances
  */
@@ -273,10 +306,26 @@ export const transformSankeyData = (
 
     const { hasCycle, maxDepth } = analyzeFlowGraph(aggregated);
 
-    const build: SankeyBuild =
-        nodeLayout === 'merged' && !hasCycle
-            ? buildMergedSankey(aggregated, maxDepth)
-            : buildSteppedSankey(aggregated);
+    let build: SankeyBuild;
+    switch (nodeLayout) {
+        case 'direct':
+            build = buildDirectSankey(aggregated);
+            break;
+        case 'merged':
+            // merging needs a DAG, so cyclic data falls back to multi-step
+            build = hasCycle
+                ? buildSteppedSankey(aggregated)
+                : buildMergedSankey(aggregated, maxDepth);
+            break;
+        case 'multi-step':
+            build = buildSteppedSankey(aggregated);
+            break;
+        default:
+            return assertUnreachable(
+                nodeLayout,
+                `Unknown sankey node layout: ${nodeLayout}`,
+            );
+    }
 
     return { ...build, hasCycle };
 };


### PR DESCRIPTION
Closes: PROD-7057
Closes: #22175

> 📚 Stacked on #24085 (Node layout: multi-step / merged). Review and merge that first.

### Description

Adds a third **Node layout** option, **Direct**, for users who want only direct flows between two categories rather than multi-step journeys.

Direct renders a strict two-column source → target view with no chaining. A label that is both a source and a target appears once on each side (e.g. a left "Email" feeding in and a right "Email" being fed into). Because source and target identities are kept separate, the output is bipartite (always acyclic), so cyclic data renders without issue too.

### Implementation notes

- Adds `'direct'` to `nodeLayout` and a `buildDirectSankey` branch in the pure transform module.
- Reuses the node id/label separation introduced in the base PR, so no ECharts-layer changes are needed.

### Testing

- Unit tests cover the bipartite "no-chaining" invariant and that cyclic data renders without errors.
- Verified manually with the `sankey_demo` model.