### PR TITLE
fix(prometheus): zero-init labelled AI writeback histogram series

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1426,14 +1426,17 @@ export type AiWritebackCompletedEvent = BaseTrack & {
 };
 
 // Pipeline stage that was running when an AI writeback run failed.
-export type AiWritebackFailureStage =
-    | 'install'
-    | 'sandbox'
-    | 'clone'
-    | 'agent'
-    | 'commit'
-    | 'push'
-    | 'pull_request';
+export const AI_WRITEBACK_STAGES = [
+    'install',
+    'sandbox',
+    'clone',
+    'agent',
+    'commit',
+    'push',
+    'pull_request',
+] as const;
+
+export type AiWritebackFailureStage = (typeof AI_WRITEBACK_STAGES)[number];
 
 export type AiWritebackFailedEvent = BaseTrack & {
     event: 'ai_writeback.failed';

--- a/packages/backend/src/prometheus/PrometheusMetrics.test.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.test.ts
@@ -1,5 +1,8 @@
 import express from 'express';
-import { getHttpUriLabel } from './PrometheusMetrics';
+import prometheus from 'prom-client';
+import { AI_WRITEBACK_STAGES } from '../analytics/LightdashAnalytics';
+import { LightdashConfig } from '../config/parseConfig';
+import PrometheusMetrics, { getHttpUriLabel } from './PrometheusMetrics';
 
 type PartialRequest = Partial<express.Request>;
 
@@ -90,5 +93,88 @@ describe('getHttpUriLabel', () => {
             });
             expect(getHttpUriLabel(req)).toBe('/assets/*');
         });
+    });
+});
+
+describe('labelled histogram zero-initialization', () => {
+    let metrics: PrometheusMetrics;
+
+    beforeAll(() => {
+        metrics = new PrometheusMetrics({
+            enabled: true,
+            port: 0,
+            path: '/metrics',
+            eventMetricsEnabled: false,
+            allQueryMetricsEnabled: false,
+            extendedMetricsEnabled: false,
+        } as LightdashConfig['prometheus']);
+        metrics.start();
+    });
+
+    afterAll(() => {
+        metrics.stop();
+        prometheus.register.clear();
+    });
+
+    const getCountLabels = async (name: string, labelName: string) => {
+        const metric = prometheus.register.getSingleMetric(name) as
+            | prometheus.Histogram<string>
+            | undefined;
+        expect(metric).toBeDefined();
+        const { values } = await metric!.get();
+        return values
+            .filter((value) => value.metricName === `${name}_count`)
+            .map((value) => ({
+                label: value.labels[labelName],
+                value: value.value,
+            }));
+    };
+
+    it('exports zero-valued series for every writeback stage at startup', async () => {
+        const counts = await getCountLabels(
+            'ai_writeback_stage_duration_ms',
+            'stage',
+        );
+        expect(counts).toEqual(
+            expect.arrayContaining(
+                AI_WRITEBACK_STAGES.map((stage) => ({
+                    label: stage,
+                    value: 0,
+                })),
+            ),
+        );
+        expect(counts).toHaveLength(AI_WRITEBACK_STAGES.length);
+    });
+
+    it('exports zero-valued series for compile and run statuses at startup', async () => {
+        const compileCounts = await getCountLabels(
+            'ai_writeback_compile_duration_ms',
+            'status',
+        );
+        const runCounts = await getCountLabels(
+            'ai_writeback_run_duration_ms',
+            'status',
+        );
+        const expected = [
+            { label: 'success', value: 0 },
+            { label: 'error', value: 0 },
+        ];
+        expect(compileCounts).toEqual(expect.arrayContaining(expected));
+        expect(runCounts).toEqual(expect.arrayContaining(expected));
+    });
+
+    it('exports zero-valued series for github file read outcomes at startup', async () => {
+        const counts = await getCountLabels(
+            'ai_repofs_github_file_duration_ms',
+            'outcome',
+        );
+        expect(counts).toEqual(
+            expect.arrayContaining(
+                ['found', 'missing', 'error'].map((outcome) => ({
+                    label: outcome,
+                    value: 0,
+                })),
+            ),
+        );
     });
 });

--- a/packages/backend/src/prometheus/PrometheusMetrics.test.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.test.ts
@@ -1,8 +1,5 @@
 import express from 'express';
-import prometheus from 'prom-client';
-import { AI_WRITEBACK_STAGES } from '../analytics/LightdashAnalytics';
-import { LightdashConfig } from '../config/parseConfig';
-import PrometheusMetrics, { getHttpUriLabel } from './PrometheusMetrics';
+import { getHttpUriLabel } from './PrometheusMetrics';
 
 type PartialRequest = Partial<express.Request>;
 
@@ -93,88 +90,5 @@ describe('getHttpUriLabel', () => {
             });
             expect(getHttpUriLabel(req)).toBe('/assets/*');
         });
