### PR TITLE
feat(ai): install Lightdash skills into the writeback sandbox

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -37,6 +37,7 @@ import type {
 import {
     ALLOWED_TOOLS,
     CLAUDE_MODEL,
+    CLAUDE_SKILLS_DIR,
     COMPILE_STRIPPED_ENV_VARS,
     COMPILE_TIMINGS_PATH,
     COMPILE_WRAPPER_PATH,
@@ -1202,7 +1203,9 @@ export class AiWritebackService extends BaseService {
                     // back to the repo root) unless /tmp is an added directory.
                     // The skills dir is outside the repo too, so it likewise needs
                     // to be added or the agent's Read of warehouse.md is refused.
-                    `--add-dir /tmp --add-dir ${SKILLS_DIR} ` +
+                    // CLAUDE_SKILLS_DIR holds the installed Agent Skills, added for
+                    // the same reason — the agent reads their resource files from there.
+                    `--add-dir /tmp --add-dir ${SKILLS_DIR} --add-dir ${CLAUDE_SKILLS_DIR} ` +
                     `--allowedTools "${ALLOWED_TOOLS}"`,
                 {
                     cwd: CWD,

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -12,6 +12,14 @@ export const SKILLS_DIR = '/home/user/.lightdash-skills';
 export const WAREHOUSE_SKILL_PATH = `${SKILLS_DIR}/warehouse.md`;
 export const SHARED_SKILL_PATH = `${SKILLS_DIR}/shared.md`;
 
+// Claude Code Agent Skills baked into the sandbox image at build time via
+// `lightdash install-skills` (see sandboxes/ai-writeback/e2b.Dockerfile). The
+// agent runs as `user`, so this matches the runtime ~/.claude/skills location
+// Claude Code auto-discovers. Distinct from SKILLS_DIR above (the host-pushed
+// warehouse markdown). The agent reads a skill's resource files from here, so
+// it must be both allowlisted (ALLOWED_TOOLS) and passed via --add-dir.
+export const CLAUDE_SKILLS_DIR = '/home/user/.claude/skills';
+
 // Files the agent writes for the host to open a PR from. Kept as a fallback
 // — the primary channel is now structured output blocks in the agent's stdout
 // (see PR_TITLE_OPEN/CLOSE etc.).
@@ -103,6 +111,11 @@ export const ALLOWED_TOOLS = [
     // skills dir also has to be passed via `--add-dir` (see runAgentInSandbox)
     // or Claude Code confines reads to the cwd workspace and refuses these.
     `Read(/${SKILLS_DIR}/**)`,
+    // Invoke the Lightdash Agent Skills installed in the image, and read the
+    // resource files they reference. Like the dirs above, CLAUDE_SKILLS_DIR is
+    // outside the cwd workspace so it must also be passed via `--add-dir`.
+    'Skill',
+    `Read(/${CLAUDE_SKILLS_DIR}/**)`,
     // PR metadata files live directly in /tmp. This permission alone is not
     // enough: Claude Code also confines Write/Edit to the cwd workspace, so
     // /tmp must additionally be passed via `--add-dir /tmp` (see

--- a/sandboxes/ai-writeback/e2b.Dockerfile
+++ b/sandboxes/ai-writeback/e2b.Dockerfile
@@ -26,4 +26,8 @@ RUN sfw npm install -g @anthropic-ai/claude-code
 
 RUN sfw npm install -g @lightdash/cli
 
+# Install Lightdash skills into /home/user/.claude/skills (HOME at runtime) so
+# the Claude Code agent discovers them, and outside the cloned repo at /home/user/repo.
+RUN lightdash install-skills --path /home/user
+
 WORKDIR /home/user


### PR DESCRIPTION
## What

Bakes the Lightdash **Agent Skills** into the AI writeback E2B sandbox image and wires up the writeback agent so it can actually use them.

- **`sandboxes/ai-writeback/e2b.Dockerfile`** — runs `lightdash install-skills --path /home/user` after the CLI install, landing the skills in `/home/user/.claude/skills` (the runtime `~/.claude/skills` that Claude Code auto-discovers), outside the cloned repo so they can't be swept into the PR.
- **`constants.ts`** — new `CLAUDE_SKILLS_DIR`; adds `Skill` and `Read(/home/user/.claude/skills/**)` to `ALLOWED_TOOLS`.
- **`AiWritebackService.ts`** — adds `--add-dir ${CLAUDE_SKILLS_DIR}` to the `claude` invocation, mirroring how `/tmp` and the warehouse skills dir are already handled.

## Why

The image already installs `@lightdash/cli`, but the writeback agent had no way to benefit from the published Lightdash skills (`developing-in-lightdash` — metrics/dimensions/joins references, YAML schemas). Discovery alone isn't enough: the agent runs with a tight `--allowedTools` allowlist with no `Skill` tool, and `Read` confined to the cwd workspace, so an installed skill would be discovered but un-invokable and its resource files unreadable. This closes that gap end to end: installed → discovered → invokable → readable.

## Notes / follow-ups

- `Skill` is allowlisted unscoped (not `Skill(developing-in-lightdash)`) — only one skill ships in the image, and an unmatched specifier could silently block it. Worth confirming the specifier syntax in a live run if we want it tighter.
- The agent's `Bash` allowlist only permits the compile wrapper, `mkdir`, and `cp`, so the CLI commands the skill suggests (`deploy`, `upload`, `sql`) are inert in this sandbox. The reference knowledge — the valuable part for editing dbt YAML — is fully usable.

## Testing

Backend typecheck + lint pass. The full path is gated behind a live E2B agent run; needs a template rebuild + writeback run to confirm the skill is invoked end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)