### PR TITLE
feat(ai): support non-streaming LLM gateways via per-provider supportsStreaming capability

### DIFF
--- a/docs/ai-agent-non-streaming-transport.md
+++ b/docs/ai-agent-non-streaming-transport.md
@@ -1,0 +1,87 @@
+# AI Agent: Non-Streaming LLM Gateways (`supportsStreaming`)
+
+This document describes the per-provider `supportsStreaming` capability (PROD-8155,
+[#23948](https://github.com/lightdash/lightdash/issues/23948)): how to run the AI agent against an
+OpenAI-compatible LLM gateway that does not support streaming (SSE) completions.
+
+---
+
+## The two streaming layers
+
+"Streaming" in the AI agent means two independent things:
+
+1. **Backend ↔ provider**: `streamText` issues a *streaming completion request* to the model
+   endpoint. This is the part a non-streaming gateway can't serve.
+2. **Frontend ↔ backend**: the `/stream` SSE endpoint that delivers tokens to the browser. This is
+   our own infrastructure and works regardless of how the provider call is made.
+
+`supportsStreaming` only changes layer 1. The browser-facing SSE endpoint, the chat UI, tool cards,
+and `smoothStream` word-chunking are unchanged.
+
+## Configuration
+
+Streaming support is a property of the gateway/endpoint a provider points at — the same place you
+configure `*_BASE_URL` and `*_CUSTOM_HEADERS` (see PR
+[#23448](https://github.com/lightdash/lightdash/pull/23448), which established the per-provider
+capability pattern with `customHeaders`). Each provider has an opt-out env var, **default on**:
+
+| Provider | Env var |
+|---|---|
+| OpenAI | `OPENAI_SUPPORTS_STREAMING` |
+| Azure OpenAI | `AZURE_AI_SUPPORTS_STREAMING` |
+| Anthropic | `ANTHROPIC_SUPPORTS_STREAMING` |
+| OpenRouter | `OPENROUTER_SUPPORTS_STREAMING` |
+| Bedrock | `BEDROCK_SUPPORTS_STREAMING` |
+
+Streaming is disabled only when the var is the literal `false`. Example for a gateway routed
+through the OpenAI provider:
+
+```bash
+AI_COPILOT_ENABLED=true
+AI_DEFAULT_PROVIDER=openai
+OPENAI_API_KEY=...
+OPENAI_BASE_URL=https://internal-gateway.example.com/v1
+OPENAI_SUPPORTS_STREAMING=false
+```
+
+The capability lives on the provider config objects in
+`packages/backend/src/config/aiConfigSchema.ts` and is parsed in `getAiConfig`
+(`packages/backend/src/config/parseConfig.ts`).
+
+## Mechanism
+
+When a provider has `supportsStreaming: false`, `getModel`
+(`packages/backend/src/ee/services/ai/models/index.ts`) wraps the resolved model with the AI SDK's
+[`simulateStreamingMiddleware`](https://ai-sdk.dev/docs/reference/ai-sdk-core/simulate-streaming-middleware)
+via `wrapLanguageModel`. The middleware implements only `wrapStream`: it calls `doGenerate()` once —
+a single non-streaming request — and replays the complete result as a simulated stream (text,
+reasoning, and tool-call parts).
+
+Because the capability is absorbed into the model object at resolution time, every consumer is
+covered without call-site branches:
+
+- Both `streamText` sites (the main agent response in `agentV2.ts` and the discoverFields subagent)
+  share the resolved model. Each agent step becomes one `doGenerate` request; multi-step tool loops
+  work unchanged.
+- `generateText` / `generateObject` consumers (Slack replies, titles, tooltips, evals) pass through
+  identically — the middleware doesn't touch `doGenerate`.
+
+The provider is chosen per request (`prompt.modelConfig.modelProvider`), which is why the wrap
+happens in `getModel` rather than at service registration: a request on a streaming provider gets
+the bare model, one on the gateway gets the wrapped model.
+
+## Verification
+
+A unit test (`packages/backend/src/ee/services/ai/models/index.test.ts`) runs `streamText` with a
+tool through the real `toUIMessageStream → readUIMessageStream` path against a mock model whose
+`doStream` throws. With the wrap applied: `doStream` is never called, each agent step is one
+`doGenerate`, the multi-step tool loop completes, and the UI message stream contains the expected
+tool and text parts.
+
+## Caveat: proxy idle timeouts on-prem
+
+With streaming, bytes flow continuously and keep proxy connections alive. With
+`supportsStreaming=false`, bytes still flow *between* agent steps, but within a single step nothing
+is sent until that `doGenerate` returns. A long final generation can approach reverse-proxy idle
+timeouts (e.g. nginx `proxy_read_timeout`). Deployments using this flag should set proxy
+read/idle timeouts comfortably above the expected single-completion time.

--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -12,6 +12,10 @@ export const DEFAULT_BEDROCK_EMBEDDING_MODEL = 'cohere.embed-english-v3';
 
 const customHeadersSchema = z.record(z.string()).default({});
 
+// Capability of the gateway/endpoint the provider points at, not a feature
+// toggle — some LLM gateways don't support streaming (SSE) completions.
+const supportsStreamingSchema = z.boolean().default(true);
+
 export const aiCopilotConfigSchema = z
     .object({
         defaultProvider: z
@@ -32,6 +36,7 @@ export const aiCopilotConfigSchema = z
                     availableModels: z.array(z.string()).optional(),
                     zeroDataRetention: z.boolean().default(false),
                     customHeaders: customHeadersSchema,
+                    supportsStreaming: supportsStreamingSchema,
                 })
                 .optional(),
             azure: z
@@ -46,6 +51,7 @@ export const aiCopilotConfigSchema = z
                         .default(DEFAULT_AZURE_EMBEDDING_MODEL),
                     useDeploymentBasedUrls: z.boolean().default(true),
                     customHeaders: customHeadersSchema,
+                    supportsStreaming: supportsStreamingSchema,
                 })
                 .optional(),
             anthropic: z
@@ -54,6 +60,7 @@ export const aiCopilotConfigSchema = z
                     modelName: z.string().default(DEFAULT_ANTHROPIC_MODEL_NAME),
                     availableModels: z.array(z.string()).optional(),
                     customHeaders: customHeadersSchema,
+                    supportsStreaming: supportsStreamingSchema,
                 })
                 .optional(),
             openrouter: z
