### PR TITLE
docs(api): surface v1 query endpoint deprecation in docs and llms.txt

### DIFF
--- a/.claude/skills/deprecate-endpoint/SKILL.md
+++ b/.claude/skills/deprecate-endpoint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deprecate-endpoint
-description: Use when deprecating, sunsetting, or removing a backend HTTP API endpoint in Lightdash — wiring deprecation logging, deadline/sunset dates, response headers, and Sentry alerting onto a TSOA controller route. Covers the first-party-caller precondition and the shared deprecation middleware.
+description: Use when deprecating, sunsetting, or removing a backend HTTP API endpoint in Lightdash — wiring deprecation logging, deadline/sunset dates, response headers, and Sentry alerting onto a TSOA controller route. Also covers making the deprecation visible on docs.lightdash.com and llms.txt (description lead line, x-mint migration banner). Covers the first-party-caller precondition and the shared deprecation middleware.
 allowed-tools: Read, Grep, Glob, Edit, Bash
 ---
 
@@ -53,6 +53,10 @@ In the controller, on the route handler:
       tag to set `deprecated: true` in the OpenAPI spec.
 - [ ] Add the TSOA `@Deprecated()` decorator — the explicit, consistent way to
       mark it (decorator order doesn't matter). Keep both this and the JSDoc.
+- [ ] Rewrite the JSDoc **description** so its first line is plain text
+      `Deprecated — use the v2 <name> endpoint instead.` (see "Make it visible
+      in the docs" below for why this exact shape matters).
+- [ ] Add an `@Extension('x-mint', ...)` migration banner (same section below).
 - [ ] Add `getDeprecatedRouteMiddleware` to the handler's `@Middlewares([...])`
       (use the same text for `suffixMessage` as the `@deprecated` JSDoc):
 
@@ -74,6 +78,56 @@ import { getDeprecatedRouteMiddleware } from './authentication';
   a different sunset has been agreed.
 - If the handler has no `@Middlewares` block (e.g. some embed routes), add one
   containing just the middleware.
+
+## Make it visible in the docs (description + x-mint)
+
+`deprecated: true` alone is nearly invisible on docs.lightdash.com — AI agents
+and scripts reading the docs keep generating code against the route. The docs
+site auto-generates API pages and llms.txt from
+`packages/backend/src/generated/swagger.json` (main branch), so docs visibility
+is wired here, in the controller JSDoc:
+
+- The llms.txt entry is `- [summary](url): first sentence of description`
+  (truncated ~60 chars), and the description renders as the page subtitle.
+  So the description's **first line must be plain text** (no markdown links,
+  no MDX) leading with the deprecation:
+
+```ts
+/**
+ * Deprecated — use the v2 Execute metric query endpoint instead.
+ *
+ * This endpoint was deprecated on <date> and will sunset on <date>. Migrate to
+ * the v2 async query flow: Execute metric query, then Get results.
+ * @summary Run metric query   // ⚠️ do NOT change — the docs page slug/URL is built from it
+ * @deprecated Use POST /api/v2/projects/{projectUuid}/query/metric-query instead
+ */
+```
+
+- The visible banner on the endpoint page comes from the Mintlify
+  `x-mint: content` OpenAPI extension (renders **above** the auto-generated
+  reference; supports MDX). MDX in the plain `description` is NOT supported —
+  don't put `<Warning>` there. Emit it with TSOA's `@Extension` (string must be
+  a literal; backtick-escape inline code so `{braces}` don't break MDX):
+
+```ts
+@Extension('x-mint', {
+    content: `<Warning>
+**This endpoint is deprecated and will sunset on <date>.**
+
+Migrate to [Execute metric query](https://docs.lightdash.com/api-reference/v2/execute-metric-query) (\`POST /api/v2/projects/{projectUuid}/query/metric-query\`), then [Get results](https://docs.lightdash.com/api-reference/v2/get-results).
+</Warning>`,
+})
+```
+
+- [ ] Run `pnpm generate-api` and check the swagger.json diff: the operation
+      keeps `deprecated: true`, summary unchanged, description starts with the
+      plain-text `Deprecated — ...` sentence, and `x-mint` is present. Expect
+      unrelated key-reordering drift in generated files — to keep the PR clean,
+      revert generated files to HEAD, graft only the changed operation objects,
+      then `pnpm -F backend formatter --write ./src/generated/swagger.json`.
+
+Docs go live on the next mintlify-docs deploy after the backend change reaches
+main (the docs site re-fetches swagger.json from main at build time).
 
 ## You get this for free
 

--- a/packages/backend/src/controllers/CLAUDE.md
+++ b/packages/backend/src/controllers/CLAUDE.md
@@ -139,6 +139,16 @@ endpoint was deprecated and `suffixMessage` names the replacement. Keep the TSOA
 @Patch('{projectUuid}/access/{userUuid}')
 ```
 
+**Docs visibility:** `deprecated: true` alone is nearly invisible on
+docs.lightdash.com (pages and llms.txt are generated from
+`src/generated/swagger.json`). Also lead the JSDoc description with a plain-text
+`Deprecated — use the v2 <name> endpoint instead.` first line (it becomes the
+llms.txt entry and page subtitle; no markdown/MDX there), add an
+`@Extension('x-mint', { content: '<Warning>...' })` migration banner (renders
+above the generated reference; MDX allowed there, not in the description), and
+keep `@summary` unchanged — the docs page URL is derived from it. Then
+`pnpm generate-api`. See the `deprecate-endpoint` skill for the full pattern.
+
 **Behavior** (`authentication/deprecation.ts`):
 
 - Every call logs. It logs a warning, escalating to an error once the removal

--- a/packages/backend/src/controllers/authentication/deprecation.ts
+++ b/packages/backend/src/controllers/authentication/deprecation.ts
@@ -65,5 +65,5 @@ export const getDeprecatedRouteMiddleware = (
 export const deprecatedResultsRoute: RequestHandler =
     getDeprecatedRouteMiddleware(new Date('2025-03-20'), {
         removeOn: new Date('2025-04-30'),
-        suffixMessage: `Please use 'POST /api/v2/projects/{projectUuid}/query' in conjuntion with 'GET /api/v2/projects/{projectUuid}/query/{queryUuid}' instead.`,
+        suffixMessage: `Please use 'POST /api/v2/projects/{projectUuid}/query' in conjunction with 'GET /api/v2/projects/{projectUuid}/query/{queryUuid}' instead.`,
     });

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -64,6 +64,7 @@ import {
     Body,
     Delete,
     Deprecated,
+    Extension,
     Get,
     Hidden,
     Middlewares,
@@ -415,20 +416,29 @@ export class ProjectController extends BaseController {
     }
 
     /**
-     * Run a raw sql query against the project's warehouse connection
+     * Deprecated — use the v2 Execute SQL query endpoint instead.
+     *
+     * This endpoint was deprecated on 17 February 2025 and is past its sunset date (17 May 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute SQL query, then Get results.
      * @summary Run SQL query
-     * @deprecated Use /api/v1/projects/<project id>/sqlRunner/run instead
+     * @deprecated Use POST /api/v2/projects/{projectUuid}/query/sql instead
      * @param projectUuid The uuid of the project to run the query against
      * @param body The query to run
      * @param req express request
      */
+    @Extension('x-mint', {
+        content: `<Warning>
+**This endpoint is deprecated and past its sunset date (17 May 2025) — it may be removed at any time.**
+
+Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.com/api-reference/v2/execute-sql-query) (\`POST /api/v2/projects/{projectUuid}/query/sql\`) to start the query, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. See also [Cancel query](https://docs.lightdash.com/api-reference/v2/cancel-query) and [Download results](https://docs.lightdash.com/api-reference/v2/download-results).
+</Warning>`,
+    })
     @Middlewares([
         allowApiKeyAuthentication,
         isAuthenticated,
         unauthorisedInDemo,
         getDeprecatedRouteMiddleware(new Date('2025-02-17'), {
             suffixMessage:
-                'Use /api/v1/projects/<project id>/sqlRunner/run instead.',
+                "Use 'POST /api/v2/projects/{projectUuid}/query/sql' in conjunction with 'GET /api/v2/projects/{projectUuid}/query/{queryUuid}' instead.",
         }),
     ])
     @SuccessResponse('200', 'Success')

--- a/packages/backend/src/controllers/runQueryController.ts
+++ b/packages/backend/src/controllers/runQueryController.ts
@@ -14,6 +14,7 @@ import {
 import {
     Body,
     Deprecated,
+    Extension,
     Middlewares,
     OperationId,
     Path,
@@ -49,13 +50,23 @@ export type ApiRunQueryResponse = {
 @Tags('Exploring')
 export class RunViewChartQueryController extends BaseController {
     /**
-     * Run a query for underlying data results
+     * Deprecated — use the v2 Execute underlying data endpoint instead.
+     *
+     * This endpoint was deprecated on 20 March 2025 and is past its sunset date (30 April 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute underlying data, then Get results.
      * @summary Run underlying data query
+     * @deprecated Use POST /api/v2/projects/{projectUuid}/query/underlying-data instead
      * @param projectUuid The uuid of the project
      * @param body metricQuery for the chart to run
      * @param exploreId table name
      * @param req express request
      */
+    @Extension('x-mint', {
+        content: `<Warning>
+**This endpoint is deprecated and past its sunset date (30 April 2025) — it may be removed at any time.**
+
+Migrate to the v2 async query flow: [Execute underlying data](https://docs.lightdash.com/api-reference/v2/execute-underlying-data) (\`POST /api/v2/projects/{projectUuid}/query/underlying-data\`) to start the query, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. See also [Cancel query](https://docs.lightdash.com/api-reference/v2/cancel-query) and [Download results](https://docs.lightdash.com/api-reference/v2/download-results).
+</Warning>`,
+    })
     @Deprecated()
     @Middlewares([
         allowApiKeyAuthentication,
@@ -119,13 +130,23 @@ export class RunViewChartQueryController extends BaseController {
     }
 
     /**
-     * Run a query for explore
+     * Deprecated — use the v2 Execute metric query endpoint instead.
+     *
+     * This endpoint was deprecated on 20 March 2025 and is past its sunset date (30 April 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute metric query, then Get results.
      * @summary Run metric query
+     * @deprecated Use POST /api/v2/projects/{projectUuid}/query/metric-query instead
      * @param projectUuid The uuid of the project
      * @param body metricQuery for the chart to run
      * @param exploreId table name
      * @param req express request
      */
+    @Extension('x-mint', {
+        content: `<Warning>
+**This endpoint is deprecated and past its sunset date (30 April 2025) — it may be removed at any time.**
+
+Migrate to the v2 async query flow: [Execute metric query](https://docs.lightdash.com/api-reference/v2/execute-metric-query) (\`POST /api/v2/projects/{projectUuid}/query/metric-query\`) to start the query, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. See also [Cancel query](https://docs.lightdash.com/api-reference/v2/cancel-query) and [Download results](https://docs.lightdash.com/api-reference/v2/download-results).
+</Warning>`,
+    })
     @Deprecated()
     @Middlewares([
         allowApiKeyAuthentication,

--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -22,6 +22,7 @@ import {
     Body,
     Delete,
     Deprecated,
+    Extension,
     Get,
     Middlewares,
     OperationId,
@@ -55,14 +56,24 @@ import { ApiRunQueryResponse } from './runQueryController';
 @Tags('Charts')
 export class SavedChartController extends BaseController {
     /**
-     * Run a query for a chart
+     * Deprecated — use the v2 Execute saved chart endpoint instead.
+     *
+     * This endpoint was deprecated on 20 March 2025 and is past its sunset date (30 April 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute saved chart, then Get results.
      * @summary Run chart query
+     * @deprecated Use POST /api/v2/projects/{projectUuid}/query/chart instead
      * @param chartUuid chartUuid for the chart to run
      * @param body
      * @param body.dashboardFilters dashboard filters
      * @param body.invalidateCache invalidate cache
      * @param req express request
      */
+    @Extension('x-mint', {
+        content: `<Warning>
+**This endpoint is deprecated and past its sunset date (30 April 2025) — it may be removed at any time.**
+
+Migrate to the v2 async query flow: [Execute saved chart](https://docs.lightdash.com/api-reference/v2/execute-saved-chart) (\`POST /api/v2/projects/{projectUuid}/query/chart\`) to start the query, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. See also [Cancel query](https://docs.lightdash.com/api-reference/v2/cancel-query) and [Download results](https://docs.lightdash.com/api-reference/v2/download-results).
+</Warning>`,
+    })
     @Deprecated()
     @Middlewares([
         allowApiKeyAuthentication,
@@ -113,9 +124,19 @@ export class SavedChartController extends BaseController {
     }
 
     /**
-     * Get chart and run query with dashboard filters
+     * Deprecated — use the v2 Execute dashboard chart endpoint instead.
+     *
+     * This endpoint was deprecated on 20 March 2025 and is past its sunset date (20 June 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute dashboard chart, then Get results.
      * @summary Get chart and results
+     * @deprecated Use POST /api/v2/projects/{projectUuid}/query/dashboard-chart instead
      */
+    @Extension('x-mint', {
+        content: `<Warning>
+**This endpoint is deprecated and past its sunset date (20 June 2025) — it may be removed at any time.**
+
+Migrate to the v2 async query flow: [Execute dashboard chart](https://docs.lightdash.com/api-reference/v2/execute-dashboard-chart) (\`POST /api/v2/projects/{projectUuid}/query/dashboard-chart\`) to start the query, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. See also [Cancel query](https://docs.lightdash.com/api-reference/v2/cancel-query) and [Download results](https://docs.lightdash.com/api-reference/v2/download-results).
+</Warning>`,
+    })
     @Deprecated()
     @Middlewares([
         allowApiKeyAuthentication,
@@ -208,12 +229,22 @@ export class SavedChartController extends BaseController {
     }
 
     /**
-     * Run a query for a chart version
+     * Deprecated — use the v2 Execute saved chart endpoint instead.
+     *
+     * This endpoint was deprecated on 20 March 2025 and is past its sunset date (30 April 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute saved chart, then Get results.
      * @summary Get chart version results
+     * @deprecated Use POST /api/v2/projects/{projectUuid}/query/chart instead
      * @param chartUuid chartUuid for the chart to run
      * @param versionUuid versionUuid for the chart version
      * @param req express request
      */
+    @Extension('x-mint', {
+        content: `<Warning>
+**This endpoint is deprecated and past its sunset date (30 April 2025) — it may be removed at any time.**
+
+Migrate to the v2 async query flow: [Execute saved chart](https://docs.lightdash.com/api-reference/v2/execute-saved-chart) (\`POST /api/v2/projects/{projectUuid}/query/chart\`) to run the chart's latest version, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. Running a query for a specific chart version has no v2 equivalent.
+</Warning>`,
+    })
     @Deprecated()
     @Middlewares([
         allowApiKeyAuthentication,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -50111,7 +50111,7 @@
                         }
                     }
                 },
-                "description": "Run a query for underlying data results",
+                "description": "Deprecated — use the v2 Execute underlying data endpoint instead.\n\nThis endpoint was deprecated on 20 March 2025 and is past its sunset date (30 April 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute underlying data, then Get results.",
                 "summary": "Run underlying data query",
                 "tags": ["Exploring"],
                 "deprecated": true,
@@ -50147,6 +50147,9 @@
                             }
                         }
                     }
+                },
+                "x-mint": {
+                    "content": "<Warning>\n**This endpoint is deprecated and past its sunset date (30 April 2025) — it may be removed at any time.**\n\nMigrate to the v2 async query flow: [Execute underlying data](https://docs.lightdash.com/api-reference/v2/execute-underlying-data) (`POST /api/v2/projects/{projectUuid}/query/underlying-data`) to start the query, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. See also [Cancel query](https://docs.lightdash.com/api-reference/v2/cancel-query) and [Download results](https://docs.lightdash.com/api-reference/v2/download-results).\n</Warning>"
                 }
             }
         },
@@ -50175,7 +50178,7 @@
                         }
                     }
                 },
-                "description": "Run a query for explore",
+                "description": "Deprecated — use the v2 Execute metric query endpoint instead.\n\nThis endpoint was deprecated on 20 March 2025 and is past its sunset date (30 April 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute metric query, then Get results.",
                 "summary": "Run metric query",
                 "tags": ["Exploring"],
                 "deprecated": true,
@@ -50211,6 +50214,9 @@
                             }
                         }
                     }
+                },
+                "x-mint": {
+                    "content": "<Warning>\n**This endpoint is deprecated and past its sunset date (30 April 2025) — it may be removed at any time.**\n\nMigrate to the v2 async query flow: [Execute metric query](https://docs.lightdash.com/api-reference/v2/execute-metric-query) (`POST /api/v2/projects/{projectUuid}/query/metric-query`) to start the query, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. See also [Cancel query](https://docs.lightdash.com/api-reference/v2/cancel-query) and [Download results](https://docs.lightdash.com/api-reference/v2/download-results).\n</Warning>"
                 }
             }
         },
