### PR TITLE
feat(ai-agents): link review findings from pull requests

### DIFF
--- a/packages/backend/src/models/PullRequestsModel.test.ts
+++ b/packages/backend/src/models/PullRequestsModel.test.ts
@@ -1,0 +1,187 @@
+import {
+    PullRequestProvider,
+    PullRequestSource,
+    type KnexPaginatedData,
+    type PullRequest,
+} from '@lightdash/common';
+import knex, { Knex } from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import KnexPaginate from '../database/pagination';
+import { PullRequestsModel } from './PullRequestsModel';
+
+jest.mock('../database/pagination', () => ({
+    __esModule: true,
+    default: { paginate: jest.fn() },
+}));
+
+const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000002';
+const USER_UUID = '00000000-0000-0000-0000-000000000003';
+const PULL_REQUEST_UUID = '00000000-0000-0000-0000-000000000004';
+const AI_THREAD_UUID = '00000000-0000-0000-0000-000000000005';
+const AI_AGENT_UUID = '00000000-0000-0000-0000-000000000006';
+const REVIEW_THREAD_UUID = '00000000-0000-0000-0000-000000000007';
+const REVIEW_PROJECT_UUID = '00000000-0000-0000-0000-000000000008';
+const REVIEW_AGENT_UUID = '00000000-0000-0000-0000-000000000009';
+const FINDING_UUID = '00000000-0000-0000-0000-000000000010';
+const CREATED_AT = new Date('2026-06-10T10:00:00.000Z');
+const FINGERPRINT = 'ai_agent_review_item:fingerprint';
+const PR_URL = 'https://github.com/acme/dbt/pull/42';
+
+const mockedPaginate = jest.mocked(KnexPaginate.paginate);
+
+const makePullRequestRow = (
+    overrides: Partial<Record<string, unknown>> = {},
+) => ({
+    pull_request_uuid: PULL_REQUEST_UUID,
+    organization_uuid: ORGANIZATION_UUID,
+    project_uuid: PROJECT_UUID,
+    created_by_user_uuid: USER_UUID,
+    provider: PullRequestProvider.GITHUB,
+    source: PullRequestSource.AI_AGENT,
+    owner: 'acme',
+    repo: 'dbt',
+    pr_number: 42,
+    pr_url: PR_URL,
+    created_at: CREATED_AT,
+    ...overrides,
+});
+
+describe('PullRequestsModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new PullRequestsModel({
+        database: database as unknown as Knex,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+        mockedPaginate.mockReset();
+        jest.restoreAllMocks();
+    });
+
+    it('enriches pull requests with persisted review remediation context', async () => {
+        mockedPaginate.mockResolvedValue({
+            data: [makePullRequestRow()],
+            pagination: {
+                page: 1,
+                pageSize: 25,
+                totalPageCount: 1,
+                totalResults: 1,
+            },
+        } as unknown as KnexPaginatedData<PullRequest[]>);
+
+        Object.assign(model as unknown as Record<string, unknown>, {
+            aiWritebackTableExists: true,
+            aiReviewTablesExist: true,
+        });
+
+        tracker.on.select('ai_writeback_thread').responseOnce([
+            {
+                pull_request_uuid: PULL_REQUEST_UUID,
+                ai_thread_uuid: AI_THREAD_UUID,
+                agent_uuid: AI_AGENT_UUID,
+            },
+        ]);
+        tracker.on.select('ai_agent_review_remediation').responseOnce([
+            {
+                pullRequestUuid: PULL_REQUEST_UUID,
+                fingerprint: FINGERPRINT,
+                reviewStatus: 'in_progress',
+                reviewItemTitle: 'Fix revenue metric guidance',
+                primaryRootCause: 'semantic_layer',
+                sourceFindingUuid: FINDING_UUID,
+                sourceThreadUuid: REVIEW_THREAD_UUID,
+                sourceProjectUuid: REVIEW_PROJECT_UUID,
+                sourceAgentUuid: REVIEW_AGENT_UUID,
+            },
+        ]);
+        tracker.on.select('ai_agent_review_item').responseOnce([]);
+
+        const result = await model.getByProject(PROJECT_UUID, {
+            page: 1,
+            pageSize: 25,
+        });
+
+        expect(result.data[0]).toMatchObject({
+            pullRequestUuid: PULL_REQUEST_UUID,
+            aiThreadUuid: AI_THREAD_UUID,
+            aiAgentUuid: AI_AGENT_UUID,
+            reviewContext: {
+                reviewItemUuid: FINGERPRINT,
+                reviewItemFingerprint: FINGERPRINT,
+                reviewTitle: 'Fix revenue metric guidance',
+                reviewStatus: 'in_progress',
+                primaryRootCause: 'semantic_layer',
+                sourceFindingUuid: FINDING_UUID,
+                sourceThreadUuid: REVIEW_THREAD_UUID,
+                sourceProjectUuid: REVIEW_PROJECT_UUID,
+                sourceAgentUuid: REVIEW_AGENT_UUID,
+            },
+        });
+    });
+
+    it('falls back to linked_pr_url for older review rows without a remediation link', async () => {
+        mockedPaginate.mockResolvedValue({
+            data: [makePullRequestRow()],
+            pagination: {
+                page: 1,
+                pageSize: 25,
+                totalPageCount: 1,
+                totalResults: 1,
+            },
+        } as unknown as KnexPaginatedData<PullRequest[]>);
+
+        Object.assign(model as unknown as Record<string, unknown>, {
+            aiWritebackTableExists: true,
+            aiReviewTablesExist: true,
+        });
+
+        tracker.on.select('ai_writeback_thread').responseOnce([]);
+        tracker.on.select('ai_agent_review_remediation').responseOnce([]);
+        tracker.on.select('ai_agent_review_item').responseOnce([
+            {
+                fingerprint: FINGERPRINT,
+                linkedPrUrl: PR_URL,
+                reviewStatus: 'resolved',
+            },
+        ]);
+        tracker.on.select('ai_agent_review_turn_signal').responseOnce([
+            {
+                fingerprint: FINGERPRINT,
+                reviewItemTitle: 'Document revenue definition',
+                primaryRootCause: 'project_context',
+                sourceFindingUuid: FINDING_UUID,
+                sourceThreadUuid: REVIEW_THREAD_UUID,
+                sourceProjectUuid: REVIEW_PROJECT_UUID,
+                sourceAgentUuid: REVIEW_AGENT_UUID,
+            },
+        ]);
+
+        const result = await model.getByProject(PROJECT_UUID, {
+            page: 1,
+            pageSize: 25,
+        });
+
+        expect(result.data[0]).toMatchObject({
+            pullRequestUuid: PULL_REQUEST_UUID,
+            aiThreadUuid: null,
+            aiAgentUuid: null,
+            reviewContext: {
+                reviewItemUuid: FINGERPRINT,
+                reviewItemFingerprint: FINGERPRINT,
+                reviewTitle: 'Document revenue definition',
+                reviewStatus: 'resolved',
+                primaryRootCause: 'project_context',
+                sourceFindingUuid: FINDING_UUID,
+                sourceThreadUuid: REVIEW_THREAD_UUID,
+                sourceProjectUuid: REVIEW_PROJECT_UUID,
+                sourceAgentUuid: REVIEW_AGENT_UUID,
+            },
+        });
+    });
+});

