### PR TITLE
fix(ai-agents): hide dismissed review findings

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -79,12 +79,9 @@ import { EXAMPLE_REVIEW_ITEMS, isExampleReviewItem } from './onboarding';
 import { ProjectContextWritebackModal } from './ProjectContextWritebackModal';
 import { SearchFilter } from './SearchFilter';
 
-const ALL_REVIEW_ITEM_STATUSES: AiAgentReviewItemStatus[] = [
+const ACTIVE_REVIEW_ITEM_STATUSES: AiAgentReviewItemStatus[] = [
     'open',
     'in_progress',
-    'resolved',
-    'dismissed',
-    'duplicate',
 ];
 
 const rootCauseLabels: Record<AiAgentRootCause, string> = {
@@ -819,7 +816,7 @@ const AiAgentAdminReviewItemsTable = ({
         showOnboardingExamples,
     );
     const { data: reviewItems = [], isLoading } = useAiAgentAdminReviewItems(
-        { statuses: ALL_REVIEW_ITEM_STATUSES },
+        { statuses: ACTIVE_REVIEW_ITEM_STATUSES },
         { select: selectReviewItems },
     );
     const { data: reviewSignals = [], isLoading: isSignalsLoading } =

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.test.ts
@@ -1,5 +1,50 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { QueryClient } from '@tanstack/react-query';
 import { describe, expect, it } from 'vitest';
-import { getReviewItemWritebackSuccessToast } from './useAiAgentAdmin';
+import {
+    getReviewItemWritebackSuccessToast,
+    updateCachedReviewItemLists,
+} from './useAiAgentAdmin';
+
+const makeReviewItem = (
+    overrides: Partial<AiAgentReviewItemSummary> = {},
+): AiAgentReviewItemSummary =>
+    ({
+        uuid: 'fingerprint-1',
+        fingerprint: 'fingerprint-1',
+        organizationUuid: 'org-1',
+        projectUuid: 'project-1',
+        agentUuid: 'agent-1',
+        title: 'Review revenue metric',
+        description: 'The answer picked the wrong metric',
+        primaryRootCause: 'semantic_layer',
+        status: 'open',
+        dismissedReason: null,
+        ownerType: 'semantic_layer_owner',
+        assignedToUserUuid: null,
+        firstSeenAt: new Date('2026-06-10T09:00:00.000Z'),
+        lastSeenAt: new Date('2026-06-10T09:00:00.000Z'),
+        findingCount: 1,
+        statusUpdatedAt: new Date('2026-06-10T09:00:00.000Z'),
+        statusUpdatedByUserUuid: null,
+        linkedIssueUrl: null,
+        linkedPrUrl: null,
+        prState: null,
+        prWritebackStatus: null,
+        prWritebackMessage: null,
+        createdAt: new Date('2026-06-10T09:00:00.000Z'),
+        updatedAt: new Date('2026-06-10T09:00:00.000Z'),
+        writebackEligible: false,
+        writebackEligibility: {
+            eligible: false,
+            reason: 'unsupported_root_cause',
+            provider: null,
+            strategy: null,
+        },
+        remediation: null,
+        latestFinding: null,
+        ...overrides,
+    }) as AiAgentReviewItemSummary;
 
 describe('getReviewItemWritebackSuccessToast', () => {
     it('shows queued copy when the async writeback request has no PR yet', () => {
@@ -48,5 +93,43 @@ describe('getReviewItemWritebackSuccessToast', () => {
             title: 'Writeback completed',
             subtitle: 'Writeback ran - no changes were needed',
         });
+    });
+});
+
+describe('updateCachedReviewItemLists', () => {
+    it('removes dismissed items from active review item queries', () => {
+        const queryClient = new QueryClient();
+        const openItem = makeReviewItem();
+        const dismissedItem = makeReviewItem({
+            status: 'dismissed',
+            dismissedReason: 'not_actionable',
+        });
+
+        queryClient.setQueryData(
+            ['ai-agent-admin-review-items', { statuses: ['open'] }],
+            [openItem],
+        );
+        queryClient.setQueryData(
+            [
+                'ai-agent-admin-review-items',
+                { statuses: ['open', 'dismissed'] },
+            ],
+            [openItem],
+        );
+
+        updateCachedReviewItemLists(queryClient, dismissedItem);
+
+        expect(
+            queryClient.getQueryData([
+                'ai-agent-admin-review-items',
+                { statuses: ['open'] },
+            ]),
+        ).toEqual([]);
+        expect(
+            queryClient.getQueryData([
+                'ai-agent-admin-review-items',
+                { statuses: ['open', 'dismissed'] },
+            ]),
+        ).toEqual([dismissedItem]);
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -19,6 +19,7 @@ import {
     useMutation,
     useQuery,
     useQueryClient,
+    type QueryClient,
     type UseInfiniteQueryOptions,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
@@ -132,6 +133,47 @@ const getAiAgentAdminReviewItems = async (args: {
     });
 };
 
+const AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY = 'ai-agent-admin-review-items';
+
+export const updateCachedReviewItemLists = (
+    queryClient: QueryClient,
+    updatedItem: AiAgentReviewItemSummary,
+) => {
+    queryClient
+        .getQueryCache()
+        .findAll({
+            queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
+        })
+        .forEach((query) => {
+            const [, args] = query.queryKey as [
+                string,
+                { statuses?: AiAgentReviewItemStatus[] } | undefined,
+            ];
+            const matchesStatus =
+                !args?.statuses || args.statuses.includes(updatedItem.status);
+
+            queryClient.setQueryData<ApiAiAgentReviewItemsResponse['results']>(
+                query.queryKey,
+                (current) => {
+                    if (!current) return current;
+
+                    if (!matchesStatus) {
+                        return current.filter(
+                            (item) =>
+                                item.fingerprint !== updatedItem.fingerprint,
+                        );
+                    }
+
+                    return current.map((item) =>
+                        item.fingerprint === updatedItem.fingerprint
+                            ? updatedItem
+                            : item,
+                    );
+                },
+            );
+        });
+};
+
 export const useAiAgentAdminReviewItems = (
     args: { statuses?: AiAgentReviewItemStatus[] },
     options?: {
@@ -146,7 +188,7 @@ export const useAiAgentAdminReviewItems = (
         ApiError,
         ApiAiAgentReviewItemsResponse['results']
     >({
-        queryKey: ['ai-agent-admin-review-items', args],
+        queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY, args],
         queryFn: () => getAiAgentAdminReviewItems(args),
         keepPreviousData: true,
         enabled: options?.enabled ?? true,
@@ -232,8 +274,9 @@ export const useUpdateAiAgentReviewItemStatus = () => {
                 ['ai-agent-admin-review-item', fingerprint],
                 updatedItem,
             );
+            updateCachedReviewItemLists(queryClient, updatedItem);
             void queryClient.invalidateQueries({
-                queryKey: ['ai-agent-admin-review-items'],
+                queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
             });
         },
         onError: ({ error }) => {


### PR DESCRIPTION
## Summary
- fetch only active AI review findings in the Ask AI > Reviews table
- update cached review item lists after status mutations so dismissed findings disappear immediately
- add regression coverage for removing dismissed items from active-status queries

## Testing
- pnpm -F frontend test -- src/ee/features/aiCopilot/hooks/useAiAgentAdmin.test.ts