@@ -50239,7 +50245,7 @@
                         }
                     }
                 },
-                "description": "Run a query for a chart",
+                "description": "Deprecated — use the v2 Execute saved chart endpoint instead.\n\nThis endpoint was deprecated on 20 March 2025 and is past its sunset date (30 April 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute saved chart, then Get results.",
                 "summary": "Run chart query",
                 "tags": ["Charts"],
                 "deprecated": true,
@@ -50269,6 +50275,9 @@
                             }
                         }
                     }
+                },
+                "x-mint": {
+                    "content": "<Warning>\n**This endpoint is deprecated and past its sunset date (30 April 2025) — it may be removed at any time.**\n\nMigrate to the v2 async query flow: [Execute saved chart](https://docs.lightdash.com/api-reference/v2/execute-saved-chart) (`POST /api/v2/projects/{projectUuid}/query/chart`) to start the query, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. See also [Cancel query](https://docs.lightdash.com/api-reference/v2/cancel-query) and [Download results](https://docs.lightdash.com/api-reference/v2/download-results).\n</Warning>"
                 }
             }
         },
@@ -50297,7 +50306,7 @@
                         }
                     }
                 },
-                "description": "Get chart and run query with dashboard filters",
+                "description": "Deprecated — use the v2 Execute dashboard chart endpoint instead.\n\nThis endpoint was deprecated on 20 March 2025 and is past its sunset date (20 June 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute dashboard chart, then Get results.",
                 "summary": "Get chart and results",
                 "tags": ["Charts"],
                 "deprecated": true,
