### PR TITLE
feat(ai-agents): surface review findings on AI threads

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -7,6 +7,7 @@ import {
     Badge,
     Box,
     Group,
+    Stack,
     Text,
     Tooltip,
     useMantineTheme,
@@ -39,6 +40,7 @@ import {
     type UIEvent,
 } from 'react';
 import { useNavigate } from 'react-router';
+import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import {
     ContentTable,
     useContentTable,
@@ -50,10 +52,21 @@ import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useGetSlack } from '../../../../../hooks/slack/useSlack';
 import { useIsTruncated } from '../../../../../hooks/useIsTruncated';
 import SlackSvg from '../../../../../svgs/slack.svg?react';
-import { useInfiniteAiAgentAdminThreads } from '../../hooks/useAiAgentAdmin';
+import {
+    useAiAgentAdminReviewItems,
+    useInfiniteAiAgentAdminThreads,
+} from '../../hooks/useAiAgentAdmin';
 import { useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
 import { AgentNamePill } from '../AgentNamePill';
 import { AiAgentAdminTopToolbar } from './AiAgentAdminTopToolbar';
+import {
+    getThreadReviewHeadline,
+    summarizeThreadReviewItems,
+    THREAD_REVIEW_ITEM_STATUSES,
+    threadReviewRootCauseColors,
+    threadReviewRootCauseLabels,
+    threadReviewStatusColors,
+} from './threadReviewContext';
 
 type AiAgentAdminThreadsTableProps = {
     onThreadSelect?: (thread: AiAgentAdminThreadSummary) => void;
@@ -144,11 +157,26 @@ const AiAgentAdminThreadsTable = ({
             },
             { keepPreviousData: true },
         );
+    const { data: reviewItems = [] } = useAiAgentAdminReviewItems(
+        { statuses: THREAD_REVIEW_ITEM_STATUSES },
+        { enabled: true },
+    );
 
     const flatData = useMemo(() => {
         if (!data) return [];
         return data.pages.flatMap((page) => page.data.threads);
     }, [data]);
+
+    const reviewSummaryByThreadUuid = useMemo(
+        () =>
+            new Map(
+                flatData.map((thread) => [
+                    thread.uuid,
+                    summarizeThreadReviewItems(reviewItems, thread.uuid),
+                ]),
+            ),
+        [flatData, reviewItems],
+    );
 
     // Temporary workaround to resolve a memoization issue with react-mantine-table
     const [tableData, setTableData] = useState<AiAgentAdminThreadSummary[]>([]);
@@ -434,6 +462,91 @@ const AiAgentAdminThreadsTable = ({
                             </Group>
                         )}
                     </Group>
+                );
+            },
+        },
+        {
+            accessorKey: 'reviewWarnings',
+            header: 'Warnings',
+            enableSorting: false,
+            enableEditing: false,
+            size: 240,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon
+                        icon={IconMessageCircleStar}
+                        color="ldGray.6"
+                    />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => {
+                const thread = row.original;
+                const summary = reviewSummaryByThreadUuid.get(thread.uuid);
+                const latestReviewItem = summary?.latestReviewItem ?? null;
+
+                if (
+                    !summary ||
+                    summary.findingCount === 0 ||
+                    !latestReviewItem
+                ) {
+                    return (
+                        <Text fz="xs" c="ldGray.5" fw={500}>
+                            Clean
+                        </Text>
+                    );
+                }
+
+                const headline =
+                    getThreadReviewHeadline(latestReviewItem) ??
+                    latestReviewItem.title;
+                const activeCount =
+                    summary.openFindingCount + summary.inProgressFindingCount;
+
+                return (
+                    <Stack gap={4} miw={0}>
+                        <Group gap={6} wrap="nowrap">
+                            <Badge variant="light" color="violet">
+                                {summary.findingCount}{' '}
+                                {summary.findingCount === 1
+                                    ? 'finding'
+                                    : 'findings'}
+                            </Badge>
+                            <Badge
+                                variant="light"
+                                color={
+                                    threadReviewStatusColors[
+                                        latestReviewItem.status
+                                    ]
+                                }
+                            >
+                                {activeCount > 0
+                                    ? `${activeCount} active`
+                                    : latestReviewItem.status.replaceAll(
+                                          '_',
+                                          ' ',
+                                      )}
+                            </Badge>
+                        </Group>
+                        <Group gap={6} wrap="nowrap" miw={0}>
+                            <CategoryBadge
+                                variant="dot"
+                                label={
+                                    threadReviewRootCauseLabels[
+                                        latestReviewItem.primaryRootCause
+                                    ]
+                                }
+                                color={
+                                    threadReviewRootCauseColors[
+                                        latestReviewItem.primaryRootCause
+                                    ]
+                                }
+                            />
+                            <Text fz="xs" c="ldGray.6" lineClamp={1}>
+                                {headline}
+                            </Text>
+                        </Group>
+                    </Stack>
                 );
             },
         },

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -1,25 +1,46 @@
 import {
     ActionIcon,
+    Badge,
     Box,
     Button,
     Divider,
     Group,
     LoadingOverlay,
+    Stack,
+    Text,
     Title,
     Tooltip,
+    useMantineTheme,
 } from '@mantine-8/core';