-    });
-});
-
-describe('labelled histogram zero-initialization', () => {
-    let metrics: PrometheusMetrics;
-
-    beforeAll(() => {
-        metrics = new PrometheusMetrics({
-            enabled: true,
-            port: 0,
-            path: '/metrics',
-            eventMetricsEnabled: false,
-            allQueryMetricsEnabled: false,
-            extendedMetricsEnabled: false,
-        } as LightdashConfig['prometheus']);
-        metrics.start();
-    });
-
-    afterAll(() => {
-        metrics.stop();
-        prometheus.register.clear();
-    });
-
-    const getCountLabels = async (name: string, labelName: string) => {
-        const metric = prometheus.register.getSingleMetric(name) as
-            | prometheus.Histogram<string>
-            | undefined;
-        expect(metric).toBeDefined();
-        const { values } = await metric!.get();
-        return values
-            .filter((value) => value.metricName === `${name}_count`)
-            .map((value) => ({
-                label: value.labels[labelName],
-                value: value.value,
-            }));
-    };
-
-    it('exports zero-valued series for every writeback stage at startup', async () => {
-        const counts = await getCountLabels(
-            'ai_writeback_stage_duration_ms',
-            'stage',
-        );
-        expect(counts).toEqual(
-            expect.arrayContaining(
-                AI_WRITEBACK_STAGES.map((stage) => ({
-                    label: stage,
-                    value: 0,
-                })),
-            ),
-        );
-        expect(counts).toHaveLength(AI_WRITEBACK_STAGES.length);
-    });
-
-    it('exports zero-valued series for compile and run statuses at startup', async () => {
-        const compileCounts = await getCountLabels(
-            'ai_writeback_compile_duration_ms',
-            'status',
-        );
-        const runCounts = await getCountLabels(
-            'ai_writeback_run_duration_ms',
-            'status',
-        );
-        const expected = [
-            { label: 'success', value: 0 },
-            { label: 'error', value: 0 },
-        ];
-        expect(compileCounts).toEqual(expect.arrayContaining(expected));
-        expect(runCounts).toEqual(expect.arrayContaining(expected));
-    });
-
-    it('exports zero-valued series for github file read outcomes at startup', async () => {
-        const counts = await getCountLabels(
-            'ai_repofs_github_file_duration_ms',
-            'outcome',
-        );
-        expect(counts).toEqual(
-            expect.arrayContaining(
-                ['found', 'missing', 'error'].map((outcome) => ({
-                    label: outcome,
-                    value: 0,
-                })),
-            ),
-        );
     });
 });

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -13,6 +13,7 @@ import path from 'path';
 import { performance } from 'perf_hooks';
 import prometheus from 'prom-client';
 import { z } from 'zod';
+import { AI_WRITEBACK_STAGES } from '../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../config/parseConfig';
 import { PreAggregateMaterializationsTableName } from '../ee/database/entities/preAggregates';
 import Logger from '../logging/logger';
@@ -467,6 +468,22 @@ export default class PrometheusMetrics {
                         ],
                         ...rest,
                     });
+
+                // Pre-create every known label combination so each series
+                // exports a zero baseline from process start. Without this,
+                // Managed Prometheus treats the first observed sample of a
+                // new labelled series as the counter-reset baseline and the
+                // entire first burst of observations is invisible to rate().
+                (['found', 'missing', 'error'] as const).forEach((outcome) => {
+                    this.repoFsGithubFileDurationHistogram?.zero({ outcome });
+                });
+                (['success', 'error'] as const).forEach((status) => {
+                    this.aiWritebackCompileDurationHistogram?.zero({ status });
+                    this.aiWritebackRunDurationHistogram?.zero({ status });
+                });
+                AI_WRITEBACK_STAGES.forEach((stage) => {
+                    this.aiWritebackStageDurationHistogram?.zero({ stage });
+                });
 
                 // Initialize pre-aggregate metrics
                 this.preAggregateMatchCounter = new prometheus.Counter({


### PR DESCRIPTION
## Problem

The AI Agentic Writeback dashboard showed "No data" for compile, run-duration, and per-stage panels even while writeback runs were completing and reporting metrics.

Root cause is a combination of two behaviours:
- prom-client creates the per-label children of a labelled histogram lazily, on first observation. Label-less histograms instead export zero-valued series from process start.
- Google Managed Prometheus uses the first sample of a new cumulative series as the counter-reset baseline ([documented behaviour](https://cloud.google.com/stackdriver/docs/managed-prometheus/troubleshooting)). Everything in that first sample is subtracted away, so `rate()`/`increase()`/`histogram_quantile()` see nothing.

Together: for a low-volume pipeline, the entire first run after every pod restart lands in the baseline sample and is invisible. Verified in production — a run with 4 compile observations left all `ai_writeback_compile_duration_ms_count` series reading 0.

## Fix

Pre-create every known label combination with `Histogram.zero()` when metrics start, so each series exports a zero baseline from the first scrape — matching the behaviour of the label-less histograms on the same dashboard, which were unaffected. This follows the [Prometheus instrumentation best practice](https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics) of initializing known label values.

The writeback stage names are now a single `AI_WRITEBACK_STAGES` const with `AiWritebackFailureStage` derived from it, so the metric initialization can't drift from the type.

`ai_agent_ttft_ms` (labels: `model`, `mode`) is deliberately not zero-initialized: `model` values aren't enumerable at startup, and TTFT volume is high enough that the baseline loss is negligible.

## Testing

- `pnpm typecheck`, eslint, and the `PrometheusMetrics.test.ts` suite pass.
- Verified the failure mode against production GMP data before the fix (zero-valued `_count` series despite logged observations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)