@@ -50349,6 +50358,9 @@
                             }
                         }
                     }
+                },
+                "x-mint": {
+                    "content": "<Warning>\n**This endpoint is deprecated and past its sunset date (20 June 2025) — it may be removed at any time.**\n\nMigrate to the v2 async query flow: [Execute dashboard chart](https://docs.lightdash.com/api-reference/v2/execute-dashboard-chart) (`POST /api/v2/projects/{projectUuid}/query/dashboard-chart`) to start the query, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. See also [Cancel query](https://docs.lightdash.com/api-reference/v2/cancel-query) and [Download results](https://docs.lightdash.com/api-reference/v2/download-results).\n</Warning>"
                 }
             }
         },
@@ -50470,7 +50482,7 @@
                         }
                     }
                 },
-                "description": "Run a query for a chart version",
+                "description": "Deprecated — use the v2 Execute saved chart endpoint instead.\n\nThis endpoint was deprecated on 20 March 2025 and is past its sunset date (30 April 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute saved chart, then Get results.",
                 "summary": "Get chart version results",
                 "tags": ["Charts"],
                 "deprecated": true,
@@ -50494,7 +50506,10 @@
                             "type": "string"
                         }
                     }
-                ]
+                ],
+                "x-mint": {
+                    "content": "<Warning>\n**This endpoint is deprecated and past its sunset date (30 April 2025) — it may be removed at any time.**\n\nMigrate to the v2 async query flow: [Execute saved chart](https://docs.lightdash.com/api-reference/v2/execute-saved-chart) (`POST /api/v2/projects/{projectUuid}/query/chart`) to run the chart's latest version, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. Running a query for a specific chart version has no v2 equivalent.\n</Warning>"
+                }
             }
         },
         "/api/v1/saved/{chartUuid}/rollback/{versionUuid}": {
@@ -51836,7 +51851,7 @@
                         }
                     }
                 },
