### PR TITLE
fix: warn when SSO provider has no verified domains

### DIFF
--- a/packages/frontend/src/components/UserSettings/OrganizationSso/AzureAdSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/AzureAdSsoPanel.tsx
@@ -33,6 +33,7 @@ import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { MICROSOFT_LOGO } from '../../common/ThirdPartySignInButton/ssoProviderLogos';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
 import SsoMethodDomainsField from './SsoMethodDomainsField';
+import SsoMissingDomainsWarning from './SsoMissingDomainsWarning';
 
 type FormValues = {
     oauth2ClientId: string;
@@ -101,19 +102,22 @@ const AzureAdSsoPanel: FC = () => {
     ]);
 
     const handleSubmit = form.onSubmit((values) => {
-        upsert.mutate({
-            oauth2ClientId: values.oauth2ClientId.trim(),
-            oauth2TenantId: values.oauth2TenantId.trim(),
-            enabled: values.enabled,
-            overrideEmailDomains: values.overrideEmailDomains,
-            emailDomains: values.emailDomains.map((d) =>
-                d.trim().toLowerCase(),
-            ),
-            allowPassword: values.allowPassword,
-            ...(values.oauth2ClientSecret.trim().length > 0
-                ? { oauth2ClientSecret: values.oauth2ClientSecret.trim() }
-                : {}),
-        });
+        upsert.mutate(
+            {
+                oauth2ClientId: values.oauth2ClientId.trim(),
+                oauth2TenantId: values.oauth2TenantId.trim(),
+                enabled: values.enabled,
+                overrideEmailDomains: values.overrideEmailDomains,
+                emailDomains: values.emailDomains.map((d) =>
+                    d.trim().toLowerCase(),
+                ),
+                allowPassword: values.allowPassword,
+                ...(values.oauth2ClientSecret.trim().length > 0
+                    ? { oauth2ClientSecret: values.oauth2ClientSecret.trim() }
+                    : {}),
+            },
+            { onSuccess: () => toggleOpen(false) },
+        );
     });
 
     // The Enabled toggle persists immediately (secret omitted = preserved), so
@@ -207,6 +211,10 @@ const AzureAdSsoPanel: FC = () => {
                                 Set up Azure AD
                             </Button>
                         )
+                    )}
+
+                    {isConfigured && form.values.enabled && !isOpen && (
+                        <SsoMissingDomainsWarning providerLabel="Azure AD" />
                     )}
 
                     <FormSection isOpen={isOpen} name="azuread-configuration">

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.tsx
@@ -33,6 +33,7 @@ import MantineModal from '../../common/MantineModal';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
 import SsoMethodDomainsField from './SsoMethodDomainsField';
+import SsoMissingDomainsWarning from './SsoMissingDomainsWarning';
 
 type FormValues = {
     clientId: string;
@@ -107,20 +108,24 @@ const GenericOidcSsoPanel: FC = () => {
     ]);
 
     const handleSubmit = form.onSubmit((values) => {
-        upsert.mutate({
-            clientId: values.clientId.trim(),
-            metadataDocumentEndpoint: values.metadataDocumentEndpoint.trim(),
-            scopes: values.scopes.trim() || null,
-            enabled: values.enabled,
-            overrideEmailDomains: values.overrideEmailDomains,
-            emailDomains: values.emailDomains.map((d) =>
-                d.trim().toLowerCase(),
-            ),
-            allowPassword: values.allowPassword,
-            ...(values.clientSecret.trim().length > 0
-                ? { clientSecret: values.clientSecret.trim() }
-                : {}),
-        });
+        upsert.mutate(
+            {
+                clientId: values.clientId.trim(),
+                metadataDocumentEndpoint:
+                    values.metadataDocumentEndpoint.trim(),
+                scopes: values.scopes.trim() || null,
+                enabled: values.enabled,
+                overrideEmailDomains: values.overrideEmailDomains,
+                emailDomains: values.emailDomains.map((d) =>
+                    d.trim().toLowerCase(),
+                ),
+                allowPassword: values.allowPassword,
+                ...(values.clientSecret.trim().length > 0
+                    ? { clientSecret: values.clientSecret.trim() }
+                    : {}),
+            },
+            { onSuccess: () => toggleOpen(false) },
+        );
     });
 
     // The Enabled toggle persists immediately (secret omitted = preserved), so
@@ -216,6 +221,10 @@ const GenericOidcSsoPanel: FC = () => {
                                 Set up OpenID Connect
                             </Button>
                         )