@@ -71,6 +78,7 @@ export const aiCopilotConfigSchema = z
                         .string()
                         .default(DEFAULT_OPENROUTER_MODEL_NAME),
                     customHeaders: customHeadersSchema,
+                    supportsStreaming: supportsStreamingSchema,
                 })
                 .optional(),
             bedrock: z
@@ -87,6 +95,7 @@ export const aiCopilotConfigSchema = z
                             .default(DEFAULT_BEDROCK_EMBEDDING_MODEL),
                         availableModels: z.array(z.string()).optional(),
                         customHeaders: customHeadersSchema,
+                        supportsStreaming: supportsStreamingSchema,
                     }),
                     z.object({
                         region: z.string(),
@@ -102,6 +111,7 @@ export const aiCopilotConfigSchema = z
                             .default(DEFAULT_BEDROCK_EMBEDDING_MODEL),
                         availableModels: z.array(z.string()).optional(),
                         customHeaders: customHeadersSchema,
+                        supportsStreaming: supportsStreamingSchema,
                     }),
                 ])
                 .optional(),

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -241,6 +241,7 @@ export const lightdashConfigMock: LightdashConfig = {
                     embeddingModelName: 'text-embedding-3-small',
                     zeroDataRetention: false,
                     customHeaders: {},
+                    supportsStreaming: true,
                 },
             },
             verifiedAnswerSimilarityThreshold: 0.6,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -463,6 +463,62 @@ test('Should parse AI provider custom headers from env', () => {
     });
 });
 
