### PR TITLE
fix(echarts): fix sub-day time-axis DST collisions and tick alignment

### DIFF
--- a/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
@@ -24,6 +24,11 @@ const SHIFTED_MS = UTC_MS + TZ_OFFSET_MS;
 const makeTimeDimension = (
     name: string,
     timeInterval: TimeFrames | undefined,
+    overrides?: {
+        type?: DimensionType;
+        skipTimezoneConversion?: boolean;
+        timeIntervalBaseDimensionType?: DimensionType;
+    },
 ): ItemsMap[string] =>
     ({
         compiledSql: '',
@@ -35,8 +40,17 @@ const makeTimeDimension = (
         table: 'orders',
         tableLabel: 'Orders',
         sql: '',
-        type: DimensionType.TIMESTAMP,
+        type: overrides?.type ?? DimensionType.TIMESTAMP,
         timeInterval,
+        ...(overrides?.skipTimezoneConversion !== undefined
+            ? { skipTimezoneConversion: overrides.skipTimezoneConversion }
+            : {}),
+        ...(overrides?.timeIntervalBaseDimensionType !== undefined
+            ? {
+                  timeIntervalBaseDimensionType:
+                      overrides.timeIntervalBaseDimensionType,
+              }
+            : {}),
     }) as ItemsMap[string];
 
 const makeMetric = (name: string): ItemsMap[string] =>
@@ -92,7 +106,7 @@ describe('resolveAxisTimezone', () => {
             resolvedTimezone: undefined,
         });
         expect(result).toEqual({
-            shiftedField: undefined,
+            timeAxisField: undefined,
             axisTimezone: undefined,
             axisDisplayTimezone: undefined,
         });
@@ -106,7 +120,7 @@ describe('resolveAxisTimezone', () => {
             itemsMap,
             resolvedTimezone: 'UTC',
         });
-        expect(result.shiftedField).toBeUndefined();
+        expect(result.timeAxisField).toBeUndefined();
         expect(result.axisTimezone).toBe('UTC');
         expect(result.axisDisplayTimezone).toBeUndefined();
     });
@@ -117,7 +131,7 @@ describe('resolveAxisTimezone', () => {
             itemsMap,
             resolvedTimezone: TZ,
         });
-        expect(result.shiftedField).toBeUndefined();
+        expect(result.timeAxisField).toBeUndefined();
         expect(result.axisTimezone).toBe(TZ);
     });
 
@@ -129,7 +143,7 @@ describe('resolveAxisTimezone', () => {
             itemsMap: undefined,
             resolvedTimezone: TZ,
         });
-        expect(result.shiftedField).toBeUndefined();
+        expect(result.timeAxisField).toBeUndefined();
     });
 
     test('no shift when the axis field is not a dimension', () => {
@@ -138,7 +152,7 @@ describe('resolveAxisTimezone', () => {
             itemsMap,
             resolvedTimezone: TZ,
         });
-        expect(result.shiftedField).toBeUndefined();
+        expect(result.timeAxisField).toBeUndefined();
     });
 
     test('no shift when the dimension has no timeInterval', () => {
@@ -149,7 +163,7 @@ describe('resolveAxisTimezone', () => {
             itemsMap,
             resolvedTimezone: TZ,
         });
-        expect(result.shiftedField).toBeUndefined();
+        expect(result.timeAxisField).toBeUndefined();
     });
 
     test.each([
@@ -167,12 +181,12 @@ describe('resolveAxisTimezone', () => {
             },
             resolvedTimezone: TZ,
         });
-        expect(result.shiftedField).toBeUndefined();
+        expect(result.timeAxisField).toBeUndefined();
         expect(result.axisTimezone).toBe(TZ);
     });
 
     test.each([TimeFrames.SECOND, TimeFrames.MINUTE, TimeFrames.HOUR])(
-        'keeps raw UTC positioning for sub-day interval %s',
+        'keeps raw UTC positioning via a sub-day-format timeAxisField for interval %s',
         (interval) => {
             const fieldId = `orders_created_${interval.toLowerCase()}`;
             const result = resolveAxisTimezone({
@@ -183,7 +197,12 @@ describe('resolveAxisTimezone', () => {
                 },
                 resolvedTimezone: TZ,
             });
-            expect(result.shiftedField).toBeUndefined();
+            expect(result.timeAxisField).toEqual({
+                fieldId,
+                timezone: TZ,
+                flipAxes: false,
+                mode: 'sub-day-format',
+            });
             expect(result.axisTimezone).toBe(TZ);
             expect(result.axisDisplayTimezone).toBeUndefined();
         },
@@ -199,13 +218,82 @@ describe('resolveAxisTimezone', () => {
             },
             resolvedTimezone: TZ,
         });
-        expect(result.shiftedField).toEqual({
+        expect(result.timeAxisField).toEqual({
             fieldId,
             timezone: TZ,
             flipAxes: false,
+            mode: 'shift',
         });
         expect(result.axisTimezone).toBeUndefined();
         expect(result.axisDisplayTimezone).toBe(TZ);
+    });
+
+    test('does not shift or format a sub-day dim opted out via skipTimezoneConversion', () => {
+        const fieldId = 'orders_created_hour';
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({ xField: fieldId }),
+            itemsMap: {
+                ...itemsMap,
+                [fieldId]: makeTimeDimension(fieldId, TimeFrames.HOUR, {
+                    skipTimezoneConversion: true,
+                }),
+            },
+            resolvedTimezone: TZ,
+        });
+        expect(result.timeAxisField).toBeUndefined();
+        expect(result.axisDisplayTimezone).toBeUndefined();
+        expect(result.axisTimezone).toBe(TZ);
+    });
+
+    test('does not shift a DAY dim opted out via skipTimezoneConversion', () => {
+        const fieldId = 'orders_created_day';
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({ xField: fieldId }),
+            itemsMap: {
+                ...itemsMap,
+                [fieldId]: makeTimeDimension(fieldId, TimeFrames.DAY, {
+                    skipTimezoneConversion: true,
+                }),
+            },
+            resolvedTimezone: TZ,
+        });
+        expect(result.timeAxisField).toBeUndefined();
+    });
+
+    test('does not shift a calendar DATE day bucket', () => {
+        const fieldId = 'orders_created_day';
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({ xField: fieldId }),
+            itemsMap: {
+                ...itemsMap,
+                [fieldId]: makeTimeDimension(fieldId, TimeFrames.DAY, {
+                    type: DimensionType.DATE,
+                }),
+            },
+            resolvedTimezone: TZ,
+        });
+        expect(result.timeAxisField).toBeUndefined();
+    });
+
+    test('shifts a DATE day bucket derived from a TIMESTAMP base', () => {
+        const fieldId = 'orders_created_day';
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({ xField: fieldId }),
+            itemsMap: {
+                ...itemsMap,
+                [fieldId]: makeTimeDimension(fieldId, TimeFrames.DAY, {
+                    type: DimensionType.DATE,
+                    timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                }),
+            },
+            resolvedTimezone: TZ,
+        });
+        expect(result.timeAxisField).toEqual({
+            fieldId,
+            timezone: TZ,
+            flipAxes: false,
+            mode: 'shift',
+        });
     });
 
     test('uses yField[0] when flipAxes is true', () => {
@@ -217,10 +305,11 @@ describe('resolveAxisTimezone', () => {
             itemsMap,
             resolvedTimezone: TZ,
         });
-        expect(result.shiftedField).toEqual({
+        expect(result.timeAxisField).toEqual({
             fieldId: 'orders_created_day',
             timezone: TZ,
             flipAxes: true,
+            mode: 'shift',
         });
     });
 
@@ -230,7 +319,7 @@ describe('resolveAxisTimezone', () => {
             itemsMap,
             resolvedTimezone: TZ,
         });
-        expect(result.shiftedField).toBeUndefined();
+        expect(result.timeAxisField).toBeUndefined();
     });
 });
 