+                    )}
+
+                    {isConfigured && form.values.enabled && !isOpen && (
+                        <SsoMissingDomainsWarning providerLabel="OpenID Connect" />
                     )}
 
                     <FormSection isOpen={isOpen} name="oidc-configuration">

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/GoogleSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/GoogleSsoPanel.tsx
@@ -103,14 +103,17 @@ const GoogleSsoPanel: FC = () => {
     ]);
 
     const handleSubmit = form.onSubmit((values) => {
-        upsert.mutate({
-            enabled: values.enabled,
-            overrideEmailDomains: values.overrideEmailDomains,
-            emailDomains: values.emailDomains.map((d) =>
-                d.trim().toLowerCase(),
-            ),
-            allowPassword: values.allowPassword,
-        });
+        upsert.mutate(
+            {
+                enabled: values.enabled,
+                overrideEmailDomains: values.overrideEmailDomains,
+                emailDomains: values.emailDomains.map((d) =>
+                    d.trim().toLowerCase(),
+                ),
+                allowPassword: values.allowPassword,
+            },
+            { onSuccess: () => toggleOpen(false) },
+        );
     });
 
     // Once configured, the Enabled toggle persists immediately so it can be

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/OktaSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/OktaSsoPanel.tsx
@@ -33,6 +33,7 @@ import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { OKTA_LOGO } from '../../common/ThirdPartySignInButton/ssoProviderLogos';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
 import SsoMethodDomainsField from './SsoMethodDomainsField';
+import SsoMissingDomainsWarning from './SsoMissingDomainsWarning';
 
 type FormValues = {
     oauth2Issuer: string;
@@ -115,22 +116,26 @@ const OktaSsoPanel: FC = () => {
     ]);
 
     const handleSubmit = form.onSubmit((values) => {
-        upsert.mutate({
-            oauth2Issuer: values.oauth2Issuer.trim(),
-            oktaDomain: values.oktaDomain.trim(),
-            oauth2ClientId: values.oauth2ClientId.trim(),
-            authorizationServerId: values.authorizationServerId.trim() || null,
-            extraScopes: values.extraScopes.trim() || null,
-            enabled: values.enabled,
-            overrideEmailDomains: values.overrideEmailDomains,
-            emailDomains: values.emailDomains.map((d) =>
-                d.trim().toLowerCase(),
-            ),
-            allowPassword: values.allowPassword,
-            ...(values.oauth2ClientSecret.trim().length > 0
-                ? { oauth2ClientSecret: values.oauth2ClientSecret.trim() }
-                : {}),
-        });
+        upsert.mutate(
+            {
+                oauth2Issuer: values.oauth2Issuer.trim(),
+                oktaDomain: values.oktaDomain.trim(),
+                oauth2ClientId: values.oauth2ClientId.trim(),
+                authorizationServerId:
+                    values.authorizationServerId.trim() || null,
+                extraScopes: values.extraScopes.trim() || null,
+                enabled: values.enabled,
+                overrideEmailDomains: values.overrideEmailDomains,
+                emailDomains: values.emailDomains.map((d) =>
+                    d.trim().toLowerCase(),
+                ),
+                allowPassword: values.allowPassword,
+                ...(values.oauth2ClientSecret.trim().length > 0
+                    ? { oauth2ClientSecret: values.oauth2ClientSecret.trim() }
+                    : {}),
+            },
+            { onSuccess: () => toggleOpen(false) },
+        );
     });
 
     // The Enabled toggle persists immediately (secret omitted = preserved), so
@@ -226,6 +231,10 @@ const OktaSsoPanel: FC = () => {
                                 Set up Okta
                             </Button>
                         )
+                    )}
+
+                    {isConfigured && form.values.enabled && !isOpen && (
+                        <SsoMissingDomainsWarning providerLabel="Okta" />
                     )}
 
                     <FormSection isOpen={isOpen} name="okta-configuration">

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/OneLoginSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/OneLoginSsoPanel.tsx
@@ -33,6 +33,7 @@ import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { ONELOGIN_LOGO } from '../../common/ThirdPartySignInButton/ssoProviderLogos';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
 import SsoMethodDomainsField from './SsoMethodDomainsField';
