### PR TITLE
feat(ai): scope content tools by agent spaces

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -67,12 +67,26 @@ const makeService = ({
     searchCatalog = jest.fn(),
     verifiedFieldUsage = new Map<string, number>(),
     searchFieldUniqueValues = jest.fn(),
+    projectSpaces = [],
+    spaceModel = {
+        hasSpaceWithPathAndUuids: jest.fn().mockResolvedValue(true),
+    },
+    dashboardService = {},
+    savedChartService = {},
+    coderService = {},
+    aiAgentContentValidation = {},
 }: {
     explores?: Record<string, Explore>;
     userAttributes?: Record<string, string[]>;
     searchCatalog?: jest.Mock;
     verifiedFieldUsage?: Map<string, number>;
     searchFieldUniqueValues?: jest.Mock;
+    projectSpaces?: Array<{ uuid: string; path: string }>;
+    spaceModel?: Record<string, unknown>;
+    dashboardService?: Record<string, unknown>;
+    savedChartService?: Record<string, unknown>;
+    coderService?: Record<string, unknown>;
+    aiAgentContentValidation?: Record<string, unknown>;
 } = {}) =>
     new AiAgentToolsService({
         builtInSkills: {
@@ -108,7 +122,7 @@ const makeService = ({
         },
         projectService: {
             searchFieldUniqueValues,
-            getSpaces: jest.fn().mockResolvedValue([]),
+            getSpaces: jest.fn().mockResolvedValue(projectSpaces),
         },
         userAttributesModel: {
             getAttributeValuesForOrgMember: jest
@@ -124,12 +138,12 @@ const makeService = ({
         searchModel: {},
         searchService: {},
         spaceService: {},
-        spaceModel: {},
-        dashboardService: {},
-        savedChartService: {},
-        coderService: {},
+        spaceModel,
+        dashboardService,
+        savedChartService,
+        coderService,
         contentService: {},
-        aiAgentContentValidation: {},
+        aiAgentContentValidation,
         projectContextModel: {},
         aiAgentDocumentModel: {},
         changesetModel: {},
@@ -258,6 +272,27 @@ describe('AiAgentToolsService', () => {
         );
     });
 
+    const denySpaceAccessModel = () => ({
+        hasSpaceWithPathAndUuids: jest.fn().mockResolvedValue(false),
+    });
+
+    const makeDashboardContent = (spaceSlug: string) => ({
+        slug: 'test-dashboard',
+        name: 'Test dashboard',
+        description: 'Test dashboard',
+        spaceSlug,
+        version: 1,
+        verified: false,
+        verification: null,
+        tiles: [],
+        tabs: [],
+        filters: {
+            dimensions: [],
+            metrics: [],
+            tableCalculations: [],
+        },
+    });
+
     it('does not search MCP field values when the field is outside the scoped explore', async () => {
         const searchFieldUniqueValues = jest.fn();
         const service = makeService({
@@ -292,5 +327,89 @@ describe('AiAgentToolsService', () => {
             }),
         ).rejects.toThrow(NotFoundError);
         expect(searchFieldUniqueValues).not.toHaveBeenCalled();
+    });
+
+    it('does not read content outside the scoped agent spaces', async () => {
+        const dashboardService = { getByIdOrSlug: jest.fn() };
+        const service = makeService({
+            spaceModel: denySpaceAccessModel(),
+            dashboardService,
+            coderService: {
+                getDashboards: jest.fn().mockResolvedValue({
+                    dashboards: [makeDashboardContent('blocked-space')],
+                }),
+            },
+        });
+        const runtime = service.createRuntime(
+            makeRuntimeContext({ spaceAccess: ['allowed-space-uuid'] }),
+        );
+
+        await expect(
+            runtime.readContent({ slug: 'test-dashboard', type: 'dashboard' }),
+        ).rejects.toThrow(NotFoundError);
+        expect(dashboardService.getByIdOrSlug).not.toHaveBeenCalled();
+    });
+
+    it('does not create content outside the scoped agent spaces', async () => {
+        const upsertDashboard = jest.fn();
+        const service = makeService({
+            spaceModel: denySpaceAccessModel(),
+            coderService: { upsertDashboard },
+            aiAgentContentValidation: { validateContent: jest.fn() },
+        });
+        const runtime = service.createRuntime(
+            makeRuntimeContext({ spaceAccess: ['allowed-space-uuid'] }),
+        );
+
+        await expect(
+            runtime.createContent({
+                type: 'dashboard',
+                content: makeDashboardContent('blocked-space'),
+            }),
+        ).rejects.toThrow(NotFoundError);
+        expect(upsertDashboard).not.toHaveBeenCalled();
+    });
+
+    it('does not edit content into a space outside the scoped agent spaces', async () => {
+        const upsertDashboard = jest.fn();
+        const service = makeService({
+            spaceModel: denySpaceAccessModel(),
+            dashboardService: {
+                getByIdOrSlug: jest
+                    .fn()
+                    .mockResolvedValue({ uuid: 'dashboard-uuid' }),
+            },
+            coderService: {
+                getDashboards: jest.fn().mockResolvedValue({
+                    dashboards: [makeDashboardContent('allowed-space')],
+                }),
+                getCurrentContentVersionBySlug: jest.fn().mockResolvedValue({
+                    versionUuid: 'version-before',
+                }),
+                upsertDashboard,
+            },
+            aiAgentContentValidation: {
+                validatePatch: jest.fn(),
+                validateContent: jest.fn(),
+            },
+        });
+        const runtime = service.createRuntime(
+            makeRuntimeContext({ spaceAccess: ['allowed-space-uuid'] }),
+        );
+
+        await expect(
+            runtime.editContent({
+                slug: 'test-dashboard',
+                type: 'dashboard',
+                patch: [
+                    {
+                        op: 'replace',
+                        path: '/spaceSlug',
+                        value: 'blocked-space',
+                    },
+                ],
+            }),
+        ).rejects.toThrow(NotFoundError);
+        expect(upsertDashboard).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -24,6 +24,8 @@ import {
     TimeoutError,
     UserAttributeValueMap,
     WarehouseQueryError,
+    type ChartAsCode,
+    type DashboardAsCode,
 } from '@lightdash/common';
 import * as JsonPatch from 'fast-json-patch';
 import Logger from '../../../logging/logger';
@@ -94,6 +96,12 @@ import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewD
 type AgentListContentResult = Awaited<ReturnType<ListContentFn>>;
 type AgentListContentItem = AgentListContentResult['items'][number];
 type ProjectSpace = Awaited<ReturnType<ProjectService['getSpaces']>>[number];
+type ContentAsCodeType = Parameters<ReadContentFn>[0]['type'];
+
+const CONTENT_AS_CODE_TYPE_LABELS = {
+    dashboard: 'Dashboard',
+    chart: 'Chart',
+} as const satisfies Record<ContentAsCodeType, string>;
 
 export type AiAgentToolsSource = 'ai_agent' | 'mcp';
 
@@ -886,6 +894,47 @@ export class AiAgentToolsService extends BaseService {
         }
     }
 
+    private static getContentTypeLabel(type: ContentAsCodeType) {
+        return CONTENT_AS_CODE_TYPE_LABELS[type];
+    }
+
+    private validateContentAsCode(
+        type: 'dashboard',
+        content: unknown,
+    ): asserts content is DashboardAsCode;
+
+    private validateContentAsCode(
+        type: 'chart',
+        content: unknown,
+    ): asserts content is ChartAsCode;
+
+    private validateContentAsCode(
+        type: ContentAsCodeType,
+        content: unknown,
+    ): asserts content is DashboardAsCode | ChartAsCode {
+        this.aiAgentContentValidation.validateContent(type, content);
+    }
+
+    private async assertContentSpaceInScope(
+        context: AiAgentToolsRuntimeContext,
+        spaceSlug: string,
+        notFoundMessage: string,
+    ) {
+        if (!context.spaceAccess || context.spaceAccess.length === 0) {
+            return;
+        }
+
+        const hasSpaceAccess = await this.spaceModel.hasSpaceWithPathAndUuids({
+            projectUuid: context.projectUuid,
+            path: getLtreePathFromContentAsCodePath(spaceSlug),
+            spaceUuids: context.spaceAccess,
+        });
+
+        if (!hasSpaceAccess) {
+            throw new NotFoundError(notFoundMessage);
+        }
+    }
+
     private readContent(
         context: AiAgentToolsRuntimeContext,
         { slug, type }: Parameters<ReadContentFn>[0],
@@ -908,6 +957,11 @@ export class AiAgentToolsService extends BaseService {
                                 `Dashboard "${slug}" was not found`,
                             );
                         }
+                        await this.assertContentSpaceInScope(
+                            context,
+                            dashboard.spaceSlug,
+                            `Dashboard "${slug}" was not found`,
+                        );
                         const savedDashboard =
                             await this.dashboardService.getByIdOrSlug(
                                 context.user,
@@ -936,6 +990,11 @@ export class AiAgentToolsService extends BaseService {
                                 `Chart "${slug}" was not found`,
                             );
                         }
+                        await this.assertContentSpaceInScope(
+                            context,
+                            chart.spaceSlug,
+                            `Chart "${slug}" was not found`,
+                        );
                         const savedChart = await this.savedChartService.get(
                             chart.slug,
                             context.account,
@@ -984,52 +1043,64 @@ export class AiAgentToolsService extends BaseService {
                         type,
                         slug,
                     );
-                const patchedContent = JsonPatch.applyPatch(
+                const patchedContent: unknown = JsonPatch.applyPatch(
                     structuredClone(currentContent.content),
                     patch,
                 ).newDocument;
-                this.aiAgentContentValidation.validateContent(
-                    type,
-                    patchedContent,
-                );
-
-                const patchedSlug =
-                    typeof patchedContent.slug === 'string' &&
-                    patchedContent.slug.length > 0
-                        ? patchedContent.slug
-                        : slug;
+                let patchedSlug = slug;
                 let uuid: string | undefined;
 
-                switch (currentContent.type) {
+                switch (type) {
                     case 'dashboard': {
+                        this.validateContentAsCode(type, patchedContent);
+                        await this.assertContentSpaceInScope(
+                            context,
+                            patchedContent.spaceSlug,
+                            `${AiAgentToolsService.getContentTypeLabel(
+                                type,
+                            )} "${slug}" was not found`,
+                        );
+                        patchedSlug =
+                            patchedContent.slug.length > 0
+                                ? patchedContent.slug
+                                : slug;
                         const promotionChanges =
                             await this.coderService.upsertDashboard(
                                 context.user,
                                 context.projectUuid,
                                 slug,
-                                patchedContent as typeof currentContent.content,
+                                patchedContent,
                                 { force: true },
                             );
                         uuid = promotionChanges.dashboards[0]?.data.uuid;
                         break;
                     }
                     case 'chart': {
+                        this.validateContentAsCode(type, patchedContent);
+                        await this.assertContentSpaceInScope(
+                            context,
+                            patchedContent.spaceSlug,
+                            `${AiAgentToolsService.getContentTypeLabel(
+                                type,
+                            )} "${slug}" was not found`,
+                        );
+                        patchedSlug =
+                            patchedContent.slug.length > 0
+                                ? patchedContent.slug
+                                : slug;
                         const promotionChanges =
                             await this.coderService.upsertChart(
                                 context.user,
                                 context.projectUuid,
                                 slug,
-                                patchedContent as typeof currentContent.content,
+                                patchedContent,
                                 { force: true },
                             );
                         uuid = promotionChanges.charts[0]?.data.uuid;
                         break;
                     }
                     default:
-                        return assertUnreachable(
-                            currentContent,
-                            'Invalid content type',
-                        );
+                        return assertUnreachable(type, 'Invalid content type');
                 }
 
                 const editedContent = await this.readContent(context, {
@@ -1076,6 +1147,11 @@ export class AiAgentToolsService extends BaseService {
             { slug: content.slug, type },
             async () => {
                 this.aiAgentContentValidation.validateContent(type, content);
+                await this.assertContentSpaceInScope(
+                    context,
+                    content.spaceSlug,
+                    `Space "${content.spaceSlug}" was not found`,
+                );
 
                 switch (type) {
                     case 'dashboard': {

--- a/packages/backend/src/ee/services/ai/tools/createContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/createContent.ts
@@ -1,7 +1,7 @@
 import { createContentToolDefinition } from '@lightdash/common';
 import { tool } from 'ai';
 import type { CreateContentFn } from '../types/aiAgentDependencies';
-import { getChartContentWarnings } from '../utils/contentWarnings';
+import { getContentWarnings } from '../utils/contentWarnings';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 
@@ -40,10 +40,7 @@ export const getCreateContent = ({ createContent }: Dependencies) =>
                     type,
                     content,
                 } as Parameters<CreateContentFn>[0]);
-                const warnings =
-                    result.type === 'chart'
-                        ? getChartContentWarnings(result.content)
-                        : [];
+                const warnings = getContentWarnings(result);
                 const metadata = {
                     status: 'success' as const,
                     slug: result.content.slug,

--- a/packages/backend/src/ee/services/ai/tools/editContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/editContent.ts
@@ -1,7 +1,7 @@
 import { editContentToolDefinition } from '@lightdash/common';
 import { tool } from 'ai';
 import type { EditContentFn } from '../types/aiAgentDependencies';
-import { getChartContentWarnings } from '../utils/contentWarnings';
+import { getContentWarnings } from '../utils/contentWarnings';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 
@@ -37,10 +37,7 @@ export const getEditContent = ({ editContent }: Dependencies) =>
         execute: async ({ slug, type, patch }) => {
             try {
                 const result = await editContent({ slug, type, patch });
-                const warnings =
-                    result.type === 'chart'
-                        ? getChartContentWarnings(result.content)
-                        : [];
+                const warnings = getContentWarnings(result);
                 const metadata = {
                     status: 'success' as const,
                     slug: result.content.slug,

--- a/packages/backend/src/ee/services/ai/utils/contentWarnings.ts
+++ b/packages/backend/src/ee/services/ai/utils/contentWarnings.ts
@@ -1,4 +1,13 @@
-import { getUnusedDimensions, type ChartAsCode } from '@lightdash/common';
+import {
+    assertUnreachable,
+    getUnusedDimensions,
+    type ChartAsCode,
+    type DashboardAsCode,
+} from '@lightdash/common';
+
+export type ContentWithWarnings =
+    | { type: 'dashboard'; content: DashboardAsCode }
+    | { type: 'chart'; content: ChartAsCode };
 
 export const getChartContentWarnings = (content: ChartAsCode): string[] => {
     const { unusedDimensions } = getUnusedDimensions({
@@ -17,4 +26,15 @@ export const getChartContentWarnings = (content: ChartAsCode): string[] => {
             ', ',
         )}. Use each dimension in layout.xField, layout.yField, or pivotConfig.columns, otherwise remove it.`,
     ];
+};
+
+export const getContentWarnings = (content: ContentWithWarnings): string[] => {
+    switch (content.type) {
+        case 'dashboard':
+            return [];
+        case 'chart':
+            return getChartContentWarnings(content.content);
+        default:
+            return assertUnreachable(content, 'Invalid content type');
+    }
 };

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -90,6 +90,32 @@ export class SpaceModel {
         return spaces.map((s: { space_uuid: string }) => s.space_uuid);
     }
 
+    async hasSpaceWithPathAndUuids({
+        projectUuid,
+        path,
+        spaceUuids,
+    }: {
+        projectUuid: string;
+        path: string;
+        spaceUuids: string[];
+    }): Promise<boolean> {
+        if (spaceUuids.length === 0) return false;
+
+        const space = await this.database(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .where(`${SpaceTableName}.path`, path)
+            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .first(`${SpaceTableName}.space_uuid`);
+
+        return space !== undefined;
+    }
+
     async getChildSpaceUuidsForParents(
         parentSpaceUuids: string[],
     ): Promise<string[]> {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Scopes content-as-code AI/MCP tools to the active agent's space access.

- `read_content` now checks the loaded chart/dashboard `spaceSlug` against `context.spaceAccess` before returning content.
- `create_content` now checks `content.spaceSlug` before creating a chart/dashboard.
- `edit_content` now checks the existing content through `read_content`, then checks the patched `spaceSlug` before persisting changes.
- Tool input schemas are unchanged; this uses the existing runtime context passed into `AiAgentToolsService`.
- Out-of-scope spaces return `NotFoundError`, matching existing browse/search behavior and avoiding private-space existence leaks.

### Testing:

- `pnpm -F backend exec jest --config jest.config.js --runTestsByPath src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts --runInBand`
- `pnpm -F backend typecheck:fast`
