### PR TITLE
feat(ai-review): show preview validation errors in the review sidebar

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewValidationList.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewValidationList.module.css
@@ -1,0 +1,21 @@
+.linkButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.2;
+    text-decoration: none;
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-dark-2)
+    );
+}
+
+.linkButton:hover {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-dark-0)
+    );
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewValidationList.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewValidationList.tsx
@@ -1,0 +1,101 @@
+import {
+    ValidationErrorType,
+    ValidationSourceType,
+    type ValidationResponse,
+} from '@lightdash/common';
+import {
+    Group,
+    List,
+    Loader,
+    Stack,
+    Text,
+    Tooltip,
+    UnstyledButton,
+} from '@mantine-8/core';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import { useProjectValidation } from '../../../../../hooks/validation/useValidation';
+import styles from './ReviewValidationList.module.css';
+
+const MAX_VISIBLE_ERRORS = 10;
+
+type Props = {
+    previewProjectUuid: string;
+};
+
+const getValidationName = (error: ValidationResponse): string =>
+    error.name ?? 'Unnamed';
+
+// Chart-configuration warnings on charts are hidden by default on the validator
+// page (includeChartConfigWarnings=false); mirror that exact condition so the
+// count and entries match what "See all" opens.
+const isHiddenConfigWarning = (error: ValidationResponse): boolean =>
+    error.source === ValidationSourceType.Chart &&
+    error.errorType === ValidationErrorType.ChartConfiguration;
+
+export const ReviewValidationList: FC<Props> = ({ previewProjectUuid }) => {
+    const { data, isInitialLoading } = useProjectValidation(previewProjectUuid);
+    const validatorUrl = `/generalSettings/projectManagement/${previewProjectUuid}/validator`;
+
+    if (isInitialLoading) {
+        return (
+            <Group gap="xs" pt="xs">
+                <Loader size={12} color="ldGray.5" />
+                <Text fz="xs" c="ldGray.6">
+                    Loading validation results…
+                </Text>
+            </Group>
+        );
+    }
+
+    const errors = (data ?? []).filter(
+        (error) => !isHiddenConfigWarning(error),
+    );
+    const total = errors.length;
+
+    if (total === 0) {
+        return (
+            <Text fz="xs" c="ldGray.6" pt="xs">
+                No validation errors found
+            </Text>
+        );
+    }
+
+    return (
+        <Stack gap="xs" pt="xs">
+            <Text fz="xs" fw={700} tt="uppercase" lts={0.4} c="ldGray.7">
+                {total} validation {total === 1 ? 'error' : 'errors'}
+            </Text>
+
+            <List size="xs" spacing={4} c="ldGray.7">
+                {errors.slice(0, MAX_VISIBLE_ERRORS).map((error) => (
+                    <List.Item key={error.validationUuid}>
+                        <Tooltip
+                            label={error.error}
+                            withArrow
+                            multiline
+                            maw={320}
+                            openDelay={300}
+                        >
+                            <Text fz="xs" c="ldGray.7" lineClamp={1}>
+                                <Text span inherit fw={600} c="ldGray.9">
+                                    {getValidationName(error)}
+                                </Text>
+                                {' - '}
+                                {error.error}
+                            </Text>
+                        </Tooltip>
+                    </List.Item>
+                ))}
+            </List>
+
+            <UnstyledButton
+                component={Link}
+                to={validatorUrl}
+                className={styles.linkButton}
+            >
+                See more
+            </UnstyledButton>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -43,6 +43,7 @@ import {
     getReviewReasoningText,
     getReviewSecondaryDetail,
 } from './reviewItemDetails';
+import { ReviewValidationList } from './ReviewValidationList';
 import styles from './ThreadPreviewSidebar.module.css';
 import {
     getThreadReviewHeadline,
@@ -199,6 +200,9 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
     const reasoningText = selectedReviewItem
         ? getReviewReasoningText(selectedReviewItem)
         : null;
+    const [showValidation, setShowValidation] = useState(false);
+    const previewProjectUuid =
+        selectedReviewItem?.remediation?.previewProjectUuid ?? null;
 
     if (!isOpen || !threadUuid) {
         return null;
@@ -369,6 +373,30 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                                 size="xs"
                                             />
                                         </UnstyledButton>
+                                        {previewProjectUuid && (
+                                            <UnstyledButton
+                                                className={styles.sectionToggle}
+                                                data-active={
+                                                    showValidation || undefined
+                                                }
+                                                onClick={() =>
+                                                    setShowValidation(
+                                                        (open) => !open,
+                                                    )
+                                                }
+                                                aria-expanded={showValidation}
+                                            >
+                                                <span>Validation</span>
+                                                <MantineIcon
+                                                    icon={
+                                                        showValidation
+                                                            ? IconChevronDown
+                                                            : IconChevronRight
+                                                    }
+                                                    size="xs"
+                                                />
+                                            </UnstyledButton>
+                                        )}
                                     </Group>
 
                                     <Collapse in={showDetails}>
@@ -425,6 +453,16 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                             )}
                                         </Stack>
                                     </Collapse>
+
+                                    {previewProjectUuid && (
+                                        <Collapse in={showValidation}>
+                                            <ReviewValidationList
+                                                previewProjectUuid={
+                                                    previewProjectUuid
+                                                }
+                                            />
+                                        </Collapse>
+                                    )}
                                 </Stack>
                             </Stack>
 

--- a/packages/frontend/src/hooks/validation/useValidation.ts
+++ b/packages/frontend/src/hooks/validation/useValidation.ts
@@ -62,6 +62,19 @@ export const usePinnedValidation = (
         enabled: validationUuid !== null,
     });
 
+/**
+ * Read-only validation results for a specific project, scoped by projectUuid in
+ * the query key (unlike useValidation, which serves the settings validator for
+ * the active project). Used to surface a preview project's validation errors.
+ */
+export const useProjectValidation = (projectUuid: string | null) =>
+    useQuery<ValidationResponse[], ApiError>({
+        queryKey: ['validation', 'project', projectUuid],
+        queryFn: () => getValidation(projectUuid!, false),
+        enabled: projectUuid !== null,
+        retry: (_, error) => error.error.statusCode !== 403,
+    });
+
 export const useValidation = (
     projectUuid: string,
     user: UseQueryResult<UserWithAbility, ApiError>,


### PR DESCRIPTION
Relates: PROD-8210

## Summary

When an AI review opens a writeback PR, a preview project is compiled from the PR branch and validated (#24148). This surfaces that validation result in the review thread sidebar, so a reviewer can see what the proposed change breaks without leaving the page.

### Validation section (review thread sidebar)

- A **Validation** toggle joins **Details** and **Why flagged** under the finding summary — shown only when the item's remediation has a preview project.
- Expanding it lists the preview project's validation errors: a total count, a bulleted list of up to 10 `name - error` entries (full message on hover), and a **See more** link to the preview's validator page.
- The list mirrors the validator page's default view: it hides chart-configuration warnings (`source = chart` and `errorType = chart configuration`) so the count and entries match what **See more** opens.

When the item has no preview project, the toggle, the list, and the validation request are all skipped — the section does not appear.

## How it looks

```
┌─ Review details ──────────────────────────────┐
│  ● Semantic layer            View PR · Test fix │
│  Review customers.average_customer_lifetime_…   │
│  The current metric includes all orders …       │
│  Show more                                      │
│                                                 │
│  Details ›   Why flagged ›   Validation ⌄       │
│                                                 │
│  2 VALIDATION ERRORS                            │
│   • Order amounts by month - Metric error: th…  │
│   • Scheduled delivery edge cases - The chart…  │
│  See more                                       │
└─────────────────────────────────────────────────┘
```

## Regression analysis

- `ThreadPreviewSidebar` — adds a third toggle + collapse, gated on `remediation.previewProjectUuid`. The Details and Why flagged toggles are unchanged.
- `useValidation.ts` — adds `useProjectValidation(projectUuid)`, a read-only query keyed by `projectUuid`. The existing `useValidation` keys only by `fromSettings`, so reusing it for a preview project would collide; the new hook also drops the settings-only notification side effects.
- No backend or API surface touched — reuses the existing `GET /projects/{uuid}/validate`.

## Test plan

- [ ] Open a review item whose writeback opened a PR with a preview → a Validation toggle appears next to Why flagged; expanding shows the count and bulleted entries.
- [ ] The count and entries match the validator page that **See more** opens (chart-configuration warnings excluded).
- [ ] Open a review item with no preview project → no Validation toggle and no `/validate` request fires.
- [ ] Verify both light and dark modes match the existing toggle styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
