### PR TITLE
fix: allow ai agent evals to scroll

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.module.css
@@ -10,6 +10,18 @@
     background-color: var(--mantine-color-ldGray-3) !important;
 }
 
+.contentPanel {
+    min-height: 0;
+    overflow: hidden;
+}
+
+.contentStack {
+    box-sizing: border-box;
+    height: 100%;
+    min-height: 0;
+    overflow-y: auto;
+}
+
 .threadPanel {
     max-height: 100%;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
@@ -204,8 +204,14 @@ export const EvalSectionLayout: FC<EvalSectionLayoutProps> = ({ children }) => {
                 id="eval-content"
                 defaultSize={isSidebarOpen ? 40 : 100}
                 minSize={30}
+                className={styles.contentPanel}
             >
-                <Stack gap="sm" mt="lg" pr="md">
+                <Stack
+                    className={styles.contentStack}
+                    gap="sm"
+                    pt="lg"
+                    pr="md"
+                >
                     <Stack gap="md">
                         <Group justify="space-between" align="flex-start">
                             <Stack gap="xs">


### PR DESCRIPTION
## Summary
- Keep the AI Agent Evals content panel constrained to the viewport-height layout
- Make the eval content stack scroll internally when evaluations exceed the visible panel height
- Move the top spacing into padding so the scroll container still fits within the panel

Closes #24033

## Testing
- git diff --check
- Pre-commit hook: unused-exports passed; frontend linter --fix attempted but failed with spawn Unknown system error -8

Local browser/dev-server verification not run because the local app environment is not set up here.