### PR TITLE
fix(ai-writeback): restrict E2B sandbox egress to an allowlist

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -14,7 +14,7 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
-import { CommandExitError, Sandbox, TimeoutError } from 'e2b';
+import { ALL_TRAFFIC, CommandExitError, Sandbox, TimeoutError } from 'e2b';
 import type {
     AiWritebackFailureStage,
     LightdashAnalytics,
@@ -218,6 +218,10 @@ export class AiWritebackService extends BaseService {
             timeoutMs: SANDBOX_TIMEOUT_MS,
             apiKey: this.getE2bApiKey(),
             lifecycle: { onTimeout: 'pause' },
+            network: {
+                allowOut: ['api.anthropic.com', 'github.com', 'gitlab.com'],
+                denyOut: [ALL_TRAFFIC],
+            },
         });
         const durationMs = AiWritebackService.elapsed(start);
         this.logger.info('AI writeback sandbox created', {


### PR DESCRIPTION
## Description

The AI writeback sandbox previously ran with **unrestricted outbound network access**. This locks its egress to an allowlist — Anthropic for the Claude CLI and GitHub/GitLab for clone/push — and denies everything else, mirroring the data-app sandbox in `AppGenerateService`.

Applied in `AiWritebackService.createSandbox` via E2B's `network` config:

```ts
network: {
    allowOut: ['api.anthropic.com', 'github.com', 'gitlab.com'],
    denyOut: [ALL_TRAFFIC],
}
```

**Sandbox egress, before → after**

Before:
- any host — allowed

After:
- `api.anthropic.com` — allowed (Claude CLI)
- `github.com` / `gitlab.com` — allowed (clone / push)
- everything else — denied (`ALL_TRAFFIC`)

Only the *fresh* sandbox path (`Sandbox.create`) is affected. Backend-side traffic — the E2B control plane and the GitHub/GitLab PR API — does not traverse sandbox egress, so it is unaffected. `lightdash compile` runs with warehouse credentials stripped, so it needs no warehouse host on the allowlist.

## Test plan

- `pnpm -F backend typecheck:fast` passes.
- Live writeback run (sandbox create → clone → agent → PR) against a GitHub-connected project — verifying the allowlist doesn't break the happy path. (Running separately; will confirm in a comment.)