### PR TITLE
fix: format count metrics in Excel exports

### DIFF
--- a/packages/backend/src/services/ExcelService/ExcelService.test.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.test.ts
@@ -1,8 +1,10 @@
 import {
     DimensionType,
     FieldType,
+    getExcelFormatExpression,
     getFormatExpression,
     ItemsMap,
+    MetricType,
     SortByDirection,
     TimeFrames,
     VizAggregationOptions,
@@ -48,6 +50,28 @@ const mockItemMapWithFormats: ItemsMap = {
         tableLabel: 'table',
         label: 'Plain Number',
         sql: '${TABLE}.plain_number',
+    },
+    count_metric_without_format: {
+        name: 'count_metric_without_format',
+        description: undefined,
+        table: 'table',
+        hidden: false,
+        fieldType: FieldType.METRIC,
+        type: MetricType.COUNT,
+        tableLabel: 'table',
+        label: 'Count',
+        sql: 'COUNT(${TABLE}.id)',
+    },
+    count_distinct_metric_without_format: {
+        name: 'count_distinct_metric_without_format',
+        description: undefined,
+        table: 'table',
+        hidden: false,
+        fieldType: FieldType.METRIC,
+        type: MetricType.COUNT_DISTINCT,
+        tableLabel: 'table',
+        label: 'Count distinct',
+        sql: 'COUNT(DISTINCT ${TABLE}.id)',
     },
     string_column: {
         name: 'string_column',
@@ -1855,6 +1879,19 @@ describe('ExcelService', () => {
 
             // Should return a default number format for fields without explicit format
             expect(formatExpression).toBe('#,##0.###');
+        });
+
+        it('should default unformatted Excel count metrics to whole numbers', () => {
+            expect(
+                getExcelFormatExpression(
+                    mockItemMapWithFormats.count_metric_without_format,
+                ),
+            ).toBe('#,##0');
+            expect(
+                getExcelFormatExpression(
+                    mockItemMapWithFormats.count_distinct_metric_without_format,
+                ),
+            ).toBe('#,##0');
         });
 
         it('should NOT return default format for date fields without explicit format', () => {

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -5,7 +5,7 @@ import {
     formatItemValue,
     formatRows,
     getErrorMessage,
-    getFormatExpression,
+    getExcelFormatExpression,
     isDimension,
     isField,
     isNumber,
@@ -534,7 +534,7 @@ export class ExcelService {
         worksheet.columns = headers.map((header, index) => {
             const fieldId = sortedFieldIds[index];
             const item = fields[fieldId];
-            const formatExpression = getFormatExpression(item);
+            const formatExpression = getExcelFormatExpression(item);
 
             const column: Partial<Excel.Column> = {
                 header,

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -968,10 +968,27 @@ export function getFormatExpression(
     if (hasValidFormatExpression(item)) {
         return item.format;
     }
+
     const customFormat = getCustomFormat(item);
     return customFormat
         ? convertCustomFormatToFormatExpression(customFormat) || undefined
         : undefined;
+}
+
+export function getExcelFormatExpression(
+    item: Item | AdditionalMetric,
+): string | undefined {
+    const formatExpression = getFormatExpression(item);
+    if (
+        formatExpression === '#,##0.###' &&
+        isMetric(item) &&
+        [MetricType.COUNT, MetricType.COUNT_DISTINCT].includes(item.type) &&
+        !hasFormatting(item)
+    ) {
+        return '#,##0';
+    }
+
+    return formatExpression;
 }
 
 export function formatItemValue(


### PR DESCRIPTION
### Description
- Add an Excel-specific format expression helper.
- Default unformatted count and count distinct metrics to whole-number Excel formatting.
- Keep generic format expression behavior unchanged.

### Testing
- pnpm -F backend test ExcelService.test.ts --runInBand
- pnpm -F common typecheck:fast
- pnpm -F backend typecheck:fast

Closes: PROD-8225
Closes: #24112