### PR TITLE
fix: emit terminal error event when SDK metric-query POST fails

### DIFF
--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -56,6 +56,17 @@ function mockFetchOk(json: Record<string, unknown>) {
     } as Response);
 }
 
+function mockFetchNonOk(json: Record<string, unknown>, status = 500) {
+    (fetch as Mock).mockResolvedValueOnce({
+        json: async () => json,
+        status,
+    } as Response);
+}
+
+function mockFetchReject(err: Error) {
+    (fetch as Mock).mockRejectedValueOnce(err);
+}
+
 function postMetricQuery() {
     dispatchFetchMessage({
         type: 'lightdash:sdk:fetch',
@@ -170,6 +181,65 @@ describe('useAppSdkBridge', () => {
             queryUuid: QUERY_UUID,
             error: 'Warehouse timeout',
         });
+    });
+
+    it('emits a terminal error event when the metric-query POST returns a non-ok payload', async () => {
+        // Without this, the pending event's id stays in MinimalApp's in-flight
+        // set forever, isReady never flips true, and the screenshot indicator
+        // never mounts — so the headless browser hits the 60s timeout.
+        const events: QueryEvent[] = [];
+        renderBridge((e) => events.push(e));
+
+        mockFetchNonOk({
+            status: 'error',
+            error: { message: 'Internal server error' },
+        });
+        postMetricQuery();
+
+        await vi.waitFor(() => expect(events).toHaveLength(2));
+        expect(events[0]).toMatchObject({ id: POST_ID, status: 'pending' });
+        expect(events[1]).toMatchObject({
+            id: POST_ID,
+            status: 'error',
+            queryUuid: null,
+            error: 'Internal server error',
+        });
+    });
+
+    it('emits a terminal error event when the metric-query POST fetch throws', async () => {
+        const events: QueryEvent[] = [];
+        renderBridge((e) => events.push(e));
+
+        mockFetchReject(new Error('Network unreachable'));
+        postMetricQuery();
+
+        await vi.waitFor(() => expect(events).toHaveLength(2));
+        expect(events[0]).toMatchObject({ id: POST_ID, status: 'pending' });
+        expect(events[1]).toMatchObject({
+            id: POST_ID,
+            status: 'error',
+            queryUuid: null,
+            error: 'Network unreachable',
+        });
+    });
+
+    it('MinimalApp-style in-flight set drains to zero when the POST fails', async () => {
+        // The bug this guards: a failed POST left its pending id stuck in the
+        // set, blocking the screenshot indicator from ever mounting on any
+        // run where a query errored. Mirrors the success-path drain test
+        // below.
+        const activeIds = new Set<string>();
+        renderBridge((event) => {
+            const inFlight =
+                event.status === 'pending' || event.status === 'running';
+            if (inFlight) activeIds.add(event.id);
+            else activeIds.delete(event.id);
+        });
+
+        mockFetchReject(new Error('boom'));
+        postMetricQuery();
+
+        await vi.waitFor(() => expect(activeIds.size).toBe(0));
     });
 
     it('MinimalApp-style in-flight set drains to zero after a query completes', async () => {

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -285,6 +285,36 @@ export function useAppSdkBridge(
                     ? `/api/v1/embed/${embedProjectUuid}/user-info`
                     : path;
 
+            // Emits a terminal `error` QueryEvent re-keyed to the POST id
+            // when a metric-query POST fails before the SDK ever gets a
+            // queryUuid. Without it, the pending entry stays in
+            // MinimalApp's in-flight set forever and the screenshot
+            // indicator never mounts. The GET-poll error/ready paths
+            // already emit their own terminal events, so this only runs
+            // for the POST.
+            const emitPostFailure = (errorMessage: string) => {
+                if (!isMetricQueryPost(method, path) || !onQueryEvent) return;
+                onQueryEvent({
+                    id,
+                    timestamp: Date.now(),
+                    label: null,
+                    exploreName: '',
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                    limit: 0,
+                    queryUuid: null,
+                    status: 'error',
+                    rowCount: null,
+                    durationMs: null,
+                    error: errorMessage,
+                    rawMetricQuery: null,
+                });
+            };
+
             try {
                 // SDK embeds: a bare `fetch(path)` resolves against the
                 // host's origin, not Lightdash. Rewrite to an absolute URL
@@ -420,15 +450,16 @@ export function useAppSdkBridge(
 
                     respond({ result: json.results });
                 } else {
-                    respond({
-                        error:
-                            json.error?.message ?? `API error (${res.status})`,
-                    });
+                    const errorMessage =
+                        json.error?.message ?? `API error (${res.status})`;
+                    emitPostFailure(errorMessage);
+                    respond({ error: errorMessage });
                 }
             } catch (err) {
-                respond({
-                    error: err instanceof Error ? err.message : 'Unknown error',
-                });
+                const errorMessage =
+                    err instanceof Error ? err.message : 'Unknown error';
+                emitPostFailure(errorMessage);
+                respond({ error: errorMessage });
             }
         },
         [


### PR DESCRIPTION
## Summary                                                                                                                                                                              
                                                                                                                                                                                          
  - When a data-app SDK metric-query POST fails (non-`ok` response or thrown                                                                                                              
    fetch error), the bridge now emits a synthetic terminal `error`                                                                                                                       
    `QueryEvent` re-keyed to the POST id. Previously only the success path
    (POST → queryUuid → GET poll → ready/error) emitted terminal events, so a                                                                                                             
    failed POST left a pending entry in the consumer's in-flight set forever.                                                                                                           
  - The visible impact is in `MinimalApp` (scheduled-delivery screenshots):                                                                                                               
    a stuck pending id keeps `activeQueryIds.size > 0`, which blocks the                                                                                                                  
    screenshot-ready indicator and times the delivery out at 60s.                                                                                                                         
  - Failure modes covered: backend returns `{ status: 'error', ... }`,                                                                                                                    
    non-2xx HTTP response, and the `fetch` itself throwing (network, abort).  
