### PR TITLE
fix(dashboard): comment bubble styling with tile actions

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -33,9 +33,8 @@ import {
     type SavedChart,
     type Series,
 } from '@lightdash/common';
-import { Menu } from '@mantine-8/core';
+import { ActionIcon, Menu } from '@mantine-8/core';
 import {
-    ActionIcon,
     Badge,
     Box,
     Group,
@@ -1372,7 +1371,11 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                     </HoverCard.Dropdown>
 
                                     <HoverCard.Target>
-                                        <ActionIcon size="sm">
+                                        <ActionIcon
+                                            size="sm"
+                                            variant="subtle"
+                                            color="gray"
+                                        >
                                             <MantineIcon icon={IconFilter} />
                                         </ActionIcon>
                                     </HoverCard.Target>
@@ -1425,7 +1428,11 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                         </HoverCard.Dropdown>
 
                                         <HoverCard.Target>
-                                            <ActionIcon size="sm">
+                                            <ActionIcon
+                                                size="sm"
+                                                variant="subtle"
+                                                color="gray"
+                                            >
                                                 <MantineIcon
                                                     icon={IconVariable}
                                                 />

--- a/packages/frontend/src/components/DashboardTiles/TileExecutionInfo.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileExecutionInfo.tsx
@@ -3,8 +3,8 @@ import {
     type CacheMetadata,
     type QueryResultsPerformance,
 } from '@lightdash/common';
-import { Divider, Stack } from '@mantine-8/core';
-import { ActionIcon, HoverCard } from '@mantine/core';
+import { ActionIcon, Divider, Stack } from '@mantine-8/core';
+import { HoverCard } from '@mantine/core';
 import {
     IconClock,
     IconClockBolt,
@@ -104,7 +104,7 @@ const TileExecutionInfo: FC<TileExecutionInfoProps> = ({
                 </Stack>
             </HoverCard.Dropdown>
             <HoverCard.Target>
-                <ActionIcon size="sm">
+                <ActionIcon size="sm" variant="subtle" color="gray">
                     <MantineIcon
                         icon={
                             cacheMetadata.preAggregate?.hit

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -276,6 +276,7 @@ export const DashboardTileComments: FC<
 
             <Popover.Target ref={targetRefComments}>
                 <Indicator
+                    inline
                     label={comments && comments.length}
                     size={12}
                     disabled={!showIndicator}
@@ -290,7 +291,7 @@ export const DashboardTileComments: FC<
                 >
                     <ActionIcon
                         size="sm"
-                        variant="light"
+                        variant="subtle"
                         color="gray"
                         onClick={() => {
                             if (openedComments) {


### PR DESCRIPTION
## Summary
- Use the default `ActionIcon` styling for dashboard comments so it matches the clock/action trigger.
- Mark the `Indicator` as `inline` to remove the extra wrapper spacing that was shifting the bubble.

## Testing
- Not run (not requested)