### PR TITLE
fix: calculate data app full height for screenshots

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1501,13 +1501,63 @@ export class UnfurlService extends BaseService {
                                 (f) => f !== mainFrame,
                             );
                             if (appFrame) {
+                                // `scrollHeight` is unreliable: it
+                                // under-reports when ancestor overflow
+                                // hides content, and over-reports when
+                                // `min-height: 100vh` is set. Instead,
+                                // walk leaf elements and use
+                                // getBoundingClientRect, which reflects
+                                // actual rendered position regardless
+                                // of overflow.
                                 const contentHeight = await appFrame.evaluate(
-                                    () =>
-                                        Math.max(
-                                            document.documentElement
-                                                .scrollHeight,
-                                            document.body?.scrollHeight ?? 0,
-                                        ),
+                                    () => {
+                                        let maxBottom = 0;
+                                        const root =
+                                            document.querySelector('#root') ??
+                                            document.body;
+                                        if (root) {
+                                            const walker =
+                                                document.createTreeWalker(
+                                                    root,
+                                                    NodeFilter.SHOW_ELEMENT,
+                                                );
+                                            let node: Node | null =
+                                                walker.currentNode;
+                                            while (node) {
+                                                const el = node as Element;
+                                                if (el.children.length === 0) {
+                                                    const rect =
+                                                        el.getBoundingClientRect();
+                                                    if (
+                                                        rect.width > 0 &&
+                                                        rect.height > 0
+                                                    ) {
+                                                        maxBottom = Math.max(
+                                                            maxBottom,
+                                                            rect.bottom,
+                                                        );
+                                                    }
+                                                }
+                                                node = walker.nextNode();
+                                            }
+                                        }
+                                        // Empty body — shouldn't happen for a
+                                        // real app, but fall back to
+                                        // scrollHeight rather than collapsing
+                                        // the iframe to zero.
+                                        if (maxBottom === 0) {
+                                            return Math.max(
+                                                document.documentElement
+                                                    .scrollHeight,
+                                                document.body?.scrollHeight ??
+                                                    0,
+                                            );
+                                        }
+                                        return Math.ceil(maxBottom);
+                                    },
+                                );
+                                this.logger.info(
+                                    `App content measured at ${contentHeight}px - unfurlId: ${imageId}`,
                                 );
                                 if (contentHeight > 0) {
                                     await page!.evaluate((h) => {


### PR DESCRIPTION
### Description:

 - Scheduled-delivery screenshots of data apps were cropping off the
    bottom of the app — only the top region rendered, leaving content
    past the iframe's initial 100vh viewport invisible (charts in lower
    rows, footer, background art).
  - Root cause: `UnfurlService` stretched the parent's iframe element to
    the inner document's `scrollHeight`. That value is unreliable for
    apps whose container has `overflow: hidden` (or equivalent) — content
    past 100vh doesn't contribute, so the iframe never stretched and the
    screenshot captured only what fit in the initial viewport. The
    inverse failure (over-report → white slab at the bottom) is also
    possible when `min-height: 100vh` is set on body/html.
  - Now walks leaf elements inside the iframe (no children, positive
    dimensions) and takes `max(getBoundingClientRect().bottom)`.
    `getBoundingClientRect` isn't clipped by ancestor overflow, so the
    natural position of every rendered leaf is visible to the
    measurement. Falls back to `scrollHeight` only if no leaves are
    found (empty body — shouldn't happen in practice).
  - Logs the measured content height at info level so future regressions
    can be diagnosed from delivery logs.
  - Stacks on top of the SDK-readiness gating fix.
