### PR TITLE
fix(ai-agents): keep chat input placeholder aligned

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -331,6 +331,28 @@
     --input-bg: transparent;
 }
 
+.minimalPlaceholder {
+    position: absolute;
+    left: rem(30px);
+    right: rem(60px);
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: var(--mantine-font-size-sm);
+    line-height: 1.5;
+
+    @mixin light {
+        color: var(--mantine-color-ldGray-6);
+    }
+
+    @mixin dark {
+        color: var(--mantine-color-ldGray-7);
+    }
+}
+
 .minimalSubmitButton {
     flex-shrink: 0;
     align-self: flex-end;
@@ -415,7 +437,7 @@
 }
 
 .minimalEditorContent {
-    padding: 0 var(--mantine-spacing-xs);
+    padding: 0 var(--mantine-spacing-xs) 0 rem(6px);
     font-size: var(--mantine-font-size-sm);
     line-height: 1.5;
     min-height: 24px;
@@ -434,19 +456,10 @@
         background: transparent;
     }
 
-    :global(p.is-empty.is-editor-empty::before) {
-        content: attr(data-placeholder);
-        float: left;
-        pointer-events: none;
-        height: 0;
-
-        @mixin light {
-            color: var(--mantine-color-ldGray-6);
-        }
-
-        @mixin dark {
-            color: var(--mantine-color-ldGray-7);
-        }
+    :global(p.is-empty.is-editor-empty::before),
+    :global(p.is-empty.is-editor-empty:first-child::before),
+    :global(.ProseMirror p.is-editor-empty:first-child::before) {
+        content: none;
     }
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -402,6 +402,7 @@ export const AgentChatInput = ({
     );
 
     const hasValue = value.trim().length > 0;
+    const showMinimalPlaceholder = isMinimalMode && !hasValue;
     const showDisabledBanner = disabled && disabledReason;
     const isThreadInput = Boolean(threadUuid);
     const showSqlModeControl = Boolean(onSqlModeChange && !disabled);
@@ -537,6 +538,15 @@ export const AgentChatInput = ({
                         >
                             <RichTextEditor.Content />
                         </RichTextEditor>
+
+                        {showMinimalPlaceholder && (
+                            <Text
+                                aria-hidden
+                                className={styles.minimalPlaceholder}
+                            >
+                                {placeholder}
+                            </Text>
+                        )}
 
                         <ActionIcon
                             right={12}


### PR DESCRIPTION
## What
- Replace the minimal chat input placeholder with a real overlay placeholder.
- Decouple placeholder and cursor spacing so the input can ellipsize cleanly.

## Why
- The built-in TipTap placeholder was wrapping/ghosting badly in the compact chat input.
- This keeps the empty state readable without affecting the editor content.

## Check
- `pnpm --dir packages/frontend lint -- src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx`
