### PR TITLE
feat(ai-agents): gate chart-as-code artifacts

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5326,22 +5326,25 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 })),
             ),
         });
-        const { enabled: agentRevampEnabled } =
-            await this.featureFlagService.get({
-                user,
-                featureFlagId: FeatureFlags.AiAgentRevamp,
-            });
-        const { enabled: searchSemanticLayerEnabled } =
-            await this.featureFlagService.get({
-                user,
-                featureFlagId: FeatureFlags.SearchSemanticLayer,
-            });
-        let { enabled: aiWritebackEnabled } = await this.featureFlagService.get(
-            {
-                user,
-                featureFlagId: FeatureFlags.AiWriteback,
-            },
+        const [
+            { enabled: agentRevampEnabled },
+            { enabled: chartAsCodeArtifactsEnabled },
+            { enabled: searchSemanticLayerEnabled },
+            { enabled: aiWritebackFlag },
+            { enabled: aiPreviewDeploySetupFlag },
+        ] = await Promise.all(
+            [
+                FeatureFlags.AiAgentRevamp,
+                FeatureFlags.AiAgentChartAsCodeArtifacts,
+                FeatureFlags.SearchSemanticLayer,
+                FeatureFlags.AiWriteback,
+                FeatureFlags.AiPreviewDeploySetup,
+            ].map((featureFlagId) =>
+                this.featureFlagService.get({ user, featureFlagId }),
+            ),
         );
+
+        let aiWritebackEnabled = aiWritebackFlag;
         if (aiWritebackEnabled && !hasTrustedPromptUserIdentity) {
             this.logger.info(
                 `Disabling editDbtProject for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
@@ -5360,11 +5363,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         // Preview-deploy setup rides the writeback infra, so it requires both
         // the writeback flag (and trusted identity, applied above) and its own
         // ai-preview-deploy-setup flag.
-        const { enabled: aiPreviewDeploySetupFlag } =
-            await this.featureFlagService.get({
-                user,
-                featureFlagId: FeatureFlags.AiPreviewDeploySetup,
-            });
         const aiPreviewDeploySetupEnabled =
             aiWritebackEnabled && aiPreviewDeploySetupFlag;
 
@@ -5446,6 +5444,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableDataAccess: agentSettings.enableDataAccess,
             enableSelfImprovement: agentSettings.enableSelfImprovement,
             enableContentTools: canUseContentTools,
+            enableChartAsCodeArtifacts: chartAsCodeArtifactsEnabled,
             enableSearchSemanticLayer: searchSemanticLayerEnabled,
             enableAiWriteback: aiWritebackEnabled,
             enablePreviewDeploySetup: aiPreviewDeploySetupEnabled,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -214,6 +214,7 @@ const getAgentTools = (
         validateContent: dependencies.validateContent,
         maxLimit: args.maxQueryLimit,
         enableDataAccess: args.enableDataAccess,
+        enableChartAsCodeArtifacts: args.enableChartAsCodeArtifacts,
     });
 
     const runSavedChart = getRunSavedChart({
@@ -404,6 +405,7 @@ const getAgentMessages = (args: AiAgentArgs, availableExplores: Explore[]) => {
             knowledgeDocuments: args.knowledgeDocuments,
             hasProjectContext,
             enableDataAccess: args.enableDataAccess,
+            enableChartAsCodeArtifacts: args.enableChartAsCodeArtifacts,
             enableSearchSemanticLayer: args.enableSearchSemanticLayer,
             enableAiWriteback: args.enableAiWriteback,
             enableRepoFs: args.enableRepoFs,

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -32,3 +32,28 @@ describe('getSystemPromptV2 project context', () => {
         expect(content).not.toContain('{{project_context}}');
     });
 });
+
+describe('getSystemPromptV2 chart-as-code artifacts', () => {
+    test('advertises chart-as-code instructions when enabled', () => {
+        const content = promptText({
+            availableExplores: [],
+            enableChartAsCodeArtifacts: true,
+        });
+
+        expect(content).toContain('using chart-as-code');
+        expect(content).toContain('`metricQuery`');
+        expect(content).toContain('`chartConfig.config.columns`');
+    });
+
+    test('uses legacy visualization instructions when disabled', () => {
+        const content = promptText({
+            availableExplores: [],
+            enableChartAsCodeArtifacts: false,
+        });
+
+        expect(content).toContain("defaultVizType: 'table'");
+        expect(content).toContain('`queryConfig.metrics`');
+        expect(content).not.toContain('using chart-as-code');
+        expect(content).not.toContain('`metricQuery`');
+    });
+});

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -19,6 +19,29 @@ import { SEARCH_SEMANTIC_LAYER_SECTION } from './systemV2SearchSemanticLayer';
 import { renderAvailableSkills } from './systemV2Skills';
 import { SYSTEM_PROMPT_TEMPLATE } from './systemV2Template';
 
+const CHART_AS_CODE_VISUALIZATION_INSTRUCTIONS = {
+    '{{table_visualization_instruction}}':
+        'When a user asks for a "table", generate a table visualization with generateVisualization using chart-as-code `chartConfig.type: "table"`. Never produce markdown tables.',
+    '{{generate_visualization_instruction}}':
+        'Use chart-as-code: put the query in `metricQuery`, the runtime visualization in `chartConfig`, table column order in top-level `tableConfig`, and pivots in top-level `pivotConfig`. For table styling, use canonical chart-as-code only: column display options go under `chartConfig.config.columns`; conditional formatting rules go under `chartConfig.config.conditionalFormattings`; never put `columns` at `chartConfig` root and never use `dataBarColor`. The server validates the payload against chart-as-code and returns errors you can repair.',
+    '{{table_calculation_shape_instruction}}':
+        'Table calc parameter shapes (frames, partitionBy, orderBy) follow the chart-as-code metric query shape.',
+    '{{custom_metric_reference_instruction}}':
+        'Use the fieldId in `metricQuery.metrics`, `chartConfig`, `sorts`, `filters`, or `tableCalculations`.',
+};
+
+const LEGACY_VISUALIZATION_INSTRUCTIONS: typeof CHART_AS_CODE_VISUALIZATION_INSTRUCTIONS =
+    {
+        '{{table_visualization_instruction}}':
+            'When a user asks for a "table", generate a table visualization with generateVisualization (defaultVizType: \'table\'). Never produce markdown tables.',
+        '{{generate_visualization_instruction}}':
+            "The tool's parameter docs describe every chart-config option — read those rather than guessing. Key conventions: `dimensions[0]` drives the x-axis; put extra grouping dimensions in `chartConfig.groupBy` (never the x-axis dim) for multi-series, leave `null` for single-series; always set `xAxisLabel` and `yAxisLabel`.",
+        '{{table_calculation_shape_instruction}}':
+            'Table calc parameter shapes (frames, partitionBy, orderBy) are documented in the generateVisualization schema.',
+        '{{custom_metric_reference_instruction}}':
+            'Use the fieldId in `queryConfig.metrics`, `chartConfig.yAxisMetrics`, `sorts`, `filters`, or `tableCalculations`.',
+    };
+
 export const getSystemPromptV2 = (args: {
     availableExplores: Explore[];
     availableSkills?: AiAgentSkillReference[];
@@ -28,6 +51,7 @@ export const getSystemPromptV2 = (args: {
     agentName?: string;
     date?: string;
     enableDataAccess?: boolean;
+    enableChartAsCodeArtifacts?: boolean;
     enableSearchSemanticLayer?: boolean;
     enableAiWriteback?: boolean;
     enableRepoFs?: boolean;
@@ -42,6 +66,7 @@ export const getSystemPromptV2 = (args: {
         agentName = 'Lightdash AI Analyst',
         date = moment().utc().format('YYYY-MM-DD'),
         enableDataAccess = false,
+        enableChartAsCodeArtifacts = false,
         enableSearchSemanticLayer = false,
         enableAiWriteback = false,
         enableRepoFs = false,
@@ -59,6 +84,10 @@ export const getSystemPromptV2 = (args: {
     const customSqlLimitation = canRunSql
         ? ''
         : '\n- You cannot execute raw SQL or add custom SQL expressions to a query.';
+
+    const visualizationInstructions = enableChartAsCodeArtifacts
+        ? CHART_AS_CODE_VISUALIZATION_INSTRUCTIONS
+        : LEGACY_VISUALIZATION_INSTRUCTIONS;
 
     const renderKnowledgeDocument = (doc: AiAgentDocumentSummary): string => {
         const { summary } = doc;
@@ -121,10 +150,13 @@ export const getSystemPromptV2 = (args: {
         availableExploresContent = `This agent has access to ${args.availableExplores.length} explores. Use findExplores to discover the relevant one for each request.`;
     }
 
-    const content = SYSTEM_PROMPT_TEMPLATE.replace(
-        '{{self_improvement_section}}',
-        '',
-    )
+    const content = Object.entries(visualizationInstructions)
+        .reduce(
+            (template, [placeholder, instruction]) =>
+                template.replace(placeholder, instruction),
+            SYSTEM_PROMPT_TEMPLATE,
+        )
+        .replace('{{self_improvement_section}}', '')
         .replace(
             '{{ai_writeback_section}}',
             enableAiWriteback ? AI_WRITEBACK_SECTION : '',

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -7,7 +7,7 @@ The user sees BOTH your final response AND your internal reasoning ("thinking").
 ## How to interpret requests
 
 - Assume questions are requests to retrieve data, even when phrased as questions ("what is total revenue?" → run a query).
-- When a user asks for a "table", generate a table visualization with generateVisualization using chart-as-code \`chartConfig.type: "table"\`. Never produce markdown tables.
+- {{table_visualization_instruction}}
 - When a user asks to find existing dashboards or charts, use findContent and format results as a markdown list of descriptive links (\`- [Name](url)\`). Never output bare URLs. If nothing matches, offer to build a new chart from available data.
 - When a user asks for a dashboard, plan a concise set of chart titles, build each with generateVisualization, and mention any relevant existing dashboards found via findContent as an alternative. Don't expose the plan.
 - If a pinned chart is in the conversation context (shown as \`Chart "..." (chartUuid: ...)\`) and the user wants to inspect its rows, use runSavedChart with that chartUuid rather than rebuilding the query.
@@ -37,7 +37,7 @@ The user sees BOTH your final response AND your internal reasoning ("thinking").
    - **Ambiguous**: multiple plausible explores. Echo the suggested clarification to the user and list the candidates — do not call generateVisualization. Before doing this, double-check that no knowledge document already resolves the ambiguity.
    - **No match**: no explore covers the request. Explain back to the user and offer alternatives if appropriate.
    Call it again when the user pivots mid-thread to a different topic. Don't re-call on follow-ups that iterate on the same data (different filter, different breakdown, follow-up with the same fields). For questions about existing dashboards/charts use findContent, and don't re-discover on follow-ups about a chart already produced.
-3. **generateVisualization** to build the chart. Use chart-as-code: put the query in \`metricQuery\`, the runtime visualization in \`chartConfig\`, table column order in top-level \`tableConfig\`, and pivots in top-level \`pivotConfig\`. For table formatting, use canonical chart-as-code only: \`chartConfig: { type: "table", config: { columns: { fieldId: { displayStyle: "bar", color: "#4CAF50" } }, conditionalFormattings: [...] } }\`. Never put \`columns\` or \`conditionalFormattings\` at the root of \`chartConfig\`, and never use \`dataBarColor\`. The server validates the payload against chart-as-code and returns errors you can repair.
+3. **generateVisualization** to build the chart. {{generate_visualization_instruction}}
 4. **searchFieldValues** when you need to validate or discover concrete dimension values (e.g., specific product names, region names).
 
 ## Verified content
@@ -72,7 +72,7 @@ Use a table calculation when the question requires row-by-row math over query re
 - **% of total, running totals, moving averages, period-over-period change**: prefer the simple types (\`percent_of_column_total\`, \`running_total\`, \`percent_change_from_previous\`) over \`window_function\` when they fit. They support \`partitionBy\` for per-group variants.
 - Default the visualization to a table when the user wants to see the calculated values, unless they ask for a chart explicitly.
 
-Table calc parameter shapes (frames, partitionBy, orderBy) follow the chart-as-code metric query shape.
+{{table_calculation_shape_instruction}}
 
 ## Custom metrics
 
@@ -82,7 +82,7 @@ Reference a custom metric by its fieldId, which is \`<table>_<name>\`:
 - \`{name: "avg_customer_age", table: "customers"}\` → \`customers_avg_customer_age\`
 - \`{name: "total_revenue", table: "payments"}\` → \`payments_total_revenue\`
 
-Use the fieldId in \`metricQuery.metrics\`, \`chartConfig\`, \`sorts\`, \`filters\`, or \`tableCalculations\`.
+{{custom_metric_reference_instruction}}
 
 ## Field usage
 

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -5070,6 +5070,1624 @@ Usage Tips:
 ]
 `;
 
+exports[`AI agent tool contracts matches the legacy generateVisualization contract snapshot when chart-as-code artifacts are disabled 1`] = `
+{
+  "description": "Execute a metric query.
+
+This tool returns metric query data only. If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after run_metric_query returns done.
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: string }] — human-readable fallback. Completed queries return bare CSV text. CSV headers are display labels, not stable field IDs; running queries return polling status text; errors return an error message.
+- If the query finishes before the MCP wait window, structuredContent: {
+    result: {
+      status: "done",
+      queryUuid: string,
+      rows: Array<Record<string, unknown>>,
+      fields: Record<string, unknown>,
+      exploreUrl: string | null
+    }
+  }
+- If the query is still running, structuredContent: {
+    result: {
+      status: "running",
+      queryUuid: string,
+      nextPollAfterMs: number,
+      heartbeatAt: string
+    }
+  }
+  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.
+
+Notes:
+- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.
+- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.
+- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.
+",
+  "inputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "chartConfig": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "defaultVizType": {
+                "description": "The default visualization type to render",
+                "enum": [
+                  "table",
+                  "bar",
+                  "horizontal",
+                  "line",
+                  "scatter",
+                  "pie",
+                  "funnel",
+                ],
+                "type": "string",
+              },
+              "funnelDataInput": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "row",
+                      "column",
+                    ],
+                    "type": "string",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "How to interpret funnel data. Use "row" when each row represents a funnel stage (most common). Use "column" when comparing multiple funnels side-by-side.",
+              },
+              "groupBy": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "Dimensions to split metrics into separate series (e.g., one line per region, one bar per status). IMPORTANT: Do NOT include the x-axis dimension in groupBy - only include dimensions you want to use for breaking down the data into multiple series. Example: dimensions=["order_date", "status"], groupBy=["status"] creates separate series for each status value. Leave null for simple single-series charts.",
+              },
+              "lineType": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "line",
+                      "area",
+                    ],
+                    "type": "string",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "default line. The type of line to display. If area then the area under the line will be filled in.",
+              },
+              "secondaryYAxisLabel": {
+                "description": "A helpful label for the secondary y-axis",
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "secondaryYAxisMetric": {
+                "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "stackBars": {
+                "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.",
+                "type": [
+                  "boolean",
+                  "null",
+                ],
+              },
+              "xAxisDimension": {
+                "description": "The dimension field ID to use for the x-axis. Must be included in queryConfig.dimensions",
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "xAxisLabel": {
+                "description": "A helpful label to explain the x-axis",
+                "type": "string",
+              },
+              "xAxisType": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "category",
+                      "time",
+                    ],
+                    "type": "string",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "The x-axis type can be categorical for string value or time if the dimension is a date or timestamp. Applies to bar, horizontal, and scatter charts.",
+              },
+              "yAxisLabel": {
+                "description": "A helpful label to explain the y-axis",
+                "type": "string",
+              },
+              "yAxisMetrics": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "The metric field IDs to display on the y-axis. Must be included in queryConfig.metrics or come from tableCalculations",
+              },
+            },
+            "required": [
+              "defaultVizType",
+              "xAxisDimension",
+              "yAxisMetrics",
+              "groupBy",
+              "xAxisType",
+              "stackBars",
+              "lineType",
+              "funnelDataInput",
+              "xAxisLabel",
+              "yAxisLabel",
+              "secondaryYAxisMetric",
+              "secondaryYAxisLabel",
+            ],
+            "type": "object",
+          },
+          {
+            "type": "null",
+          },
+        ],
+      },
+      "customMetrics": {
+        "anyOf": [
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "baseDimensionName": {
+                      "description": "Name of the base dimension/column this metric calculates from",
+                      "type": "string",
+                    },
+                    "description": {
+                      "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                      "type": "string",
+                    },
+                    "filters": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "filter": {
+                                "anyOf": [
+                                  {
+                                    "anyOf": [
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "boolean",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "boolean",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "isNull",
+                                              "notNull",
+                                            ],
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
+                                          },
+                                          "fieldId": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldId",
+                                          },
+                                          "fieldType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldType",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "notEquals",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "boolean",
+                                            },
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                    ],
+                                  },
+                                  {
+                                    "anyOf": [
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "string",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "string",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "isNull",
+                                              "notNull",
+                                            ],
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
+                                          },
+                                          "fieldId": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldId",
+                                          },
+                                          "fieldType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldType",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "notEquals",
+                                              "startsWith",
+                                              "endsWith",
+                                              "include",
+                                              "doesNotInclude",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "string",
+                                            },
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                    ],
+                                  },
+                                  {
+                                    "anyOf": [
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "number",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "number",
+                                              "percentile",
+                                              "median",
+                                              "average",
+                                              "count",
+                                              "count_distinct",
+                                              "sum",
+                                              "sum_distinct",
+                                              "average_distinct",
+                                              "min",
+                                              "max",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "isNull",
+                                              "notNull",
+                                            ],
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                          },
+                                          "fieldId": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                          },
+                                          "fieldType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "notEquals",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "number",
+                                            },
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                          },
+                                          "fieldId": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                          },
+                                          "fieldType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "lessThan",
+                                              "lessThanOrEqual",
+                                              "greaterThan",
+                                              "greaterThanOrEqual",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "number",
+                                            },
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                          },
+                                          "fieldId": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                          },
+                                          "fieldType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "inBetween",
+                                              "notInBetween",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "number",
+                                            },
+                                            "maxItems": 2,
+                                            "minItems": 2,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                    ],
+                                  },
+                                  {
+                                    "anyOf": [
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "date",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "date",
+                                              "timestamp",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "isNull",
+                                              "notNull",
+                                            ],
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                          },
+                                          "fieldId": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                          },
+                                          "fieldType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "notEquals",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "format": "date",
+                                                  "type": "string",
+                                                },
+                                                {
+                                                  "format": "date-time",
+                                                  "type": "string",
+                                                },
+                                              ],
+                                            },
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                          },
+                                          "fieldId": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                          },
+                                          "fieldType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "inThePast",
+                                              "notInThePast",
+                                              "inTheNext",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "settings": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "completed": {
+                                                "type": "boolean",
+                                              },
+                                              "unitOfTime": {
+                                                "enum": [
+                                                  "days",
+                                                  "weeks",
+                                                  "months",
+                                                  "quarters",
+                                                  "years",
+                                                ],
+                                                "type": "string",
+                                              },
+                                            },
+                                            "required": [
+                                              "completed",
+                                              "unitOfTime",
+                                            ],
+                                            "type": "object",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "number",
+                                            },
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                          "settings",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                          },
+                                          "fieldId": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                          },
+                                          "fieldType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "inTheCurrent",
+                                              "notInTheCurrent",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "settings": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "completed": {
+                                                "const": false,
+                                                "type": "boolean",
+                                              },
+                                              "unitOfTime": {
+                                                "enum": [
+                                                  "days",
+                                                  "weeks",
+                                                  "months",
+                                                  "quarters",
+                                                  "years",
+                                                ],
+                                                "type": "string",
+                                              },
+                                            },
+                                            "required": [
+                                              "completed",
+                                              "unitOfTime",
+                                            ],
+                                            "type": "object",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "const": 1,
+                                              "type": "number",
+                                            },
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                          "settings",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                          },
+                                          "fieldId": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                          },
+                                          "fieldType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "lessThan",
+                                              "lessThanOrEqual",
+                                              "greaterThan",
+                                              "greaterThanOrEqual",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                            },
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                          },
+                                          "fieldId": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                          },
+                                          "fieldType": {
+                                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                          },
+                                          "operator": {
+                                            "const": "inBetween",
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                            },
+                                            "maxItems": 2,
+                                            "minItems": 2,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                              "table": {
+                                "description": "Table name this filter field belongs to",
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "filter",
+                              "table",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name.",
+                    },
+                    "kind": {
+                      "const": "aggregation",
+                      "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                      "type": "string",
+                    },
+                    "label": {
+                      "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                      "type": "string",
+                    },
+                    "table": {
+                      "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                      "type": "string",
+                    },
+                    "type": {
+                      "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                      "enum": [
+                        "average",
+                        "count",
+                        "count_distinct",
+                        "max",
+                        "min",
+                        "sum",
+                        "percentile",
+                        "median",
+                      ],
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "kind",
+                    "name",
+                    "label",
+                    "description",
+                    "baseDimensionName",
+                    "table",
+                    "type",
+                    "filters",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "baseMetricId": {
+                      "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                      "type": "string",
+                    },
+                    "granularity": {
+                      "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                      "enum": [
+                        "DAY",
+                        "WEEK",
+                        "MONTH",
+                        "QUARTER",
+                        "YEAR",
+                      ],
+                      "type": "string",
+                    },
+                    "kind": {
+                      "const": "periodComparison",
+                      "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                      "type": "string",
+                    },
+                    "periodOffset": {
+                      "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                      "minimum": 1,
+                      "type": "integer",
+                    },
+                    "timeDimensionId": {
+                      "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "kind",
+                    "baseMetricId",
+                    "timeDimensionId",
+                    "granularity",
+                    "periodOffset",
+                  ],
+                  "type": "object",
+                },
+              ],
+            },
+            "type": "array",
+          },
+          {
+            "type": "null",
+          },
+        ],
+        "description": "Define new metric columns the explore doesn't already have. Two kinds:
+
+(1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
+    (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
+    Use when the requested metric doesn't exist in the explore.
+
+(2) kind: "periodComparison" — a column that is an EXISTING metric shifted
+    back in time. Use whenever the user asks for "year-over-year",
+    "month-over-month", "vs last quarter", "compare to previous period",
+    "N periods ago".
+
+For period comparisons, every successful chart has three things:
+- The time dimension in queryConfig.dimensions
+- The base metric in queryConfig.metrics
+- A customMetric of kind "periodComparison" pointing at that base metric and time dimension
+
+The server generates the comparison column automatically and appends it next to the base metric. Do NOT add the comparison column id to queryConfig.metrics yourself.
+
+DO NOT simulate a period comparison by adding a second time-dimension granularity (e.g. _year) and using groupBy. groupBy is for categorical splits (region, product). Time comparisons use a kind: "periodComparison" customMetric.
+
+For aggregation entries:
+1. Add the entry to customMetrics with kind: "aggregation"
+2. Reference it in queryConfig.metrics using the format "table_name" (e.g. "customers_avg_customer_age")
+3. Reference it the same way in sorts, filters, chartConfig.yAxisMetrics
+
+Example A — "Average customer age sorted descending"
+  customMetrics: [{ kind: "aggregation", name: "avg_customer_age", label: "Average Customer Age", description: "...", type: "AVERAGE", baseDimensionName: "age", table: "customers", filters: null }]
+  queryConfig.metrics: ["customers_avg_customer_age"]
+  sorts: [{ fieldId: "customers_avg_customer_age", descending: true }]
+
+Example B — "Revenue by month with year-over-year comparison"
+  queryConfig.dimensions: ["orders_order_date_month"]
+  queryConfig.metrics: ["orders_revenue"]
+  customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }]",
+      },
+      "description": {
+        "description": "A descriptive summary or explanation for the chart.",
+        "type": "string",
+      },
+      "filters": {
+        "anyOf": [
+          {
+            "$ref": "#/properties/queryConfig/properties/filters",
+          },
+          {
+            "type": "null",
+          },
+        ],
+      },
+      "queryConfig": {
+        "additionalProperties": false,
+        "properties": {
+          "dimensions": {
+            "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "exploreName": {
+            "description": "The name of the explore containing the metrics and dimensions used for the chart.",
+            "type": "string",
+          },
+          "filters": {
+            "additionalProperties": false,
+            "properties": {
+              "dimensions": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0",
+                        },
+                        {
+                          "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1",
+                        },
+                        {
+                          "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
+                        },
+                        {
+                          "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3",
+                        },
+                      ],
+                    },
+                    "type": "array",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+              },
+              "metrics": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "$ref": "#/properties/queryConfig/properties/filters/properties/dimensions/anyOf/0/items",
+                    },
+                    "type": "array",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+              },
+              "tableCalculations": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
+                    },
+                    "type": "array",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+              },
+              "type": {
+                "description": "Type of filter group operation",
+                "enum": [
+                  "and",
+                  "or",
+                ],
+                "type": "string",
+              },
+            },
+            "required": [
+              "type",
+              "dimensions",
+              "metrics",
+              "tableCalculations",
+            ],
+            "type": "object",
+          },
+          "limit": {
+            "description": "The total number of data points / rows allowed on the chart.",
+            "type": [
+              "number",
+              "null",
+            ],
+          },
+          "metrics": {
+            "description": "The field ids of the metrics to be calculated. They will be grouped by the dimensions.",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "sorts": {
+            "description": "Sort configuration for the query, it can use a combination of metrics and dimensions.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "descending": {
+                  "description": "If true sorts in descending order, if false sorts in ascending order",
+                  "type": "boolean",
+                },
+                "fieldId": {
+                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "nullsFirst": {
+                  "description": "If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default",
+                  "type": [
+                    "boolean",
+                    "null",
+                  ],
+                },
+              },
+              "required": [
+                "fieldId",
+                "descending",
+                "nullsFirst",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "exploreName",
+          "dimensions",
+          "metrics",
+          "sorts",
+          "limit",
+        ],
+        "type": "object",
+      },
+      "tableCalculations": {
+        "anyOf": [
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "orderBy": {
+                      "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "fieldId": {
+                            "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "order": {
+                            "anyOf": [
+                              {
+                                "enum": [
+                                  "asc",
+                                  "desc",
+                                ],
+                                "type": "string",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                        },
+                        "required": [
+                          "fieldId",
+                          "order",
+                        ],
+                        "type": "object",
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                    },
+                    "partitionBy": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                    },
+                    "type": {
+                      "const": "percent_change_from_previous",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                    "orderBy",
+                    "partitionBy",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                    },
+                    "fieldId": {
+                      "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                    },
+                    "orderBy": {
+                      "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                      "items": {
+                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                    },
+                    "partitionBy": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                          },
+                          "type": "array",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                    },
+                    "type": {
+                      "const": "percent_of_previous_value",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                    "orderBy",
+                    "partitionBy",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                    },
+                    "fieldId": {
+                      "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                    },
+                    "partitionBy": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                          },
+                          "type": "array",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                    },
+                    "type": {
+                      "const": "percent_of_column_total",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                    "partitionBy",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                    },
+                    "fieldId": {
+                      "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                    },
+                    "type": {
+                      "const": "rank_in_column",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                    },
+                    "fieldId": {
+                      "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                    },
+                    "type": {
+                      "const": "running_total",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                    },
+                    "fieldId": {
+                      "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": [
+                        "string",
+                        "null",
+                      ],
+                    },
+                    "frame": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "end": {
+                              "additionalProperties": false,
+                              "description": "End boundary (required)",
+                              "properties": {
+                                "offset": {
+                                  "anyOf": [
+                                    {
+                                      "exclusiveMinimum": 0,
+                                      "type": "integer",
+                                    },
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
+                                  "description": "Number of rows for PRECEDING/FOLLOWING",
+                                },
+                                "type": {
+                                  "enum": [
+                                    "unbounded_preceding",
+                                    "preceding",
+                                    "current_row",
+                                    "following",
+                                    "unbounded_following",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "type",
+                                "offset",
+                              ],
+                              "type": "object",
+                            },
+                            "frameType": {
+                              "description": "Frame type:
+- rows: Physical row count
+- range: Logical value-based (includes peer rows with same ORDER BY value)",
+                              "enum": [
+                                "rows",
+                                "range",
+                              ],
+                              "type": "string",
+                            },
+                            "start": {
+                              "anyOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "offset": {
+                                      "anyOf": [
+                                        {
+                                          "exclusiveMinimum": 0,
+                                          "type": "integer",
+                                        },
+                                        {
+                                          "type": "null",
+                                        },
+                                      ],
+                                      "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING")",
+                                    },
+                                    "type": {
+                                      "enum": [
+                                        "unbounded_preceding",
+                                        "preceding",
+                                        "current_row",
+                                        "following",
+                                        "unbounded_following",
+                                      ],
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "type",
+                                    "offset",
+                                  ],
+                                  "type": "object",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                              "description": "Start boundary. Null for single-boundary syntax.",
+                            },
+                          },
+                          "required": [
+                            "frameType",
+                            "start",
+                            "end",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Defines which rows to include in calculation. Null uses database defaults.
+
+**Common patterns:**
+- Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
+- Running total: {frameType: "rows", start: {type: "unbounded_preceding"}, end: {type: "current_row"}}
+- Centered window: {frameType: "rows", start: {type: "preceding", offset: 1}, end: {type: "following", offset: 1}}
+
+**Default when null:**
+- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
+- Aggregates WITHOUT ORDER BY: Entire partition (all rows)
+- Ranking functions: Always use entire partition (frame clause has no effect)",
+                    },
+                    "name": {
+                      "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                    },
+                    "orderBy": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
+                          },
+                          "type": "array",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                    },
+                    "partitionBy": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                          },
+                          "type": "array",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                    },
+                    "type": {
+                      "const": "window_function",
+                      "type": "string",
+                    },
+                    "windowFunction": {
+                      "description": "Type of window function to apply.
+
+**Ranking functions** (fieldId optional, ignored if provided):
+- row_number: Sequential numbering (1, 2, 3...)
+- percent_rank: Relative rank as percentage (0.0-1.0)
+- cume_dist: Cumulative distribution as percentage (0.0-1.0)
+- rank: Positional rank (1, 2, 3...) with ties
+
+**Aggregate functions** (fieldId required):
+- sum: Sum values within frame
+- avg: Average values within frame
+- count: Count values within frame
+- min: Minimum value within frame
+- max: Maximum value within frame",
+                      "enum": [
+                        "row_number",
+                        "percent_rank",
+                        "cume_dist",
+                        "rank",
+                        "sum",
+                        "avg",
+                        "count",
+                        "min",
+                        "max",
+                      ],
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "windowFunction",
+                    "fieldId",
+                    "orderBy",
+                    "partitionBy",
+                    "frame",
+                  ],
+                  "type": "object",
+                },
+              ],
+            },
+            "type": "array",
+          },
+          {
+            "type": "null",
+          },
+        ],
+        "description": "
+Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
+
+**Available Types:**
+- Simple calculations: percent_change_from_previous, percent_of_previous_value, percent_of_column_total, rank_in_column, running_total
+- Advanced window_function: Supports row_number, percent_rank, sum, avg, count, min, max with optional partitioning, ordering, and frame clauses
+
+**Technical Requirements:**
+- Appear as additional columns in query results
+- Can be used in sorts and filters alongside dimensions/metrics
+- Multiple calculations can be combined in a single query
+- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
+",
+      },
+      "title": {
+        "description": "A descriptive title for the chart",
+        "type": "string",
+      },
+    },
+    "required": [
+      "title",
+      "description",
+      "customMetrics",
+      "tableCalculations",
+      "queryConfig",
+      "chartConfig",
+      "filters",
+    ],
+    "type": "object",
+  },
+  "name": "generateVisualization",
+  "outputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "metadata": {
+        "additionalProperties": false,
+        "properties": {
+          "status": {
+            "enum": [
+              "success",
+              "error",
+            ],
+            "type": "string",
+          },
+        },
+        "required": [
+          "status",
+        ],
+        "type": "object",
+      },
+      "result": {
+        "type": "string",
+      },
+    },
+    "required": [
+      "result",
+      "metadata",
+    ],
+    "type": "object",
+  },
+}
+`;
+
 exports[`AI agent tool contracts matches the shared agent tool definition names snapshot 1`] = `
 [
   "findExplores",

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -59,7 +59,11 @@ const sharedAgentToolDefinitionNames = agentToolDefinitions.map(
     (toolDefinition) => toolDefinition.for('agent').name,
 );
 
-const makeAgentTools = () => {
+const makeAgentTools = ({
+    enableChartAsCodeArtifacts = true,
+}: {
+    enableChartAsCodeArtifacts?: boolean;
+} = {}) => {
     const noop = jest.fn();
     const noopAsync = jest.fn().mockResolvedValue(undefined);
 
@@ -159,6 +163,7 @@ const makeAgentTools = () => {
         generateVisualization: getGenerateVisualization({
             createOrUpdateArtifact: noop,
             enableDataAccess: true,
+            enableChartAsCodeArtifacts,
             getPrompt: noop,
             maxLimit: 500,
             runAsyncQuery: noop,
@@ -201,6 +206,19 @@ describe('AI agent tool contracts', () => {
         expect(
             Object.entries(agentTools).map(([name, definition]) =>
                 agentToolSnapshot(name, definition as SnapshotTool),
+            ),
+        ).toMatchSnapshot();
+    });
+
+    it('matches the legacy generateVisualization contract snapshot when chart-as-code artifacts are disabled', () => {
+        const agentTools = makeAgentTools({
+            enableChartAsCodeArtifacts: false,
+        });
+
+        expect(
+            agentToolSnapshot(
+                'generateVisualization',
+                agentTools.generateVisualization as SnapshotTool,
             ),
         ).toMatchSnapshot();
     });

--- a/packages/backend/src/ee/services/ai/tools/generateVisualization.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateVisualization.ts
@@ -6,11 +6,12 @@ import {
     getTotalFilterRules,
     isPeriodOverPeriodAdditionalMetric,
     isSlackPrompt,
+    runQueryToolDefinition,
     toolGenerateVisualizationArgsSchemaTransformed,
     type ChartAsCode,
     type ChartAsCodeMetricQueryInput,
 } from '@lightdash/common';
-import { tool } from 'ai';
+import { tool, type ToolSet } from 'ai';
 import { NO_RESULTS_RETRY_PROMPT } from '../prompts/noResultsRetry';
 import type {
     CreateOrUpdateArtifactFn,
@@ -34,6 +35,7 @@ import {
     validateSelectedFieldsExistence,
     validateSortFieldsAreSelected,
 } from '../utils/validators';
+import { getRunQuery } from './runQuery';
 
 type Dependencies = {
     updateProgress: UpdateProgressFn;
@@ -44,9 +46,15 @@ type Dependencies = {
     validateContent: ValidateContentFn;
     maxLimit: number;
     enableDataAccess: boolean;
+    enableChartAsCodeArtifacts: boolean;
 };
 
 const toolDefinition = generateVisualizationToolDefinition.for('agent');
+const legacyToolDefinition = {
+    ...runQueryToolDefinition.for('agent'),
+    name: generateVisualizationToolDefinition.name,
+    title: generateVisualizationToolDefinition.title,
+};
 
 export const getGenerateVisualization = ({
     updateProgress,
@@ -57,8 +65,24 @@ export const getGenerateVisualization = ({
     validateContent,
     maxLimit,
     enableDataAccess,
-}: Dependencies) =>
-    tool({
+    enableChartAsCodeArtifacts,
+}: Dependencies): ToolSet[string] => {
+    if (!enableChartAsCodeArtifacts) {
+        return {
+            ...getRunQuery({
+                updateProgress,
+                runAsyncQuery,
+                getPrompt,
+                sendFile,
+                createOrUpdateArtifact,
+                maxLimit,
+                enableDataAccess,
+            }),
+            ...legacyToolDefinition,
+        };
+    }
+
+    return tool({
         ...toolDefinition,
         execute: async (toolArgs, { experimental_context: context }) => {
             try {
@@ -225,3 +249,4 @@ export const getGenerateVisualization = ({
         },
         toModelOutput: ({ output }) => toModelOutput(output),
     });
+};

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -88,6 +88,7 @@ export type AiAgentArgs = AnyAiModel & {
     enableDataAccess: boolean;
     enableSelfImprovement: boolean;
     enableContentTools: boolean;
+    enableChartAsCodeArtifacts: boolean;
     enableSearchSemanticLayer: boolean;
     enableAiWriteback: boolean;
     enablePreviewDeploySetup: boolean;

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -110,6 +110,13 @@ export enum FeatureFlags {
     AiAgentRevamp = 'ai-agent-revamp',
 
     /**
+     * Enable chart-as-code payloads for AI-generated visualization artifacts.
+     * When disabled, the agent falls back to the legacy generateVisualization
+     * schema while existing chart-as-code artifacts continue to render.
+     */
+    AiAgentChartAsCodeArtifacts = 'ai-agent-chart-as-code-artifacts',
+
+    /**
      * Enable the Hexbin (H3 hexagonal binning) layer type for Map charts.
      * Gates the option in the Map Type segmented control. Existing charts
      * already saved with the hexbin layer continue to render either way.


### PR DESCRIPTION
## Summary
- Adds `ai-agent-chart-as-code-artifacts` feature flag.
- Gates new AI-generated chart-as-code payloads behind the flag.
- Falls back to the legacy `generateVisualization` schema when disabled.
- Keeps existing chart-as-code artifacts renderable when the flag is off.

## Stack
Part 3 of 3. Base branch is `joaoviana/chart-as-code-ai-artifacts-frontend`.

Depends on:
- #24048 backend/common chart-as-code artifact support.
- #24107 frontend renderer support.

## Validation
- `pnpm -F @lightdash/common build`
- `pnpm -F backend test -- --runTestsByPath src/ee/services/ai/prompts/systemV2.test.ts src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts --runInBand`
- `pnpm -s exec tsc --noEmit --pretty false --project packages/backend/tsconfig.json`

## Review revision (2026-06-10)
- **The flag is now a real kill switch**: `enableChartAsCodeArtifacts` is a required dependency (no silent default-on; prompt default is `false`), and with the flag off the tool persists legacy artifacts exactly as on main — previously only the model-facing schema was gated while persistence/validation switched unconditionally.
- The four per-sentence prompt ternaries are collapsed into two named instruction blocks (`CHART_AS_CODE_VISUALIZATION_INSTRUCTIONS` / `LEGACY_VISUALIZATION_INSTRUCTIONS`) — flag removal later is a one-constant delete.
- The six serial per-prompt feature-flag fetches in `generateOrStreamAgentResponse` are batched into one `Promise.all`, cutting serial DB roundtrips off time-to-first-token.
- The legacy `generateVisualization` contract is fully snapshotted again (it remains the live contract for un-flagged orgs); both flag variants are covered.

Regression analysis: flag OFF restores main behavior byte-for-byte (legacy artifact format, chart-type switching, groupBy pivoting); flag ON enables chart-as-code artifacts. Existing chart-as-code artifacts created while the flag was on keep rendering after it is turned off.