-                "description": "Run a raw sql query against the project's warehouse connection",
+                "description": "Deprecated — use the v2 Execute SQL query endpoint instead.\n\nThis endpoint was deprecated on 17 February 2025 and is past its sunset date (17 May 2025) — it may be removed at any time. Migrate to the v2 async query flow: Execute SQL query, then Get results.",
                 "summary": "Run SQL query",
                 "tags": ["Exploring", "Projects"],
                 "deprecated": true,
@@ -51869,6 +51884,9 @@
                             }
                         }
                     }
+                },
+                "x-mint": {
+                    "content": "<Warning>\n**This endpoint is deprecated and past its sunset date (17 May 2025) — it may be removed at any time.**\n\nMigrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.com/api-reference/v2/execute-sql-query) (`POST /api/v2/projects/{projectUuid}/query/sql`) to start the query, then [Get results](https://docs.lightdash.com/api-reference/v2/get-results) to fetch rows. See also [Cancel query](https://docs.lightdash.com/api-reference/v2/cancel-query) and [Download results](https://docs.lightdash.com/api-reference/v2/download-results).\n</Warning>"
                 }
             }
         },


### PR DESCRIPTION
Closes: SPK-488

### Description:

AI agents and scripts keep generating code against the deprecated v1 run-query endpoints because the auto-generated API docs (and their llms.txt entries) carry only the OpenAPI `deprecated: true` flag with no visible migration note. This PR updates the TSOA JSDoc for all six past-sunset v1 query endpoints (run metric query, run underlying data query, run SQL query, run chart query, get chart and results, get chart version results) so their descriptions lead with a plain-text "Deprecated — use the v2 … endpoint instead." line, which is exactly what flows into the llms.txt index and the docs page subtitle. Each endpoint also gets a prominent `<Warning>` migration banner on its docs page via the Mintlify `x-mint: content` OpenAPI extension (TSOA `@Extension`), linking the v2 async query flow (execute → get results, plus cancel/download). The v1 `sqlQuery` replacement hint now points to `POST /api/v2/projects/{projectUuid}/query/sql` (docs + `Sunset`/`Warning` middleware message) instead of v1 `sqlRunner/run`, and a typo in the shared deprecation message is fixed. The `deprecate-endpoint` skill and controllers `CLAUDE.md` now document these docs-visibility steps so future deprecations include them; page titles/URLs are unchanged and swagger.json carries only the six updated operations.

Banner as rendered on an endpoint page (local Mintlify preview):

> ⚠️ **This endpoint is deprecated and past its sunset date (30 April 2025) — it may be removed at any time.**
> Migrate to the v2 async query flow: Execute metric query (`POST /api/v2/projects/{projectUuid}/query/metric-query`) to start the query, then Get results to fetch rows. See also Cancel query and Download results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
