### PR TITLE
fix(ai-review): stop false "Writeback timed out" on non-UTC servers

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -7,7 +7,10 @@ import {
     AiAgentReviewRemediationTableName,
     AiAgentTurnSignalTableName,
 } from '../database/entities/aiAgentReviewClassifier';
-import { AiAgentReviewClassifierModel } from './AiAgentReviewClassifierModel';
+import {
+    AiAgentReviewClassifierModel,
+    WRITEBACK_STALE_MS,
+} from './AiAgentReviewClassifierModel';
 
 const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
 const PROJECT_UUID = '00000000-0000-0000-0000-000000000002';
@@ -148,6 +151,7 @@ const makeRemediationRow = (
     resolved_at: null,
     created_at: SEEN_AT,
     updated_at: SEEN_AT,
+    updated_at_age_ms: 0,
     ...overrides,
 });
 
@@ -393,6 +397,7 @@ describe('AiAgentReviewClassifierModel', () => {
                     status_updated_by_user_uuid: null,
                     created_at: SEEN_AT,
                     updated_at: SEEN_AT,
+                    updated_at_age_ms: 0,
                 },
             ]);
             tracker.on
@@ -458,6 +463,229 @@ describe('AiAgentReviewClassifierModel', () => {
             });
 
             expect(result).toHaveLength(0);
