### PR TITLE
fix(common): format MIN/MAX timestamp aggregations in project timezone (GLITCH-485)

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -28,6 +28,7 @@ import {
     getEffectiveSeparator,
     isCalendarValueDimension,
     isMomentInput,
+    isTimestampString,
     shouldShiftItemTimezone,
     toIsoWithProjectOffset,
 } from './formatting';
@@ -732,6 +733,28 @@ describe('Formatting', () => {
         });
     });
 
+    describe('isTimestampString', () => {
+        test('true only for strings with a date AND a time component', () => {
+            expect(isTimestampString('2018-10-31T06:44:22.667Z')).toBe(true);
+            expect(isTimestampString('2020-08-11 16:44:00')).toBe(true);
+        });
+
+        test('false for date-only, numbers, Dates, and non-temporal strings', () => {
+            // bare date — must not be timezone-shifted, so excluded
+            expect(isTimestampString('2018-10-31')).toBe(false);
+            // date-shaped but no time component
+            expect(isTimestampString('2018-13-99')).toBe(false);
+            expect(isTimestampString('42')).toBe(false);
+            expect(isTimestampString(5000)).toBe(false);
+            expect(isTimestampString('hello')).toBe(false);
+            // type-guard is for strings only; Date instances are handled separately
+            expect(
+                isTimestampString(new Date('2018-10-31T06:44:22.667Z')),
+            ).toBe(false);
+            expect(isTimestampString(undefined)).toBe(false);
+        });
+    });
+
     describe('isCalendarValueDimension', () => {
         const dateBaseColumn: Dimension = {
             ...dimension,
@@ -1064,6 +1087,66 @@ describe('Formatting', () => {
                     1000,
                 ),
             ).toEqual('1K');
+        });
+
+        test('formatItemValue MIN/MAX timestamps format in project tz from a Date OR an ISO string (GLITCH-485)', () => {
+            const maxMetric = { ...metric, type: MetricType.MAX };
+            const isoString = '2018-10-31T06:44:22.667Z';
+            const asDate = new Date(isoString);
+            const tz = 'Asia/Tokyo'; // +09:00, no DST
+
+            // Fresh queries deliver a Date (already formatted); cached results
+            // rehydrate from S3 as ISO strings and must format identically —
+            // not fall through and show the raw UTC value.
+            const fromDate = formatItemValue(
+                maxMetric,
+                asDate,
+                false,
+                undefined,
+                tz,
+            );
+            const fromString = formatItemValue(
+                maxMetric,
+                isoString,
+                false,
+                undefined,
+                tz,
+            );
+            expect(fromDate).toEqual('2018-10-31, 15:44:22:667 (+09:00)');
+            expect(fromString).toEqual(fromDate);
+        });
+
+        test('formatItemValue MIN/MAX does not coerce non-timestamp values (GLITCH-485)', () => {
+            const tz = 'Pacific/Pago_Pago'; // -11:00, exposes any wrong shift
+            // Numeric aggregations stay numbers — fresh (number) or cached (string)
+            expect(
+                formatItemValue(
+                    { ...metric, type: MetricType.MAX },
+                    5000,
+                    false,
+                    undefined,
+                    tz,
+                ),
+            ).toEqual('5,000');
+            expect(
+                formatItemValue(
+                    { ...metric, type: MetricType.MIN },
+                    '42',
+                    false,
+                    undefined,
+                    tz,
+                ),
+            ).toEqual('42');
+            // A date-only aggregate is a wall-clock date — never tz-shifted
+            expect(
+                formatItemValue(
+                    { ...metric, type: MetricType.MAX },
+                    '2018-10-31',
+                    false,
+                    undefined,
+                    tz,
+                ),
+            ).toEqual('2018-10-31');
         });
 
         describe('formatItemValue timestamp handling', () => {

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -132,6 +132,14 @@ export const isMomentInput = (value: unknown): value is MomentInput =>
     value instanceof moment ||
     value instanceof dayjs;
 
+// A string carrying both a date and a time component (e.g. "2024-01-02T03:04…"
+// or "2024-01-02 03:04…") — as opposed to a bare date, a number, or text.
+// Unlike a parse-validity check, this requires a time part, so date-only values
+// are excluded (they must not be timezone-shifted).
+export const isTimestampString = (value: unknown): value is string =>
+    typeof value === 'string' &&
+    /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(value);
+
 export function formatDate(
     date: MomentInput,
     timeInterval: TimeFrames = TimeFrames.DAY,
@@ -1114,17 +1122,31 @@ export function formatItemValue(
                           )
                         : 'NaT';
                 case MetricType.MAX:
-                case MetricType.MIN:
-                    if (value instanceof Date && customFormat === undefined) {
+                case MetricType.MIN: {
+                    // MIN/MAX inherit the aggregated column's type. A temporal
+                    // result must render in the resolved project timezone like
+                    // a dimension does — whether it arrives as a Date (fresh
+                    // query) or an ISO datetime string (rehydrated from cached
+                    // results). The auto-derived numeric format must not
+                    // suppress this; a user-chosen display format still wins.
+                    const formatType = customFormat?.type;
+                    const userChoseDisplayFormat =
+                        formatType === CustomFormatType.DATE ||
+                        formatType === CustomFormatType.TIMESTAMP ||
+                        formatType === CustomFormatType.CUSTOM;
+                    const isTimestampValue =
+                        value instanceof Date || isTimestampString(value);
+                    if (isTimestampValue && !userChoseDisplayFormat) {
                         return formatTimestamp(
                             value,
-                            isDimension(item) ? item.timeInterval : undefined,
+                            undefined,
                             convertToUTC,
                             effectiveTimezone,
                             displayTimezone,
                         );
                     }
                     break;
+                }
                 case DimensionType.NUMBER:
                     if (
                         isDimension(item) &&


### PR DESCRIPTION
Closes: GLITCH-485

### Description:

MIN/MAX aggregations over a TIMESTAMP column were never formatted in the resolved project timezone — they rendered in UTC (fresh queries) or as raw ISO 8601 (cached results), while the raw dimension beside them formatted correctly.

**Root cause (deeper than the ticket's "only when `value instanceof Date`"):** MIN/MAX metrics are *numeric*, so `getCustomFormat` returns an auto-derived `{ type: NUMBER }` format — never `undefined`. The existing guard `value instanceof Date && customFormat === undefined` was therefore **always false**, making the `formatTimestamp` branch unreachable. Both paths fell into `applyCustomFormat`:
- a `Date` → `formatTimestamp` with **no timezone** → UTC
- an ISO string (rehydrated from cached S3 results) → `applyDefaultFormat` → **raw value**

### Fix

In the MIN/MAX branch, format any temporal value — a `Date` (fresh query) or an ISO **datetime** string (cached) — through `formatTimestamp` in the resolved timezone, matching dimension formatting. Gated only on a user-chosen display format (`DATE`/`TIMESTAMP`/`CUSTOM`), which still wins; the auto-derived numeric format no longer suppresses temporal formatting. A `^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}` guard keeps numbers and date-only values out.

Naturally Phase-2-gated: without the timezone feature flag the resolved timezone is UTC, so behavior is unchanged; with it on, MIN/MAX now match dimensions.

### Tests (`formatting.test.ts`)

- MIN/MAX timestamp formats in the resolved project tz **identically from a `Date` and from an ISO string** (fresh vs cached parity).
- MIN/MAX does **not** coerce non-temporal values — numeric aggregates stay numbers (fresh number + cached string); a date-only aggregate is never tz-shifted (verified under a -11:00 zone).
- Full common suite green (2262 passed); typecheck + lint clean.

### Known edge (out of scope)

A MAX-**of-DATE** that arrives as a `Date` instance at midnight is indistinguishable from a midnight timestamp and would be tz-formatted; real DATE columns come back as date-only strings (handled correctly), so this only bites if a driver returns a `Date`-at-midnight.
