### PR TITLE
chore: deprecate test-only backend endpoints and migrate their tests

### DIFF
--- a/.claude/skills/deprecate-endpoint/SKILL.md
+++ b/.claude/skills/deprecate-endpoint/SKILL.md
@@ -59,6 +59,12 @@ In the controller, on the route handler:
 ```ts
 import { getDeprecatedRouteMiddleware } from './authentication';
 
+/**
+ * Get role assignments for a project
+ * @summary Get role assignments
+ *
+ * @deprecated Use GET /api/v2/.../roleAssignments instead
+ */
 @Middlewares([
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -68,6 +74,10 @@ import { getDeprecatedRouteMiddleware } from './authentication';
 ])
 @Deprecated()
 ```
+
+Keep the existing description and `@summary` lines in the JSDoc (lint requires
+`@summary` on every endpoint) and append the `@deprecated` line after a blank
+line.
 
 - `new Date(...)` is the date you are deprecating it (today). The removal/sunset
   date **defaults to deprecatedOn + 3 months**; only pass `{ removeOn: ... }` when

--- a/packages/api-tests/tests/api.test.ts
+++ b/packages/api-tests/tests/api.test.ts
@@ -170,23 +170,11 @@ describe('Lightdash API', () => {
             `/org/projects`,
             `/org/users`,
             `/org/onboardingStatus`,
-            `/org/users/email/demo@lightdash.com`,
         ];
         for (const endpoint of endpoints) {
             const resp = await admin.get(`${apiUrl}${endpoint}`);
             expect(resp.status).toBe(200);
             expect(resp.body).toHaveProperty('status', 'ok');
-        }
-    });
-
-    it('Should get not found response (404) from GET organizationRouter endpoints', async () => {
-        const endpoints = [`/org/users/email/another@lightdash.com`];
-        for (const endpoint of endpoints) {
-            const resp = await admin.get(`${apiUrl}${endpoint}`, {
-                failOnStatusCode: false,
-            });
-            expect(resp.status).toBe(404);
-            expect(resp.body).toHaveProperty('status', 'error');
         }
     });
 

--- a/packages/api-tests/tests/embedManagement.test.ts
+++ b/packages/api-tests/tests/embedManagement.test.ts
@@ -48,23 +48,6 @@ async function updateEmbedConfig(
     );
 }
 