+describe('AI provider supportsStreaming', () => {
+    beforeEach(() => {
+        process.env.OPENAI_API_KEY = 'test-openai-key';
+        process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
+        process.env.OPENROUTER_API_KEY = 'test-openrouter-key';
+        process.env.AZURE_AI_API_KEY = 'test-azure-key';
+        process.env.AZURE_AI_ENDPOINT = 'https://example.openai.azure.com';
+        process.env.AZURE_AI_API_VERSION = '2026-01-01';
+        process.env.AZURE_AI_DEPLOYMENT_NAME = 'gpt-5';
+        process.env.BEDROCK_API_KEY = 'test-bedrock-key';
+        process.env.BEDROCK_REGION = 'eu-west-1';
+    });
+
+    test('defaults to true when env vars are unset', () => {
+        expect(parseConfig().ai.copilot.providers).toMatchObject({
+            openai: { supportsStreaming: true },
+            anthropic: { supportsStreaming: true },
+            openrouter: { supportsStreaming: true },
+            azure: { supportsStreaming: true },
+            bedrock: { supportsStreaming: true },
+        });
+    });
+
+    test('stays true when env vars are explicitly "true"', () => {
+        process.env.OPENAI_SUPPORTS_STREAMING = 'true';
+        process.env.ANTHROPIC_SUPPORTS_STREAMING = 'true';
+        process.env.OPENROUTER_SUPPORTS_STREAMING = 'true';
+        process.env.AZURE_AI_SUPPORTS_STREAMING = 'true';
+        process.env.BEDROCK_SUPPORTS_STREAMING = 'true';
+
+        expect(parseConfig().ai.copilot.providers).toMatchObject({
+            openai: { supportsStreaming: true },
+            anthropic: { supportsStreaming: true },
+            openrouter: { supportsStreaming: true },
+            azure: { supportsStreaming: true },
+            bedrock: { supportsStreaming: true },
+        });
+    });
+
+    test('is false only when env vars are the literal "false"', () => {
+        process.env.OPENAI_SUPPORTS_STREAMING = 'false';
+        process.env.ANTHROPIC_SUPPORTS_STREAMING = 'false';
+        process.env.OPENROUTER_SUPPORTS_STREAMING = 'false';
+        process.env.AZURE_AI_SUPPORTS_STREAMING = 'false';
+        process.env.BEDROCK_SUPPORTS_STREAMING = 'false';
+
+        expect(parseConfig().ai.copilot.providers).toMatchObject({
+            openai: { supportsStreaming: false },
+            anthropic: { supportsStreaming: false },
+            openrouter: { supportsStreaming: false },
+            azure: { supportsStreaming: false },
+            bedrock: { supportsStreaming: false },
+        });
+    });
+});
+
 // test parseOrganizationMemberRoleArray
 describe('parseOrganizationMemberRoleArray', () => {
     beforeEach(() => {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -851,6 +851,10 @@ const parseAndSanitizeSchedulerTasks = (): Array<SchedulerTaskName> => {
     return ALL_TASK_NAMES;
 };
 
+// Default-on: streaming is disabled only when the env var is the literal 'false'
+const getProviderSupportsStreaming = (envVar: string): boolean =>
+    process.env[envVar] !== 'false';
+
 const getBedrockConfig = (customHeaders: Record<string, string>) => {
     if (process.env.BEDROCK_API_KEY) {
         return {
@@ -865,6 +869,9 @@ const getBedrockConfig = (customHeaders: Record<string, string>) => {
                 'BEDROCK_AVAILABLE_MODELS',
             ),
             customHeaders,
+            supportsStreaming: getProviderSupportsStreaming(
+                'BEDROCK_SUPPORTS_STREAMING',
+            ),
         } as const;
     }
     if (process.env.BEDROCK_ACCESS_KEY_ID) {
@@ -882,6 +889,9 @@ const getBedrockConfig = (customHeaders: Record<string, string>) => {
                 'BEDROCK_AVAILABLE_MODELS',
             ),
             customHeaders,
+            supportsStreaming: getProviderSupportsStreaming(
+                'BEDROCK_SUPPORTS_STREAMING',
+            ),
         } as const;
     }
 
@@ -919,6 +929,9 @@ export const getAiConfig = () => ({
                   customHeaders: getProviderCustomHeaders(
                       'AZURE_AI_CUSTOM_HEADERS',
                   ),
+                  supportsStreaming: getProviderSupportsStreaming(
+                      'AZURE_AI_SUPPORTS_STREAMING',
+                  ),
               }
             : undefined,
         openai: process.env.OPENAI_API_KEY
@@ -939,6 +952,9 @@ export const getAiConfig = () => ({
                   customHeaders: getProviderCustomHeaders(
                       'OPENAI_CUSTOM_HEADERS',
                   ),
+                  supportsStreaming: getProviderSupportsStreaming(
+                      'OPENAI_SUPPORTS_STREAMING',
+                  ),
               }
             : undefined,
         anthropic:
@@ -955,6 +971,9 @@ export const getAiConfig = () => ({
                       customHeaders: getProviderCustomHeaders(
                           'ANTHROPIC_CUSTOM_HEADERS',
                       ),
+                      supportsStreaming: getProviderSupportsStreaming(
+                          'ANTHROPIC_SUPPORTS_STREAMING',
+                      ),
                   }
                 : undefined,
         openrouter: process.env.OPENROUTER_API_KEY
@@ -969,6 +988,9 @@ export const getAiConfig = () => ({
                   ),
                   customHeaders: getProviderCustomHeaders(
                       'OPENROUTER_CUSTOM_HEADERS',
+                  ),
+                  supportsStreaming: getProviderSupportsStreaming(
+                      'OPENROUTER_SUPPORTS_STREAMING',
                   ),
               }
             : undefined,

--- a/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
@@ -48,6 +48,7 @@ describeOrSkip.concurrent('agent integration tests', () => {
             embeddingModelName: 'text-embedding-3-small',
             zeroDataRetention: false,
             customHeaders: {},
+            supportsStreaming: true,
         },
         getModelPreset('openai', 'gpt-5.4')!,
     );

--- a/packages/backend/src/ee/services/ai/models/index.test.ts
+++ b/packages/backend/src/ee/services/ai/models/index.test.ts
@@ -1,0 +1,161 @@
+import {
+    readUIMessageStream,
+    stepCountIs,
+    streamText,
+    tool,
+    wrapLanguageModel,
+} from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { z } from 'zod';
+import { lightdashConfigMock } from '../../../../config/lightdashConfig.mock';
+import { applyStreamingCapability, getModel } from './index';
+
+jest.mock('ai', () => {
+    const actual = jest.requireActual('ai');
+    return {
+        ...actual,
+        wrapLanguageModel: jest.fn(actual.wrapLanguageModel),
+    };
+});
+
+const baseCopilotConfig = lightdashConfigMock.ai.copilot;
+
+const copilotConfigWithStreaming = (supportsStreaming: boolean) => ({
+    ...baseCopilotConfig,
+    providers: {
+        ...baseCopilotConfig.providers,
+        openai: {
+            ...baseCopilotConfig.providers.openai!,
+            supportsStreaming,
+        },
+    },
+});
+
+describe('getModel', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('does not wrap the model when the provider supports streaming', () => {
+        getModel(copilotConfigWithStreaming(true));
+
+        expect(wrapLanguageModel).not.toHaveBeenCalled();
+    });
+
+    it('wraps the model with simulateStreamingMiddleware when the provider does not support streaming', () => {
+        const { model } = getModel(copilotConfigWithStreaming(false));
+
+        expect(wrapLanguageModel).toHaveBeenCalledTimes(1);
+        expect(model).toBe(
+            jest.mocked(wrapLanguageModel).mock.results[0].value,
+        );
+    });
+});
+
+describe('applyStreamingCapability', () => {
+    const usage = {
+        inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 5, text: 5, reasoning: 0 },
+        totalTokens: 15,
+    };
+
+    const createNonStreamingMockModel = () => {
+        let generateCallCount = 0;
+        return new MockLanguageModelV3({
+            modelId: 'mock-gateway-model',
+            doStream: async () => {
+                throw new Error(
+                    'doStream called — gateway stream endpoint hit!',
+                );
+            },
+            doGenerate: async () => {
+                generateCallCount += 1;
+                return generateCallCount === 1
+                    ? {
+                          content: [
+                              {
+                                  type: 'tool-call' as const,
+                                  toolCallId: 'tc1',
+                                  toolName: 'getWeather',
+                                  input: JSON.stringify({ city: 'Tallinn' }),
+                              },
+                          ],
+                          finishReason: {
+                              unified: 'tool-calls' as const,
+                              raw: undefined,
+                          },
+                          usage,
+                          warnings: [],
+                      }
+                    : {
+                          content: [
+                              {
+                                  type: 'text' as const,
+                                  text: 'The weather in Tallinn is sunny.',
+                              },
+                          ],
+                          finishReason: {
+                              unified: 'stop' as const,
+                              raw: undefined,
+                          },
+                          usage,
+                          warnings: [],
+                      };
+            },
+        });
+    };
+
+    const toModelProperties = (model: MockLanguageModelV3) => ({
+        model,
+        callOptions: {},
+        providerOptions: undefined,
+    });
+
+    it('returns the model unwrapped when streaming is supported', () => {
+        const mockModel = createNonStreamingMockModel();
+        const modelProperties = toModelProperties(mockModel);
+
+        expect(applyStreamingCapability(modelProperties, true)).toBe(
+            modelProperties,
+        );
+    });
+
+    it('serves streamText through doGenerate only, preserving multi-step tool calls', async () => {
+        const mockModel = createNonStreamingMockModel();
+        const { model } = applyStreamingCapability(
+            toModelProperties(mockModel),
+            false,
+        );
+
+        const getWeather = tool({
+            description: 'Get weather',
+            inputSchema: z.object({ city: z.string() }),
+            execute: async ({ city }) => ({ city, forecast: 'sunny' }),
+        });
+
+        const result = streamText({
+            model,
+            tools: { getWeather },
+            stopWhen: stepCountIs(5),
+            prompt: 'Weather in Tallinn?',
+        });
+
+        let lastUiMessage;
+        // eslint-disable-next-line no-restricted-syntax
+        for await (const uiMessage of readUIMessageStream({
+            stream: result.toUIMessageStream(),
+        })) {
+            lastUiMessage = uiMessage;
+        }
+
+        expect(mockModel.doStreamCalls).toHaveLength(0);
+        expect(mockModel.doGenerateCalls).toHaveLength(2);
+        expect(await result.text).toBe('The weather in Tallinn is sunny.');
+        expect(lastUiMessage?.parts.map((part) => part.type)).toEqual([
+            'step-start',
+            'tool-getWeather',
+            'step-start',
+            'text',
+        ]);
+    });
+});

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -1,4 +1,5 @@
 import { assertUnreachable, ParameterError } from '@lightdash/common';
+import { simulateStreamingMiddleware, wrapLanguageModel } from 'ai';
 import { LightdashConfig } from '../../../../config/parseConfig';
 import Logger from '../../../../logging/logger';
 import { getAnthropicModel } from './anthropic-claude';
@@ -12,6 +13,7 @@ import {
     ModelPreset,
     ModelPresetProvider,
 } from './presets';
+import { AiModel, AiProvider } from './types';
 
 export { MODEL_PRESETS };
 
@@ -133,6 +135,38 @@ export const getModelPreset = <T extends 'openai' | 'anthropic' | 'bedrock'>(
     };
 };
 
+/**
+ * Some LLM gateways don't support streaming (SSE) completions. When a provider
+ * is marked `supportsStreaming: false`, wrap its model with the AI SDK's
+ * simulateStreamingMiddleware: `streamText` then issues a single non-streaming
+ * `doGenerate` request per step and replays the result as a simulated stream,
+ * so call sites (and the browser-facing SSE endpoint) are unaffected.
+ */
+export const applyStreamingCapability = <P extends AiProvider>(
+    modelProperties: AiModel<P>,
+    supportsStreaming: boolean,
+): AiModel<P> => {
+    if (supportsStreaming) {
+        return modelProperties;
+    }
+    const { model } = modelProperties;
+    if (model.specificationVersion !== 'v3') {
+        throw new ParameterError(
+            `Provider model "${model.modelId}" does not support disabling streaming`,
+        );
+    }
+    Logger.debug(
+        `Provider does not support streaming: serving "${model.modelId}" calls as non-streaming requests via simulated streaming`,
+    );
+    return {
+        ...modelProperties,
+        model: wrapLanguageModel({
+            model,
+            middleware: simulateStreamingMiddleware(),
+        }),
+    };
+};
+
 export const getModel = (
     config: LightdashConfig['ai']['copilot'],
     options?: {
@@ -162,9 +196,12 @@ export const getModel = (
                 config,
                 resolveModelName('openai'),
             );
-            return getOpenaiGptmodel(openaiConfig, preset, {
-                enableReasoning: options?.enableReasoning,
-            });
+            return applyStreamingCapability(
+                getOpenaiGptmodel(openaiConfig, preset, {
+                    enableReasoning: options?.enableReasoning,
+                }),
+                openaiConfig.supportsStreaming,
+            );
         }
         case 'azure': {
             const azureConfig = config.providers.azure;
@@ -172,7 +209,10 @@ export const getModel = (
                 throw new ParameterError('Azure configuration is required');
             }
             // Azure doesn't use presets - uses deployment name directly
-            return getAzureGpt41Model(azureConfig);
+            return applyStreamingCapability(
+                getAzureGpt41Model(azureConfig),
+                azureConfig.supportsStreaming,
+            );
         }
         case 'anthropic': {
             const { config: anthropicConfig, preset } = getModelPreset(
@@ -180,9 +220,12 @@ export const getModel = (
                 config,
                 resolveModelName('anthropic'),
             );
-            return getAnthropicModel(anthropicConfig, preset, {
-                enableReasoning: options?.enableReasoning,
-            });
+            return applyStreamingCapability(
+                getAnthropicModel(anthropicConfig, preset, {
+                    enableReasoning: options?.enableReasoning,
+                }),
+                anthropicConfig.supportsStreaming,
+            );
         }
         case 'openrouter': {
             const openrouterConfig = config.providers.openrouter;
@@ -192,7 +235,10 @@ export const getModel = (
                 );
             }
             // OpenRouter doesn't use presets - uses model name directly
-            return getOpenRouterModel(openrouterConfig);
+            return applyStreamingCapability(
+                getOpenRouterModel(openrouterConfig),
+                openrouterConfig.supportsStreaming,
+            );
         }
         case 'bedrock': {
             const { config: bedrockConfig, preset } = getModelPreset(
@@ -200,9 +246,12 @@ export const getModel = (
                 config,
                 resolveModelName('bedrock'),
             );
-            return getBedrockModel(bedrockConfig, preset, {
-                enableReasoning: options?.enableReasoning,
-            });
+            return applyStreamingCapability(
+                getBedrockModel(bedrockConfig, preset, {
+                    enableReasoning: options?.enableReasoning,
+                }),
+                bedrockConfig.supportsStreaming,
+            );
         }
         default:
             return assertUnreachable(provider, `Invalid provider: ${provider}`);


### PR DESCRIPTION
Adds a per-provider `supportsStreaming` capability (default `true`) so the AI agent works behind OpenAI-compatible LLM gateways that don't support streaming (SSE) completions.

When a provider is marked non-streaming (e.g. `OPENAI_SUPPORTS_STREAMING=false`), `getModel` wraps the resolved model with the AI SDK's `simulateStreamingMiddleware`: each model call becomes a single non-streaming request whose result is replayed as a simulated stream. `streamText`, multi-step tool calls, and the browser-facing SSE endpoint are unchanged — no call-site or frontend changes, existing deployments unaffected. Follows the per-provider config pattern from #23448 (`customHeaders`).

- New opt-out env vars: `OPENAI_` / `AZURE_AI_` / `ANTHROPIC_` / `OPENROUTER_` / `BEDROCK_SUPPORTS_STREAMING`
- Rationale + proxy-timeout caveat documented in `docs/ai-agent-non-streaming-transport.md`

**Testing**: config unit tests for the env vars; unit test proving a wrapped model with a throwing `doStream` completes a multi-step tool loop with zero streaming calls; manual end-to-end run against a strict local gateway that rejects `stream: true` — all requests went out non-streaming and the agent worked, while without the flag it reproduces the reported failure.

Closes: PROD-8155
Closes: #23948