--- a/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
@@ -171,18 +171,31 @@ describe('resolveAxisTimezone', () => {
         expect(result.axisTimezone).toBe(TZ);
     });
 
-    test.each([
-        TimeFrames.SECOND,
-        TimeFrames.MINUTE,
-        TimeFrames.HOUR,
-        TimeFrames.DAY,
-    ])('shifts for time-axis interval %s', (interval) => {
-        const fieldId = `orders_created_${interval.toLowerCase()}`;
+    test.each([TimeFrames.SECOND, TimeFrames.MINUTE, TimeFrames.HOUR])(
+        'keeps raw UTC positioning for sub-day interval %s',
+        (interval) => {
+            const fieldId = `orders_created_${interval.toLowerCase()}`;
+            const result = resolveAxisTimezone({
+                validCartesianConfig: makeCartesian({ xField: fieldId }),
+                itemsMap: {
+                    ...itemsMap,
+                    [fieldId]: makeTimeDimension(fieldId, interval),
+                },
+                resolvedTimezone: TZ,
+            });
+            expect(result.shiftedField).toBeUndefined();
+            expect(result.axisTimezone).toBe(TZ);
+            expect(result.axisDisplayTimezone).toBeUndefined();
+        },
+    );
+
+    test('shifts day buckets to wall-clock for time-axis interval DAY', () => {
+        const fieldId = 'orders_created_day';
         const result = resolveAxisTimezone({
             validCartesianConfig: makeCartesian({ xField: fieldId }),
             itemsMap: {
                 ...itemsMap,
-                [fieldId]: makeTimeDimension(fieldId, interval),
+                [fieldId]: makeTimeDimension(fieldId, TimeFrames.DAY),
             },
             resolvedTimezone: TZ,
         });

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -2,6 +2,7 @@ import {
     extractableTimeFrames,
     isDimension,
     isSubDayTimeFrame,
+    shouldShiftItemTimezone,
     TimeFrames,
     type CartesianChart,
     type ItemsMap,
@@ -32,11 +33,18 @@ type DetectedTimezoneAxisField = TimezoneShiftedField & {
     timeInterval: TimeFrames;
 };
 
-// Exactly one of axisTimezone / axisDisplayTimezone is set: axisDisplayTimezone
-// when values are shifted to wall-clock, axisTimezone when raw UTC instants
-// should be formatted in the project timezone.
+// The detected time-axis field and how to apply its zone: 'shift' rewrites rows
+// to wall-clock (DAY+); 'sub-day-format' keeps raw UTC positions and only
+// relabels ticks (sub-day grains, where wall-clock shifting breaks across DST).
+export type DetectedTimeAxisField = TimezoneShiftedField & {
+    mode: 'shift' | 'sub-day-format';
+};
+
+// timeAxisField is the single source of truth for both paths. axisTimezone /
+// axisDisplayTimezone are the formatter zone inputs: axisDisplayTimezone for
+// pre-shifted values, axisTimezone for raw UTC formatted in-zone.
 export type AxisTimezoneConfig = {
-    shiftedField: TimezoneShiftedField | undefined;
+    timeAxisField: DetectedTimeAxisField | undefined;
     axisTimezone: string | undefined;
     axisDisplayTimezone: string | undefined;
 };
@@ -91,6 +99,11 @@ const detectTimezoneShiftedField = ({
     ) {
         return undefined;
     }
+    // Honor the same opt-out as the table and exports: calendar DATEs and
+    // skipTimezoneConversion dims are not shiftable instants.
+    if (!shouldShiftItemTimezone(field)) {
+        return undefined;
+    }
     return {
         fieldId: timeFieldId,
         timezone: resolvedTimezone,
@@ -107,24 +120,30 @@ export const resolveAxisTimezone = (params: {
     const detectedField = detectTimezoneShiftedField(params);
     if (detectedField && isSubDayTimeFrame(detectedField.timeInterval)) {
         return {
-            shiftedField: undefined,
+            timeAxisField: {
+                fieldId: detectedField.fieldId,
+                timezone: detectedField.timezone,
+                flipAxes: detectedField.flipAxes,
+                mode: 'sub-day-format',
+            },
             axisTimezone: detectedField.timezone,
             axisDisplayTimezone: undefined,
         };
     }
     if (detectedField) {
         return {
-            shiftedField: {
+            timeAxisField: {
                 fieldId: detectedField.fieldId,
                 timezone: detectedField.timezone,
                 flipAxes: detectedField.flipAxes,
+                mode: 'shift',
             },
             axisTimezone: undefined,
             axisDisplayTimezone: detectedField.timezone,
         };
     }
     return {
-        shiftedField: undefined,
+        timeAxisField: undefined,
         axisTimezone: params.resolvedTimezone,
         axisDisplayTimezone: undefined,
     };

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -1,6 +1,7 @@
 import {
     extractableTimeFrames,
     isDimension,
+    isSubDayTimeFrame,
     TimeFrames,
     type CartesianChart,
     type ItemsMap,
@@ -27,8 +28,13 @@ export type TimezoneShiftedField = {
     flipAxes: boolean;
 };
 
+type DetectedTimezoneAxisField = TimezoneShiftedField & {
+    timeInterval: TimeFrames;
+};
+
 // Exactly one of axisTimezone / axisDisplayTimezone is set: axisDisplayTimezone
-// when values are shifted to wall-clock, axisTimezone otherwise.
+// when values are shifted to wall-clock, axisTimezone when raw UTC instants
+// should be formatted in the project timezone.
 export type AxisTimezoneConfig = {
     shiftedField: TimezoneShiftedField | undefined;
     axisTimezone: string | undefined;
@@ -59,7 +65,7 @@ const detectTimezoneShiftedField = ({
     validCartesianConfig: CartesianChart | undefined;
     itemsMap: ItemsMap | undefined;
     resolvedTimezone: string | undefined;
-}): TimezoneShiftedField | undefined => {
+}): DetectedTimezoneAxisField | undefined => {
     if (
         !resolvedTimezone ||
         resolvedTimezone === 'UTC' ||
@@ -85,7 +91,12 @@ const detectTimezoneShiftedField = ({
     ) {
         return undefined;
     }
-    return { fieldId: timeFieldId, timezone: resolvedTimezone, flipAxes };
+    return {
+        fieldId: timeFieldId,
+        timezone: resolvedTimezone,
+        flipAxes,
+        timeInterval,
+    };
 };
 
 export const resolveAxisTimezone = (params: {
@@ -93,12 +104,23 @@ export const resolveAxisTimezone = (params: {
     itemsMap: ItemsMap | undefined;
     resolvedTimezone: string | undefined;
 }): AxisTimezoneConfig => {
-    const shiftedField = detectTimezoneShiftedField(params);
-    if (shiftedField) {
+    const detectedField = detectTimezoneShiftedField(params);
+    if (detectedField && isSubDayTimeFrame(detectedField.timeInterval)) {
         return {
-            shiftedField,
+            shiftedField: undefined,
+            axisTimezone: detectedField.timezone,
+            axisDisplayTimezone: undefined,
+        };
+    }
+    if (detectedField) {
+        return {
+            shiftedField: {
+                fieldId: detectedField.fieldId,
+                timezone: detectedField.timezone,
+                flipAxes: detectedField.flipAxes,
+            },
             axisTimezone: undefined,
-            axisDisplayTimezone: shiftedField.timezone,
+            axisDisplayTimezone: detectedField.timezone,
         };
     }
     return {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -840,40 +840,58 @@ describe('getSubDayTimeAxisConfig', () => {
             [axisId]: { value: { raw: d, formatted: d } },
         }));
 
-    const createAxisField = (timeInterval: TimeFrames) =>
+    const subDayField = (timezone: string) =>
         ({
-            fieldType: FieldType.DIMENSION,
-            timeInterval,
-            name: 'test_time',
-            table: 'test_table',
-            type: DimensionType.TIMESTAMP,
-        }) as unknown as Field;
+            fieldId: axisId,
+            timezone,
+            flipAxes: false,
+            mode: 'sub-day-format',
+        }) as const;
 
-    test('returns empty object when axisType is not time', () => {
+    test('returns empty object when timeAxisField is undefined', () => {
         const result = getSubDayTimeAxisConfig(
             axisId,
-            createAxisField(TimeFrames.HOUR),
             createRows([
                 '2024-10-26T23:00:00.000Z',
                 '2024-10-27T02:00:00.000Z',
             ]),
-            'category',
-            'Europe/London',
+            undefined,
         );
 
         expect(result).toEqual({});
     });
 
-    test('returns empty object for day intervals', () => {
+    test('returns empty object when timeAxisField targets another axis', () => {
         const result = getSubDayTimeAxisConfig(
             axisId,
-            createAxisField(TimeFrames.DAY),
             createRows([
                 '2024-10-26T23:00:00.000Z',
                 '2024-10-27T02:00:00.000Z',
             ]),
-            'time',
-            'Europe/London',
+            {
+                fieldId: 'a_different_axis',
+                timezone: 'Europe/London',
+                flipAxes: false,
+                mode: 'sub-day-format',
+            },
+        );
+
+        expect(result).toEqual({});
+    });
+
+    test('returns empty object when timeAxisField is in shift mode', () => {
+        const result = getSubDayTimeAxisConfig(
+            axisId,
+            createRows([
+                '2024-10-26T23:00:00.000Z',
+                '2024-10-27T02:00:00.000Z',
+            ]),
+            {
+                fieldId: axisId,
+                timezone: 'Europe/London',
+                flipAxes: false,
+                mode: 'shift',
+            },
         );
 
         expect(result).toEqual({});
@@ -882,15 +900,13 @@ describe('getSubDayTimeAxisConfig', () => {
     test('uses raw UTC instants as custom tick values across DST fall-back', () => {
         const result = getSubDayTimeAxisConfig(
             axisId,
-            createAxisField(TimeFrames.HOUR),
             createRows([
                 '2024-10-26T23:00:00.000Z',
                 '2024-10-27T00:00:00.000Z',
                 '2024-10-27T01:00:00.000Z',
                 '2024-10-27T02:00:00.000Z',
             ]),
-            'time',
-            'Europe/London',
+            subDayField('Europe/London'),
         );
 
         expect(result.axisTick?.customValues).toEqual([
@@ -904,17 +920,25 @@ describe('getSubDayTimeAxisConfig', () => {
         );
     });
 
+    test('clears the leveled rich-text style left by the default formatter', () => {
+        const result = getSubDayTimeAxisConfig(
+            axisId,
+            createRows(['2024-01-01T00:15:00.000Z']),
+            subDayField('Asia/Kathmandu'),
+        );
+
+        expect(result.axisLabel?.rich).toBeUndefined();
+    });
+
     test('preserves fractional-offset bucket boundaries for hourly ticks', () => {
         const result = getSubDayTimeAxisConfig(
             axisId,
-            createAxisField(TimeFrames.HOUR),
             createRows([
                 '2024-01-01T00:15:00.000Z',
                 '2024-01-01T01:15:00.000Z',
                 '2024-01-01T02:15:00.000Z',
             ]),
-            'time',
-            'Asia/Kathmandu',
+            subDayField('Asia/Kathmandu'),
         );
 
         expect(result.axisTick?.customValues).toEqual([
@@ -924,22 +948,15 @@ describe('getSubDayTimeAxisConfig', () => {
         ]);
     });
 
-    const getFormatter = (
-        timeInterval: TimeFrames,
-        timezone: string,
-        raw: string,
-    ) =>
+    const getFormatter = (timezone: string, raw: string) =>
         getSubDayTimeAxisConfig(
             axisId,
-            createAxisField(timeInterval),
             createRows([raw]),
-            'time',
-            timezone,
+            subDayField(timezone),
         ).axisLabel?.formatter as ((value: number) => string) | undefined;
 
     test('labels ticks in the resolved zone across the fall-back boundary', () => {
         const format = getFormatter(
-            TimeFrames.HOUR,
             'Europe/London',
             '2024-10-27T00:00:00.000Z',
         )!;
@@ -953,7 +970,6 @@ describe('getSubDayTimeAxisConfig', () => {
 
     test('labels ticks in the resolved zone across the spring-forward boundary', () => {
         const format = getFormatter(
-            TimeFrames.HOUR,
             'Europe/London',
             '2024-03-31T00:00:00.000Z',
         )!;
@@ -965,7 +981,6 @@ describe('getSubDayTimeAxisConfig', () => {
 
     test('labels fractional-offset zones at their real wall-clock minute', () => {
         const format = getFormatter(
-            TimeFrames.HOUR,
             'Asia/Kathmandu',
             '2024-01-01T00:15:00.000Z',
         )!;
@@ -980,7 +995,7 @@ describe('getSubDayTimeAxisConfig', () => {
         ['2024-01-01T10:30:45.000Z', '19:30:45'],
         ['2024-01-01T10:30:45.500Z', '19:30:45 500'],
     ])('renders %s at the finest non-zero unit', (raw, expected) => {
-        const format = getFormatter(TimeFrames.SECOND, 'Asia/Tokyo', raw)!;
+        const format = getFormatter('Asia/Tokyo', raw)!;
         expect(format(Date.parse(raw))).toBe(expected);
     });
 });

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -923,6 +923,66 @@ describe('getSubDayTimeAxisConfig', () => {
             Date.parse('2024-01-01T02:15:00.000Z'),
         ]);
     });
+
+    const getFormatter = (
+        timeInterval: TimeFrames,
+        timezone: string,
+        raw: string,
+    ) =>
+        getSubDayTimeAxisConfig(
+            axisId,
+            createAxisField(timeInterval),
+            createRows([raw]),
+            'time',
+            timezone,
+        ).axisLabel?.formatter as ((value: number) => string) | undefined;
+
+    test('labels ticks in the resolved zone across the fall-back boundary', () => {
+        const format = getFormatter(
+            TimeFrames.HOUR,
+            'Europe/London',
+            '2024-10-27T00:00:00.000Z',
+        )!;
+        // 23:00Z is 00:00 BST — a day boundary, so ECharts shows the date (day-of-month).
+        expect(format(Date.parse('2024-10-26T23:00:00.000Z'))).toBe('27');
+        // Both folded 01:00 wall-clock hours (00:00Z BST and 01:00Z GMT) read 01:00.
+        expect(format(Date.parse('2024-10-27T00:00:00.000Z'))).toBe('01:00');
+        expect(format(Date.parse('2024-10-27T01:00:00.000Z'))).toBe('01:00');
+        expect(format(Date.parse('2024-10-27T02:00:00.000Z'))).toBe('02:00');
+    });
+
+    test('labels ticks in the resolved zone across the spring-forward boundary', () => {
+        const format = getFormatter(
+            TimeFrames.HOUR,
+            'Europe/London',
+            '2024-03-31T00:00:00.000Z',
+        )!;
+        expect(format(Date.parse('2024-03-31T00:00:00.000Z'))).toBe('31');
+        // 01:00Z springs forward to 02:00 BST — the 01:00 wall-clock hour is skipped.
+        expect(format(Date.parse('2024-03-31T01:00:00.000Z'))).toBe('02:00');
+        expect(format(Date.parse('2024-03-31T02:00:00.000Z'))).toBe('03:00');
+    });
+
+    test('labels fractional-offset zones at their real wall-clock minute', () => {
+        const format = getFormatter(
+            TimeFrames.HOUR,
+            'Asia/Kathmandu',
+            '2024-01-01T00:15:00.000Z',
+        )!;
+        // +05:45 → 00:15Z is 06:00 NPT.
+        expect(format(Date.parse('2024-01-01T00:15:00.000Z'))).toBe('06:00');
+    });
+
+    // Precision follows the value's finest non-zero unit (ECharts' getUnitFromValue
+    // rule), not the dimension grain. Asia/Tokyo is UTC+9 with no DST.
+    test.each([
+        ['2024-01-01T10:30:00.000Z', '19:30'],
+        ['2024-01-01T10:30:45.000Z', '19:30:45'],
+        ['2024-01-01T10:30:45.500Z', '19:30:45 500'],
+    ])('renders %s at the finest non-zero unit', (raw, expected) => {
+        const format = getFormatter(TimeFrames.SECOND, 'Asia/Tokyo', raw)!;
+        expect(format(Date.parse(raw))).toBe(expected);
+    });
 });
 
 describe('filterSeriesWithNoData', () => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -20,6 +20,7 @@ import {
     getAxisDefaultMinValue,
     getCategoryDateAxisConfig,
     getMinAndMaxValues,
+    getSubDayTimeAxisConfig,
     getStackTotalSeries,
     mergeLegendSettings,
     padDatasetForContinuousAxis,
@@ -828,6 +829,99 @@ describe('getCategoryDateAxisConfig', () => {
                 expect(result.data).toEqual(expectedMonthlyRange(tz, years));
             });
         });
+    });
+});
+
+describe('getSubDayTimeAxisConfig', () => {
+    const axisId = 'hour_axis';
+
+    const createRows = (dates: string[]): ResultRow[] =>
+        dates.map((d) => ({
+            [axisId]: { value: { raw: d, formatted: d } },
+        }));
+
+    const createAxisField = (timeInterval: TimeFrames) =>
+        ({
+            fieldType: FieldType.DIMENSION,
+            timeInterval,
+            name: 'test_time',
+            table: 'test_table',
+            type: DimensionType.TIMESTAMP,
+        }) as unknown as Field;
+
+    test('returns empty object when axisType is not time', () => {
+        const result = getSubDayTimeAxisConfig(
+            axisId,
+            createAxisField(TimeFrames.HOUR),
+            createRows([
+                '2024-10-26T23:00:00.000Z',
+                '2024-10-27T02:00:00.000Z',
+            ]),
+            'category',
+            'Europe/London',
+        );
+
+        expect(result).toEqual({});
+    });
+
+    test('returns empty object for day intervals', () => {
+        const result = getSubDayTimeAxisConfig(
+            axisId,
+            createAxisField(TimeFrames.DAY),
+            createRows([
+                '2024-10-26T23:00:00.000Z',
+                '2024-10-27T02:00:00.000Z',
+            ]),
+            'time',
+            'Europe/London',
+        );
+
+        expect(result).toEqual({});
+    });
+
+    test('uses raw UTC instants as custom tick values across DST fall-back', () => {
+        const result = getSubDayTimeAxisConfig(
+            axisId,
+            createAxisField(TimeFrames.HOUR),
+            createRows([
+                '2024-10-26T23:00:00.000Z',
+                '2024-10-27T00:00:00.000Z',
+                '2024-10-27T01:00:00.000Z',
+                '2024-10-27T02:00:00.000Z',
+            ]),
+            'time',
+            'Europe/London',
+        );
+
+        expect(result.axisTick?.customValues).toEqual([
+            Date.parse('2024-10-26T23:00:00.000Z'),
+            Date.parse('2024-10-27T00:00:00.000Z'),
+            Date.parse('2024-10-27T01:00:00.000Z'),
+            Date.parse('2024-10-27T02:00:00.000Z'),
+        ]);
+        expect(result.axisLabel?.customValues).toEqual(
+            result.axisTick?.customValues,
+        );
+    });
+
+    test('preserves fractional-offset bucket boundaries for hourly ticks', () => {
+        const result = getSubDayTimeAxisConfig(
+            axisId,
+            createAxisField(TimeFrames.HOUR),
+            createRows([
+                '2024-01-01T00:15:00.000Z',
+                '2024-01-01T01:15:00.000Z',
+                '2024-01-01T02:15:00.000Z',
+            ]),
+            'time',
+            'Asia/Kathmandu',
+        );
+
+        expect(result.axisTick?.customValues).toEqual([
+            Date.parse('2024-01-01T00:15:00.000Z'),
+            Date.parse('2024-01-01T01:15:00.000Z'),
+            Date.parse('2024-01-01T02:15:00.000Z'),
+        ]);
     });
 });
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -45,7 +45,6 @@ import {
     isField,
     isMetric,
     isPivotReferenceWithValues,
-    isSubDayTimeFrame,
     isTableCalculation,
     LightdashParameters,
     MetricType,
@@ -105,6 +104,7 @@ import {
     applyTimezoneShiftToEchartsOptions,
     resolveAxisTimezone,
     TIME_INTERVALS_FOR_CATEGORY_AXIS,
+    type DetectedTimeAxisField,
 } from './timezoneShift';
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 
@@ -1506,15 +1506,20 @@ export const padDatasetForContinuousAxis = (
  */
 type CategoryDateAxisConfig = {
     data?: string[];
-    axisTick?: Record<string, unknown>;
-    axisLabel?: Record<string, unknown>;
+    axisTick?: { alignWithLabel: boolean; interval: number };
     boundaryGap?: boolean;
 };
 
-type SubDayTimeAxisConfig = Pick<
-    CategoryDateAxisConfig,
-    'axisTick' | 'axisLabel'
->;
+// Sub-day axes pin ticks/labels to the raw UTC bucket instants and relabel them
+// in-zone, so both configs are keyed on the same `customValues` instant list.
+type SubDayTimeAxisConfig = {
+    axisTick?: { customValues: number[] };
+    axisLabel?: {
+        customValues: number[];
+        rich: undefined;
+        formatter: (value: number) => string;
+    };
+};
 
 const getAxisInstantMs = (raw: unknown): number | undefined => {
     if (typeof raw === 'number') {
@@ -1546,27 +1551,19 @@ const formatSubDayAxisLabel = (value: number, timezone: string): string => {
     return date.format('YYYY');
 };
 
+// resolveAxisTimezone decides which field qualifies and forwards it as a
+// sub-day-format timeAxisField; here we only build its tick/label config.
 export const getSubDayTimeAxisConfig = (
-    axisId?: string,
-    axisField?: Field | TableCalculation | CustomDimension,
-    rows?: ResultRow[],
-    axisType?: string,
-    resolvedTimezone?: string,
+    axisId: string | undefined,
+    rows: ResultRow[] | undefined,
+    timeAxisField: DetectedTimeAxisField | undefined,
 ): SubDayTimeAxisConfig => {
     if (
         !axisId ||
         !rows ||
-        !axisField ||
-        axisType !== 'time' ||
-        !resolvedTimezone ||
-        !isDimension(axisField) ||
-        isCalendarValueDimension(axisField)
+        timeAxisField?.mode !== 'sub-day-format' ||
+        timeAxisField.fieldId !== axisId
     ) {
-        return {};
-    }
-
-    const { timeInterval } = axisField;
-    if (!timeInterval || !isSubDayTimeFrame(timeInterval)) {
         return {};
     }
 
@@ -1586,8 +1583,10 @@ export const getSubDayTimeAxisConfig = (
         axisTick: { customValues },
         axisLabel: {
             customValues,
+            // Drop the rich-text style ECharts' leveled formatter leaves behind.
+            rich: undefined,
             formatter: (value: number) =>
-                formatSubDayAxisLabel(value, resolvedTimezone),
+                formatSubDayAxisLabel(value, timeAxisField.timezone),
         },
     };
 };
@@ -1717,6 +1716,7 @@ const getEchartAxes = ({
     parameters,
     resolvedTimezone,
     displayTimezone,
+    timeAxisField,
 }: {
     validCartesianConfig: CartesianChart;
     itemsMap: ItemsMap;
@@ -1727,6 +1727,7 @@ const getEchartAxes = ({
     parameters?: ParametersValuesMap;
     resolvedTimezone?: string;
     displayTimezone?: string;
+    timeAxisField: DetectedTimeAxisField | undefined;
 }) => {
     const xAxisItemId = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.layout?.yField?.[0]
@@ -1931,17 +1932,13 @@ const getEchartAxes = ({
     );
     const bottomAxisSubDayConfig = getSubDayTimeAxisConfig(
         bottomAxisXId,
-        bottomAxisXField,
         axisRows,
-        bottomAxisType,
-        resolvedTimezone,
+        timeAxisField,
     );
     const leftAxisSubDayConfig = getSubDayTimeAxisConfig(
         leftAxisYId,
-        leftAxisYField,
         axisRows,
-        leftAxisType,
-        resolvedTimezone,
+        timeAxisField,
     );
 
     const axisLabelFontSize =
@@ -2596,7 +2593,7 @@ const useEchartsCartesianConfig = (
         return visualizationConfig.chartConfig.validConfig;
     }, [visualizationConfig]);
 
-    const { shiftedField, axisTimezone, axisDisplayTimezone } = useMemo(
+    const { timeAxisField, axisTimezone, axisDisplayTimezone } = useMemo(
         () =>
             resolveAxisTimezone({
                 validCartesianConfig,
@@ -2700,6 +2697,7 @@ const useEchartsCartesianConfig = (
             parameters,
             resolvedTimezone: axisTimezone,
             displayTimezone: axisDisplayTimezone,
+            timeAxisField,
         });
     }, [
         itemsMap,
@@ -2711,6 +2709,7 @@ const useEchartsCartesianConfig = (
         parameters,
         axisTimezone,
         axisDisplayTimezone,
+        timeAxisField,
     ]);
 
     // Shared by stackedSeriesWithColorAssignments (non-stacked bar styling) and
@@ -3729,8 +3728,8 @@ const useEchartsCartesianConfig = (
             }),
         };
 
-        return shiftedField
-            ? applyTimezoneShiftToEchartsOptions(baseOptions, shiftedField)
+        return timeAxisField?.mode === 'shift'
+            ? applyTimezoneShiftToEchartsOptions(baseOptions, timeAxisField)
             : baseOptions;
     }, [
         sortedAxes,
@@ -3743,7 +3742,7 @@ const useEchartsCartesianConfig = (
         currentGrid,
         theme?.other.chartFont,
         validCartesianConfig,
-        shiftedField,
+        timeAxisField,
     ]);
 
     if (

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -45,6 +45,7 @@ import {
     isField,
     isMetric,
     isPivotReferenceWithValues,
+    isSubDayTimeFrame,
     isTableCalculation,
     LightdashParameters,
     MetricType,
@@ -1505,8 +1506,70 @@ export const padDatasetForContinuousAxis = (
  */
 type CategoryDateAxisConfig = {
     data?: string[];
-    axisTick?: { alignWithLabel: boolean; interval: number };
+    axisTick?: Record<string, unknown>;
+    axisLabel?: Record<string, unknown>;
     boundaryGap?: boolean;
+};
+
+type SubDayTimeAxisConfig = Pick<
+    CategoryDateAxisConfig,
+    'axisTick' | 'axisLabel'
+>;
+
+const getAxisInstantMs = (raw: unknown): number | undefined => {
+    if (typeof raw === 'number') {
+        return Number.isFinite(raw) ? raw : undefined;
+    }
+    if (raw instanceof Date) {
+        return Number.isFinite(raw.getTime()) ? raw.getTime() : undefined;
+    }
+    if (typeof raw !== 'string') {
+        return undefined;
+    }
+    const parsed = dayjs.utc(raw).valueOf();
+    return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export const getSubDayTimeAxisConfig = (
+    axisId?: string,
+    axisField?: Field | TableCalculation | CustomDimension,
+    rows?: ResultRow[],
+    axisType?: string,
+    resolvedTimezone?: string,
+): SubDayTimeAxisConfig => {
+    if (
+        !axisId ||
+        !rows ||
+        !axisField ||
+        axisType !== 'time' ||
+        !resolvedTimezone ||
+        !isDimension(axisField) ||
+        isCalendarValueDimension(axisField)
+    ) {
+        return {};
+    }
+
+    const { timeInterval } = axisField;
+    if (!timeInterval || !isSubDayTimeFrame(timeInterval)) {
+        return {};
+    }
+
+    const customValues = Array.from(
+        new Set(
+            rows
+                .map((row) => getAxisInstantMs(row[axisId]?.value.raw))
+                .filter((value): value is number => value !== undefined),
+        ),
+    ).sort((a, b) => a - b);
+
+    if (!customValues.length) {
+        return {};
+    }
+
+    return {
+        axisTick: { customValues },
+        axisLabel: { customValues },
+    };
 };
 
 export const getCategoryDateAxisConfig = (
@@ -1846,6 +1909,20 @@ const getEchartAxes = ({
         eChartsSeries,
         resolvedTimezone,
     );
+    const bottomAxisSubDayConfig = getSubDayTimeAxisConfig(
+        bottomAxisXId,
+        bottomAxisXField,
+        axisRows,
+        bottomAxisType,
+        resolvedTimezone,
+    );
+    const leftAxisSubDayConfig = getSubDayTimeAxisConfig(
+        leftAxisYId,
+        leftAxisYField,
+        axisRows,
+        leftAxisType,
+        resolvedTimezone,
+    );
 
     const axisLabelFontSize =
         validCartesianConfig?.eChartsConfig?.axisLabelFontSize;
@@ -2073,6 +2150,44 @@ const getEchartAxes = ({
         ? rightAxisYFieldIds && rightAxisYFieldIds.length > 0
         : false;
 
+    const bottomAxisLabelConfig = bottomAxisConfigWithStyle.axisLabel
+        ? {
+              ...bottomAxisConfigWithStyle.axisLabel,
+              ...(shouldStack100 && validCartesianConfig.layout.flipAxes
+                  ? { formatter: '{value}%' }
+                  : {}),
+              ...(!validCartesianConfig.layout.flipAxes &&
+              (xAxisConfiguration?.[0] as XAxis | undefined)?.enableDataZoom &&
+              bottomAxisType === 'category' &&
+              showXAxis
+                  ? {
+                        interval: 0,
+                        hideOverlap: true,
+                    }
+                  : {}),
+              ...bottomAxisSubDayConfig.axisLabel,
+          }
+        : undefined;
+
+    const leftAxisLabelConfig = leftAxisConfigWithStyle.axisLabel
+        ? {
+              ...leftAxisConfigWithStyle.axisLabel,
+              ...(shouldStack100 && !validCartesianConfig.layout.flipAxes
+                  ? { formatter: '{value}%' }
+                  : {}),
+              ...(validCartesianConfig.layout.flipAxes &&
+              (yAxisConfiguration?.[0] as XAxis | undefined)?.enableDataZoom &&
+              leftAxisType === 'category' &&
+              showLeftYAxis
+                  ? {
+                        interval: 0,
+                        hideOverlap: false,
+                    }
+                  : {}),
+              ...leftAxisSubDayConfig.axisLabel,
+          }
+        : undefined;
+
     return {
         xAxis: [
             {
@@ -2108,33 +2223,19 @@ const getEchartAxes = ({
                       ? gridStyle
                       : { show: false },
                 axisLine: getAxisLineStyle(),
-                axisTick: getAxisTickStyle(
-                    validCartesianConfig?.eChartsConfig?.showAxisTicks,
-                ),
-                // Override formatter for 100% stacking with flipped axes
-                ...(shouldStack100 &&
-                    validCartesianConfig.layout.flipAxes &&
-                    showXAxis && {
-                        axisLabel: {
-                            ...(bottomAxisConfigWithStyle.axisLabel || {}),
-                            formatter: '{value}%',
-                        },
-                    }),
-                // Override axisLabel settings when scrollable is enabled (not flipped)
-                ...(!validCartesianConfig.layout.flipAxes &&
-                    (xAxisConfiguration?.[0] as XAxis | undefined)
-                        ?.enableDataZoom &&
-                    bottomAxisType === 'category' &&
-                    showXAxis && {
-                        axisLabel: {
-                            ...(bottomAxisConfigWithStyle.axisLabel || {}),
-                            interval: 0,
-                            // Keep hideOverlap true to avoid overlapping when labels are long on X axis
-                            hideOverlap: true,
-                        },
-                    }),
                 inverse: !!xAxisConfiguration?.[0]?.inverse,
+                axisTick: {
+                    ...getAxisTickStyle(
+                        validCartesianConfig?.eChartsConfig?.showAxisTicks,
+                    ),
+                    ...bottomAxisSubDayConfig.axisTick,
+                },
+                // Spread last so a category-date axisTick keeps replacing the
+                // tick style (sub-day time axes never set extraConfig.axisTick).
                 ...bottomAxisExtraConfig,
+                ...(bottomAxisLabelConfig
+                    ? { axisLabel: bottomAxisLabelConfig }
+                    : {}),
                 min: bottomAxisBounds.min,
                 max: maxXAxisValue,
             },
@@ -2216,28 +2317,6 @@ const getEchartAxes = ({
                 min: minYAxisValue,
                 max: maxYAxisValue,
                 ...leftAxisConfigWithStyle,
-                // Override formatter for 100% stacking without flipped axes
-                ...(shouldStack100 &&
-                    !validCartesianConfig.layout.flipAxes &&
-                    showLeftYAxis && {
-                        axisLabel: {
-                            ...(leftAxisConfigWithStyle.axisLabel || {}),
-                            formatter: '{value}%',
-                        },
-                    }),
-                // Override axisLabel settings when scrollable is enabled and axes are flipped
-                ...(validCartesianConfig.layout.flipAxes &&
-                    (yAxisConfiguration?.[0] as XAxis | undefined)
-                        ?.enableDataZoom &&
-                    leftAxisType === 'category' &&
-                    showLeftYAxis && {
-                        axisLabel: {
-                            ...(leftAxisConfigWithStyle.axisLabel || {}),
-                            interval: 0,
-                            // Set hideOverlap to false to avoid hiding labels
-                            hideOverlap: false,
-                        },
-                    }),
                 splitLine: validCartesianConfig.layout.flipAxes
                     ? showGridX
                         ? gridStyle
@@ -2246,11 +2325,19 @@ const getEchartAxes = ({
                       ? gridStyle
                       : { show: false },
                 axisLine: getAxisLineStyle(),
-                axisTick: getAxisTickStyle(
-                    validCartesianConfig?.eChartsConfig?.showAxisTicks,
-                ),
                 inverse: !!yAxisConfiguration?.[0]?.inverse,
+                axisTick: {
+                    ...getAxisTickStyle(
+                        validCartesianConfig?.eChartsConfig?.showAxisTicks,
+                    ),
+                    ...leftAxisSubDayConfig.axisTick,
+                },
+                // Spread last so a category-date axisTick keeps replacing the
+                // tick style (sub-day time axes never set extraConfig.axisTick).
                 ...leftAxisExtraConfig,
+                ...(leftAxisLabelConfig
+                    ? { axisLabel: leftAxisLabelConfig }
+                    : {}),
             },
             {
                 type: rightAxisType,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1530,6 +1530,22 @@ const getAxisInstantMs = (raw: unknown): number | undefined => {
     return Number.isFinite(parsed) ? parsed : undefined;
 };
 
+// Sub-day axes are positioned by raw UTC instant, so ECharts (useUTC) would
+// label the ticks in UTC. Render each tick in the resolved zone instead,
+// mirroring ECharts' own getUnitFromValue + defaultLeveledFormatter
+// (echarts/lib/util/time): the most-significant non-zero unit selects the
+// format, and a day boundary shows the date. Labels only — positions stay raw
+// UTC, so DST continuity is untouched.
+const formatSubDayAxisLabel = (value: number, timezone: string): string => {
+    const date = dayjs.utc(value).tz(timezone);
+    if (date.millisecond() !== 0) return date.format('HH:mm:ss SSS');
+    if (date.second() !== 0) return date.format('HH:mm:ss');
+    if (date.minute() !== 0 || date.hour() !== 0) return date.format('HH:mm');
+    if (date.date() !== 1) return date.format('D');
+    if (date.month() !== 0) return date.format('MMM');
+    return date.format('YYYY');
+};
+
 export const getSubDayTimeAxisConfig = (
     axisId?: string,
     axisField?: Field | TableCalculation | CustomDimension,
@@ -1568,7 +1584,11 @@ export const getSubDayTimeAxisConfig = (
 
     return {
         axisTick: { customValues },
-        axisLabel: { customValues },
+        axisLabel: {
+            customValues,
+            formatter: (value: number) =>
+                formatSubDayAxisLabel(value, resolvedTimezone),
+        },
     };
 };
 


### PR DESCRIPTION
Sub-day time-interval dimensions (hour/minute/second) on a `time` cartesian axis were positioned by a per-row wall-clock shift. Wall-clock isn't injective across a DST transition, so two distinct buckets collapse onto one x-coordinate at fall-back (and a phantom slot opens at spring-forward); fractional offsets only stayed aligned by coincidence.

This positions sub-day grains by their true UTC instants and pins axis ticks/labels to the actual bucket instants via `customValues`, keeping points injective and gridlines aligned across DST and for fractional offsets. Axis labels render in the project timezone.

Day and coarser grains keep the existing wall-clock shift, with one deliberate tightening: calendar DATE dimensions and `convert_timezone: false` dims are no longer shifted on the axis, matching how the table and exports already treat them (a bare calendar date in a negative-offset zone could otherwise roll to the previous day). Gated transitively by `EnableTimezoneSupport`.

Verified live on the `timezone_test` model:
- DST fall-back (`America/New_York`, Nov 3, split warehouse): the two distinct 1 AM buckets (EDT/EST) collide into one degenerate bar on `main`; render as two correct adjacent bars with the fix.
- Spring-forward (`America/New_York`, Mar 10): the skipped 02:00 wall-clock hour is absent and the 01:00 / 03:00 bars sit adjacent, with no phantom gap.
- Fractional offset (`Asia/Kathmandu` +05:45): hour/minute ticks misaligned on `main`, one aligned tick per bar with the fix.
- Flag off (`EnableTimezoneSupport` disabled): the same query reverts to UTC values and ECharts default ticks, the sub-day path stays inert.


Closes: GLITCH-449