--- a/packages/backend/src/models/PullRequestsModel.test.ts
+++ b/packages/backend/src/models/PullRequestsModel.test.ts
@@ -1,187 +1,64 @@
-import {
-    PullRequestProvider,
-    PullRequestSource,
-    type KnexPaginatedData,
-    type PullRequest,
-} from '@lightdash/common';
-import knex, { Knex } from 'knex';
-import { getTracker, MockClient, Tracker } from 'knex-mock-client';
-import KnexPaginate from '../database/pagination';
-import { PullRequestsModel } from './PullRequestsModel';
+import { toPullRequestReviewContext } from './PullRequestsModel';
 
-jest.mock('../database/pagination', () => ({
-    __esModule: true,
-    default: { paginate: jest.fn() },
-}));
-
-const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
-const PROJECT_UUID = '00000000-0000-0000-0000-000000000002';
-const USER_UUID = '00000000-0000-0000-0000-000000000003';
-const PULL_REQUEST_UUID = '00000000-0000-0000-0000-000000000004';
-const AI_THREAD_UUID = '00000000-0000-0000-0000-000000000005';
-const AI_AGENT_UUID = '00000000-0000-0000-0000-000000000006';
 const REVIEW_THREAD_UUID = '00000000-0000-0000-0000-000000000007';
 const REVIEW_PROJECT_UUID = '00000000-0000-0000-0000-000000000008';
 const REVIEW_AGENT_UUID = '00000000-0000-0000-0000-000000000009';
 const FINDING_UUID = '00000000-0000-0000-0000-000000000010';
-const CREATED_AT = new Date('2026-06-10T10:00:00.000Z');
 const FINGERPRINT = 'ai_agent_review_item:fingerprint';
-const PR_URL = 'https://github.com/acme/dbt/pull/42';
 
-const mockedPaginate = jest.mocked(KnexPaginate.paginate);
+const sourceInfo = {
+    fingerprint: FINGERPRINT,
+    sourceFindingUuid: FINDING_UUID,
+    sourceThreadUuid: REVIEW_THREAD_UUID,
+    sourceProjectUuid: REVIEW_PROJECT_UUID,
+    sourceAgentUuid: REVIEW_AGENT_UUID,
+};
 
