### PR TITLE
feat(ai-review): validate writeback preview projects after compile

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -1037,14 +1037,17 @@ export class ProjectController extends BaseController {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
 
-        const results = await this.services
-            .getProjectService()
-            .createPreview(
-                toSessionUser(req.account),
-                projectUuid,
-                body,
-                RequestMethod.WEB_APP,
-            );
+        const results = await this.services.getProjectService().createPreview(
+            toSessionUser(req.account),
+            projectUuid,
+            {
+                name: body.name,
+                copyContent: body.copyContent,
+                dbtConnectionOverrides: body.dbtConnectionOverrides,
+                warehouseConnectionOverrides: body.warehouseConnectionOverrides,
+            },
+            RequestMethod.WEB_APP,
+        );
 
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.test.ts
@@ -131,5 +131,14 @@ describe('WritebackPreviewService.createPreviewForPullRequest', () => {
                 'https://lightdash.example.com/projects/preview-project-1/home',
             compileJobUuid: 'compile-job-1',
         });
+        expect(projectService.createPreview).toHaveBeenCalledWith(
+            expect.anything(),
+            PROJECT,
+            expect.objectContaining({
+                copyContent: true,
+                validateAfterCompile: true,
+            }),
+            expect.anything(),
+        );
     });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.ts
@@ -152,6 +152,7 @@ export class WritebackPreviewService extends BaseService {
                     name: `Preview: ${pullRequest.headRef}`,
                     copyContent: true,
                     dbtConnectionOverrides: { branch: pullRequest.headRef },
+                    validateAfterCompile: true,
                 },
                 RequestMethod.BACKEND,
             );

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1900,7 +1900,10 @@ export default class SchedulerTask {
                 },
                 status: SchedulerJobStatus.COMPLETED,
             });
-            if (process.env.IS_PULL_REQUEST !== 'true' && !payload.isPreview) {
+            if (
+                process.env.IS_PULL_REQUEST !== 'true' &&
+                (!payload.isPreview || payload.validateAfterCompile === true)
+            ) {
                 void this.schedulerClient.generateValidation({
                     projectUuid: payload.projectUuid,
                     context: 'dbt_refresh',

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6020,6 +6020,7 @@ export class ProjectService extends BaseService {
         projectUuid: string,
         requestMethod: RequestMethod,
         skipPermissionCheck: boolean = false,
+        validateAfterCompile: boolean = false,
     ): Promise<{ jobUuid: string }> {
         const { organizationUuid, type } =
             await this.projectModel.getSummary(projectUuid);
@@ -6063,6 +6064,7 @@ export class ProjectService extends BaseService {
             requestMethod,
             jobUuid: job.jobUuid,
             isPreview: type === ProjectType.PREVIEW,
+            validateAfterCompile,
             userUuid: user.userUuid,
         });
 
@@ -7773,6 +7775,7 @@ export class ProjectService extends BaseService {
                 manifest?: string;
             };
             warehouseConnectionOverrides?: { schema?: string };
+            validateAfterCompile?: boolean;
         },
         context: RequestMethod,
     ): Promise<ApiCreatePreviewResults> {
@@ -7818,6 +7821,7 @@ export class ProjectService extends BaseService {
             previewProject.project.projectUuid,
             context,
             true, // Skip permission check
+            data.validateAfterCompile ?? false,
         );
         return {
             projectUuid: previewProject.project.projectUuid,

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -705,6 +705,7 @@ export type CompileProjectPayload = TraceTaskBase & {
     requestMethod: string;
     jobUuid: string;
     isPreview: boolean;
+    validateAfterCompile?: boolean;
 };
 
 export type PreAggregateMaterializationTrigger =


### PR DESCRIPTION
## Summary

When an AI review or writeback opens a dbt PR, Charlie's server-side preview (#24123) spins up a preview Lightdash project compiled from the PR's branch — but post-compile validation was skipped for all previews, so the generated change was never validated. This threads an opt-in `validateAfterCompile` flag so writeback previews run project validation as soon as their compile finishes, surfacing validation errors (broken charts, missing metrics) caused by the proposed change.

```
writeback PR opened
  └─ WritebackPreviewService.createPreviewForPullRequest   (validateAfterCompile: true)
       └─ ProjectService.createPreview → scheduleCompileProject → compileProject job
            └─ compile COMPLETED
                 ├─ before: !payload.isPreview → validation skipped for previews
                 └─ after:  !payload.isPreview || payload.validateAfterCompile
                              └─ generateValidation → validateProject job
                                   └─ errors stored on the preview project
```

## How it works

- `CompileProjectPayload.validateAfterCompile?: boolean` (`packages/common`) — optional so already-queued compile jobs deserialize unchanged; absent/false preserves today's behavior (previews skip validation).
- `SchedulerTask.compileProject` — the existing post-compile `generateValidation` trigger now also fires when a preview opted in.
- `ProjectService.createPreview` / `scheduleCompileProject` — pass the flag through; it is internal-only. The `createPreview` controller now forwards only its declared body fields, since TSOA does not strip undeclared properties (`noImplicitAdditionalProperties: 'ignore'`), so the flag cannot be set over HTTP.
- `WritebackPreviewService` — writeback previews opt in. Regular dev/UI previews are unaffected.

Validation results land on the preview project (Validator UI / `GET /api/v1/projects/{previewUuid}/validate`). Surfacing them on the review-item finding detail and blocking approval is the remaining scope of the ticket, handled separately.

## Test plan

- [x] `pnpm -F common typecheck:fast`, `pnpm -F backend typecheck:fast`, both lints
- [x] `jest WritebackPreviewService` — asserts `createPreview` is called with `validateAfterCompile: true`; full backend suite run by review (277 tests pass)
- [x] Manual end-to-end on a dev instance: created a writeback preview for a real PR → compile completed (62 explores, 0 errors) → `validateProject` ran against the preview within the same second → 7 validation errors persisted (`chart`, `chart configuration`, `metric`) — real breakages caused by the PR's metric-definition change
- [x] Manual: non-preview compile and plain (non-writeback) preview compile behavior unchanged

Closes: PROD-8210