+        });
+
+        const makeReviewItemRow = (
+            overrides: Partial<Record<string, unknown>> = {},
+        ) => ({
+            ai_agent_review_item_uuid: '00000000-0000-0000-0000-000000000099',
+            fingerprint: FINGERPRINT,
+            organization_uuid: ORGANIZATION_UUID,
+            project_uuid: PROJECT_UUID,
+            agent_uuid: AGENT_UUID,
+            status: 'open',
+            dismissed_reason: null,
+            assigned_to_user_uuid: null,
+            linked_issue_url: null,
+            linked_pr_url: null,
+            pr_writeback_thread_uuid: null,
+            pr_state: null,
+            pr_writeback_status: 'running',
+            pr_writeback_message: 'Compiling project',
+            status_updated_at: SEEN_AT,
+            created_at: SEEN_AT,
+            updated_at: SEEN_AT,
+            updated_at_age_ms: 2 * 60 * 1000,
+            ...overrides,
+        });
+
+        const stubListQueries = (
+            itemRows: Record<string, unknown>[],
+            remediationRows: Record<string, unknown>[],
+        ) => {
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
+                {
+                    fingerprint: FINGERPRINT,
+                    first_seen_at: SEEN_AT,
+                    last_seen_at: SEEN_AT,
+                    finding_count: '1',
+                },
+            ]);
+            tracker.on
+                .select(AiAgentTurnSignalTableName)
+                .responseOnce([makeTurnSignalRow()]);
+            tracker.on
+                .select(AiAgentReviewItemTableName)
+                .responseOnce(itemRows);
+            tracker.on
+                .select(AiAgentReviewRemediationTableName)
+                .responseOnce(remediationRows);
+        };
+
+        it('keeps a fresh running writeback as running', async () => {
+            stubListQueries([makeReviewItemRow()], []);
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result[0]).toEqual(
+                expect.objectContaining({
+                    prWritebackStatus: 'running',
+                    prWritebackMessage: 'Compiling project',
+                }),
+            );
+        });
+
+        it('keeps a running writeback at exactly the stale threshold as running', async () => {
+            stubListQueries(
+                [makeReviewItemRow({ updated_at_age_ms: WRITEBACK_STALE_MS })],
+                [],
+            );
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result[0]).toEqual(
+                expect.objectContaining({
+                    prWritebackStatus: 'running',
+                    prWritebackMessage: 'Compiling project',
+                }),
+            );
+        });
+
+        it('presents a stale running writeback as timed out using the SQL-computed age', async () => {
+            stubListQueries(
+                [
+                    makeReviewItemRow({
+                        updated_at_age_ms: WRITEBACK_STALE_MS + 1,
+                    }),
+                ],
+                [],
+            );
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result[0]).toEqual(
+                expect.objectContaining({
+                    prWritebackStatus: 'failed',
+                    prWritebackMessage: 'Writeback timed out',
+                }),
+            );
+        });
+
+        it('presents a stale queued writeback as timed out', async () => {
+            stubListQueries(
+                [
+                    makeReviewItemRow({
+                        pr_writeback_status: 'queued',
+                        pr_writeback_message: 'Queued',
+                        updated_at_age_ms: WRITEBACK_STALE_MS + 1,
+                    }),
+                ],
+                [],
+            );
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result[0]).toEqual(
+                expect.objectContaining({
+                    prWritebackStatus: 'failed',
+                    prWritebackMessage: 'Writeback timed out',
+                }),
+            );
+        });
+
+        it('presents a stale running remediation as failed', async () => {
+            stubListQueries(
+                [],
+                [
+                    makeRemediationRow({
+                        status: 'running',
+                        updated_at_age_ms: WRITEBACK_STALE_MS + 1,
+                    }),
+                ],
+            );
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result[0].remediation).toEqual(
+                expect.objectContaining({
+                    status: 'failed',
+                    errorMessage: 'Writeback timed out',
+                }),
+            );
+        });
+
+        it('never presents a stale pr_open remediation as failed', async () => {
+            stubListQueries(
+                [],
+                [
+                    makeRemediationRow({
+                        status: 'pr_open',
+                        updated_at_age_ms: WRITEBACK_STALE_MS + 1,
+                    }),
+                ],
+            );
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result[0].remediation).toEqual(
+                expect.objectContaining({
+                    status: 'pr_open',
+                    errorMessage: null,
+                }),
+            );
+        });
+
+        it('keeps a fresh running remediation as running', async () => {
+            stubListQueries(
+                [],
+                [
+                    makeRemediationRow({
+                        status: 'running',
+                        updated_at_age_ms: 2 * 60 * 1000,
+                    }),
+                ],
+            );
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result[0].remediation).toEqual(
+                expect.objectContaining({
+                    status: 'running',
+                    errorMessage: null,
+                }),
+            );
+        });
+    });
+
+    describe('failStaleReviewRemediation', () => {
+        it('fails the remediation in SQL only when active and past the stale threshold', async () => {
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce(0);
+
+            await model.failStaleReviewRemediation({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            const [update] = tracker.history.update;
+            expect(update.sql).toContain('make_interval');
+            expect(update.sql).toMatch(/"status" in \(\$\d+, \$\d+\)/);
+            expect(update.bindings).toEqual(
+                expect.arrayContaining([
+                    'failed',
+                    'Writeback timed out',
+                    'queued',
+                    'running',
+                    WRITEBACK_STALE_MS / 1000,
+                    REMEDIATION_UUID,
+                    ORGANIZATION_UUID,
+                ]),
+            );
         });
     });
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -67,7 +67,30 @@ type ReviewItemAggregateRow = {
 
 type ReviewRemediationRow = DbAiAgentReviewRemediation & {
     linked_pr_url: string | null;
+    updated_at_age_ms: number;
 };
+
+type ReviewItemRow = DbAiAgentReviewItem & {
+    updated_at_age_ms: number;
+};
+
+// Longer than the worker's 30-min job timeout — past this, a queued/running
+// writeback has lost its worker and is reported as failed so the UI recovers
+// and retries. Ages are computed in SQL (now() - updated_at) so the check is
+// immune to the driver parsing tz-less timestamps in the process's local
+// timezone and to app/DB clock drift.
+export const WRITEBACK_STALE_MS = 35 * 60 * 1000;
+
+const WRITEBACK_TIMED_OUT_MESSAGE = 'Writeback timed out';
+
+const isStaleWritebackStatus = (
+    status:
+        | AiAgentReviewItemWritebackStatus
+        | AiAgentReviewRemediationStatus
+        | null,
+    ageMs: number,
+): boolean =>
+    (status === 'queued' || status === 'running') && ageMs > WRITEBACK_STALE_MS;
 
 const defaultWritebackEligibility: AiAgentReviewItemWritebackEligibility = {
     eligible: false,
@@ -85,29 +108,32 @@ const ACTIVE_REMEDIATION_STATUSES: AiAgentReviewRemediationStatus[] = [
 
 const mapReviewRemediation = (
     row: ReviewRemediationRow,
-): AiAgentReviewRemediation => ({
-    uuid: row.ai_agent_review_remediation_uuid,
-    fingerprint: row.fingerprint,
-    organizationUuid: row.organization_uuid,
-    sourceFindingUuid: row.source_ai_agent_review_turn_signal_uuid,
-    sourcePromptUuid: row.source_prompt_uuid,
-    sourceThreadUuid: row.source_thread_uuid,
-    sourceProjectUuid: row.source_project_uuid,
-    sourceAgentUuid: row.source_agent_uuid,
-    pullRequestUuid: row.pull_request_uuid,
-    linkedPrUrl: row.linked_pr_url,
-    previewProjectUuid: row.preview_project_uuid,
-    previewAgentUuid: row.preview_agent_uuid,
-    previewThreadUuid: row.preview_thread_uuid,
-    status: row.status,
-    errorMessage: row.error_message,
-    retryPrompt: row.retry_prompt,
-    createdByUserUuid: row.created_by_user_uuid,
-    resolvedByUserUuid: row.resolved_by_user_uuid,
-    resolvedAt: row.resolved_at,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-});
+): AiAgentReviewRemediation => {
+    const stale = isStaleWritebackStatus(row.status, row.updated_at_age_ms);
+    return {
+        uuid: row.ai_agent_review_remediation_uuid,
+        fingerprint: row.fingerprint,
+        organizationUuid: row.organization_uuid,
+        sourceFindingUuid: row.source_ai_agent_review_turn_signal_uuid,
+        sourcePromptUuid: row.source_prompt_uuid,
+        sourceThreadUuid: row.source_thread_uuid,
+        sourceProjectUuid: row.source_project_uuid,
+        sourceAgentUuid: row.source_agent_uuid,
+        pullRequestUuid: row.pull_request_uuid,
+        linkedPrUrl: row.linked_pr_url,
+        previewProjectUuid: row.preview_project_uuid,
+        previewAgentUuid: row.preview_agent_uuid,
+        previewThreadUuid: row.preview_thread_uuid,
+        status: stale ? 'failed' : row.status,
+        errorMessage: stale ? WRITEBACK_TIMED_OUT_MESSAGE : row.error_message,
+        retryPrompt: row.retry_prompt,
+        createdByUserUuid: row.created_by_user_uuid,
+        resolvedByUserUuid: row.resolved_by_user_uuid,
+        resolvedAt: row.resolved_at,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    };
+};
 
 type CreateRunArgs = {
     organizationUuid: string;
@@ -1029,6 +1055,12 @@ export class AiAgentReviewClassifierModel {
                 const item = persisted.get(fingerprint) ?? null;
                 const remediation =
                     remediationByFingerprint.get(fingerprint) ?? null;
+                const writebackStale =
+                    item !== null &&
+                    isStaleWritebackStatus(
+                        item.pr_writeback_status,
+                        item.updated_at_age_ms,
+                    );
                 return {
                     uuid: fingerprint,
                     fingerprint,
@@ -1051,8 +1083,12 @@ export class AiAgentReviewClassifierModel {
                     linkedIssueUrl: item?.linked_issue_url ?? null,
                     linkedPrUrl: item?.linked_pr_url ?? null,
                     prState: item?.pr_state ?? null,
-                    prWritebackStatus: item?.pr_writeback_status ?? null,
-                    prWritebackMessage: item?.pr_writeback_message ?? null,
+                    prWritebackStatus: writebackStale
+                        ? 'failed'
+                        : (item?.pr_writeback_status ?? null),
+                    prWritebackMessage: writebackStale
+                        ? WRITEBACK_TIMED_OUT_MESSAGE
+                        : (item?.pr_writeback_message ?? null),
                     writebackEligible: false,
                     writebackEligibility: defaultWritebackEligibility,
                     remediation,
@@ -1085,13 +1121,20 @@ export class AiAgentReviewClassifierModel {
 
     async getReviewItemsByFingerprint(
         fingerprints: string[],
-    ): Promise<Map<string, DbAiAgentReviewItem>> {
+    ): Promise<Map<string, ReviewItemRow>> {
         if (fingerprints.length === 0) {
             return new Map();
         }
-        const items = await this.database<AiAgentReviewItemTable>(
+        const items = (await this.database<AiAgentReviewItemTable>(
             AiAgentReviewItemTableName,
-        ).whereIn('fingerprint', fingerprints);
+        )
+            .whereIn('fingerprint', fingerprints)
+            .select<ReviewItemRow[]>(
+                '*',
+                this.database.raw(
+                    '(extract(epoch from (now() - updated_at)) * 1000)::float8 as updated_at_age_ms',
+                ),
+            )) as ReviewItemRow[];
         return new Map(items.map((item) => [item.fingerprint, item]));
     }
 
@@ -1113,9 +1156,15 @@ export class AiAgentReviewClassifierModel {
             )
             .where('remediation.organization_uuid', args.organizationUuid)
             .whereIn('remediation.fingerprint', args.fingerprints)
-            .select<ReviewRemediationRow[]>('remediation.*', {
-                linked_pr_url: 'pull_request.pr_url',
-            })
+            .select<ReviewRemediationRow[]>(
+                'remediation.*',
+                {
+                    linked_pr_url: 'pull_request.pr_url',
+                },
+                this.database.raw(
+                    '(extract(epoch from (now() - remediation.updated_at)) * 1000)::float8 as updated_at_age_ms',
+                ),
+            )
             .orderBy('remediation.fingerprint')
             .orderByRaw(
                 `CASE WHEN remediation.status IN (${ACTIVE_REMEDIATION_STATUSES.map(
@@ -1154,9 +1203,15 @@ export class AiAgentReviewClassifierModel {
                 'remediation.ai_agent_review_remediation_uuid',
                 args.remediationUuid,
             )
-            .select<ReviewRemediationRow>('remediation.*', {
-                linked_pr_url: 'pull_request.pr_url',
-            })
+            .select<ReviewRemediationRow>(
+                'remediation.*',
+                {
+                    linked_pr_url: 'pull_request.pr_url',
+                },
+                this.database.raw(
+                    '(extract(epoch from (now() - remediation.updated_at)) * 1000)::float8 as updated_at_age_ms',
+                ),
+            )
             .first()) as ReviewRemediationRow | undefined;
 
         return row ? mapReviewRemediation(row) : null;
@@ -1181,7 +1236,11 @@ export class AiAgentReviewClassifierModel {
             })
             .returning('*');
 
-        return mapReviewRemediation({ ...row, linked_pr_url: null });
+        return mapReviewRemediation({
+            ...row,
+            linked_pr_url: null,
+            updated_at_age_ms: 0,
+        });
     }
 
     async updateReviewRemediationStatus(
@@ -1203,6 +1262,33 @@ export class AiAgentReviewClassifierModel {
                     args.status === 'resolved'
                         ? (this.database.fn.now() as never)
                         : null,
+                updated_at: this.database.fn.now() as never,
+            });
+    }
+
+    /**
+     * Persists a stale (queued/running past WRITEBACK_STALE_MS) remediation as
+     * failed so the one-active-per-fingerprint index allows a retry. The age
+     * check runs in SQL against the DB clock, so it agrees with the stale
+     * presentation in mapReviewRemediation. No-op when the remediation is
+     * still fresh or already terminal.
+     */
+    async failStaleReviewRemediation(args: {
+        remediationUuid: string;
+        organizationUuid: string;
+    }): Promise<void> {
+        await this.database<AiAgentReviewRemediationTable>(
+            AiAgentReviewRemediationTableName,
+        )
+            .where('ai_agent_review_remediation_uuid', args.remediationUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .whereIn('status', ['queued', 'running'])
+            .whereRaw('updated_at < now() - make_interval(secs => ?)', [
+                WRITEBACK_STALE_MS / 1000,
+            ])
+            .update({
+                status: 'failed',
+                error_message: WRITEBACK_TIMED_OUT_MESSAGE,
                 updated_at: this.database.fn.now() as never,
             });
     }

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -9,6 +9,7 @@ import {
     AiAgentReviewSignalSummary,
     AiAgentReviewWritebackJobPayload,
     AiAgentSummary,
+    AlreadyExistsError,
     DbtProjectType,
     extractPreviewProjectUuidFromUrl,
     extractPreviewUrlFromComments,
@@ -39,6 +40,7 @@ import {
     getPullRequestComments,
 } from '../../clients/github/Github';
 import { type LightdashConfig } from '../../config/parseConfig';
+import { isUniqueConstraintViolation } from '../../database/errors';
 import { type GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import { type GitlabAppInstallationsModel } from '../../models/GitlabAppInstallations/GitlabAppInstallationsModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -85,9 +87,6 @@ const parsePullRequestUrl = (
     }
     return { owner: match[1], repo: match[2], pullNumber: Number(match[3]) };
 };
-
-// Longer than the worker's 30-min job timeout — past this, a queued/running writeback has lost its worker and is treated as failed so the UI recovers and retries.
-const WRITEBACK_STALE_MS = 35 * 60 * 1000;
 
 type ProjectWritebackAccess =
     | {
@@ -253,56 +252,6 @@ export const getAiAgentReviewItemWritebackEligibility = (args: {
     };
 };
 
-const isWritebackStale = (
-    item: AiAgentReviewItemSummary,
-    now: number,
-): boolean =>
-    (item.prWritebackStatus === 'queued' ||
-        item.prWritebackStatus === 'running') &&
-    now - new Date(item.updatedAt).getTime() > WRITEBACK_STALE_MS;
-
-// queued/running are worker-bound states; jobs run with maxAttempts: 1, so a
-// crashed worker would otherwise leave the remediation active forever and the
-// eligibility gate (plus the one-active-per-fingerprint index) would block any
-// retry. pr_open/preview_ready are deliberately excluded — a PR can stay open
-// for a long time legitimately.
-const isRemediationStale = (
-    remediation: NonNullable<AiAgentReviewItemSummary['remediation']>,
-    now: number,
-): boolean =>
-    (remediation.status === 'queued' || remediation.status === 'running') &&
-    now - new Date(remediation.updatedAt).getTime() > WRITEBACK_STALE_MS;
-
-const withStaleWritebackOverride = (
-    item: AiAgentReviewItemSummary,
-    now: number,
-): AiAgentReviewItemSummary => {
-    const writebackStale = isWritebackStale(item, now);
-    const remediationStale =
-        item.remediation !== null && isRemediationStale(item.remediation, now);
-    if (!writebackStale && !remediationStale) {
-        return item;
-    }
-    return {
-        ...item,
-        ...(writebackStale
-            ? {
-                  prWritebackStatus: 'failed',
-                  prWritebackMessage: 'Writeback timed out',
-              }
-            : {}),
-        ...(remediationStale && item.remediation
-            ? {
-                  remediation: {
-                      ...item.remediation,
-                      status: 'failed',
-                      errorMessage: 'Writeback timed out',
-                  },
-              }
-            : {}),
-    };
-};
-
 export class AiAgentAdminService extends BaseService {
     private readonly analytics: LightdashAnalytics;
 
@@ -446,21 +395,17 @@ export class AiAgentAdminService extends BaseService {
                 .filter((uuid): uuid is string => uuid !== null),
         );
 
-        const now = Date.now();
         const reconciled = items.map((item) => {
             const override = overrides.get(item.fingerprint);
-            const staleAwareItem = withStaleWritebackOverride(
-                { ...item, ...(override ?? {}) },
-                now,
-            );
+            const reconciledItem = { ...item, ...(override ?? {}) };
             const writebackEligibility =
                 getAiAgentReviewItemWritebackEligibility({
-                    item: staleAwareItem,
+                    item: reconciledItem,
                     reviewsEnabled,
                     projectContextEnabled,
-                    projectAccess: staleAwareItem.projectUuid
+                    projectAccess: reconciledItem.projectUuid
                         ? (projectAccessByUuid.get(
-                              staleAwareItem.projectUuid,
+                              reconciledItem.projectUuid,
                           ) ?? null)
                         : null,
                     hasSemanticWritebackConfig:
@@ -468,7 +413,7 @@ export class AiAgentAdminService extends BaseService {
                 });
 
             return {
-                ...staleAwareItem,
+                ...reconciledItem,
                 writebackEligible: writebackEligibility.eligible,
                 writebackEligibility,
             };
@@ -916,20 +861,16 @@ export class AiAgentAdminService extends BaseService {
                 ? this.isProjectContextFeatureEnabled(user)
                 : false,
         ]);
-        const staleAwareItem = withStaleWritebackOverride(
-            reviewItem,
-            Date.now(),
-        );
         const projectAccessByUuid = await this.getProjectWritebackAccessByUuid(
             organizationUuid,
-            staleAwareItem.projectUuid ? [staleAwareItem.projectUuid] : [],
+            reviewItem.projectUuid ? [reviewItem.projectUuid] : [],
         );
         const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
-            item: staleAwareItem,
+            item: reviewItem,
             reviewsEnabled,
             projectContextEnabled,
-            projectAccess: staleAwareItem.projectUuid
-                ? (projectAccessByUuid.get(staleAwareItem.projectUuid) ?? null)
+            projectAccess: reviewItem.projectUuid
+                ? (projectAccessByUuid.get(reviewItem.projectUuid) ?? null)
                 : null,
             hasSemanticWritebackConfig: this.hasSemanticWritebackConfig(),
         });
@@ -946,21 +887,15 @@ export class AiAgentAdminService extends BaseService {
             throw new NotFoundError('Review item not found');
         }
 
-        // The stale override above only relaxes the eligibility check; the
-        // partial unique index still sees the old remediation as active, so it
-        // must be persisted as failed before a new one can be inserted.
-        if (
-            reviewItem.remediation &&
-            isRemediationStale(reviewItem.remediation, Date.now())
-        ) {
-            await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
-                {
-                    remediationUuid: reviewItem.remediation.uuid,
-                    organizationUuid,
-                    status: 'failed',
-                    errorMessage: 'Writeback timed out',
-                },
-            );
+        // The model presents a stale remediation as failed, which relaxes the
+        // eligibility check above — but the partial unique index still sees
+        // the row as active, so it must be persisted as failed (the model
+        // re-checks staleness in SQL) before a new one can be inserted.
+        if (reviewItem.remediation) {
+            await this.aiAgentReviewClassifierModel.failStaleReviewRemediation({
+                remediationUuid: reviewItem.remediation.uuid,
+                organizationUuid,
+            });
         }
 
         const retryPrompt =
@@ -968,18 +903,33 @@ export class AiAgentAdminService extends BaseService {
                 organizationUuid,
                 promptUuid: finding.promptUuid,
             });
-        const remediation =
-            await this.aiAgentReviewClassifierModel.createReviewRemediation({
-                fingerprint,
-                organizationUuid,
-                sourceFindingUuid: finding.uuid,
-                sourcePromptUuid: finding.promptUuid,
-                sourceThreadUuid: finding.threadUuid,
-                sourceProjectUuid: finding.projectUuid,
-                sourceAgentUuid: finding.agentUuid,
-                retryPrompt,
-                createdByUserUuid: user.userUuid,
-            });
+        // The one-active-per-fingerprint index can still reject the insert in
+        // a race (concurrent retry, or a worker reviving the row between the
+        // read and the stale update) — surface that as a conflict, not a 500.
+        let remediation: AiAgentReviewRemediation;
+        try {
+            remediation =
+                await this.aiAgentReviewClassifierModel.createReviewRemediation(
+                    {
+                        fingerprint,
+                        organizationUuid,
+                        sourceFindingUuid: finding.uuid,
+                        sourcePromptUuid: finding.promptUuid,
+                        sourceThreadUuid: finding.threadUuid,
+                        sourceProjectUuid: finding.projectUuid,
+                        sourceAgentUuid: finding.agentUuid,
+                        retryPrompt,
+                        createdByUserUuid: user.userUuid,
+                    },
+                );
+        } catch (error) {
+            if (isUniqueConstraintViolation(error)) {
+                throw new AlreadyExistsError(
+                    'A writeback for this review item is already in progress',
+                );
+            }
+            throw error;
+        }
 
         await this.aiAgentReviewClassifierModel.setReviewItemWritebackStatus({
             fingerprint,
@@ -1511,22 +1461,18 @@ export class AiAgentAdminService extends BaseService {
             organizationUuid,
             reviewItem.projectUuid ? [reviewItem.projectUuid] : [],
         );
-        const staleAwareItem = withStaleWritebackOverride(
-            reviewItem,
-            Date.now(),
-        );
         const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
-            item: staleAwareItem,
+            item: reviewItem,
             reviewsEnabled,
             projectContextEnabled,
-            projectAccess: staleAwareItem.projectUuid
-                ? (projectAccessByUuid.get(staleAwareItem.projectUuid) ?? null)
+            projectAccess: reviewItem.projectUuid
+                ? (projectAccessByUuid.get(reviewItem.projectUuid) ?? null)
                 : null,
             hasSemanticWritebackConfig: this.hasSemanticWritebackConfig(),
         });
 
         return {
-            ...staleAwareItem,
+            ...reviewItem,
             writebackEligible: writebackEligibility.eligible,
             writebackEligibility,
         };


### PR DESCRIPTION
## Summary

On any backend whose process timezone is ahead of UTC (e.g. Europe/London during BST), every review-item writeback was presented as failed with "Writeback timed out" the moment it started — while the writeback itself ran fine and opened its PR a couple of minutes later. Clicking **Create PR** again during that window persisted the running remediation as failed and launched a concurrent duplicate writeback.

UTC deployments (our cloud, CI) were unaffected, which is why this only surfaced on local dev machines.

## Root cause

The review tables store timestamps in `timestamp without time zone` columns holding UTC wall time, but node-postgres parses tz-less timestamps in the **process's local timezone**, so on a UTC+1 machine every read comes back one hour in the past. The staleness check compared that skewed value against the app clock:

```ts
// AiAgentAdminService.ts (before)
const isWritebackStale = (item, now) =>
    (item.prWritebackStatus === 'queued' || item.prWritebackStatus === 'running') &&
    now - new Date(item.updatedAt).getTime() > WRITEBACK_STALE_MS; // 35 min
```

```
DB stores (UTC wall):     updated_at = 14:44:06
node-pg parses (BST):     14:44:06 local → 13:44:06Z
Date.now():               14:47:11Z
perceived age:            63.1 min  >  35 min threshold → "Writeback timed out"
actual age:               ~3 min (writeback running)
```

The comparison shipped in #23669 and was extended to remediations in #24014; the columns have been tz-less since #23548.

## Fix

Staleness is now computed entirely in SQL — DB clock against DB clock — so it is immune to driver timezone parsing and to app/DB clock drift. (A `timestamptz` column migration was considered and skipped: `useTz: false` is the prevailing convention across the schema, and SQL-side ages make the column type irrelevant for this check.)

- `AiAgentReviewClassifierModel.ts` — item and remediation read queries select `(extract(epoch from (now() - updated_at)) * 1000)::float8 as updated_at_age_ms`; the stale presentation override ("Writeback timed out" for queued/running past 35 min, never for `pr_open`/`preview_ready`) moved here, next to the data it depends on. New `failStaleReviewRemediation` persists a stale remediation as failed with the same guard re-checked in SQL (`status IN ('queued','running') AND updated_at < now() - make_interval(...)`).
- `AiAgentAdminService.ts` — deletes the `Date.now()`-based helpers (`isWritebackStale` / `isRemediationStale` / `withStaleWritebackOverride`); the three call sites now consume the model's already-corrected summaries. The persist-before-retry path calls `failStaleReviewRemediation`, and the remediation insert now maps a unique-constraint race (concurrent retry) to a 409 `AlreadyExistsError` instead of an unhandled 500.
- Out of scope: `createdAt`/`updatedAt` fields serialized from these tables still parse in process-local time on non-UTC servers (display-only skew, schema-wide pattern).

## Before

`GET /api/v1/aiAgents/admin/review-items` ~3 minutes after starting a writeback, backend under BST:

```json
{ "prWritebackStatus": "failed", "prWritebackMessage": "Writeback timed out" }
```

## After

Same request, same conditions (verified live on a BST dev instance against this branch):

```json
{ "prWritebackStatus": "running", "prWritebackMessage": "Compiling project" }
```

Backdating the row 40 minutes still presents `failed` / "Writeback timed out", and the list read persists nothing — the override stays presentation-only.

## Test plan

- [x] `pnpm -F backend typecheck:fast` and `pnpm -F backend lint`
- [x] `jest AiAgentReviewClassifierModel AiAgentAdminService` — 38 tests pass; new regression tests stub `updated_at_age_ms` independently of `updated_at` so both a revert to Date-based math and removal of the override fail
- [x] Manual on a BST dev instance: fresh running writeback presents `running` (was `failed`), 40-min-old writeback presents `failed`/"Writeback timed out", raw DB rows untouched by list reads

Closes: ZAP-490