+import SsoMissingDomainsWarning from './SsoMissingDomainsWarning';
 
 type FormValues = {
     oauth2Issuer: string;
@@ -101,19 +102,22 @@ const OneLoginSsoPanel: FC = () => {
     ]);
 
     const handleSubmit = form.onSubmit((values) => {
-        upsert.mutate({
-            oauth2Issuer: values.oauth2Issuer.trim(),
-            oauth2ClientId: values.oauth2ClientId.trim(),
-            enabled: values.enabled,
-            overrideEmailDomains: values.overrideEmailDomains,
-            emailDomains: values.emailDomains.map((d) =>
-                d.trim().toLowerCase(),
-            ),
-            allowPassword: values.allowPassword,
-            ...(values.oauth2ClientSecret.trim().length > 0
-                ? { oauth2ClientSecret: values.oauth2ClientSecret.trim() }
-                : {}),
-        });
+        upsert.mutate(
+            {
+                oauth2Issuer: values.oauth2Issuer.trim(),
+                oauth2ClientId: values.oauth2ClientId.trim(),
+                enabled: values.enabled,
+                overrideEmailDomains: values.overrideEmailDomains,
+                emailDomains: values.emailDomains.map((d) =>
+                    d.trim().toLowerCase(),
+                ),
+                allowPassword: values.allowPassword,
+                ...(values.oauth2ClientSecret.trim().length > 0
+                    ? { oauth2ClientSecret: values.oauth2ClientSecret.trim() }
+                    : {}),
+            },
+            { onSuccess: () => toggleOpen(false) },
+        );
     });
 
     // The Enabled toggle persists immediately (secret omitted = preserved), so
@@ -207,6 +211,10 @@ const OneLoginSsoPanel: FC = () => {
                                 Set up OneLogin
                             </Button>
                         )
+                    )}
+
+                    {isConfigured && form.values.enabled && !isOpen && (
+                        <SsoMissingDomainsWarning providerLabel="OneLogin" />
                     )}
 
                     <FormSection isOpen={isOpen} name="onelogin-configuration">

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/SsoMethodDomainsField.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/SsoMethodDomainsField.tsx
@@ -55,8 +55,8 @@ const SsoMethodDomainsField: FC<Props> = ({
                             `Only users whose email domain matches one of these will see ${providerLabel}.`
                         ) : (
                             <Text span size="xs">
-                                Verify a domain in {verifiedDomainsLink} before
-                                you can route it to {providerLabel}.
+                                {providerLabel} cannot be used until you verify
+                                a domain in {verifiedDomainsLink}.
                             </Text>
                         )
                     }
@@ -81,9 +81,9 @@ const SsoMethodDomainsField: FC<Props> = ({
                         </>
                     ) : (
                         <Text span size="sm" c="dimmed">
-                            No verified domains yet. Verify a domain in{' '}
-                            {verifiedDomainsLink} to route it to {providerLabel}
-                            .
+                            {providerLabel} cannot be used yet. Verify a domain
+                            in {verifiedDomainsLink} before users can sign in
+                            with this provider.
                         </Text>
                     )}
                 </Text>

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/SsoMissingDomainsWarning.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/SsoMissingDomainsWarning.tsx
@@ -1,0 +1,53 @@
+import { Button, Group, Stack, Text, Tooltip } from '@mantine-8/core';
+import { IconArrowRight } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import { useVerifiedDomains } from '../../../hooks/organization/useOrganizationDomainVerification';
+import Callout from '../../common/Callout';
+import MantineIcon from '../../common/MantineIcon';
+
+type Props = {
+    providerLabel: string;
+};
+
+const SsoMissingDomainsWarning: FC<Props> = ({ providerLabel }) => {
+    const { data: verifiedDomains, isInitialLoading } = useVerifiedDomains();
+    const hasNoVerifiedDomains =
+        !isInitialLoading && (verifiedDomains ?? []).length === 0;
+
+    if (!hasNoVerifiedDomains) return null;
+
+    return (
+        <Callout variant="warning" title={`${providerLabel} is not active yet`}>
+            <Group justify="space-between" align="center" gap="md">
+                <Stack gap={2}>
+                    <Text size="sm">
+                        Users cannot sign in with {providerLabel} until this
+                        organization has a verified email domain.
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                        Verify a domain first, then users with matching email
+                        addresses can be routed to this provider.
+                    </Text>
+                </Stack>
+                <Tooltip
+                    label="SSO routing is based on verified email domains."
+                    withArrow
+                    multiline
+                    maw={260}
+                >
+                    <Button
+                        component={Link}
+                        to="/generalSettings/verifiedDomains"
+                        variant="default"
+                        rightSection={<MantineIcon icon={IconArrowRight} />}
+                    >
+                        Add verified domain
+                    </Button>
+                </Tooltip>
+            </Group>
+        </Callout>
+    );
+};
+
+export default SsoMissingDomainsWarning;


### PR DESCRIPTION
### Description
- Warn when an enabled configured SSO provider cannot route sign-ins because the organization has no verified domains.
- Link directly to Verified domains from the collapsed provider card.
- Clarify the in-form discovery copy and collapse SSO forms after successful saves.

### Testing
- pnpm -F frontend typecheck:fast
- pnpm -F frontend lint -- --quiet packages/frontend/src/components/UserSettings/OrganizationSso

Closes: [PROD-8224](https://linear.app/lightdash/issue/PROD-8224)