-import { IconExternalLink, IconSettings, IconX } from '@tabler/icons-react';
-import { type FC } from 'react';
-import { Link } from 'react-router';
+import {
+    IconArrowRight,
+    IconExternalLink,
+    IconGitPullRequest,
+    IconSettings,
+    IconX,
+} from '@tabler/icons-react';
+import { type FC, useMemo } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiAgentAdminReviewItems } from '../../hooks/useAiAgentAdmin';
 import { useAiAgentThread } from '../../hooks/useProjectAiAgents';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { EvalAssessmentDisplay } from '../Evals/EvalAssessmentDisplay';
+import {
+    getThreadReviewHeadline,
+    summarizeThreadReviewItems,
+    THREAD_REVIEW_ITEM_STATUSES,
+    threadReviewRootCauseColors,
+    threadReviewRootCauseLabels,
+    threadReviewStatusColors,
+} from './threadReviewContext';
 
 type ThreadPreviewSidebarProps = {
     projectUuid: string;
     agentUuid: string;
     threadUuid: string;
+    selectedReviewItemUuid?: string;
     isOpen: boolean;
     onClose: () => void;
     showAddToEvalsButton?: boolean;
@@ -31,16 +52,27 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
     projectUuid,
     agentUuid,
     threadUuid,
+    selectedReviewItemUuid,
     isOpen,
     onClose,
     showAddToEvalsButton = false,
     evalUuid,
     runUuid,
 }) => {
+    const theme = useMantineTheme();
+    const navigate = useNavigate();
     const { data: threadData, isLoading: isLoadingThread } = useAiAgentThread(
         projectUuid,
         agentUuid,
         threadUuid,
+    );
+    const { data: reviewItems = [] } = useAiAgentAdminReviewItems(
+        { statuses: THREAD_REVIEW_ITEM_STATUSES },
+        { enabled: isOpen },
+    );
+    const reviewSummary = useMemo(
+        () => summarizeThreadReviewItems(reviewItems, threadUuid),
+        [reviewItems, threadUuid],
     );
 
     if (!isOpen || !threadUuid) {
@@ -104,6 +136,181 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
 
             {threadData && (
                 <Box mah="calc(100vh - 150px)" style={{ overflowY: 'auto' }}>
+                    {reviewSummary.findingCount > 0 && (
+                        <>
+                            <Stack p="sm" gap="sm">
+                                <Group justify="space-between" align="center">
+                                    <Title order={6} fw={600}>
+                                        Review findings
+                                    </Title>
+                                    <Badge variant="light" color="violet">
+                                        {reviewSummary.findingCount}
+                                    </Badge>
+                                </Group>
+
+                                {reviewSummary.items.map((reviewItem) => {
+                                    const isSelected =
+                                        selectedReviewItemUuid ===
+                                        reviewItem.uuid;
+                                    const headline =
+                                        getThreadReviewHeadline(reviewItem) ??
+                                        reviewItem.title;
+
+                                    return (
+                                        <Stack
+                                            key={reviewItem.uuid}
+                                            gap={8}
+                                            p="sm"
+                                            bg={
+                                                isSelected
+                                                    ? theme.colors.ldGray[0]
+                                                    : 'white'
+                                            }
+                                            style={{
+                                                border: `1px solid ${
+                                                    isSelected
+                                                        ? theme.colors.violet[3]
+                                                        : theme.colors.ldGray[2]
+                                                }`,
+                                                borderRadius: theme.radius.md,
+                                            }}
+                                        >
+                                            <Group
+                                                justify="space-between"
+                                                align="flex-start"
+                                            >
+                                                <CategoryBadge
+                                                    variant="dot"
+                                                    label={
+                                                        threadReviewRootCauseLabels[
+                                                            reviewItem
+                                                                .primaryRootCause
+                                                        ]
+                                                    }
+                                                    color={
+                                                        threadReviewRootCauseColors[
+                                                            reviewItem
+                                                                .primaryRootCause
+                                                        ]
+                                                    }
+                                                />
+                                                <Badge
+                                                    variant="light"
+                                                    color={
+                                                        threadReviewStatusColors[
+                                                            reviewItem.status
+                                                        ]
+                                                    }
+                                                >
+                                                    {reviewItem.status.replaceAll(
+                                                        '_',
+                                                        ' ',
+                                                    )}
+                                                </Badge>
+                                            </Group>
+
+                                            <Stack gap={4}>
+                                                <Text fw={600} fz="sm">
+                                                    {headline}
+                                                </Text>
+                                                <Text
+                                                    fz="xs"
+                                                    c="ldGray.6"
+                                                    lineClamp={2}
+                                                >
+                                                    {reviewItem.description}
+                                                </Text>
+                                            </Stack>
+
+                                            <Group gap="xs">
+                                                <Button
+                                                    size="compact-xs"
+                                                    variant={
+                                                        isSelected
+                                                            ? 'default'
+                                                            : 'subtle'
+                                                    }
+                                                    color="gray"
+                                                    rightSection={
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconArrowRight
+                                                            }
+                                                            size="xs"
+                                                        />
+                                                    }
+                                                    onClick={() => {
+                                                        const params =
+                                                            new URLSearchParams();
+                                                        params.set(
+                                                            'reviewProjectUuid',
+                                                            reviewItem
+                                                                .latestFinding
+                                                                ?.projectUuid ??
+                                                                projectUuid,
+                                                        );
+                                                        params.set(
+                                                            'reviewAgentUuid',
+                                                            reviewItem
+                                                                .latestFinding
+                                                                ?.agentUuid ??
+                                                                agentUuid,
+                                                        );
+                                                        params.set(
+                                                            'reviewThreadUuid',
+                                                            reviewItem
+                                                                .latestFinding
+                                                                ?.threadUuid ??
+                                                                threadUuid,
+                                                        );
+                                                        params.set(
+                                                            'reviewItemUuid',
+                                                            reviewItem.uuid,
+                                                        );
+                                                        void navigate(
+                                                            `/generalSettings/ai/reviews?${params.toString()}`,
+                                                        );
+                                                    }}
+                                                >
+                                                    View review
+                                                </Button>
+
+                                                {reviewItem.linkedPrUrl && (
+                                                    <Button
+                                                        component="a"
+                                                        href={
+                                                            reviewItem.linkedPrUrl
+                                                        }
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        size="compact-xs"
+                                                        variant="subtle"
+                                                        color="gray"
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconGitPullRequest
+                                                                }
+                                                                size="xs"
+                                                            />
+                                                        }
+                                                        onClick={(event) =>
+                                                            event.stopPropagation()
+                                                        }
+                                                    >
+                                                        View PR
+                                                    </Button>
+                                                )}
+                                            </Group>
+                                        </Stack>
+                                    );
+                                })}
+                            </Stack>
+
+                            <Divider />
+                        </>
+                    )}
+
                     {evalUuid && runUuid && (
                         <EvalAssessmentDisplay
                             projectUuid={projectUuid}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { Button, Drawer, Group, Stack, Text } from '@mantine-8/core';
 import { IconRoute } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router';
 import { GuidedTour } from '../../../../../../components/common/GuidedTour';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
@@ -17,10 +18,29 @@ import drawerClasses from './ThreadPreviewDrawer.module.css';
 
 export const AiReviewsSettingsPage = () => {
     const { data: settings } = useAiOrganizationSettings();
+    const [searchParams, setSearchParams] = useSearchParams();
 
     const [selectedReviewItem, setSelectedReviewItem] =
         useState<AiAgentAdminReviewItemPreviewTarget | null>(null);
     const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+    const reviewItemFromSearchParams = useMemo(() => {
+        const projectUuid = searchParams.get('reviewProjectUuid');
+        const agentUuid = searchParams.get('reviewAgentUuid');
+        const threadUuid = searchParams.get('reviewThreadUuid');
+        const reviewItemUuid = searchParams.get('reviewItemUuid');
+
+        if (!projectUuid || !agentUuid || !threadUuid || !reviewItemUuid) {
+            return null;
+        }
+
+        return {
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            reviewItemUuid,
+        };
+    }, [searchParams]);
 
     // While the tour is running, the table always shows sample rows so it
     // highlights the same findings every time. Closing it flips to real data.
@@ -30,16 +50,49 @@ export const AiReviewsSettingsPage = () => {
         closeTour,
     } = useGuidedTour({ storageKey: 'ld.aiReviews.tour.v1' });
 
+    useEffect(() => {
+        if (!reviewItemFromSearchParams) {
+            return;
+        }
+
+        setSelectedReviewItem(reviewItemFromSearchParams);
+        setIsSidebarOpen(true);
+    }, [reviewItemFromSearchParams]);
+
+    const updateReviewSearchParams = (
+        reviewItem: AiAgentAdminReviewItemPreviewTarget | null,
+    ) => {
+        const nextParams = new URLSearchParams(searchParams);
+
+        nextParams.delete('reviewProjectUuid');
+        nextParams.delete('reviewAgentUuid');
+        nextParams.delete('reviewThreadUuid');
+        nextParams.delete('reviewItemUuid');
+
+        if (reviewItem) {
+            nextParams.set('reviewProjectUuid', reviewItem.projectUuid);
+            nextParams.set('reviewAgentUuid', reviewItem.agentUuid);
+            nextParams.set('reviewThreadUuid', reviewItem.threadUuid);
+            if (reviewItem.reviewItemUuid) {
+                nextParams.set('reviewItemUuid', reviewItem.reviewItemUuid);
+            }
+        }
+
+        setSearchParams(nextParams, { replace: true });
+    };
+
     const handleReviewItemSelect = (
         reviewItem: AiAgentAdminReviewItemPreviewTarget,
     ): void => {
         setSelectedReviewItem(reviewItem);
         setIsSidebarOpen(true);
+        updateReviewSearchParams(reviewItem);
     };
 
     const handleCloseSidebar = () => {
         setIsSidebarOpen(false);
         setSelectedReviewItem(null);
+        updateReviewSearchParams(null);
     };
 
     return (
@@ -114,6 +167,9 @@ export const AiReviewsSettingsPage = () => {
                         projectUuid={selectedReviewItem.projectUuid}
                         agentUuid={selectedReviewItem.agentUuid}
                         threadUuid={selectedReviewItem.threadUuid}
+                        selectedReviewItemUuid={
+                            selectedReviewItem.reviewItemUuid ?? undefined
+                        }
                         isOpen={isSidebarOpen}
                         onClose={handleCloseSidebar}
                         showAddToEvalsButton

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/threadReviewContext.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/threadReviewContext.test.ts
@@ -1,0 +1,133 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    getThreadReviewHeadline,
+    getThreadReviewItems,
+    summarizeThreadReviewItems,
+} from './threadReviewContext';
+
+const makeReviewItem = (
+    overrides: Partial<AiAgentReviewItemSummary> = {},
+): AiAgentReviewItemSummary =>
+    ({
+        uuid: 'review-1',
+        fingerprint: 'fingerprint-1',
+        organizationUuid: 'org-1',
+        projectUuid: 'project-1',
+        agentUuid: 'agent-1',
+        title: 'Review revenue metric',
+        description: 'The answer picked the wrong metric',
+        primaryRootCause: 'semantic_layer',
+        status: 'open',
+        dismissedReason: null,
+        ownerType: 'semantic_layer_owner',
+        assignedToUserUuid: null,
+        firstSeenAt: new Date('2026-06-10T09:00:00.000Z'),
+        lastSeenAt: new Date('2026-06-10T09:00:00.000Z'),
+        findingCount: 1,
+        statusUpdatedAt: new Date('2026-06-10T09:00:00.000Z'),
+        statusUpdatedByUserUuid: null,
+        linkedIssueUrl: null,
+        linkedPrUrl: null,
+        prState: null,
+        prWritebackStatus: null,
+        prWritebackMessage: null,
+        createdAt: new Date('2026-06-10T09:00:00.000Z'),
+        updatedAt: new Date('2026-06-10T09:00:00.000Z'),
+        writebackEligible: false,
+        writebackEligibility: {
+            eligible: false,
+            reason: 'unsupported_root_cause',
+            provider: null,
+            strategy: null,
+        },
+        latestFinding: {
+            uuid: 'finding-1',
+            promptUuid: 'prompt-1',
+            threadUuid: 'thread-1',
+            projectUuid: 'project-1',
+            agentUuid: 'agent-1',
+            subcategories: [],
+            fixTargets: ['semantic_yaml_patch'],
+            targetRefs: [],
+            evidenceExcerpts: [],
+            recommendation: {
+                actionType: 'update_semantic_yaml',
+                title: 'Update revenue metric guidance',
+                rationale: 'Metric guidance is stale',
+                targetRefs: [],
+            },
+            projectContextEntry: null,
+            createdAt: new Date('2026-06-10T09:00:00.000Z'),
+        },
+        ...overrides,
+    }) as AiAgentReviewItemSummary;
+
+describe('threadReviewContext', () => {
+    it('filters review items down to the source thread', () => {
+        const items = getThreadReviewItems(
+            [
+                makeReviewItem(),
+                makeReviewItem({
+                    uuid: 'review-2',
+                    latestFinding: {
+                        ...makeReviewItem().latestFinding!,
+                        threadUuid: 'thread-2',
+                    },
+                }),
+            ],
+            'thread-1',
+        );
+
+        expect(items.map((item) => item.uuid)).toEqual(['review-1']);
+    });
+
+    it('prioritizes open findings ahead of resolved ones', () => {
+        const items = getThreadReviewItems(
+            [
+                makeReviewItem({
+                    uuid: 'resolved-review',
+                    status: 'resolved',
+                    updatedAt: new Date('2026-06-10T12:00:00.000Z'),
+                }),
+                makeReviewItem({
+                    uuid: 'open-review',
+                    status: 'open',
+                    updatedAt: new Date('2026-06-10T10:00:00.000Z'),
+                }),
+            ],
+            'thread-1',
+        );
+
+        expect(items.map((item) => item.uuid)).toEqual([
+            'open-review',
+            'resolved-review',
+        ]);
+    });
+
+    it('summarizes counts by review status', () => {
+        const summary = summarizeThreadReviewItems(
+            [
+                makeReviewItem({ uuid: 'open-review', status: 'open' }),
+                makeReviewItem({
+                    uuid: 'in-progress-review',
+                    status: 'in_progress',
+                }),
+                makeReviewItem({ uuid: 'resolved-review', status: 'resolved' }),
+            ],
+            'thread-1',
+        );
+
+        expect(summary.findingCount).toBe(3);
+        expect(summary.openFindingCount).toBe(1);
+        expect(summary.inProgressFindingCount).toBe(1);
+        expect(summary.resolvedFindingCount).toBe(1);
+        expect(summary.latestReviewItem?.uuid).toBe('open-review');
+    });
+
+    it('prefers the recommendation title for the thread headline', () => {
+        expect(getThreadReviewHeadline(makeReviewItem())).toBe(
+            'Update revenue metric guidance',
+        );
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/threadReviewContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/threadReviewContext.ts
@@ -1,0 +1,117 @@
+import {
+    type AiAgentReviewItemStatus,
+    type AiAgentReviewItemSummary,
+    type AiAgentRootCause,
+} from '@lightdash/common';
+
+export const THREAD_REVIEW_ITEM_STATUSES: AiAgentReviewItemStatus[] = [
+    'open',
+    'in_progress',
+    'resolved',
+    'dismissed',
+    'duplicate',
+];
+
+export const threadReviewRootCauseLabels: Record<AiAgentRootCause, string> = {
+    semantic_layer: 'Semantic layer',
+    project_context: 'Project context',
+    agent_configuration: 'Agent config',
+    data_gap: 'Data gap',
+    product_capability: 'Product',
+    runtime_reliability: 'Runtime',
+    feedback_quality: 'Feedback',
+    not_a_failure: 'Not failure',
+    ambiguous: 'Ambiguous',
+};
+
+export const threadReviewRootCauseColors: Record<AiAgentRootCause, string> = {
+    semantic_layer: 'indigo',
+    project_context: 'violet',
+    agent_configuration: 'cyan',
+    data_gap: 'orange',
+    product_capability: 'grape',
+    runtime_reliability: 'red',
+    feedback_quality: 'teal',
+    not_a_failure: 'gray',
+    ambiguous: 'gray',
+};
+
+export const threadReviewStatusColors: Record<AiAgentReviewItemStatus, string> =
+    {
+        open: 'red',
+        in_progress: 'yellow',
+        resolved: 'green',
+        dismissed: 'gray',
+        duplicate: 'gray',
+    };
+
+export type ThreadReviewSummary = {
+    items: AiAgentReviewItemSummary[];
+    latestReviewItem: AiAgentReviewItemSummary | null;
+    findingCount: number;
+    openFindingCount: number;
+    inProgressFindingCount: number;
+    resolvedFindingCount: number;
+    dismissedFindingCount: number;
+    duplicateFindingCount: number;
+};
+
+const reviewStatusPriority: Record<AiAgentReviewItemStatus, number> = {
+    open: 0,
+    in_progress: 1,
+    resolved: 2,
+    dismissed: 3,
+    duplicate: 4,
+};
+
+const getReviewItemTimestamp = (reviewItem: AiAgentReviewItemSummary) =>
+    new Date(reviewItem.updatedAt ?? reviewItem.lastSeenAt ?? 0).getTime();
+
+export const getThreadReviewItems = (
+    reviewItems: AiAgentReviewItemSummary[],
+    threadUuid: string,
+): AiAgentReviewItemSummary[] =>
+    reviewItems
+        .filter(
+            (reviewItem) => reviewItem.latestFinding?.threadUuid === threadUuid,
+        )
+        .sort((a, b) => {
+            const statusDelta =
+                reviewStatusPriority[a.status] - reviewStatusPriority[b.status];
+            if (statusDelta !== 0) {
+                return statusDelta;
+            }
+            return getReviewItemTimestamp(b) - getReviewItemTimestamp(a);
+        });
+
+export const summarizeThreadReviewItems = (
+    reviewItems: AiAgentReviewItemSummary[],
+    threadUuid: string,
+): ThreadReviewSummary => {
+    const items = getThreadReviewItems(reviewItems, threadUuid);
+
+    return {
+        items,
+        latestReviewItem: items[0] ?? null,
+        findingCount: items.length,
+        openFindingCount: items.filter((item) => item.status === 'open').length,
+        inProgressFindingCount: items.filter(
+            (item) => item.status === 'in_progress',
+        ).length,
+        resolvedFindingCount: items.filter((item) => item.status === 'resolved')
+            .length,
+        dismissedFindingCount: items.filter(
+            (item) => item.status === 'dismissed',
+        ).length,
+        duplicateFindingCount: items.filter(
+            (item) => item.status === 'duplicate',
+        ).length,
+    };
+};
+
+export const getThreadReviewHeadline = (
+    reviewItem: AiAgentReviewItemSummary | null,
+): string | null =>
+    reviewItem?.latestFinding?.recommendation?.title ??
+    reviewItem?.title ??
+    null;


### PR DESCRIPTION
## Summary
Adds a first launch-ready `ZAP-483` slice on the admin AI Threads surface.

- adds a `Warnings` column on AI Threads with review finding count, active state, and top root-cause context
- adds a review findings panel inside the thread preview sidebar with `View review` and `View PR` actions
- makes review-thread navigation shareable by syncing the selected review item into AI Reviews page query params
- adds pure helper coverage for the thread/review summarization logic

## Why
The current AI Threads view shows the source conversation but not whether it produced review findings or linked PR work. This patch closes that loop enough for launch/demo use without introducing a new backend contract.

## Validation
- `pnpm -F @lightdash/frontend test -- src/ee/features/aiCopilot/components/Admin/threadReviewContext.test.ts`
- commit hooks ran frontend lint/format successfully during commit
- full frontend `typecheck` in this fresh worktree is currently noisy for unrelated workspace resolution reasons (`@lightdash/common` import resolution fails broadly), so I did not treat that as a signal on this diff