### PR TITLE
feat: add dashboard xlsx workbook export

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8915,6 +8915,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                xlsxFileLayout: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['zip'] },
+                        { dataType: 'enum', enums: ['workbook'] },
+                    ],
+                },
                 exportPivotedData: { dataType: 'boolean' },
                 asAttachment: { dataType: 'boolean' },
                 limit: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10285,6 +10285,10 @@
             },
             "SchedulerCsvOptions": {
                 "properties": {
+                    "xlsxFileLayout": {
+                        "type": "string",
+                        "enum": ["zip", "workbook"]
+                    },
                     "exportPivotedData": {
                         "type": "boolean"
                     },

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -155,6 +155,7 @@ import {
 import { DashboardService } from '../services/DashboardService/DashboardService';
 import { DeployService } from '../services/DeployService';
 import { ExcelService } from '../services/ExcelService/ExcelService';
+import { WorkbookExportHelper } from '../services/ExcelService/WorkbookExportHelper';
 import type { FeatureFlagService } from '../services/FeatureFlag/FeatureFlagService';
 import { resolveOrganizationExportLimits } from '../services/OrganizationSettingsService/resolveExportLimits';
 import { PersistentDownloadFileService } from '../services/PersistentDownloadFileService/PersistentDownloadFileService';
@@ -1074,6 +1075,31 @@ export default class SchedulerTask {
                             failures = csvFailures;
                         }
 
+                        if (
+                            format === SchedulerFormat.XLSX &&
+                            csvUrls.length > 0 &&
+                            csvOptions?.xlsxFileLayout === 'workbook'
+                        ) {
+                            const workbookResult =
+                                await this.createWorkbookDownloadUrl({
+                                    files: csvUrls,
+                                    workbookNameBase: details.name,
+                                    organizationUuid,
+                                    projectUuid,
+                                    createdByUserUuid: userUuid,
+                                    expirationSecondsOverride,
+                                });
+
+                            csvUrls = [
+                                {
+                                    filename: details.name,
+                                    path: workbookResult.url,
+                                    localPath: workbookResult.url,
+                                    truncated: false,
+                                },
+                            ];
+                        }
+
                         this.analytics.trackAccount(account, {
                             event: 'download_results.completed',
                             userId: account.user.id,
@@ -1091,7 +1117,7 @@ export default class SchedulerTask {
                         `Unable to download XLSX on scheduled task: ${e}`,
                     );
 
-                    if (this.slackClient.isEnabled) {
+                    if (this.slackClient.isEnabled && isFinalAttempt) {
                         await this.slackClient.postMessageToNotificationChannel(
                             {
                                 organizationUuid,
@@ -4428,6 +4454,80 @@ export default class SchedulerTask {
         });
     }
 
+    private async createWorkbookDownloadUrl({
+        files,
+        workbookNameBase,
+        organizationUuid,
+        projectUuid,
+        createdByUserUuid,
+        expirationSecondsOverride,
+    }: {
+        files: NonNullable<NotificationPayloadBase['page']['csvUrls']>;
+        workbookNameBase: string;
+        organizationUuid: string;
+        projectUuid: string;
+        createdByUserUuid: string;
+        expirationSecondsOverride?: number;
+    }) {
+        if (!this.fileStorageClient.isEnabled()) {
+            throw new MissingConfigError('Cloud storage is not enabled');
+        }
+
+        if (files.length === 0) {
+            throw new UnexpectedServerError('No files to include in workbook');
+        }
+
+        const workbookPath = `/tmp/${nanoid()}.xlsx`;
+        let workbookFileName: string;
+        let workbookResult: Awaited<
+            ReturnType<typeof WorkbookExportHelper.createWorkbookFile>
+        >;
+        try {
+            workbookResult = await WorkbookExportHelper.createWorkbookFile({
+                files: files.map((file) => ({
+                    filename: file.filename,
+                    sheetName: file.chartName ?? file.filename,
+                    localPath: file.localPath,
+                })),
+                outputPath: workbookPath,
+                onFileError: (filename, error) => {
+                    Logger.warn(
+                        `Failed to add XLSX file "${filename}" to workbook: ${error}`,
+                    );
+                },
+            });
+
+            if (workbookResult.worksheetCount === 0) {
+                throw new UnexpectedServerError(
+                    'All XLSX downloads failed — no files to include in workbook',
+                );
+            }
+
+            workbookFileName = `${sanitizeGenericFileName(
+                workbookNameBase,
+            )}-${new Date().toISOString().replace(/[:.]/g, '-')}.xlsx`;
+
+            await this.fileStorageClient.uploadExcel(
+                fsSync.createReadStream(workbookPath),
+                workbookFileName,
+            );
+        } finally {
+            await fs.unlink(workbookPath).catch(() => {});
+        }
+
+        return {
+            url: await this.persistentDownloadFileService.createPersistentUrl({
+                s3Key: workbookFileName,
+                fileType: DownloadFileType.XLSX,
+                organizationUuid,
+                projectUuid,
+                createdByUserUuid,
+                expirationSeconds: expirationSecondsOverride,
+            }),
+            numFileFailures: workbookResult.failedFileCount,
+        };
+    }
+
     protected async exportContent(
         jobId: string,
         scheduledTime: Date,
@@ -4512,6 +4612,26 @@ export default class SchedulerTask {
                         );
                     }
 
+                    const shouldCreateWorkbook =
+                        payload.format === SchedulerFormat.XLSX &&
+                        isSchedulerCsvOptions(payload.options) &&
+                        payload.options.xlsxFileLayout === 'workbook';
+
+                    if (shouldCreateWorkbook) {
+                        const workbookUrl = page.csvUrls[0]?.path;
+                        if (!workbookUrl) {
+                            throw new UnexpectedServerError(
+                                'Dashboard workbook export failed',
+                            );
+                        }
+
+                        return {
+                            url: workbookUrl,
+                            fileType: DownloadFileType.XLSX,
+                            numFailures: page.failures?.length ?? 0,
+                        };
+                    }
+
                     const url = await this.createZipDownloadUrl({
                         files: page.csvUrls.map((file) => ({
                             entryNameBase: file.filename,
@@ -4526,7 +4646,7 @@ export default class SchedulerTask {
 
                     return {
                         url,
-                        fileType: payload.format,
+                        fileType: 'zip',
                         numFailures: page.failures?.length ?? 0,
                     };
                 }

--- a/packages/backend/src/services/ExcelService/WorkbookExportHelper.test.ts
+++ b/packages/backend/src/services/ExcelService/WorkbookExportHelper.test.ts
@@ -1,0 +1,110 @@
+import * as Excel from 'exceljs';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { WorkbookExportHelper } from './WorkbookExportHelper';
+
+const toArrayBuffer = (buffer: Buffer) =>
+    buffer.buffer.slice(
+        buffer.byteOffset,
+        buffer.byteOffset + buffer.byteLength,
+    ) as ArrayBuffer;
+
+const createWorkbookBuffer = async (value: number) => {
+    const workbook = new Excel.Workbook();
+    const worksheet = workbook.addWorksheet('Sheet1');
+    worksheet.columns = [{ header: 'Amount', key: 'amount', width: 22 }];
+    const row = worksheet.addRow({ amount: value });
+    row.getCell(1).numFmt = '$#,##0.00';
+
+    return Buffer.from(await workbook.xlsx.writeBuffer());
+};
+
+describe('WorkbookExportHelper', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    it('creates one workbook with safe sheets and counts failed files', async () => {
+        const outputPath = path.join(
+            os.tmpdir(),
+            `lightdash-dashboard-workbook-${Date.now()}.xlsx`,
+        );
+        const firstBuffer = await createWorkbookBuffer(123.45);
+        const secondBuffer = await createWorkbookBuffer(67.89);
+        const fileErrors: Array<{ filename: string; error: string }> = [];
+
+        global.fetch = jest.fn(async (url) => {
+            if (url === 'first') {
+                return {
+                    ok: true,
+                    arrayBuffer: async () => toArrayBuffer(firstBuffer),
+                };
+            }
+
+            if (url === 'second') {
+                return {
+                    ok: true,
+                    arrayBuffer: async () => toArrayBuffer(secondBuffer),
+                };
+            }
+
+            return {
+                ok: false,
+                status: 404,
+                statusText: 'Not Found',
+            };
+        }) as unknown as typeof fetch;
+
+        try {
+            const result = await WorkbookExportHelper.createWorkbookFile({
+                files: [
+                    {
+                        filename: 'first',
+                        sheetName:
+                            'Revenue: by / customer ? segment * really long',
+                        localPath: 'first',
+                    },
+                    {
+                        filename: 'second',
+                        sheetName:
+                            'Revenue: by / customer ? segment * really long',
+                        localPath: 'second',
+                    },
+                    {
+                        filename: 'missing',
+                        localPath: 'missing',
+                    },
+                ],
+                outputPath,
+                onFileError: (filename, error) =>
+                    fileErrors.push({ filename, error }),
+            });
+
+            expect(result).toEqual({
+                worksheetCount: 2,
+                failedFileCount: 1,
+            });
+            expect(fileErrors).toEqual([
+                { filename: 'missing', error: 'HTTP 404 Not Found' },
+            ]);
+
+            const workbook = new Excel.Workbook();
+            await workbook.xlsx.readFile(outputPath);
+            expect(workbook.worksheets).toHaveLength(2);
+            expect(workbook.worksheets.map((sheet) => sheet.name)).toEqual([
+                'Revenue_ by _ customer _ segmen',
+                'Revenue_ by _ customer _ segm_2',
+            ]);
+            expect(workbook.worksheets[0].getColumn(1).width).toBe(22);
+            expect(workbook.worksheets[0].getCell('A2').numFmt).toBe(
+                '$#,##0.00',
+            );
+        } finally {
+            await fs.unlink(outputPath).catch(() => undefined);
+        }
+    });
+});

--- a/packages/backend/src/services/ExcelService/WorkbookExportHelper.ts
+++ b/packages/backend/src/services/ExcelService/WorkbookExportHelper.ts
@@ -1,0 +1,149 @@
+import { getErrorMessage } from '@lightdash/common';
+import * as Excel from 'exceljs';
+
+type WorkbookExportFile = {
+    filename: string;
+    sheetName?: string;
+    localPath: string;
+};
+
+type CreateWorkbookFileArgs = {
+    files: WorkbookExportFile[];
+    outputPath: string;
+    onFileError: (filename: string, error: string) => void;
+};
+
+export class WorkbookExportHelper {
+    private static async loadSourceWorksheet({
+        file,
+        onFileError,
+    }: {
+        file: WorkbookExportFile;
+        onFileError: (filename: string, error: string) => void;
+    }) {
+        try {
+            const response = await fetch(file.localPath);
+            if (!response.ok) {
+                onFileError(
+                    file.filename,
+                    `HTTP ${response.status} ${response.statusText}`,
+                );
+                return undefined;
+            }
+
+            const buffer = Buffer.from(await response.arrayBuffer());
+            const sourceWorkbook = new Excel.Workbook();
+            await sourceWorkbook.xlsx.load(
+                buffer as unknown as Parameters<
+                    typeof sourceWorkbook.xlsx.load
+                >[0],
+            );
+
+            const sourceWorksheet = sourceWorkbook.worksheets[0];
+            if (!sourceWorksheet) {
+                onFileError(file.filename, 'No worksheet found');
+                return undefined;
+            }
+
+            return { file, sourceWorksheet };
+        } catch (e) {
+            onFileError(file.filename, getErrorMessage(e));
+            return undefined;
+        }
+    }
+
+    private static getWorksheetName(name: string, usedNames: Set<string>) {
+        const fallbackName = 'Sheet';
+        const sanitizedName =
+            name.replace(/[:\\/?*[\]]/g, '_').trim() || fallbackName;
+        const maxLength = 31;
+        let sheetName = sanitizedName.slice(0, maxLength);
+
+        if (usedNames.has(sheetName)) {
+            let suffix = 2;
+            do {
+                const suffixText = `_${suffix}`;
+                sheetName = `${sanitizedName.slice(
+                    0,
+                    maxLength - suffixText.length,
+                )}${suffixText}`;
+                suffix += 1;
+            } while (usedNames.has(sheetName));
+        }
+
+        usedNames.add(sheetName);
+        return sheetName;
+    }
+
+    private static copyWorksheet(
+        sourceWorksheet: Excel.Worksheet,
+        targetWorksheet: Excel.Worksheet,
+    ) {
+        sourceWorksheet.columns.forEach((column, index) => {
+            if (column.width) {
+                const targetColumn = targetWorksheet.getColumn(index + 1);
+                targetColumn.width = column.width;
+            }
+        });
+
+        sourceWorksheet.eachRow((sourceRow, rowNumber) => {
+            const targetRow = targetWorksheet.getRow(rowNumber);
+            targetRow.height = sourceRow.height;
+            targetRow.values = sourceRow.values;
+
+            sourceRow.eachCell(
+                { includeEmpty: true },
+                (sourceCell, colNumber) => {
+                    const targetCell = targetRow.getCell(colNumber);
+                    targetCell.value = sourceCell.value;
+                    targetCell.style = { ...sourceCell.style };
+                    targetCell.numFmt = sourceCell.numFmt;
+                },
+            );
+
+            targetRow.commit();
+        });
+    }
+
+    static async createWorkbookFile({
+        files,
+        outputPath,
+        onFileError,
+    }: CreateWorkbookFileArgs) {
+        const workbook = new Excel.Workbook();
+        const usedSheetNames = new Set<string>();
+        const sourceWorksheets = await Promise.all(
+            files.map((file) =>
+                this.loadSourceWorksheet({ file, onFileError }),
+            ),
+        );
+        const failedFileCount = sourceWorksheets.filter(
+            (sourceWorksheet) => sourceWorksheet === undefined,
+        ).length;
+
+        sourceWorksheets.forEach((sourceFile) => {
+            if (sourceFile) {
+                const targetWorksheet = workbook.addWorksheet(
+                    this.getWorksheetName(
+                        sourceFile.file.sheetName ?? sourceFile.file.filename,
+                        usedSheetNames,
+                    ),
+                );
+                this.copyWorksheet(sourceFile.sourceWorksheet, targetWorksheet);
+            }
+        });
+
+        if (workbook.worksheets.length === 0) {
+            return {
+                worksheetCount: 0,
+                failedFileCount,
+            };
+        }
+
+        await workbook.xlsx.writeFile(outputPath);
+        return {
+            worksheetCount: workbook.worksheets.length,
+            failedFileCount,
+        };
+    }
+}

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -17,6 +17,7 @@ export type SchedulerCsvOptions = {
     limit: 'table' | 'all' | number;
     asAttachment?: boolean;
     exportPivotedData?: boolean;
+    xlsxFileLayout?: 'zip' | 'workbook';
 };
 
 export type SchedulerImageOptions = {
@@ -597,6 +598,7 @@ export type NotificationPayloadBase = {
         csvUrls?: {
             path: string;
             filename: string;
+            chartName?: string;
             localPath: string;
             truncated: boolean;
         }[];

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -85,6 +85,8 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
     const [selectedTabs, setSelectedTabs] = useState<string[]>(
         dashboard?.tabs?.map((tab) => tab.uuid) || [],
     );
+    const [xlsxFileLayout, setXlsxFileLayout] =
+        useState<NonNullable<SchedulerCsvOptions['xlsxFileLayout']>>('zip');
 
     const exportSelectedTabs =
         isDashboardTabsAvailable && !allTabsSelected && selectedTabs.length > 0
@@ -117,8 +119,19 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
             limit: limit === Limit.CUSTOM ? customLimit : limit,
             asAttachment: false,
             exportPivotedData,
+            xlsxFileLayout:
+                exportType === SchedulerFormat.XLSX
+                    ? xlsxFileLayout
+                    : undefined,
         }),
-        [customLimit, exportPivotedData, formatted, limit],
+        [
+            customLimit,
+            exportPivotedData,
+            exportType,
+            formatted,
+            limit,
+            xlsxFileLayout,
+        ],
     );
 
     const handleAsyncExport = useCallback(() => {
@@ -281,7 +294,11 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
                     {exportType !== SchedulerFormat.IMAGE && (
                         <Text fs="italic" fz="sm" c="dimmed">
                             Charts from the selected tabs will be exported as
-                            tables in a ZIP file.
+                            tables
+                            {exportType === SchedulerFormat.XLSX &&
+                            xlsxFileLayout === 'workbook'
+                                ? ' in one workbook.'
+                                : ' in a ZIP file.'}
                         </Text>
                     )}
                 </Stack>
@@ -317,6 +334,53 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
                         </Button>
                         <Collapse in={showFormatting} pl="md">
                             <Group align="start" gap="xxl">
+                                {exportType === SchedulerFormat.XLSX && (
+                                    <Radio.Group
+                                        label={
+                                            <>
+                                                XLSX output
+                                                <Tooltip
+                                                    withinPortal
+                                                    maw={300}
+                                                    multiline
+                                                    label="Separate files puts each dashboard tile in its own XLSX file inside a ZIP. Single workbook puts each tile on its own sheet in one XLSX file."
+                                                    position="top"
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconHelpCircle}
+                                                        size="md"
+                                                        display="inline"
+                                                        color="gray"
+                                                        style={{
+                                                            marginLeft: '4px',
+                                                            marginBottom:
+                                                                '-4px',
+                                                        }}
+                                                    />
+                                                </Tooltip>
+                                            </>
+                                        }
+                                        value={xlsxFileLayout}
+                                        onChange={(value) =>
+                                            setXlsxFileLayout(
+                                                value as NonNullable<
+                                                    SchedulerCsvOptions['xlsxFileLayout']
+                                                >,
+                                            )
+                                        }
+                                    >
+                                        <Stack gap="xxs" pt="xs">
+                                            <Radio
+                                                label="Separate files (ZIP)"
+                                                value="zip"
+                                            />
+                                            <Radio
+                                                label="Single workbook"
+                                                value="workbook"
+                                            />
+                                        </Stack>
+                                    </Radio.Group>
+                                )}
                                 <Radio.Group
                                     label="Values"
                                     value={formatted}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormSetupTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormSetupTab.tsx
@@ -11,6 +11,7 @@ import {
     type Dashboard,
     type Field,
     type Metric,
+    type SchedulerCsvOptions,
     type TableCalculation,
 } from '@lightdash/common';
 import {
@@ -423,6 +424,61 @@ export const SchedulerFormSetupTab: FC<Props> = ({
                             </Button>
                             <Collapse in={showFormatting} pl="md">
                                 <Group align="start" gap="xxl">
+                                    {form.values.format ===
+                                        SchedulerFormat.XLSX && (
+                                        <Radio.Group
+                                            label={
+                                                <>
+                                                    XLSX output
+                                                    <Tooltip
+                                                        withinPortal
+                                                        maw={300}
+                                                        multiline
+                                                        label="Separate files puts each dashboard tile in its own XLSX file inside a ZIP. Single workbook puts each tile on its own sheet in one XLSX file."
+                                                        position="top"
+                                                    >
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconHelpCircle
+                                                            }
+                                                            size="md"
+                                                            display="inline"
+                                                            color="gray"
+                                                            style={{
+                                                                marginLeft:
+                                                                    '4px',
+                                                                marginBottom:
+                                                                    '-4px',
+                                                            }}
+                                                        />
+                                                    </Tooltip>
+                                                </>
+                                            }
+                                            value={
+                                                form.values.options
+                                                    .xlsxFileLayout
+                                            }
+                                            onChange={(value) =>
+                                                form.setFieldValue(
+                                                    'options.xlsxFileLayout',
+                                                    value as NonNullable<
+                                                        SchedulerCsvOptions['xlsxFileLayout']
+                                                    >,
+                                                )
+                                            }
+                                        >
+                                            <Stack gap="xxs" pt="xs">
+                                                <Radio
+                                                    label="Separate files (ZIP)"
+                                                    value="zip"
+                                                />
+                                                <Radio
+                                                    label="Single workbook"
+                                                    value="workbook"
+                                                />
+                                            </Stack>
+                                        </Radio.Group>
+                                    )}
                                     <Radio.Group
                                         label="Values"
                                         {...form.getInputProps(

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -34,6 +34,7 @@ export interface SchedulerFormValues {
         withPdf: boolean;
         asAttachment: boolean;
         exportPivotedData: boolean;
+        xlsxFileLayout: NonNullable<SchedulerCsvOptions['xlsxFileLayout']>;
     };
     emailTargets: string[];
     slackTargets: string[];
@@ -70,6 +71,7 @@ export const DEFAULT_VALUES: SchedulerFormValues = {
         withPdf: false,
         asAttachment: false,
         exportPivotedData: true,
+        xlsxFileLayout: 'zip',
     },
     emailTargets: [],
     slackTargets: [],
@@ -139,6 +141,7 @@ export const getFormValuesFromScheduler = (
         }
         formOptions.asAttachment = options.asAttachment || false;
         formOptions.exportPivotedData = options.exportPivotedData !== false;
+        formOptions.xlsxFileLayout = options.xlsxFileLayout ?? 'zip';
     } else if (isSchedulerImageOptions(options)) {
         formOptions.withPdf = options.withPdf || false;
     }
@@ -202,6 +205,10 @@ export const transformFormValues = (
                     ? values.options.asAttachment
                     : false,
             exportPivotedData: values.options.exportPivotedData,
+            xlsxFileLayout:
+                values.format === SchedulerFormat.XLSX
+                    ? values.options.xlsxFileLayout
+                    : undefined,
         } satisfies SchedulerCsvOptions;
     } else if (values.format === SchedulerFormat.IMAGE) {
         options = {


### PR DESCRIPTION
### Description
- Adds an XLSX dashboard export layout option for a single workbook with one sheet per chart.
- Keeps ZIP as the default XLSX/CSV dashboard export layout.
- Moves workbook merge logic into `ExcelService/WorkbookExportHelper` and preserves basic worksheet formatting.

### Verification
- `pnpm -F backend test -- WorkbookExportHelper.test.ts --runInBand`
- `pnpm -F frontend typecheck:fast`
- `git diff --check`

Closes: PROD-4880