-const makePullRequestRow = (
-    overrides: Partial<Record<string, unknown>> = {},
-) => ({
-    pull_request_uuid: PULL_REQUEST_UUID,
-    organization_uuid: ORGANIZATION_UUID,
-    project_uuid: PROJECT_UUID,
-    created_by_user_uuid: USER_UUID,
-    provider: PullRequestProvider.GITHUB,
-    source: PullRequestSource.AI_AGENT,
-    owner: 'acme',
-    repo: 'dbt',
-    pr_number: 42,
-    pr_url: PR_URL,
-    created_at: CREATED_AT,
-    ...overrides,
-});
-
-describe('PullRequestsModel', () => {
-    const database = knex({ client: MockClient, dialect: 'pg' });
-    const model = new PullRequestsModel({
-        database: database as unknown as Knex,
-    });
-    let tracker: Tracker;
-
-    beforeAll(() => {
-        tracker = getTracker();
-    });
-
-    afterEach(() => {
-        tracker.reset();
-        mockedPaginate.mockReset();
-        jest.restoreAllMocks();
-    });
-
-    it('enriches pull requests with persisted review remediation context', async () => {
-        mockedPaginate.mockResolvedValue({
-            data: [makePullRequestRow()],
-            pagination: {
-                page: 1,
-                pageSize: 25,
-                totalPageCount: 1,
-                totalResults: 1,
-            },
-        } as unknown as KnexPaginatedData<PullRequest[]>);
-
-        Object.assign(model as unknown as Record<string, unknown>, {
-            aiWritebackTableExists: true,
-            aiReviewTablesExist: true,
-        });
-
-        tracker.on.select('ai_writeback_thread').responseOnce([
-            {
-                pull_request_uuid: PULL_REQUEST_UUID,
-                ai_thread_uuid: AI_THREAD_UUID,
-                agent_uuid: AI_AGENT_UUID,
-            },
-        ]);
-        tracker.on.select('ai_agent_review_remediation').responseOnce([
-            {
-                pullRequestUuid: PULL_REQUEST_UUID,
-                fingerprint: FINGERPRINT,
+describe('toPullRequestReviewContext', () => {
+    it('maps a fully populated review source into review context', () => {
+        expect(
+            toPullRequestReviewContext({
+                ...sourceInfo,
                 reviewStatus: 'in_progress',
                 reviewItemTitle: 'Fix revenue metric guidance',
                 primaryRootCause: 'semantic_layer',
-                sourceFindingUuid: FINDING_UUID,
-                sourceThreadUuid: REVIEW_THREAD_UUID,
-                sourceProjectUuid: REVIEW_PROJECT_UUID,
-                sourceAgentUuid: REVIEW_AGENT_UUID,
-            },
-        ]);
-        tracker.on.select('ai_agent_review_item').responseOnce([]);
-
-        const result = await model.getByProject(PROJECT_UUID, {
-            page: 1,
-            pageSize: 25,
-        });
-
-        expect(result.data[0]).toMatchObject({
-            pullRequestUuid: PULL_REQUEST_UUID,
-            aiThreadUuid: AI_THREAD_UUID,
-            aiAgentUuid: AI_AGENT_UUID,
-            reviewContext: {
-                reviewItemUuid: FINGERPRINT,
-                reviewItemFingerprint: FINGERPRINT,
-                reviewTitle: 'Fix revenue metric guidance',
-                reviewStatus: 'in_progress',
-                primaryRootCause: 'semantic_layer',
-                sourceFindingUuid: FINDING_UUID,
-                sourceThreadUuid: REVIEW_THREAD_UUID,
-                sourceProjectUuid: REVIEW_PROJECT_UUID,
-                sourceAgentUuid: REVIEW_AGENT_UUID,
-            },
+            }),
+        ).toEqual({
+            reviewItemUuid: FINGERPRINT,
+            reviewItemFingerprint: FINGERPRINT,
+            reviewTitle: 'Fix revenue metric guidance',
+            reviewStatus: 'in_progress',
+            primaryRootCause: 'semantic_layer',
+            sourceFindingUuid: FINDING_UUID,
+            sourceThreadUuid: REVIEW_THREAD_UUID,
+            sourceProjectUuid: REVIEW_PROJECT_UUID,
+            sourceAgentUuid: REVIEW_AGENT_UUID,
         });
     });
 
-    it('falls back to linked_pr_url for older review rows without a remediation link', async () => {
-        mockedPaginate.mockResolvedValue({
-            data: [makePullRequestRow()],
-            pagination: {
-                page: 1,
-                pageSize: 25,
-                totalPageCount: 1,
-                totalResults: 1,
-            },
-        } as unknown as KnexPaginatedData<PullRequest[]>);
-
-        Object.assign(model as unknown as Record<string, unknown>, {
-            aiWritebackTableExists: true,
-            aiReviewTablesExist: true,
+    it('applies fallback defaults when title, status, and root cause are absent', () => {
+        const context = toPullRequestReviewContext({
+            ...sourceInfo,
+            reviewStatus: null,
+            reviewItemTitle: null,
+            primaryRootCause: null,
         });
 
-        tracker.on.select('ai_writeback_thread').responseOnce([]);
-        tracker.on.select('ai_agent_review_remediation').responseOnce([]);
-        tracker.on.select('ai_agent_review_item').responseOnce([
-            {
-                fingerprint: FINGERPRINT,
-                linkedPrUrl: PR_URL,
-                reviewStatus: 'resolved',
-            },
-        ]);
-        tracker.on.select('ai_agent_review_turn_signal').responseOnce([
-            {
-                fingerprint: FINGERPRINT,
-                reviewItemTitle: 'Document revenue definition',
-                primaryRootCause: 'project_context',
-                sourceFindingUuid: FINDING_UUID,
-                sourceThreadUuid: REVIEW_THREAD_UUID,
-                sourceProjectUuid: REVIEW_PROJECT_UUID,
-                sourceAgentUuid: REVIEW_AGENT_UUID,
-            },
-        ]);
+        expect(context.reviewTitle).toBe('Review AI agent issue');
+        expect(context.reviewStatus).toBe('open');
+        expect(context.primaryRootCause).toBe('ambiguous');
+    });
 
-        const result = await model.getByProject(PROJECT_UUID, {
-            page: 1,
-            pageSize: 25,
+    it('identifies the review item by fingerprint (the review surface is fingerprint-keyed, not UUID-keyed)', () => {
+        const context = toPullRequestReviewContext({
+            ...sourceInfo,
+            reviewStatus: 'open',
+            reviewItemTitle: 'Document revenue definition',
+            primaryRootCause: 'project_context',
         });
 
-        expect(result.data[0]).toMatchObject({
-            pullRequestUuid: PULL_REQUEST_UUID,
-            aiThreadUuid: null,
-            aiAgentUuid: null,
-            reviewContext: {
-                reviewItemUuid: FINGERPRINT,
-                reviewItemFingerprint: FINGERPRINT,
-                reviewTitle: 'Document revenue definition',
-                reviewStatus: 'resolved',
-                primaryRootCause: 'project_context',
-                sourceFindingUuid: FINDING_UUID,
-                sourceThreadUuid: REVIEW_THREAD_UUID,
-                sourceProjectUuid: REVIEW_PROJECT_UUID,
-                sourceAgentUuid: REVIEW_AGENT_UUID,
-            },
-        });
+        expect(context.reviewItemUuid).toBe(FINGERPRINT);
+        expect(context.reviewItemFingerprint).toBe(FINGERPRINT);
+        expect(context.reviewItemUuid).toBe(context.reviewItemFingerprint);
     });
 });

--- a/packages/backend/src/models/PullRequestsModel.ts
+++ b/packages/backend/src/models/PullRequestsModel.ts
@@ -5,6 +5,9 @@ import {
     PullRequestProvider,
     PullRequestSource,
     UnexpectedDatabaseError,
+    type AiAgentReviewItemStatus,
+    type AiAgentRootCause,
+    type PullRequestReviewContext,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import {
@@ -16,6 +19,11 @@ import {
     AiThreadTableName,
     AiWritebackThreadTableName,
 } from '../ee/database/entities/ai';
+import {
+    AiAgentReviewItemTableName,
+    AiAgentReviewRemediationTableName,
+    AiAgentTurnSignalTableName,
+} from '../ee/database/entities/aiAgentReviewClassifier';
 
 type PullRequestsModelArguments = {
     database: Knex;
@@ -34,10 +42,29 @@ type CreatePullRequest = {
 };
 
 type AiThreadInfo = { aiThreadUuid: string; aiAgentUuid: string | null };
+type ReviewSourceInfo = {
+    reviewItemTitle: string | null;
+    primaryRootCause: AiAgentRootCause | null;
+    sourceFindingUuid: string;
+    sourceThreadUuid: string;
+    sourceProjectUuid: string;
+    sourceAgentUuid: string;
+};
+type DirectReviewContextRow = ReviewSourceInfo & {
+    pullRequestUuid: string;
+    fingerprint: string;
+    reviewStatus: AiAgentReviewItemStatus | null;
+};
+type FallbackReviewContextRow = {
+    fingerprint: string;
+    linkedPrUrl: string;
+    reviewStatus: AiAgentReviewItemStatus | null;
+};
 
 const mapDbPullRequest = (
     row: DbPullRequest,
     aiThread: AiThreadInfo | null,
+    reviewContext: PullRequestReviewContext | null,
 ): PullRequest => ({
     pullRequestUuid: row.pull_request_uuid,
     organizationUuid: row.organization_uuid,
@@ -51,7 +78,38 @@ const mapDbPullRequest = (
     prUrl: row.pr_url,
     aiThreadUuid: aiThread?.aiThreadUuid ?? null,
     aiAgentUuid: aiThread?.aiAgentUuid ?? null,
+    reviewContext,
     createdAt: row.created_at,
+});
+
+const toPullRequestReviewContext = ({
+    fingerprint,
+    reviewStatus,
+    reviewItemTitle,
+    primaryRootCause,
+    sourceFindingUuid,
+    sourceThreadUuid,
+    sourceProjectUuid,
+    sourceAgentUuid,
+}: {
+    fingerprint: string;
+    reviewStatus: AiAgentReviewItemStatus | null;
+    reviewItemTitle: string | null;
+    primaryRootCause: AiAgentRootCause | null;
+    sourceFindingUuid: string;
+    sourceThreadUuid: string;
+    sourceProjectUuid: string;
+    sourceAgentUuid: string;
+}): PullRequestReviewContext => ({
+    reviewItemUuid: fingerprint,
+    reviewItemFingerprint: fingerprint,
+    reviewTitle: reviewItemTitle ?? 'Review AI agent issue',
+    reviewStatus: reviewStatus ?? 'open',
+    primaryRootCause: primaryRootCause ?? 'ambiguous',
+    sourceFindingUuid,
+    sourceThreadUuid,
+    sourceProjectUuid,
+    sourceAgentUuid,
 });
 
 export class PullRequestsModel {
@@ -59,6 +117,8 @@ export class PullRequestsModel {
 
     // Cached result of whether the enterprise ai_writeback_thread table exists.
     private aiWritebackTableExists: boolean | undefined;
+
+    private aiReviewTablesExist: boolean | undefined;
 
     constructor(args: PullRequestsModelArguments) {
         this.database = args.database;
@@ -115,6 +175,202 @@ export class PullRequestsModel {
         return result;
     }
 
+    private async hasAiReviewTables(): Promise<boolean> {
+        if (this.aiReviewTablesExist === undefined) {
+            const [hasReviewItemTable, hasRemediationTable, hasSignalTable] =
+                await Promise.all([
+                    this.database.schema.hasTable(AiAgentReviewItemTableName),
+                    this.database.schema.hasTable(
+                        AiAgentReviewRemediationTableName,
+                    ),
+                    this.database.schema.hasTable(AiAgentTurnSignalTableName),
+                ]);
+            this.aiReviewTablesExist =
+                hasReviewItemTable && hasRemediationTable && hasSignalTable;
+        }
+
+        return this.aiReviewTablesExist;
+    }
+
+    private async getDirectReviewContextByPullRequestUuid(
+        pullRequestUuids: string[],
+    ): Promise<Map<string, PullRequestReviewContext>> {
+        const result = new Map<string, PullRequestReviewContext>();
+        if (pullRequestUuids.length === 0) {
+            return result;
+        }
+
+        const rows = await this.database(
+            `${AiAgentReviewRemediationTableName} as remediation`,
+        )
+            .leftJoin(
+                `${AiAgentReviewItemTableName} as review_item`,
+                function joinReviewItem() {
+                    this.on(
+                        'review_item.fingerprint',
+                        'remediation.fingerprint',
+                    ).andOn(
+                        'review_item.organization_uuid',
+                        'remediation.organization_uuid',
+                    );
+                },
+            )
+            .leftJoin(
+                `${AiAgentTurnSignalTableName} as source_finding`,
+                'source_finding.ai_agent_review_turn_signal_uuid',
+                'remediation.source_ai_agent_review_turn_signal_uuid',
+            )
+            .whereIn('remediation.pull_request_uuid', pullRequestUuids)
+            .select<DirectReviewContextRow[]>({
+                pullRequestUuid: 'remediation.pull_request_uuid',
+                fingerprint: 'remediation.fingerprint',
+                reviewStatus: 'review_item.status',
+                reviewItemTitle: 'source_finding.review_item_title',
+                primaryRootCause: 'source_finding.primary_root_cause',
+                sourceFindingUuid:
+                    'remediation.source_ai_agent_review_turn_signal_uuid',
+                sourceThreadUuid: 'remediation.source_thread_uuid',
+                sourceProjectUuid: 'remediation.source_project_uuid',
+                sourceAgentUuid: 'remediation.source_agent_uuid',
+            })
+            .orderBy('remediation.updated_at', 'desc');
+
+        rows.forEach((row) => {
+            if (!result.has(row.pullRequestUuid)) {
+                result.set(
+                    row.pullRequestUuid,
+                    toPullRequestReviewContext({
+                        fingerprint: row.fingerprint,
+                        reviewStatus: row.reviewStatus,
+                        reviewItemTitle: row.reviewItemTitle,
+                        primaryRootCause: row.primaryRootCause,
+                        sourceFindingUuid: row.sourceFindingUuid,
+                        sourceThreadUuid: row.sourceThreadUuid,
+                        sourceProjectUuid: row.sourceProjectUuid,
+                        sourceAgentUuid: row.sourceAgentUuid,
+                    }),
+                );
+            }
+        });
+
+        return result;
+    }
+
+    private async getLatestReviewSourceInfoByFingerprint(
+        fingerprints: string[],
+    ): Promise<Map<string, ReviewSourceInfo>> {
+        const result = new Map<string, ReviewSourceInfo>();
+        if (fingerprints.length === 0) {
+            return result;
+        }
+
+        const rows = await this.database(AiAgentTurnSignalTableName)
+            .distinctOn('fingerprint')
+            .whereIn('fingerprint', fingerprints)
+            .where('promoted_to_finding', true)
+            .select<({ fingerprint: string } & ReviewSourceInfo)[]>({
+                fingerprint: 'fingerprint',
+                reviewItemTitle: 'review_item_title',
+                primaryRootCause: 'primary_root_cause',
+                sourceFindingUuid: 'ai_agent_review_turn_signal_uuid',
+                sourceThreadUuid: 'ai_thread_uuid',
+                sourceProjectUuid: 'project_uuid',
+                sourceAgentUuid: 'agent_uuid',
+            })
+            .orderBy('fingerprint')
+            .orderBy('created_at', 'desc');
+
+        rows.forEach((row) => {
+            result.set(row.fingerprint, {
+                reviewItemTitle: row.reviewItemTitle,
+                primaryRootCause: row.primaryRootCause,
+                sourceFindingUuid: row.sourceFindingUuid,
+                sourceThreadUuid: row.sourceThreadUuid,
+                sourceProjectUuid: row.sourceProjectUuid,
+                sourceAgentUuid: row.sourceAgentUuid,
+            });
+        });
+
+        return result;
+    }
+
+    private async getFallbackReviewContextByPrUrl(
+        prUrls: string[],
+    ): Promise<Map<string, PullRequestReviewContext>> {
+        const result = new Map<string, PullRequestReviewContext>();
+        if (prUrls.length === 0) {
+            return result;
+        }
+
+        const rows = await this.database(
+            `${AiAgentReviewItemTableName} as review_item`,
+        )
+            .whereIn('review_item.linked_pr_url', prUrls)
+            .select<FallbackReviewContextRow[]>({
+                fingerprint: 'review_item.fingerprint',
+                linkedPrUrl: 'review_item.linked_pr_url',
+                reviewStatus: 'review_item.status',
+            })
+            .orderBy('review_item.updated_at', 'desc');
+
+        const sourceInfoByFingerprint =
+            await this.getLatestReviewSourceInfoByFingerprint(
+                rows.map((row) => row.fingerprint),
+            );
+
+        rows.forEach((row) => {
+            if (result.has(row.linkedPrUrl)) {
+                return;
+            }
+
+            const sourceInfo = sourceInfoByFingerprint.get(row.fingerprint);
+            if (!sourceInfo) {
+                return;
+            }
+
+            result.set(
+                row.linkedPrUrl,
+                toPullRequestReviewContext({
+                    fingerprint: row.fingerprint,
+                    reviewStatus: row.reviewStatus,
+                    reviewItemTitle: sourceInfo.reviewItemTitle,
+                    primaryRootCause: sourceInfo.primaryRootCause,
+                    sourceFindingUuid: sourceInfo.sourceFindingUuid,
+                    sourceThreadUuid: sourceInfo.sourceThreadUuid,
+                    sourceProjectUuid: sourceInfo.sourceProjectUuid,
+                    sourceAgentUuid: sourceInfo.sourceAgentUuid,
+                }),
+            );
+        });
+
+        return result;
+    }
+
+    private async getReviewContextInfo(
+        pullRequests: Pick<PullRequest, 'pullRequestUuid' | 'prUrl'>[],
+    ): Promise<{
+        byPullRequestUuid: Map<string, PullRequestReviewContext>;
+        byPrUrl: Map<string, PullRequestReviewContext>;
+    }> {
+        if (pullRequests.length === 0 || !(await this.hasAiReviewTables())) {
+            return {
+                byPullRequestUuid: new Map(),
+                byPrUrl: new Map(),
+            };
+        }
+
+        const [byPullRequestUuid, byPrUrl] = await Promise.all([
+            this.getDirectReviewContextByPullRequestUuid(
+                pullRequests.map((row) => row.pullRequestUuid),
+            ),
+            this.getFallbackReviewContextByPrUrl(
+                pullRequests.map((row) => row.prUrl),
+            ),
+        ]);
+
+        return { byPullRequestUuid, byPrUrl };
+    }
+
     async create(data: CreatePullRequest): Promise<PullRequest> {
         const [row] = await this.database(PullRequestsTableName)
             .insert({
@@ -131,7 +387,7 @@ export class PullRequestsModel {
             .returning('*');
 
         // A newly created PR has no ai_writeback_thread link yet.
-        return mapDbPullRequest(row, null);
+        return mapDbPullRequest(row, null, null);
     }
 
     /**
@@ -162,7 +418,7 @@ export class PullRequestsModel {
             .returning('*');
 
         if (inserted.length > 0) {
-            return mapDbPullRequest(inserted[0], null);
+            return mapDbPullRequest(inserted[0], null, null);
         }
 
         // The insert was ignored because a row already exists — return it.
@@ -180,7 +436,7 @@ export class PullRequestsModel {
                 'Failed to record pull request: row neither inserted nor found',
             );
         }
-        return mapDbPullRequest(existing, null);
+        return mapDbPullRequest(existing, null, null);
     }
 
     async getByProject(
@@ -200,12 +456,23 @@ export class PullRequestsModel {
         const threadInfo = await this.getAiThreadInfo(
             data.map((row) => row.pull_request_uuid),
         );
+        const reviewContext = await this.getReviewContextInfo(
+            data.map((row) => ({
+                pullRequestUuid: row.pull_request_uuid,
+                prUrl: row.pr_url,
+            })),
+        );
 
         return {
             data: data.map((row) =>
                 mapDbPullRequest(
                     row,
                     threadInfo.get(row.pull_request_uuid) ?? null,
+                    reviewContext.byPullRequestUuid.get(
+                        row.pull_request_uuid,
+                    ) ??
+                        reviewContext.byPrUrl.get(row.pr_url) ??
+                        null,
                 ),
             ),
             pagination,
@@ -222,7 +489,17 @@ export class PullRequestsModel {
         }
 
         const threadInfo = await this.getAiThreadInfo([pullRequestUuid]);
-        return mapDbPullRequest(row, threadInfo.get(pullRequestUuid) ?? null);
+        const reviewContext = await this.getReviewContextInfo([
+            { pullRequestUuid, prUrl: row.pr_url },
+        ]);
+
+        return mapDbPullRequest(
+            row,
+            threadInfo.get(pullRequestUuid) ?? null,
+            reviewContext.byPullRequestUuid.get(pullRequestUuid) ??
+                reviewContext.byPrUrl.get(row.pr_url) ??
+                null,
+        );
     }
 
     /**
@@ -245,9 +522,15 @@ export class PullRequestsModel {
         }
 
         const threadInfo = await this.getAiThreadInfo([row.pull_request_uuid]);
+        const reviewContext = await this.getReviewContextInfo([
+            { pullRequestUuid: row.pull_request_uuid, prUrl: row.pr_url },
+        ]);
         return mapDbPullRequest(
             row,
             threadInfo.get(row.pull_request_uuid) ?? null,
+            reviewContext.byPullRequestUuid.get(row.pull_request_uuid) ??
+                reviewContext.byPrUrl.get(row.pr_url) ??
+                null,
         );
     }
 

--- a/packages/backend/src/models/PullRequestsModel.ts
+++ b/packages/backend/src/models/PullRequestsModel.ts
@@ -82,7 +82,7 @@ const mapDbPullRequest = (
     createdAt: row.created_at,
 });
 
-const toPullRequestReviewContext = ({
+export const toPullRequestReviewContext = ({
     fingerprint,
     reviewStatus,
     reviewItemTitle,
@@ -91,15 +91,9 @@ const toPullRequestReviewContext = ({
     sourceThreadUuid,
     sourceProjectUuid,
     sourceAgentUuid,
-}: {
+}: ReviewSourceInfo & {
     fingerprint: string;
     reviewStatus: AiAgentReviewItemStatus | null;
-    reviewItemTitle: string | null;
-    primaryRootCause: AiAgentRootCause | null;
-    sourceFindingUuid: string;
-    sourceThreadUuid: string;
-    sourceProjectUuid: string;
-    sourceAgentUuid: string;
 }): PullRequestReviewContext => ({
     reviewItemUuid: fingerprint,
     reviewItemFingerprint: fingerprint,

--- a/packages/backend/src/services/PullRequestsService/PullRequestsService.test.ts
+++ b/packages/backend/src/services/PullRequestsService/PullRequestsService.test.ts
@@ -66,6 +66,7 @@ const makePullRequest = (provider: PullRequestProvider): PullRequest => ({
     prUrl: 'https://gitlab.com/my-group/my-repo/-/merge_requests/42',
     aiThreadUuid: null,
     aiAgentUuid: null,
+    reviewContext: null,
     createdAt: new Date(),
 });
 

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -1,3 +1,7 @@
+import type {
+    AiAgentReviewItemStatus,
+    AiAgentRootCause,
+} from '../ee/AiAgent/aiAgentReviewClassifierTypes';
 import { type KnexPaginatedData } from './knex-paginate';
 
 export type GitIntegrationConfiguration = {
@@ -8,6 +12,18 @@ export type GitIntegrationConfiguration = {
 export type PullRequestCreated = {
     prTitle: string;
     prUrl: string;
+};
+
+export type PullRequestReviewContext = {
+    reviewItemUuid: string;
+    reviewItemFingerprint: string;
+    reviewTitle: string;
+    reviewStatus: AiAgentReviewItemStatus;
+    primaryRootCause: AiAgentRootCause;
+    sourceFindingUuid: string;
+    sourceThreadUuid: string;
+    sourceProjectUuid: string;
+    sourceAgentUuid: string;
 };
 
 export enum PullRequestProvider {
@@ -56,6 +72,11 @@ export type PullRequest = {
      * build the in-app thread link. Null whenever `aiThreadUuid` is null.
      */
     aiAgentUuid: string | null;
+    /**
+     * Source review context for AI review remediation PRs. Present when the PR
+     * was opened to address a review finding.
+     */
+    reviewContext: PullRequestReviewContext | null;
     createdAt: Date;
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { Button, Drawer, Group, Stack, Text } from '@mantine-8/core';
 import { IconRoute } from '@tabler/icons-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { GuidedTour } from '../../../../../../components/common/GuidedTour';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
@@ -20,11 +20,10 @@ export const AiReviewsSettingsPage = () => {
     const { data: settings } = useAiOrganizationSettings();
     const [searchParams, setSearchParams] = useSearchParams();
 
-    const [selectedReviewItem, setSelectedReviewItem] =
-        useState<AiAgentAdminReviewItemPreviewTarget | null>(null);
-    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-
-    const reviewItemFromSearchParams = useMemo(() => {
+    // The selected review item and the sidebar's open state are derived
+    // directly from the URL — every mutation (deep-link, row select, close)
+    // goes through `setSearchParams`, so there's no separate state to sync.
+    const selectedReviewItem = useMemo(() => {
         const projectUuid = searchParams.get('reviewProjectUuid');
         const agentUuid = searchParams.get('reviewAgentUuid');
         const threadUuid = searchParams.get('reviewThreadUuid');
@@ -42,6 +41,8 @@ export const AiReviewsSettingsPage = () => {
         };
     }, [searchParams]);
 
+    const isSidebarOpen = selectedReviewItem !== null;
+
     // While the tour is running, the table always shows sample rows so it
     // highlights the same findings every time. Closing it flips to real data.
     const {
@@ -49,15 +50,6 @@ export const AiReviewsSettingsPage = () => {
         startTour,
         closeTour,
     } = useGuidedTour({ storageKey: 'ld.aiReviews.tour.v1' });
-
-    useEffect(() => {
-        if (!reviewItemFromSearchParams) {
-            return;
-        }
-
-        setSelectedReviewItem(reviewItemFromSearchParams);
-        setIsSidebarOpen(true);
-    }, [reviewItemFromSearchParams]);
 
     const updateReviewSearchParams = (
         reviewItem: AiAgentAdminReviewItemPreviewTarget | null,
@@ -84,14 +76,10 @@ export const AiReviewsSettingsPage = () => {
     const handleReviewItemSelect = (
         reviewItem: AiAgentAdminReviewItemPreviewTarget,
     ): void => {
-        setSelectedReviewItem(reviewItem);
-        setIsSidebarOpen(true);
         updateReviewSearchParams(reviewItem);
     };
 
     const handleCloseSidebar = () => {
-        setIsSidebarOpen(false);
-        setSelectedReviewItem(null);
         updateReviewSearchParams(null);
     };
 
@@ -148,7 +136,7 @@ export const AiReviewsSettingsPage = () => {
             />
 
             <Drawer
-                opened={isSidebarOpen && !!selectedReviewItem}
+                opened={isSidebarOpen}
                 onClose={handleCloseSidebar}
                 position="right"
                 size="lg"

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.module.css
@@ -14,6 +14,14 @@
     min-width: 0;
 }
 
+.reviewContext {
+    min-width: 0;
+}
+
+.reviewTitle {
+    max-width: 240px;
+}
+
 /* Row actions fade in on row hover (and stay visible while focused) */
 .rowActions {
     opacity: 0;

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -6,6 +6,7 @@ import {
 import {
     ActionIcon,
     Alert,
+    Button,
     Center,
     Drawer,
     Group,
@@ -34,6 +35,7 @@ import {
     type FC,
     type UIEvent,
 } from 'react';
+import { Link } from 'react-router';
 import { CategoryBadge } from '../../../components/common/CategoryBadge/CategoryBadge';
 import {
     ContentTable,
@@ -43,14 +45,21 @@ import {
 import MantineIcon from '../../../components/common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
 import { ThreadPreviewSidebar } from '../../../ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar';
+import {
+    threadReviewRootCauseColors,
+    threadReviewRootCauseLabels,
+} from '../../../ee/features/aiCopilot/components/Admin/threadReviewContext';
 import { usePullRequestsTable } from '../hooks/usePullRequestsTable';
 import { type PullRequestRow } from '../types';
 import {
     getProviderLabel,
+    getReviewPath,
     getSourceColor,
     getSourceLabel,
     getStateColor,
     getThreadPath,
+    getThreadPreviewTarget,
+    type PullRequestThreadPreviewTarget,
 } from '../utils';
 import classes from './PullRequestsPage.module.css';
 
@@ -100,7 +109,8 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
     } = usePullRequestsTable(projectUuid);
 
     const [stateFilter, setStateFilter] = useState<StateFilter>('open');
-    const [previewPr, setPreviewPr] = useState<PullRequestRow | null>(null);
+    const [previewTarget, setPreviewTarget] =
+        useState<PullRequestThreadPreviewTarget | null>(null);
 
     const filteredRows = useMemo(
         () => rows.filter((row) => matchesStateFilter(row, stateFilter)),
@@ -140,6 +150,8 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                 size: 620,
                 Cell: ({ row }) => {
                     const pr = row.original;
+                    const reviewPath = getReviewPath(pr);
+                    const threadPreviewTarget = getThreadPreviewTarget(pr);
                     // title/state are both null when the live lookup from the
                     // provider failed (PR deleted, access revoked, API down).
                     const liveLookupFailed =
@@ -224,6 +236,95 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                                         )}
                                     </Text>
                                 </Tooltip>
+
+                                {pr.reviewContext && (
+                                    <Stack
+                                        gap={6}
+                                        mt={4}
+                                        className={classes.reviewContext}
+                                    >
+                                        <Group gap="xs" wrap="wrap">
+                                            <Text fz="xs" fw={600} c="ldGray.6">
+                                                Fixes review:
+                                            </Text>
+                                            <Tooltip
+                                                label={
+                                                    pr.reviewContext.reviewTitle
+                                                }
+                                                openDelay={300}
+                                                withinPortal
+                                            >
+                                                <Text
+                                                    fz="xs"
+                                                    fw={600}
+                                                    truncate
+                                                    className={
+                                                        classes.reviewTitle
+                                                    }
+                                                >
+                                                    {
+                                                        pr.reviewContext
+                                                            .reviewTitle
+                                                    }
+                                                </Text>
+                                            </Tooltip>
+                                            <CategoryBadge
+                                                variant="token"
+                                                label={
+                                                    threadReviewRootCauseLabels[
+                                                        pr.reviewContext
+                                                            .primaryRootCause
+                                                    ]
+                                                }
+                                                color={
+                                                    threadReviewRootCauseColors[
+                                                        pr.reviewContext
+                                                            .primaryRootCause
+                                                    ]
+                                                }
+                                            />
+                                        </Group>
+
+                                        <Group gap="xs" wrap="wrap">
+                                            {reviewPath && (
+                                                <Button
+                                                    component={Link}
+                                                    to={reviewPath}
+                                                    size="compact-xs"
+                                                    variant="subtle"
+                                                    color="gray"
+                                                >
+                                                    View review
+                                                </Button>
+                                            )}
+                                            {threadPreviewTarget && (
+                                                <Button
+                                                    size="compact-xs"
+                                                    variant="subtle"
+                                                    color="gray"
+                                                    onClick={() =>
+                                                        setPreviewTarget(
+                                                            threadPreviewTarget,
+                                                        )
+                                                    }
+                                                >
+                                                    View thread
+                                                </Button>
+                                            )}
+                                            <Button
+                                                component="a"
+                                                href={pr.prUrl}
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                size="compact-xs"
+                                                variant="subtle"
+                                                color="gray"
+                                            >
+                                                View PR
+                                            </Button>
+                                        </Group>
+                                    </Stack>
+                                )}
                             </Stack>
                         </Group>
                     );
@@ -270,9 +371,10 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
         renderRowActions: ({ row }) => {
             const pr = row.original;
             const threadPath = getThreadPath(pr);
+            const threadTarget = getThreadPreviewTarget(pr);
             return (
                 <Group gap="two" wrap="nowrap" className={classes.rowActions}>
-                    {threadPath !== null ? (
+                    {threadPath !== null && threadTarget ? (
                         <Tooltip
                             label="Preview thread"
                             openDelay={300}
@@ -282,7 +384,7 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                                 variant="subtle"
                                 color="gray"
                                 aria-label="Preview thread"
-                                onClick={() => setPreviewPr(pr)}
+                                onClick={() => setPreviewTarget(threadTarget)}
                             >
                                 <MantineIcon icon={IconMessageCircle} />
                             </ActionIcon>
@@ -421,8 +523,8 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
             )}
 
             <Drawer
-                opened={previewPr !== null}
-                onClose={() => setPreviewPr(null)}
+                opened={previewTarget !== null}
+                onClose={() => setPreviewTarget(null)}
                 position="right"
                 size="lg"
                 withCloseButton={false}
@@ -433,13 +535,16 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                 }}
                 __vars={{ '--drawer-top-offset': `${NAVBAR_HEIGHT}px` }}
             >
-                {previewPr?.aiAgentUuid && previewPr?.aiThreadUuid ? (
+                {previewTarget ? (
                     <ThreadPreviewSidebar
-                        projectUuid={previewPr.projectUuid}
-                        agentUuid={previewPr.aiAgentUuid}
-                        threadUuid={previewPr.aiThreadUuid}
-                        isOpen={previewPr !== null}
-                        onClose={() => setPreviewPr(null)}
+                        projectUuid={previewTarget.projectUuid}
+                        agentUuid={previewTarget.agentUuid}
+                        threadUuid={previewTarget.threadUuid}
+                        selectedReviewItemUuid={
+                            previewTarget.reviewItemUuid ?? undefined
+                        }
+                        isOpen={previewTarget !== null}
+                        onClose={() => setPreviewTarget(null)}
                     />
                 ) : null}
             </Drawer>

--- a/packages/frontend/src/features/pullRequests/utils.test.ts
+++ b/packages/frontend/src/features/pullRequests/utils.test.ts
@@ -1,0 +1,96 @@
+import type { PullRequestProvider, PullRequestSource } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { type PullRequestRow } from './types';
+import { getReviewPath, getThreadPath, getThreadPreviewTarget } from './utils';
+
+const makeRow = (overrides: Partial<PullRequestRow> = {}): PullRequestRow => ({
+    pullRequestUuid: 'pr-1',
+    organizationUuid: 'org-1',
+    projectUuid: 'project-1',
+    createdByUserUuid: 'user-1',
+    provider: 'github' as PullRequestProvider,
+    source: 'ai_agent' as PullRequestSource,
+    owner: 'acme',
+    repo: 'dbt',
+    prNumber: 42,
+    prUrl: 'https://github.com/acme/dbt/pull/42',
+    aiThreadUuid: 'thread-1',
+    aiAgentUuid: 'agent-1',
+    reviewContext: null,
+    title: 'Fix metrics',
+    state: null,
+    createdAt: new Date('2026-06-10T10:00:00.000Z'),
+    author: null,
+    ...overrides,
+});
+
+describe('pullRequests utils', () => {
+    it('prefers the source review thread over the writeback thread', () => {
+        expect(
+            getThreadPreviewTarget(
+                makeRow({
+                    reviewContext: {
+                        reviewItemUuid: 'fingerprint-1',
+                        reviewItemFingerprint: 'fingerprint-1',
+                        reviewTitle: 'Review revenue metric',
+                        reviewStatus: 'open',
+                        primaryRootCause: 'semantic_layer',
+                        sourceFindingUuid: 'finding-1',
+                        sourceThreadUuid: 'review-thread-1',
+                        sourceProjectUuid: 'review-project-1',
+                        sourceAgentUuid: 'review-agent-1',
+                    },
+                }),
+            ),
+        ).toEqual({
+            projectUuid: 'review-project-1',
+            agentUuid: 'review-agent-1',
+            threadUuid: 'review-thread-1',
+            reviewItemUuid: 'fingerprint-1',
+        });
+    });
+
+    it('builds a reviews deep link for pull requests tied to findings', () => {
+        expect(
+            getReviewPath(
+                makeRow({
+                    reviewContext: {
+                        reviewItemUuid: 'fingerprint-1',
+                        reviewItemFingerprint: 'fingerprint-1',
+                        reviewTitle: 'Review revenue metric',
+                        reviewStatus: 'open',
+                        primaryRootCause: 'semantic_layer',
+                        sourceFindingUuid: 'finding-1',
+                        sourceThreadUuid: 'review-thread-1',
+                        sourceProjectUuid: 'review-project-1',
+                        sourceAgentUuid: 'review-agent-1',
+                    },
+                }),
+            ),
+        ).toBe(
+            '/generalSettings/ai/reviews?reviewProjectUuid=review-project-1&reviewAgentUuid=review-agent-1&reviewThreadUuid=review-thread-1&reviewItemUuid=fingerprint-1',
+        );
+    });
+
+    it('adds the review query param when linking into a review source thread', () => {
+        expect(
+            getThreadPath(
+                makeRow({
+                    reviewContext: {
+                        reviewItemUuid: 'fingerprint-1',
+                        reviewItemFingerprint: 'fingerprint-1',
+                        reviewTitle: 'Review revenue metric',
+                        reviewStatus: 'open',
+                        primaryRootCause: 'semantic_layer',
+                        sourceFindingUuid: 'finding-1',
+                        sourceThreadUuid: 'review-thread-1',
+                        sourceProjectUuid: 'review-project-1',
+                        sourceAgentUuid: 'review-agent-1',
+                    },
+                }),
+            ),
+        ).toBe(
+            '/projects/review-project-1/ai-agents/review-agent-1/threads/review-thread-1?reviewItem=fingerprint-1',
+        );
+    });
+});

--- a/packages/frontend/src/features/pullRequests/utils.ts
+++ b/packages/frontend/src/features/pullRequests/utils.ts
@@ -7,6 +7,12 @@ import {
 import { type PullRequestRow } from './types';
 
 export const DEFAULT_PULL_REQUESTS_PAGE_SIZE = 25;
+export type PullRequestThreadPreviewTarget = {
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    reviewItemUuid?: string;
+};
 
 export const getSourceLabel = (source: PullRequestSource): string => {
     switch (source) {
@@ -62,10 +68,52 @@ export const getSourceColor = (source: PullRequestSource): string => {
 };
 
 /**
- * In-app AI agent thread path for a PR, or null when the PR didn't originate
- * from an AI thread (no agent/thread to link to).
+ * In-app AI agent thread path for a PR. Review remediation PRs link back to
+ * the source review thread; other AI PRs fall back to the writeback thread.
  */
 export const getThreadPath = (row: PullRequestRow): string | null => {
-    if (!row.aiThreadUuid || !row.aiAgentUuid) return null;
-    return `/projects/${row.projectUuid}/ai-agents/${row.aiAgentUuid}/threads/${row.aiThreadUuid}`;
+    const target = getThreadPreviewTarget(row);
+    if (!target) return null;
+
+    const query = target.reviewItemUuid
+        ? `?reviewItem=${encodeURIComponent(target.reviewItemUuid)}`
+        : '';
+    return `/projects/${target.projectUuid}/ai-agents/${target.agentUuid}/threads/${target.threadUuid}${query}`;
+};
+
+export const getThreadPreviewTarget = (
+    row: PullRequestRow,
+): PullRequestThreadPreviewTarget | null => {
+    if (row.reviewContext) {
+        return {
+            projectUuid: row.reviewContext.sourceProjectUuid,
+            agentUuid: row.reviewContext.sourceAgentUuid,
+            threadUuid: row.reviewContext.sourceThreadUuid,
+            reviewItemUuid: row.reviewContext.reviewItemUuid,
+        };
+    }
+
+    if (!row.aiThreadUuid || !row.aiAgentUuid) {
+        return null;
+    }
+
+    return {
+        projectUuid: row.projectUuid,
+        agentUuid: row.aiAgentUuid,
+        threadUuid: row.aiThreadUuid,
+    };
+};
+
+export const getReviewPath = (row: PullRequestRow): string | null => {
+    if (!row.reviewContext) {
+        return null;
+    }
+
+    const params = new URLSearchParams();
+    params.set('reviewProjectUuid', row.reviewContext.sourceProjectUuid);
+    params.set('reviewAgentUuid', row.reviewContext.sourceAgentUuid);
+    params.set('reviewThreadUuid', row.reviewContext.sourceThreadUuid);
+    params.set('reviewItemUuid', row.reviewContext.reviewItemUuid);
+
+    return `/generalSettings/ai/reviews?${params.toString()}`;
 };


### PR DESCRIPTION
## Summary
- enrich pull request rows with linked AI review context, including direct remediation joins and URL-based fallback for older rows
- surface Fixes review context, View review/View thread/View PR actions, and source-thread preview flows in the pull requests UI
- add focused backend and frontend tests for review linkage and cross-navigation helpers

## Testing
- pnpm -F backend test -- PullRequestsModel.test.ts PullRequestsService.test.ts AiAgentAdminService.test.ts
- pnpm -F frontend test -- src/features/pullRequests/utils.test.ts src/ee/features/aiCopilot/components/Admin/threadReviewContext.test.ts
- pnpm -F frontend typecheck *(fails in this worktree on existing `@lightdash/formula` resolution issues outside this diff)*