### PR TITLE
feat: add project default to disable column total calculations

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -26649,7 +26649,10 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
-            nestedProperties: { case_sensitive: { dataType: 'boolean' } },
+            nestedProperties: {
+                column_totals: { dataType: 'boolean' },
+                case_sensitive: { dataType: 'boolean' },
+            },
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -27437,6 +27437,10 @@
             },
             "ProjectDefaults": {
                 "properties": {
+                    "column_totals": {
+                        "type": "boolean",
+                        "description": "Default behavior for column totals in results tables.\nWhen false, the extra warehouse query that calculates column totals\nis not run by default for new queries. Charts that explicitly enable\n\"Show column totals\" still calculate them.\nDefaults to true if not specified."
+                    },
                     "case_sensitive": {
                         "type": "boolean",
                         "description": "Default case sensitivity for string filters across the project.\nWhen false, all string filters will be case insensitive by default.\nCan be overridden at explore or field level.\nDefaults to true if not specified."

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1233,6 +1233,7 @@ export class ProjectModel {
             organizationWarehouseCredentialsUuid:
                 project.organizationWarehouseCredentialsUuid,
             hasDefaultUserSpaces: project.hasDefaultUserSpaces,
+            projectDefaults: project.projectDefaults,
             colorPaletteUuid: project.colorPaletteUuid ?? null,
             expiresAt: project.expiresAt,
         };

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2566,6 +2566,14 @@ export class ProjectService extends BaseService {
                         newProjectUuid,
                         lightdashProjectConfig.table_groups,
                     );
+                    // Mirrors CLI deploy semantics: only overwrite stored
+                    // defaults when the config file defines them
+                    if (lightdashProjectConfig.defaults) {
+                        await this.projectModel.updateProjectDefaults(
+                            newProjectUuid,
+                            lightdashProjectConfig.defaults,
+                        );
+                    }
                     await this.replaceProjectContext(
                         newProjectUuid,
                         projectContext,
@@ -3097,6 +3105,14 @@ export class ProjectService extends BaseService {
                                 projectUuid,
                                 lightdashProjectConfig.table_groups,
                             );
+                            // Mirrors CLI deploy semantics: only overwrite
+                            // stored defaults when the config file defines them
+                            if (lightdashProjectConfig.defaults) {
+                                await this.projectModel.updateProjectDefaults(
+                                    projectUuid,
+                                    lightdashProjectConfig.defaults,
+                                );
+                            }
                             await this.replaceProjectContext(
                                 projectUuid,
                                 projectContext,
@@ -6166,6 +6182,14 @@ export class ProjectService extends BaseService {
                             projectUuid,
                             lightdashProjectConfig.table_groups,
                         );
+                        // Mirrors CLI deploy semantics: only overwrite stored
+                        // defaults when the config file defines them
+                        if (lightdashProjectConfig.defaults) {
+                            await this.projectModel.updateProjectDefaults(
+                                projectUuid,
+                                lightdashProjectConfig.defaults,
+                            );
+                        }
                         await this.replaceProjectContext(
                             projectUuid,
                             projectContext,

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -49,6 +49,14 @@ export type ProjectDefaults = {
      * Defaults to true if not specified.
      */
     case_sensitive?: boolean;
+    /**
+     * Default behavior for column totals in results tables.
+     * When false, the extra warehouse query that calculates column totals
+     * is not run by default for new queries. Charts that explicitly enable
+     * "Show column totals" still calculate them.
+     * Defaults to true if not specified.
+     */
+    column_totals?: boolean;
     // Room for future project-wide defaults like:
     // date_format?: string;
     // number_format?: string;

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -14,6 +14,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useColumnTotalsEnabledByDefault } from '../../../hooks/useAsyncCalculateTotal';
 import { useColumns } from '../../../hooks/useColumns';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
@@ -91,7 +92,12 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         unpivotedQueryResults,
         unpivotedEnabled,
         missingRequiredParameters,
+        projectUuid,
     } = useExplorerQuery();
+
+    // Hide the totals footer entirely when the `column_totals` project
+    // default disables totals for the results table
+    const totalsEnabledByDefault = useColumnTotalsEnabledByDefault(projectUuid);
 
     const dimensions = query.data?.metricQuery?.dimensions ?? [];
     const metrics = query.data?.metricQuery?.metrics ?? [];
@@ -372,9 +378,9 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
     );
     const footer = useMemo(
         () => ({
-            show: true,
+            show: totalsEnabledByDefault,
         }),
-        [],
+        [totalsEnabledByDefault],
     );
 
     if (!activeTableName) return <NoTableSelected />;

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.test.tsx
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.test.tsx
@@ -1,0 +1,116 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { vi, type Mock } from 'vitest';
+import { useColumnTotalsEnabledByDefault } from './useAsyncCalculateTotal';
+
+vi.mock('../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+vi.mock('./useQueryError', () => ({
+    default: () => vi.fn(),
+}));
+
+let mockEmbedToken: string | undefined;
+vi.mock('../ee/providers/Embed/useEmbed', () => ({
+    default: () => ({ embedToken: mockEmbedToken }),
+}));
+
+import { lightdashApi } from '../api';
+
+const mockApi = lightdashApi as unknown as Mock;
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+}
+
+describe('useColumnTotalsEnabledByDefault', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockEmbedToken = undefined;
+    });
+
+    it('is false while the project is loading, then true when the project has no defaults', async () => {
+        mockApi.mockResolvedValue({ projectDefaults: undefined });
+
+        const { result } = renderHook(
+            () => useColumnTotalsEnabledByDefault('project-uuid'),
+            { wrapper: createWrapper() },
+        );
+
+        // never enables totals before the project default is known
+        expect(result.current).toBe(false);
+
+        await waitFor(() => expect(result.current).toBe(true));
+    });
+
+    it('is true when the project default explicitly enables column totals', async () => {
+        mockApi.mockResolvedValue({
+            projectDefaults: { column_totals: true },
+        });
+
+        const { result } = renderHook(
+            () => useColumnTotalsEnabledByDefault('project-uuid'),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => expect(result.current).toBe(true));
+    });
+
+    it('is false when the project default disables column totals', async () => {
+        mockApi.mockResolvedValue({
+            projectDefaults: { column_totals: false },
+        });
+
+        const { result } = renderHook(
+            () => useColumnTotalsEnabledByDefault('project-uuid'),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() =>
+            expect(mockApi).toHaveBeenCalledWith(
+                expect.objectContaining({ url: '/projects/project-uuid' }),
+            ),
+        );
+
+        expect(result.current).toBe(false);
+    });
+
+    it('falls back to enabled when the project fetch fails', async () => {
+        mockApi.mockRejectedValue({
+            error: { statusCode: 500, message: 'oops' },
+        });
+
+        const { result } = renderHook(
+            () => useColumnTotalsEnabledByDefault('project-uuid'),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => expect(result.current).toBe(true));
+    });
+
+    it('is true in embed mode without fetching the project', async () => {
+        mockEmbedToken = 'embed-token';
+
+        const { result } = renderHook(
+            () => useColumnTotalsEnabledByDefault('project-uuid'),
+            { wrapper: createWrapper() },
+        );
+
+        expect(result.current).toBe(true);
+        // give the project query a chance to (incorrectly) fire
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        expect(mockApi).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -13,7 +13,9 @@ import {
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
+import useEmbed from '../ee/providers/Embed/useEmbed';
 import { pollForResults } from '../features/queryRunner/executeQuery';
+import { useProject } from './useProject';
 
 // Reads every page of a ready query from the paginated results endpoint.
 const fetchAllResultRows = async (
@@ -95,6 +97,31 @@ const fetchTotals = async (
     // Polling endpoint defaults to page=1, so the READY response already
     // contains the single totals row — no separate stream fetch needed.
     return buildWarehouseColumnTotals(query.rows);
+};
+
+/**
+ * Whether column totals should be calculated when nothing has explicitly
+ * enabled them, e.g. the explorer results table. Controlled by the
+ * `column_totals` project default; charts that explicitly enable
+ * "Show column totals" should not use this.
+ *
+ * Returns false while the project is still loading so the totals query never
+ * fires before the default is known. The project endpoint requires app
+ * authentication, so embed mode skips it and keeps the default behavior.
+ */
+export const useColumnTotalsEnabledByDefault = (
+    projectUuid: string | undefined,
+): boolean => {
+    const { embedToken } = useEmbed();
+    const projectQuery = useProject(projectUuid, {
+        enabled: !embedToken && !!projectUuid,
+        // Errors fall back to the default behavior (totals enabled), so they
+        // shouldn't surface to the user
+        onError: () => {},
+    });
+    if (embedToken) return true;
+    if (projectQuery.isInitialLoading) return false;
+    return projectQuery.data?.projectDefaults?.column_totals !== false;
 };
 
 export const useAsyncCalculateTotal = ({

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -100,14 +100,10 @@ const fetchTotals = async (
 };
 
 /**
- * Whether column totals should be calculated when nothing has explicitly
- * enabled them, e.g. the explorer results table. Controlled by the
- * `column_totals` project default; charts that explicitly enable
- * "Show column totals" should not use this.
- *
- * Returns false while the project is still loading so the totals query never
- * fires before the default is known. The project endpoint requires app
- * authentication, so embed mode skips it and keeps the default behavior.
+ * Resolves the `column_totals` project default for callers with no explicit
+ * "Show column totals" toggle (e.g. the explorer results table). Returns false
+ * while loading so the totals query never fires before the default is known;
+ * embed mode skips the app-only project endpoint and keeps default behavior.
  */
 export const useColumnTotalsEnabledByDefault = (
     projectUuid: string | undefined,
@@ -115,8 +111,7 @@ export const useColumnTotalsEnabledByDefault = (
     const { embedToken } = useEmbed();
     const projectQuery = useProject(projectUuid, {
         enabled: !embedToken && !!projectUuid,
-        // Errors fall back to the default behavior (totals enabled), so they
-        // shouldn't surface to the user
+        // Errors fall back to totals enabled, so don't surface them
         onError: () => {},
     });
     if (embedToken) return true;

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -59,7 +59,10 @@ import {
 } from '../features/explorer/store';
 import { getFieldColors } from '../utils/fieldColors';
 import { TableCellBar } from './TableCellBar';
-import { useAsyncCalculateTotal } from './useAsyncCalculateTotal';
+import {
+    useAsyncCalculateTotal,
+    useColumnTotalsEnabledByDefault,
+} from './useAsyncCalculateTotal';
 import { useExplore } from './useExplore';
 import { useExplorerQuery } from './useExplorerQuery';
 
@@ -513,10 +516,13 @@ export const useColumns = (): TableColumn[] => {
         ? unpivotedQueryResults.queryUuid
         : queryResults.queryUuid;
     const hasMetricFields = !!resultsMetricQuery?.metrics.length;
+    // The results table has no explicit "Show column totals" setting, so the
+    // `column_totals` project default decides whether the totals query runs
+    const totalsEnabledByDefault = useColumnTotalsEnabledByDefault(projectUuid);
     const { data: totals } = useAsyncCalculateTotal({
         projectUuid,
         sourceQueryUuid,
-        enabled: !!sourceQueryUuid && hasMetricFields,
+        enabled: !!sourceQueryUuid && hasMetricFields && totalsEnabledByDefault,
         invalidateCache: validQueryArgs?.invalidateCache,
     });
 


### PR DESCRIPTION
## Summary

Closes #19179 ([PROD-2233](https://linear.app/lightdash/issue/PROD-2233/i-want-an-option-to-disable-column-total-calculations-by-default))

Adds a new project default `column_totals` that, when set to `false`, stops the warehouse query that calculates column totals from running by default. For cost-conscious users this saves one extra query per explore run.

### How to enable

Either via `lightdash.config.yml` (like the existing `case_sensitive` default — applied on CLI deploy **and** on dbt refresh):

```yaml
defaults:
  column_totals: false
```

or via the API:

```
PUT /api/v2/projects/{projectUuid}/defaults
{ "column_totals": false }
```

### Behavior

- **Default behavior is unchanged** when the setting is absent (or `true`).
- With `column_totals: false`, the explorer results table no longer runs the totals query and no longer renders the totals footer row. This is the one totals query that fires unconditionally for every query run — table charts already only fetch totals when "Show column totals" is explicitly checked.
- Charts that explicitly enable "Show column totals" still calculate totals — this is a default, not a kill switch.
- Embed mode is untouched (the project endpoint isn't available there), so embedded content behaves exactly as before.

<div>
    <a href="https://www.loom.com/share/70d96af6b1474ef287e3a5ae0357fa9b">
      <p>Enabling Setting Removes Total Row - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/70d96af6b1474ef287e3a5ae0357fa9b">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/70d96af6b1474ef287e3a5ae0357fa9b-cabc783e1f7a5a79-full-play.gif#t=0.1">
    </a>
  </div>

### Implementation

- `ProjectDefaults` (common) gets `column_totals?: boolean` (generated TSOA spec/routes updated for just this field).
- New `useColumnTotalsEnabledByDefault` hook reads the project default (shared `['project', uuid]` cache; returns `false` while loading so the query we're avoiding can't fire early; skipped in embed mode) and gates the `useAsyncCalculateTotal` call in `useColumns` plus the footer row in `ExplorerResults`.
- Two gaps found while verifying locally:
  - `ProjectModel.get()` dropped `projectDefaults` when rebuilding the project object, so the API never returned it (pre-existing bug, invisible until something consumed it).
  - Backend dbt refresh/compile paths persisted YAML `parameters`/`table_groups` but not `defaults`, so the setting only applied via CLI deploy. Now persisted alongside them, mirroring CLI semantics.

### Verification

Tested end-to-end on a local instance with the jaffle shop project — `query_history` shows the proof:

```
    context     | status |         created_at
----------------+--------+----------------------------
 calculateTotal | ready  | 02:43:46   <- default re-enabled: totals query runs, Total row shows
 exploreView    | ready  | 02:43:46
 exploreView    | ready  | 02:42:51   <- column_totals: false (via YAML + dbt refresh): no totals query
 exploreView    | ready  | 02:38:17   <- column_totals: false: no totals query
```

Also verified: YAML `defaults.column_totals: false` → dbt refresh → `project_defaults` in DB → `GET /projects/{uuid}` returns it → explorer skips totals and hides the Total footer; removing the default brings the totals row back (Total: 97).

### Tests

- New `useAsyncCalculateTotal.test.tsx` covering: loading state, no defaults, explicit enable, disabled default, project fetch failure fallback, and embed mode not fetching the project.
- ProjectService/ProjectModel suites (92 tests), typechecks, and lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)