-async function updateEmbedConfigDashboards(
-    client: ApiClient,
-    dashboardUuids: string[],
-    options?: { failOnStatusCode?: boolean },
-) {
-    return client.patch<Body<unknown>>(
-        `${EMBED_API_PREFIX}/config/dashboards`,
-        {
-            dashboardUuids,
-            chartUuids: [],
-            allowAllDashboards: false,
-            allowAllCharts: false,
-        },
-        options,
-    );
-}
-
 async function getEmbedUrl(
     client: ApiClient,
     body: CreateEmbedJwt,
@@ -214,10 +197,12 @@ describe('Embed Management API', () => {
         );
         expect(dashboardsUuids.length).toBeGreaterThan(1);
 
-        const updateResp = await updateEmbedConfigDashboards(
-            admin,
-            dashboardsUuids,
-        );
+        const updateResp = await updateEmbedConfig(admin, {
+            dashboardUuids: dashboardsUuids,
+            chartUuids: [],
+            allowAllDashboards: false,
+            allowAllCharts: false,
+        });
         expect(updateResp.status).toBe(200);
 
         const newConfigResp = await getEmbedConfig(admin);
@@ -387,13 +372,6 @@ describe('Embed Management API - invalid permissions', () => {
             { dashboardUuids: ['uuid'] },
             { failOnStatusCode: false },
         );
-        expect(resp.status).toBe(403);
-    });
-
-    it('should not update embed configuration (dashboards endpoint)', async () => {
-        const resp = await updateEmbedConfigDashboards(otherClient, ['uuid'], {
-            failOnStatusCode: false,
-        });
         expect(resp.status).toBe(403);
     });
 

--- a/packages/api-tests/tests/groups.test.ts
+++ b/packages/api-tests/tests/groups.test.ts
@@ -60,13 +60,6 @@ describe('Groups API', () => {
         expect(resp.body.results.data).toHaveLength(0);
     });
 
-    it('should add members to group', async () => {
-        const resp = await admin.put(
-            `api/v1/groups/${SEED_GROUP.groupUuid}/members/${SEED_ORG_1_ADMIN.user_uuid}`,
-        );
-        expect([201, 204]).toContain(resp.status);
-    });
-
     it('should delete group from organization', async () => {
         const createResp = await admin.post<Body<{ uuid: string }>>(
             'api/v1/org/groups',
@@ -97,10 +90,11 @@ describe('Groups API', () => {
     });
 
     it('should get group members', async () => {
-        const resp = await admin.get(
-            `api/v1/groups/${SEED_GROUP.groupUuid}/members`,
-        );
+        const resp = await admin.get<
+            Body<{ members: Array<{ userUuid: string }> }>
+        >(`api/v1/groups/${SEED_GROUP.groupUuid}?includeMembers=100`);
         expect(resp.status).toBe(200);
+        expect(resp.body.results.members).toBeInstanceOf(Array);
     });
 
     it('should successfully update group name and members', async () => {

--- a/packages/api-tests/tests/projectPermissions.test.ts
+++ b/packages/api-tests/tests/projectPermissions.test.ts
@@ -1,7 +1,6 @@
 import {
     MetricQuery,
     ProjectMemberProfile,
-    SEED_ORG_1_ADMIN,
     SEED_PROJECT,
 } from '@lightdash/common';
 import { ApiClient, Body } from '../helpers/api-client';
@@ -81,10 +80,10 @@ describe('Lightdash API tests for member user with admin project permissions', (
         }
     });
 
-    it('Should get success response (200) from GET scheduler logs', async () => {
+    it('Should get success response (200) from GET scheduler runs', async () => {
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.get(
-            `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/logs`,
+            `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/runs`,
         );
         expect(resp.status).toBe(200);
         expect(resp.body).toHaveProperty('status', 'ok');
@@ -438,10 +437,10 @@ describe('Lightdash API tests for member user with editor project permissions', 
         expect(resp.status).toBe(403);
     });
 
-    it('Should get forbidden (403) from GET scheduler logs', async () => {
+    it('Should get forbidden (403) from GET scheduler runs', async () => {
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.get(
-            `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/logs`,
+            `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/runs`,
             { failOnStatusCode: false },
         );
         expect(resp.status).toBe(403);
@@ -616,10 +615,10 @@ describe('Lightdash API tests for member user with developer project permissions
         email = perm.email;
     });
 
-    it('Should get success response (200) from GET scheduler logs', async () => {
+    it('Should get success response (200) from GET scheduler runs', async () => {
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.get(
-            `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/logs`,
+            `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/runs`,
         );
         expect(resp.status).toBe(200);
         expect(resp.body).toHaveProperty('status', 'ok');
@@ -698,10 +697,10 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
         expect(resp.body).toHaveProperty('status', 'ok');
     });
 
-    it('Should get forbidden error (403) from GET Scheduler logs', async () => {
+    it('Should get forbidden error (403) from GET scheduler runs', async () => {
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.get(
-            `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/logs`,
+            `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/runs`,
             { failOnStatusCode: false },
         );
         expect(resp.status).toBe(403);
@@ -877,10 +876,10 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         }
     });
 
-    it('Should get forbidden error (403) from GET Scheduler logs', async () => {
+    it('Should get forbidden error (403) from GET scheduler runs', async () => {
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.get(
-            `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/logs`,
+            `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/runs`,
             { failOnStatusCode: false },
         );
         expect(resp.status).toBe(403);
@@ -1148,7 +1147,7 @@ describe('Lightdash API tests for member user with NO project permissions', () =
             `/projects/${projectUuid}/catalog`,
             `/projects/${projectUuid}/tablesConfiguration`,
             `/projects/${projectUuid}/hasSavedCharts`,
-            `/schedulers/${projectUuid}/logs`,
+            `/schedulers/${projectUuid}/runs`,
         ];
         for (const endpoint of endpoints) {
             // eslint-disable-next-line no-await-in-loop
@@ -1255,25 +1254,18 @@ describe('Lightdash API tests for project members access', () => {
         expect(resp.status).toBe(200);
         expect(resp.body.results.length).toBeGreaterThan(0);
 
-        for (const member of resp.body.results) {
-            // eslint-disable-next-line no-await-in-loop
-            const resp2 = await admin.get<
-                Body<{ userUuid: string; projectUuid: string; role: string }>
-            >(`${apiUrl}/projects/${projectUuid}/user/${member.userUuid}`);
-            expect(resp2.status).toBe(200);
-            expect(resp2.body.results.userUuid).toBe(member.userUuid);
-            expect(resp2.body.results.projectUuid).toBe(member.projectUuid);
-            expect(resp2.body.results.role).toBe(member.role);
-        }
-    });
-
-    it('Should not get project member access for user that gets access via the org role', async () => {
-        const projectUuid = SEED_PROJECT.project_uuid;
         // eslint-disable-next-line no-await-in-loop
-        const resp = await admin.get(
-            `${apiUrl}/projects/${projectUuid}/user/${SEED_ORG_1_ADMIN.user_uuid}`,
-            { failOnStatusCode: false },
-        );
-        expect(resp.status).toBe(404);
+        const assignmentsResp = await admin.get<
+            Body<Array<{ assigneeId: string; roleName: string }>>
+        >(`/api/v2/projects/${projectUuid}/roles/assignments`);
+        expect(assignmentsResp.status).toBe(200);
+
+        for (const member of resp.body.results) {
+            const assignment = assignmentsResp.body.results.find(
+                (a) => a.assigneeId === member.userUuid,
+            );
+            expect(assignment).toBeDefined();
+            expect(assignment!.roleName).toBe(member.role);
+        }
     });
 });

--- a/packages/api-tests/tests/roles.test.ts
+++ b/packages/api-tests/tests/roles.test.ts
@@ -120,9 +120,14 @@ describe('Roles API Tests', () => {
                 rolesToCleanup.push(roleUuid);
 
                 // Test: add scopes to the role
-                const scopeResp = await admin.post<Body<unknown>>(
-                    `${orgRolesApiUrl}/${testOrgUuid}/roles/${roleUuid}/scopes`,
-                    { scopeNames: ['view_project', 'view_dashboard'] },
+                const scopeResp = await admin.patch<Body<unknown>>(
+                    `${orgRolesApiUrl}/${testOrgUuid}/roles/${roleUuid}`,
+                    {
+                        scopes: {
+                            add: ['view_project', 'view_dashboard'],
+                            remove: [],
+                        },
+                    },
                 );
 
                 expect(scopeResp.status).toBe(200);
@@ -145,14 +150,17 @@ describe('Roles API Tests', () => {
                 rolesToCleanup.push(originalRoleUuid);
 
                 // Setup: add scopes to the original role
-                await admin.post<Body<unknown>>(
-                    `${orgRolesApiUrl}/${testOrgUuid}/roles/${originalRoleUuid}/scopes`,
+                await admin.patch<Body<unknown>>(
+                    `${orgRolesApiUrl}/${testOrgUuid}/roles/${originalRoleUuid}`,
                     {
-                        scopeNames: [
-                            'view_project',
-                            'view_dashboard',
-                            'create:Space',
-                        ],
+                        scopes: {
+                            add: [
+                                'view_project',
+                                'view_dashboard',
+                                'create:Space',
+                            ],
+                            remove: [],
+                        },
                     },
                 );
 
@@ -305,9 +313,14 @@ describe('Roles API Tests', () => {
             rolesToCleanup.push(roleUuid);
 
             // Add scopes to role
-            const scopeResp = await admin.post<Body<unknown>>(
-                `${orgRolesApiUrl}/${testOrgUuid}/roles/${roleUuid}/scopes`,
-                { scopeNames: ['view_project', 'view_dashboard'] },
+            const scopeResp = await admin.patch<Body<unknown>>(
+                `${orgRolesApiUrl}/${testOrgUuid}/roles/${roleUuid}`,
+                {
+                    scopes: {
+                        add: ['view_project', 'view_dashboard'],
+                        remove: [],
+                    },
+                },
             );
             expect(scopeResp.status).toBe(200);
             expect(scopeResp.body).toHaveProperty('status', 'ok');
@@ -736,9 +749,9 @@ describe('Roles API Tests', () => {
             );
 
             if (systemRole) {
-                const scopeResp = await admin.post<Body<unknown>>(
-                    `${orgRolesApiUrl}/${testOrgUuid}/roles/${systemRole.roleUuid}/scopes`,
-                    { scopeNames: ['view:Dashboard'] },
+                const scopeResp = await admin.patch<Body<unknown>>(
+                    `${orgRolesApiUrl}/${testOrgUuid}/roles/${systemRole.roleUuid}`,
+                    { scopes: { add: ['view:Dashboard'], remove: [] } },
                     { failOnStatusCode: false },
                 );
 
@@ -758,8 +771,9 @@ describe('Roles API Tests', () => {
             );
 
             if (systemRole) {
-                const removeResp = await admin.delete(
-                    `${orgRolesApiUrl}/${testOrgUuid}/roles/${systemRole.roleUuid}/scopes/create:Space`,
+                const removeResp = await admin.patch<Body<unknown>>(
+                    `${orgRolesApiUrl}/${testOrgUuid}/roles/${systemRole.roleUuid}`,
+                    { scopes: { add: [], remove: ['create:Space'] } },
                     { failOnStatusCode: false },
                 );
 
@@ -782,16 +796,22 @@ describe('Roles API Tests', () => {
             rolesToCleanup.push(roleUuid);
 
             // Add scopes to role
-            const scopeResp = await admin.post<Body<unknown>>(
-                `${orgRolesApiUrl}/${testOrgUuid}/roles/${roleUuid}/scopes`,
-                { scopeNames: ['view_project', 'view_dashboard'] },
+            const scopeResp = await admin.patch<Body<unknown>>(
+                `${orgRolesApiUrl}/${testOrgUuid}/roles/${roleUuid}`,
+                {
+                    scopes: {
+                        add: ['view_project', 'view_dashboard'],
+                        remove: [],
+                    },
+                },
             );
             expect(scopeResp.status).toBe(200);
             expect(scopeResp.body).toHaveProperty('status', 'ok');
 
             // Remove a scope from role
-            const removeResp = await admin.delete(
-                `${orgRolesApiUrl}/${testOrgUuid}/roles/${roleUuid}/scopes/view_project`,
+            const removeResp = await admin.patch<Body<unknown>>(
+                `${orgRolesApiUrl}/${testOrgUuid}/roles/${roleUuid}`,
+                { scopes: { add: [], remove: ['view_project'] } },
             );
             expect(removeResp.status).toBe(200);
             expect(removeResp.body).toHaveProperty('status', 'ok');

--- a/packages/api-tests/tests/scheduler.test.ts
+++ b/packages/api-tests/tests/scheduler.test.ts
@@ -14,7 +14,6 @@ import {
     type Dashboard,
     type DashboardScheduler,
     type SavedChart,
-    type ScheduledJobs,
     type SchedulerAndTargets,
     type SchedulerSlackTarget,
     type UpdateSchedulerAndTargetsWithoutId,
@@ -173,15 +172,6 @@ describe('Lightdash scheduler endpoints', () => {
         );
         expect(schedulerIds).toContain(schedulerUuid);
 
-        // Get created jobs
-        const jobsResp = await admin.get<{ results: ScheduledJobs[] }>(
-            `${apiUrl}/schedulers/${schedulerUuid}/jobs`,
-        );
-        expect(jobsResp.body.results).toHaveLength(1);
-        expect(`${jobsResp.body.results[0].date}`.split('T')[1]).toBe(
-            '23:59:00.000Z',
-        );
-
         // Update
         const updateResponse = await admin.patch<{
             results: SchedulerAndTargets;
@@ -210,12 +200,12 @@ describe('Lightdash scheduler endpoints', () => {
         );
         expect(deleteResponse.status).toBe(200);
 
-        // Jobs are deleted
-        const deletedJobsResp = await admin.get(
-            `${apiUrl}/schedulers/${schedulerUuid}/jobs`,
+        // Scheduler is deleted
+        const deletedSchedulerResp = await admin.get(
+            `${apiUrl}/schedulers/${schedulerUuid}`,
             { failOnStatusCode: false },
         );
-        expect(deletedJobsResp.status).toBe(404);
+        expect(deletedSchedulerResp.status).toBe(404);
     });
 
     it('Should create/update/delete dashboard scheduler', async () => {
@@ -239,15 +229,6 @@ describe('Lightdash scheduler endpoints', () => {
         expect(createResponse.body.results.targets).toHaveLength(2);
 
         const { schedulerUuid, targets } = createResponse.body.results;
-
-        // Get created jobs
-        const jobsResp = await admin.get<{ results: ScheduledJobs[] }>(
-            `${apiUrl}/schedulers/${schedulerUuid}/jobs`,
-        );
-        expect(jobsResp.body.results).toHaveLength(1);
-        expect(`${jobsResp.body.results[0].date}`.split('T')[1]).toBe(
-            '23:59:00.000Z',
-        );
 
         // Get all dashboard schedulers
         const dashSchedulersResp = await admin.get<{
@@ -288,12 +269,12 @@ describe('Lightdash scheduler endpoints', () => {
         );
         expect(deleteResponse.status).toBe(200);
 
-        // Jobs are deleted
-        const deletedJobsResp = await admin.get(
-            `${apiUrl}/schedulers/${schedulerUuid}/jobs`,
+        // Scheduler is deleted
+        const deletedSchedulerResp = await admin.get(
+            `${apiUrl}/schedulers/${schedulerUuid}`,
             { failOnStatusCode: false },
         );
-        expect(deletedJobsResp.status).toBe(404);
+        expect(deletedSchedulerResp.status).toBe(404);
     });
 
     it('Should search schedulers by full name substring instead of loose token matches', async () => {

--- a/packages/api-tests/tests/sqlRunner.test.ts
+++ b/packages/api-tests/tests/sqlRunner.test.ts
@@ -8,7 +8,6 @@ import {
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ApiClient, SITE_URL } from '../helpers/api-client';
 import { login } from '../helpers/auth';
-import { waitForJobCompletion } from '../helpers/polling';
 import {
     bigqueryWarehouseConfig,
     createProject,
@@ -17,29 +16,39 @@ import {
 } from '../helpers/projects';
 
 const apiUrl = '/api/v1';
+const apiV2Url = '/api/v2';
 
 /**
- * Poll a job status until completed or error.
+ * Poll an async query until it is ready, then return the streamed JSONL rows.
  */
-async function pollJobStatus(
+async function getAsyncSqlQueryRows(
     client: ApiClient,
-    jobId: string,
-    maxRetries = 20,
-    interval = 500,
-): Promise<any> {
+    projectUuid: string,
+    queryUuid: string,
+    maxRetries = 60,
+    interval = 1000,
+): Promise<any[]> {
     for (let i = 0; i < maxRetries; i++) {
-        await new Promise((r) => setTimeout(r, interval));
         const resp = await client.get<any>(
-            `${apiUrl}/schedulers/job/${jobId}/status`,
+            `${apiV2Url}/projects/${projectUuid}/query/${queryUuid}`,
         );
         expect(resp.status).toBe(200);
         const { status } = resp.body.results;
-        if (status === 'completed' || status === 'error') {
-            return resp.body.results;
+        if (status === 'error') {
+            throw new Error(`Query failed: ${resp.body.results.error}`);
         }
+        if (status === 'ready') {
+            const fileResp = await client.get<any>(
+                `${apiV2Url}/projects/${projectUuid}/query/${queryUuid}/results`,
+            );
+            expect(fileResp.status).toBe(200);
+            const lines = (fileResp.body as string).trim().split('\n');
+            return lines.map((line: string) => JSON.parse(line));
+        }
+        await new Promise((r) => setTimeout(r, interval));
     }
     throw new Error(
-        `Reached max retries (${maxRetries}) without job completion`,
+        `Reached max retries (${maxRetries}) without query completion`,
     );
 }
 
@@ -48,9 +57,9 @@ const postgresConfig = {
     host: process.env.PGHOST || 'db-dev',
     user: process.env.PGUSER || 'postgres',
     password: process.env.PGPASSWORD || 'password',
-    dbname: 'postgres',
+    dbname: process.env.PGDATABASE || 'postgres',
     schema: 'jaffle',
-    port: 5432,
+    port: Number(process.env.PGPORT) || 5432,
     sslmode: 'disable',
     type: WarehouseTypes.POSTGRES,
 };
@@ -220,21 +229,17 @@ for (const [warehouseName, warehouseConfig] of warehouseEntries) {
                          ORDER BY payment_id asc LIMIT 2`;
 
             const runResp = await admin.post<any>(
-                `${apiUrl}/projects/${projectUuid}/sqlRunner/run`,
+                `${apiV2Url}/projects/${projectUuid}/query/sql`,
                 { sql },
             );
             expect(runResp.status).toBe(200);
-            const { jobId } = runResp.body.results;
+            const { queryUuid } = runResp.body.results;
 
-            const jobResult = await pollJobStatus(admin, jobId, 20, 500);
-            expect(jobResult.status).toBe('completed');
-
-            const { fileUrl } = jobResult.details;
-            const fileResp = await admin.get<any>(fileUrl);
-            expect(fileResp.status).toBe(200);
-
-            const lines = (fileResp.body as string).trim().split('\n');
-            const results = lines.map((line: string) => JSON.parse(line));
+            const results = await getAsyncSqlQueryRows(
+                admin,
+                projectUuid,
+                queryUuid,
+            );
 
             expect(results).toHaveLength(2);
             expect(results[0].payment_id).toBe(1);
@@ -253,27 +258,27 @@ for (const [warehouseName, warehouseConfig] of warehouseEntries) {
                     : `SELECT * FROM ${database}.${schema}.orders`;
             const pivotQueryPayload = {
                 sql,
-                indexColumn: { reference: 'status', type: 'category' },
-                valuesColumns: [{ reference: 'order_id', aggregation: 'sum' }],
+                pivotConfiguration: {
+                    indexColumn: { reference: 'status', type: 'category' },
+                    valuesColumns: [
+                        { reference: 'order_id', aggregation: 'sum' },
+                    ],
+                },
                 limit: 500,
             };
 
             const runResp = await admin.post<any>(
-                `${apiUrl}/projects/${projectUuid}/sqlRunner/runPivotQuery`,
+                `${apiV2Url}/projects/${projectUuid}/query/sql`,
                 pivotQueryPayload,
             );
             expect(runResp.status).toBe(200);
-            const { jobId } = runResp.body.results;
+            const { queryUuid } = runResp.body.results;
 
-            const jobResult = await pollJobStatus(admin, jobId, 50, 1000);
-            expect(jobResult.status).toBe('completed');
-
-            const { fileUrl } = jobResult.details;
-            const fileResp = await admin.get<any>(fileUrl);
-            expect(fileResp.status).toBe(200);
-
-            const lines = (fileResp.body as string).trim().split('\n');
-            const results = lines.map((line: string) => JSON.parse(line));
+            const results = await getAsyncSqlQueryRows(
+                admin,
+                projectUuid,
+                queryUuid,
+            );
 
             expect(results.length).toBeGreaterThan(0);
             expect(results[0]).toHaveProperty('status');

--- a/packages/backend/src/controllers/groupsController.ts
+++ b/packages/backend/src/controllers/groupsController.ts
@@ -12,6 +12,7 @@ import {
 import {
     Body,
     Delete,
+    Deprecated,
     Get,
     Middlewares,
     OperationId,
@@ -106,14 +107,21 @@ export class GroupsController extends BaseController {
      * @summary Add user to group
      * @param groupUuid the UUID for the group to add the user to
      * @param userUuid the UUID for the user to add to the group
+     *
+     * @deprecated Use PATCH /api/v1/groups/{groupUuid} with the full member set instead
      */
     @Middlewares([
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use PATCH /api/v1/groups/{groupUuid} with the full member set instead.',
+        }),
     ])
     @Put('{groupUuid}/members/{userUuid}')
     @OperationId('addUserToGroup')
+    @Deprecated()
     async addUserToGroup(
         @Path() groupUuid: string,
         @Path() userUuid: string,
@@ -138,14 +146,21 @@ export class GroupsController extends BaseController {
      * @summary Remove user from group
      * @param groupUuid the UUID for the group to remove the user from
      * @param userUuid the UUID for the user to remove from the group
+     *
+     * @deprecated Use PATCH /api/v1/groups/{groupUuid} with the full member set instead
      */
     @Middlewares([
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use PATCH /api/v1/groups/{groupUuid} with the full member set instead.',
+        }),
     ])
     @Delete('{groupUuid}/members/{userUuid}')
     @OperationId('removeUserFromGroup')
+    @Deprecated()
     async removeUserFromGroup(
         @Path() groupUuid: string,
         @Path() userUuid: string,
@@ -169,10 +184,20 @@ export class GroupsController extends BaseController {
      * View members of a group
      * @summary Get group members
      * @param groupUuid the UUID for the group to view the members of
+     *
+     * @deprecated Use GET /api/v1/groups/{groupUuid}?includeMembers=N instead
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use GET /api/v1/groups/{groupUuid}?includeMembers=N instead.',
+        }),
+    ])
     @Get('{groupUuid}/members')
     @OperationId('getGroupMembers')
+    @Deprecated()
     async getGroupMembers(
         @Path() groupUuid: string,
         @Request() req: express.Request,

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -277,10 +277,20 @@ export class OrganizationController extends BaseController {
      * @summary Get organization member by email
      * @param req express request
      * @param email the email of the user
+     *
+     * @deprecated Use the GET /api/v1/org/users list endpoint instead
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use the GET /api/v1/org/users list endpoint instead.',
+        }),
+    ])
     @Get('/users/email/{email}')
     @OperationId('GetOrganizationMemberByEmail')
+    @Deprecated()
     async getOrganizationMemberByEmail(
         @Request() req: express.Request,
         @Path() email: string,

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -228,15 +228,21 @@ export class ProjectController extends BaseController {
      * There may be users that have access to the project via their organization membership.
      * @summary Get project member access
      *
-     * NOTE:
-     * We don't use the API on the frontend. Instead, we can call the API
-     * so that we make sure of the user's access to the project.
+     * @deprecated Use GET /api/v2/projects/{projectId}/roles/assignments instead
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use GET /api/v2/projects/{projectId}/roles/assignments instead.',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Get('{projectUuid}/user/{userUuid}')
     @OperationId('GetProjectMemberAccess')
     @Tags('Roles & Permissions')
+    @Deprecated()
     async getProjectMember(
         @Path() projectUuid: string,
         @Path() userUuid: string,

--- a/packages/backend/src/controllers/schedulerController.ts
+++ b/packages/backend/src/controllers/schedulerController.ts
@@ -19,6 +19,7 @@ import {
 import {
     Body,
     Delete,
+    Deprecated,
     Get,
     Middlewares,
     OperationId,
@@ -41,6 +42,7 @@ import {
 } from '../utils/inputValidation';
 import {
     allowApiKeyAuthentication,
+    getDeprecatedRouteMiddleware,
     isAuthenticated,
     unauthorisedInDemo,
 } from './authentication';
@@ -62,11 +64,21 @@ export class SchedulerController extends BaseController {
      * @param statuses filter by log statuses (comma-separated)
      * @param createdByUserUuids filter by creator user UUIDs (comma-separated)
      * @param destinations filter by destination types (comma-separated: email, slack, msteams, googlechat)
+     *
+     * @deprecated Use GET /api/v1/schedulers/{projectUuid}/runs instead
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use GET /api/v1/schedulers/{projectUuid}/runs instead.',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Get('/{projectUuid}/logs')
     @OperationId('getSchedulerLogs')
+    @Deprecated()
     async getLogs(
         @Path() projectUuid: string,
         @Request() req: express.Request,
@@ -539,11 +551,21 @@ export class SchedulerController extends BaseController {
      * @summary Get scheduled jobs
      * @param schedulerUuid The uuid of the scheduler to update
      * @param req express request
+     *
+     * @deprecated This endpoint will be removed; there is no replacement
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'This endpoint will be removed; there is no replacement.',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Get('{schedulerUuid}/jobs')
     @OperationId('getScheduledJobs')
+    @Deprecated()
     async getJobs(
         @Path() schedulerUuid: string,
         @Request() req: express.Request,

--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -119,15 +119,22 @@ export class SqlRunnerController extends BaseController {
     /**
      * Run a SQL query
      * @summary Run SQL query
+     *
+     * @deprecated Use POST /api/v2/projects/{projectUuid}/query/sql instead
      */
     @Middlewares([
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use POST /api/v2/projects/{projectUuid}/query/sql instead.',
+        }),
     ])
     @SuccessResponse('200', 'Success')
     @Post('/run')
     @OperationId('runSql')
+    @Deprecated()
     async runSql(
         @Path() projectUuid: string,
         @Body() body: SqlRunnerBody,
@@ -152,15 +159,22 @@ export class SqlRunnerController extends BaseController {
     /**
      * Run a SQL pivot query
      * @summary Run SQL pivot query
+     *
+     * @deprecated Use POST /api/v2/projects/{projectUuid}/query/sql with pivotConfiguration instead
      */
     @Middlewares([
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use POST /api/v2/projects/{projectUuid}/query/sql with pivotConfiguration instead.',
+        }),
     ])
     @SuccessResponse('200', 'Success')
     @Post('/runPivotQuery')
     @OperationId('runSqlPivotQuery')
+    @Deprecated()
     async runSqlPivotQuery(
         @Path() projectUuid: string,
         @Body() body: SqlRunnerPivotQueryBody,

--- a/packages/backend/src/ee/controllers/CustomRolesController.ts
+++ b/packages/backend/src/ee/controllers/CustomRolesController.ts
@@ -11,6 +11,7 @@ import {
 import {
     Body,
     Delete,
+    Deprecated,
     Get,
     Middlewares,
     OperationId,
@@ -26,6 +27,7 @@ import {
 import express from 'express';
 import {
     allowApiKeyAuthentication,
+    getDeprecatedRouteMiddleware,
     isAuthenticated,
     unauthorisedInDemo,
 } from '../../controllers/authentication';
@@ -174,15 +176,22 @@ export class CustomRolesController extends BaseController {
     /**
      * Add scopes to role
      * @summary Add scopes to role
+     *
+     * @deprecated Use PATCH /api/v2/orgs/{orgUuid}/roles/{roleUuid} with scopes.add instead
      */
     @Middlewares([
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use PATCH /api/v2/orgs/{orgUuid}/roles/{roleUuid} with scopes.add instead.',
+        }),
     ])
     @SuccessResponse('200', 'Success')
     @Post('/{roleUuid}/scopes')
     @OperationId('AddScopesToRole')
+    @Deprecated()
     async addScopesToRole(
         @Request() req: express.Request,
         @Path() orgUuid: string,
@@ -205,15 +214,22 @@ export class CustomRolesController extends BaseController {
     /**
      * Remove scope from role
      * @summary Remove scope from role
+     *
+     * @deprecated Use PATCH /api/v2/orgs/{orgUuid}/roles/{roleUuid} with scopes.remove instead
      */
     @Middlewares([
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use PATCH /api/v2/orgs/{orgUuid}/roles/{roleUuid} with scopes.remove instead.',
+        }),
     ])
     @SuccessResponse('200', 'Success')
     @Delete('/{roleUuid}/scopes/{scopeName}')
     @OperationId('RemoveScopeFromRole')
+    @Deprecated()
     async removeScopeFromRole(
         @Request() req: express.Request,
         @Path() orgUuid: string,

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -155,11 +155,24 @@ export class EmbedController extends BaseController {
         };
     }
 
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    /**
+     * Update the dashboards allowed in the project embed config
+     * @summary Update embedded dashboards
+     *
+     * @deprecated Use PATCH /api/v1/embed/{projectUuid}/config instead
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        getDeprecatedRouteMiddleware(new Date('2026-06-10'), {
+            suffixMessage:
+                'Use PATCH /api/v1/embed/{projectUuid}/config instead.',
+        }),
+    ])
     @SuccessResponse('200', 'Success')
     @Patch('/config/dashboards')
     @OperationId('updateEmbeddedDashboards')
-    @Deprecated() // Use /config endpoint below instead
+    @Deprecated()
     async updateEmbeddedDashboards(
         @Request() req: express.Request,
         @Path() projectUuid: string,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12432,11 +12432,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -12494,11 +12494,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -12554,11 +12554,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -26209,12 +26209,42 @@ const models: TsoaRoute.Models = {
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PullRequestReviewContext: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                sourceAgentUuid: { dataType: 'string', required: true },
+                sourceProjectUuid: { dataType: 'string', required: true },
+                sourceThreadUuid: { dataType: 'string', required: true },
+                sourceFindingUuid: { dataType: 'string', required: true },
+                primaryRootCause: { ref: 'AiAgentRootCause', required: true },
+                reviewStatus: {
+                    ref: 'AiAgentReviewItemStatus',
+                    required: true,
+                },
+                reviewTitle: { dataType: 'string', required: true },
+                reviewItemFingerprint: { dataType: 'string', required: true },
+                reviewItemUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PullRequest: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 createdAt: { dataType: 'datetime', required: true },
+                reviewContext: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'PullRequestReviewContext' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 aiAgentUuid: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13995,8 +13995,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14054,8 +14054,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -26872,11 +26872,63 @@
                 ],
                 "type": "string"
             },
+            "PullRequestReviewContext": {
+                "properties": {
+                    "sourceAgentUuid": {
+                        "type": "string"
+                    },
+                    "sourceProjectUuid": {
+                        "type": "string"
+                    },
+                    "sourceThreadUuid": {
+                        "type": "string"
+                    },
+                    "sourceFindingUuid": {
+                        "type": "string"
+                    },
+                    "primaryRootCause": {
+                        "$ref": "#/components/schemas/AiAgentRootCause"
+                    },
+                    "reviewStatus": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemStatus"
+                    },
+                    "reviewTitle": {
+                        "type": "string"
+                    },
+                    "reviewItemFingerprint": {
+                        "type": "string"
+                    },
+                    "reviewItemUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "sourceAgentUuid",
+                    "sourceProjectUuid",
+                    "sourceThreadUuid",
+                    "sourceFindingUuid",
+                    "primaryRootCause",
+                    "reviewStatus",
+                    "reviewTitle",
+                    "reviewItemFingerprint",
+                    "reviewItemUuid"
+                ],
+                "type": "object"
+            },
             "PullRequest": {
                 "properties": {
                     "createdAt": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "reviewContext": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PullRequestReviewContext"
+                            }
+                        ],
+                        "nullable": true,
+                        "description": "Source review context for AI review remediation PRs. Present when the PR\nwas opened to address a review finding."
                     },
                     "aiAgentUuid": {
                         "type": "string",
@@ -26923,6 +26975,7 @@
                 },
                 "required": [
                     "createdAt",
+                    "reviewContext",
                     "aiAgentUuid",
                     "aiThreadUuid",
                     "prUrl",
@@ -38547,7 +38600,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3129.1",
+        "version": "0.3135.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -45003,6 +45056,7 @@
                 "description": "Add scopes to role",
                 "summary": "Add scopes to role",
                 "tags": ["v2", "Custom Roles"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -45062,6 +45116,7 @@
                 "description": "Remove scope from role",
                 "summary": "Remove scope from role",
                 "tags": ["v2", "Custom Roles"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -47101,6 +47156,7 @@
                 "description": "Run a SQL query",
                 "summary": "Run SQL query",
                 "tags": ["SQL runner"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -47152,6 +47208,7 @@
                 "description": "Run a SQL pivot query",
                 "summary": "Run SQL pivot query",
                 "tags": ["SQL runner"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -49267,6 +49324,7 @@
                 "description": "Get scheduled logs",
                 "summary": "Get scheduler logs",
                 "tags": ["Schedulers"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -50082,6 +50140,7 @@
                 "description": "Get scheduled jobs",
                 "summary": "Get scheduled jobs",
                 "tags": ["Schedulers"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -51724,8 +51783,9 @@
                     }
                 },
                 "description": "Get a project explicit member's access.\nThere may be users that have access to the project via their organization membership.",
-                "summary": "Get project member access\n\nNOTE:\nWe don't use the API on the frontend. Instead, we can call the API\nso that we make sure of the user's access to the project.",
+                "summary": "Get project member access",
                 "tags": ["Roles & Permissions", "Projects"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -55306,6 +55366,7 @@
                 "description": "Get the member profile for a user in the current user's organization by email",
                 "summary": "Get organization member by email",
                 "tags": ["Organizations"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -56492,6 +56553,7 @@
                 "description": "Add a Lightdash user to a group",
                 "summary": "Add user to group",
                 "tags": ["User Groups"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -56541,6 +56603,7 @@
                 "description": "Remove a user from a group",
                 "summary": "Remove user from group",
                 "tags": ["User Groups"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -56592,6 +56655,7 @@
                 "description": "View members of a group",
                 "summary": "Get group members",
                 "tags": ["User Groups"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {

--- a/packages/e2e/cypress/e2e/app/embed.cy.ts
+++ b/packages/e2e/cypress/e2e/app/embed.cy.ts
@@ -8,7 +8,7 @@ const EMBED_API_PREFIX = `/api/v1/embed/${SEED_PROJECT.project_uuid}`;
 
 const updateEmbedConfigDashboards = (dashboardUuids: string[]) =>
     cy.request({
-        url: `${EMBED_API_PREFIX}/config/dashboards`,
+        url: `${EMBED_API_PREFIX}/config`,
         headers: { 'Content-type': 'application/json' },
         method: 'PATCH',
         body: {

--- a/packages/e2e/cypress/e2e/app/sqlRunner.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlRunner.cy.ts
@@ -307,7 +307,7 @@ describe('SQL Runner (new)', () => {
             .should('be.visible');
 
         // Intercept the API call we don't expect to happen
-        cy.intercept('POST', '**/api/v1/projects/*/sqlRunner/runPivotQuery').as(
+        cy.intercept('POST', '**/api/v2/projects/*/query/sql').as(
             'runPivotQuery',
         );
 


### PR DESCRIPTION
Closes: SPK-487

### Description:

Deprecates the 12 Group C endpoints whose only callers were api-tests/e2e, wiring `@Deprecated()`, the `@deprecated` JSDoc, and `getDeprecatedRouteMiddleware` (deprecated 2026-06-10, default sunset +3 months) onto group members add/remove/get, org user by email, project member access, scheduler logs and scheduled jobs, SQL runner run/runPivotQuery, embed config/dashboards, and v2 role scope add/remove. The affected tests were migrated to the replacement endpoints first (PATCH group with members, v2 roles assignments, `/schedulers/{projectUuid}/runs`, v2 async `POST /query/sql` with `pivotConfiguration`, unified `PATCH /embed/{projectUuid}/config`, and role PATCH with `scopes.add`/`scopes.remove`) or removed where no equivalent exists, so no first-party caller triggers the deprecation logging/Sentry alerts. `pnpm generate-api` regenerated swagger with `deprecated: true` on all touched operationIds, and the migrated api-test suites were run green against a local stack with the deprecation headers verified by hand. Also updates the `deprecate-endpoint` skill example to show the `@deprecated` JSDoc placement alongside the decorator and middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)