### PR TITLE
feat(ai-agents): render chart-as-code artifacts

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
@@ -163,8 +163,11 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
             ? getGroupByDimensions(parsedChartConfig)
             : undefined;
 
+        // Chart-type switching only applies to legacy query-result artifacts;
+        // chart-as-code artifacts carry their own runtime chart config.
         const shouldShowPill =
-            parsedChartConfig?.type === AiResultType.QUERY_RESULT;
+            parsedChartConfig?.type === AiResultType.QUERY_RESULT &&
+            !!parsedChartConfig.vizTool;
 
         if (isArtifactLoading || !message) {
             return (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -7,6 +7,7 @@ import {
     type AiAgentChartTypeOption,
     type AiArtifactChartConfig,
     type ApiAiAgentThreadMessageVizQuery,
+    type ChartAsCode,
     type ChartConfig,
     type EChartsSeries,
 } from '@lightdash/common';
@@ -150,9 +151,11 @@ export const AiVisualizationRenderer: FC<Props> = ({
         selectedChartType,
     ]);
 
-    const chartAsCodeConfig =
-        webAiChartConfig?.type === AiResultType.QUERY_RESULT
-            ? webAiChartConfig.chartAsCode
+    const chartAsCodeConfig: ChartAsCode | null =
+        webAiChartConfig &&
+        webAiChartConfig.type === AiResultType.QUERY_RESULT &&
+        'chartAsCode' in webAiChartConfig
+            ? (webAiChartConfig.chartAsCode as ChartAsCode | null)
             : null;
 
     const visualizationChartConfig = webAiChartConfig?.echartsConfig;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -108,13 +108,15 @@ export const AiVisualizationRenderer: FC<Props> = ({
     const [expandedChartConfig, setExpandedChartConfig] = useState<
         | {
               forChartType: AiAgentChartTypeOption | null;
+              sourceConfig: Props['chartConfig'];
               config: ChartConfig;
           }
         | undefined
     >(undefined);
 
     const activeExpandedChartConfig =
-        expandedChartConfig?.forChartType === selectedChartType
+        expandedChartConfig?.forChartType === selectedChartType &&
+        expandedChartConfig.sourceConfig === chartConfig
             ? expandedChartConfig.config
             : undefined;
 
@@ -128,26 +130,38 @@ export const AiVisualizationRenderer: FC<Props> = ({
         [results, metricQuery, fields, resolvedTimezone],
     );
 
-    const webAiChartConfig = useMemo(
-        () =>
-            getWebAiChartConfig({
+    const webAiChartConfig = useMemo(() => {
+        try {
+            return getWebAiChartConfig({
                 vizConfig: chartConfig,
                 metricQuery,
                 maxQueryLimit: health?.query.maxLimit,
                 fieldsMap: fields,
                 overrideChartType: selectedChartType ?? undefined,
-            }),
-        [
-            chartConfig,
-            metricQuery,
-            health?.query.maxLimit,
-            fields,
-            selectedChartType,
-        ],
-    );
+            });
+        } catch {
+            return null;
+        }
+    }, [
+        chartConfig,
+        metricQuery,
+        health?.query.maxLimit,
+        fields,
+        selectedChartType,
+    ]);
+
+    const chartAsCodeConfig =
+        webAiChartConfig?.type === AiResultType.QUERY_RESULT
+            ? webAiChartConfig.chartAsCode
+            : null;
+
+    const visualizationChartConfig = webAiChartConfig?.echartsConfig;
 
     const groupByDimensions: string[] | undefined = useMemo(
-        () => getGroupByDimensions(webAiChartConfig),
+        () =>
+            webAiChartConfig
+                ? getGroupByDimensions(webAiChartConfig)
+                : undefined,
         [webAiChartConfig],
     );
 
@@ -164,7 +178,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
     const displayDetails = fieldsCount > 0 || filtersCount > 0;
 
     const defaultChartType: AiAgentChartTypeOption =
-        webAiChartConfig.type === AiResultType.QUERY_RESULT
+        webAiChartConfig?.type === AiResultType.QUERY_RESULT
             ? (webAiChartConfig.vizTool?.chartConfig?.defaultVizType ?? 'table')
             : 'table';
 
@@ -172,14 +186,15 @@ export const AiVisualizationRenderer: FC<Props> = ({
         (newConfig: ChartConfig) => {
             setExpandedChartConfig({
                 forChartType: selectedChartType,
+                sourceConfig: chartConfig,
                 config: newConfig,
             });
             onExpandedChartConfigChange?.(newConfig);
         },
-        [onExpandedChartConfigChange, selectedChartType],
+        [chartConfig, onExpandedChartConfigChange, selectedChartType],
     );
 
-    if (!webAiChartConfig.echartsConfig) {
+    if (!visualizationChartConfig) {
         return (
             <Center h={300}>
                 <Stack gap="xs" align="center">
@@ -204,14 +219,16 @@ export const AiVisualizationRenderer: FC<Props> = ({
                 key={selectedChartType ?? 'default'}
                 resultsData={resultsData}
                 chartConfig={
-                    activeExpandedChartConfig ?? webAiChartConfig.echartsConfig
+                    activeExpandedChartConfig ?? visualizationChartConfig
                 }
                 parameters={vizQueryData.query.usedParametersValues}
-                columnOrder={[
-                    ...metricQuery.dimensions,
-                    ...metricQuery.metrics,
-                    ...metricQuery.tableCalculations.map((tc) => tc.name),
-                ]}
+                columnOrder={
+                    chartAsCodeConfig?.tableConfig?.columnOrder ?? [
+                        ...metricQuery.dimensions,
+                        ...metricQuery.metrics,
+                        ...metricQuery.tableCalculations.map((tc) => tc.name),
+                    ]
+                }
                 initialPivotDimensions={groupByDimensions}
                 colorPalette={colorPalette}
                 isLoading={resultsData.isFetchingRows}
@@ -227,7 +244,8 @@ export const AiVisualizationRenderer: FC<Props> = ({
             >
                 <Stack gap="md" h="100%" style={{ minHeight: 0 }}>
                     {headerContent}
-                    {webAiChartConfig.type === AiResultType.QUERY_RESULT &&
+                    {webAiChartConfig?.type === AiResultType.QUERY_RESULT &&
+                        webAiChartConfig.vizTool &&
                         onChartTypeChange && (
                             <Group justify="flex-end">
                                 <AgentVisualizationChartTypeSwitcher
@@ -256,7 +274,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
                             data-testid="ai-visualization"
                         />
 
-                        {webAiChartConfig.echartsConfig.type ===
+                        {visualizationChartConfig.type ===
                             ChartType.CARTESIAN && (
                             <SeriesContextMenu
                                 echartsSeriesClickEvent={


### PR DESCRIPTION
## Summary
- Updates the AI artifact panel to recognize chart-as-code artifact configs.
- Renders chart-as-code `chartConfig` directly in the visualization renderer.
- Keeps legacy AI artifact rendering and chart-type switching intact for legacy artifacts.

## Stack
Part 2 of 3. Base branch is `joaoviana/chart-as-code-ai-artifacts`.

Depends on:
- #24048 backend/common chart-as-code artifact support.

Follow-up:
- #24106 feature flag rollout gate.

## Validation
- pre-commit frontend lint/format ran on commit
- `pnpm -F frontend unused-exports` ran from commit hook

## Review revision (2026-06-10)
- The renderer now has a single path through `getWebAiChartConfig` (extended in #24048 to handle chart-as-code) instead of a duck-typed chart-as-code/legacy split with an `as LegacyAiChartConfig` cast.
- `AiArtifactPanel`/`AiChartVisualization` call plain `parseVizConfig` — the per-consumer `isChartAsCodeArtifactConfig` forks are gone.
- Chart-type switcher/pill is shown only for legacy query-result artifacts (`vizTool` present); chart-as-code artifacts carry their own runtime chart config.

Regression analysis: legacy artifacts keep the switcher and identical rendering; chart-as-code artifacts render their persisted `chartConfig` directly. A parse failure now shows the "unable to render" fallback instead of throwing during render.