### PR TITLE
fix: support Okta issuer initiated login

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/oktaStrategy.test.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oktaStrategy.test.ts
@@ -77,14 +77,27 @@ const perOrgMethod = {
     allowPassword: true,
 };
 
-const makeReq = (
-    loginHint: string | undefined,
-    findEnabledMethodForEmail: jest.Mock,
-): Request =>
+const makeReq = ({
+    loginHint,
+    issuer,
+    findEnabledMethodForEmail = jest.fn(),
+    findEnabledOktaMethodForIssuer = jest.fn(),
+}: {
+    loginHint?: string;
+    issuer?: string;
+    findEnabledMethodForEmail?: jest.Mock;
+    findEnabledOktaMethodForIssuer?: jest.Mock;
+}): Request =>
     ({
-        query: loginHint ? { login_hint: loginHint } : {},
+        query: {
+            ...(loginHint ? { login_hint: loginHint } : {}),
+            ...(issuer ? { iss: issuer } : {}),
+        },
         services: {
-            getOrganizationSsoService: () => ({ findEnabledMethodForEmail }),
+            getOrganizationSsoService: () => ({
+                findEnabledMethodForEmail,
+                findEnabledOktaMethodForIssuer,
+            }),
         },
     }) as unknown as Request;
 
@@ -117,7 +130,10 @@ describe('resolveOktaConfig', () => {
         const findEnabledMethodForEmail = jest
             .fn()
             .mockResolvedValue(undefined);
-        const req = makeReq('user@env-customer.com', findEnabledMethodForEmail);
+        const req = makeReq({
+            loginHint: 'user@env-customer.com',
+            findEnabledMethodForEmail,
+        });
 
         const resolved = await resolveOktaConfig(req);
         expect(resolved).toEqual({
@@ -136,7 +152,7 @@ describe('resolveOktaConfig', () => {
     test('no login hint + env present → env config', async () => {
         setEnv(FULL_ENV);
         const findEnabledMethodForEmail = jest.fn();
-        const req = makeReq(undefined, findEnabledMethodForEmail);
+        const req = makeReq({ findEnabledMethodForEmail });
 
         const resolved = await resolveOktaConfig(req);
         expect(resolved?.organizationUuid).toBeNull();
@@ -150,7 +166,13 @@ describe('resolveOktaConfig', () => {
         const findEnabledMethodForEmail = jest
             .fn()
             .mockResolvedValue(perOrgMethod);
-        const req = makeReq('user@acme.com', findEnabledMethodForEmail);
+        const findEnabledOktaMethodForIssuer = jest.fn();
+        const req = makeReq({
+            loginHint: 'user@acme.com',
+            issuer: 'https://env.okta.com',
+            findEnabledMethodForEmail,
+            findEnabledOktaMethodForIssuer,
+        });
 
         const resolved = await resolveOktaConfig(req);
         expect(findEnabledMethodForEmail).toHaveBeenCalledWith(
@@ -161,6 +183,50 @@ describe('resolveOktaConfig', () => {
             config: perOrgMethod.config,
             organizationUuid: 'org-1',
         });
+        expect(findEnabledOktaMethodForIssuer).not.toHaveBeenCalled();
+    });
+
+    test('per-org issuer match supports Okta dashboard launch', async () => {
+        setEnv({});
+        const findEnabledMethodForEmail = jest.fn();
+        const findEnabledOktaMethodForIssuer = jest
+            .fn()
+            .mockResolvedValue(perOrgMethod);
+        const req = makeReq({
+            issuer: 'https://acme.okta.com',
+            findEnabledMethodForEmail,
+            findEnabledOktaMethodForIssuer,
+        });
+
+        const resolved = await resolveOktaConfig(req);
+
+        expect(findEnabledMethodForEmail).not.toHaveBeenCalled();
+        expect(findEnabledOktaMethodForIssuer).toHaveBeenCalledWith(
+            'https://acme.okta.com',
+        );
+        expect(resolved).toEqual({
+            config: perOrgMethod.config,
+            organizationUuid: 'org-1',
+        });
+    });
+
+    test('issuer miss falls back to env config', async () => {
+        setEnv(FULL_ENV);
+        const findEnabledOktaMethodForIssuer = jest
+            .fn()
+            .mockResolvedValue(undefined);
+        const req = makeReq({
+            issuer: 'https://unknown.okta.com',
+            findEnabledOktaMethodForIssuer,
+        });
+
+        const resolved = await resolveOktaConfig(req);
+
+        expect(findEnabledOktaMethodForIssuer).toHaveBeenCalledWith(
+            'https://unknown.okta.com',
+        );
+        expect(resolved?.organizationUuid).toBeNull();
+        expect(resolved?.config.oauth2ClientId).toBe('env-client');
     });
 
     test('no per-org match and no env config → undefined', async () => {
@@ -168,7 +234,10 @@ describe('resolveOktaConfig', () => {
         const findEnabledMethodForEmail = jest
             .fn()
             .mockResolvedValue(undefined);
-        const req = makeReq('user@nowhere.com', findEnabledMethodForEmail);
+        const req = makeReq({
+            loginHint: 'user@nowhere.com',
+            findEnabledMethodForEmail,
+        });
 
         expect(await resolveOktaConfig(req)).toBeUndefined();
     });

--- a/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
@@ -10,12 +10,16 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { Request, RequestHandler } from 'express';
+import isString from 'lodash/isString';
 import { generators, Issuer, UserinfoResponse } from 'openid-client';
 import { Strategy } from 'passport-strategy';
 import { URL } from 'url';
 import { lightdashConfig } from '../../../config/lightdashConfig';
 import Logger from '../../../logging/logger';
 import { getLoginHint } from '../utils';
+
+const getIssuerHint = (req: Request) =>
+    isString(req.query?.iss) ? req.query.iss : undefined;
 
 const createOpenIdUserFromUserInfo = (
     userInfo: UserinfoResponse,
@@ -126,6 +130,18 @@ export const resolveOktaConfig = async (
         const method = await req.services
             .getOrganizationSsoService()
             .findEnabledMethodForEmail(email, OrganizationSsoProvider.OKTA);
+        if (method) {
+            return {
+                config: method.config,
+                organizationUuid: method.organizationUuid,
+            };
+        }
+    }
+    const issuer = getIssuerHint(req);
+    if (issuer) {
+        const method = await req.services
+            .getOrganizationSsoService()
+            .findEnabledOktaMethodForIssuer(issuer);
         if (method) {
             return {
                 config: method.config,

--- a/packages/backend/src/models/OrganizationSsoModel.test.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.test.ts
@@ -168,4 +168,30 @@ describe('OrganizationSsoModel', () => {
             ]);
         });
     });
+
+    describe('findEnabledOktaMethodByStoredIssuer', () => {
+        it('selects only fields needed to finish the Okta OAuth flow', async () => {
+            tracker.on
+                .select(OrganizationSsoConfigurationsTableName)
+                .responseOnce([]);
+
+            await model.findEnabledOktaMethodByStoredIssuer(
+                'https://example.okta.com',
+            );
+
+            const { sql, bindings } = tracker.history.select[0];
+            const lowered = sql.toLowerCase();
+            const selectList = lowered.slice(0, lowered.indexOf(' from '));
+            expect(bindings).toContain(OrganizationSsoProvider.OKTA);
+            expect(bindings).toContain(true);
+            expect(selectList).toContain('"organization_uuid"');
+            expect(selectList).toContain('"config"');
+            expect(selectList).not.toContain('"provider"');
+            expect(selectList).not.toContain('"enabled"');
+            expect(selectList).not.toContain('"override_email_domains"');
+            expect(selectList).not.toContain('"email_domains"');
+            expect(selectList).not.toContain('"allow_password"');
+            expect(lowered).not.toContain('select *');
+        });
+    });
 });

--- a/packages/backend/src/models/OrganizationSsoModel.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.ts
@@ -32,6 +32,9 @@ export type OrganizationSsoMethod<P extends OrganizationSsoProvider> = {
     config: ProviderConfigTypeMap[P];
 } & OrganizationSsoMethodFlags;
 
+export type OrganizationSsoConfigLookup<P extends OrganizationSsoProvider> =
+    Pick<OrganizationSsoMethod<P>, 'organizationUuid' | 'config'>;
+
 /**
  * Lightweight projection of a per-org Google policy row. Google has no
  * credentials, so only the flags matter — and unlike the credential
@@ -172,6 +175,36 @@ export class OrganizationSsoModel {
             emailDomains: row.email_domains ?? [],
             allowPassword: row.allow_password,
         }));
+    }
+
+    async findEnabledOktaMethodByStoredIssuer(
+        oauth2Issuer: string,
+    ): Promise<
+        OrganizationSsoConfigLookup<OrganizationSsoProvider.OKTA> | undefined
+    > {
+        const rows = await this.database(OrganizationSsoConfigurationsTableName)
+            .where(
+                `${OrganizationSsoConfigurationsTableName}.provider`,
+                OrganizationSsoProvider.OKTA,
+            )
+            .where(`${OrganizationSsoConfigurationsTableName}.enabled`, true)
+            .select(
+                `${OrganizationSsoConfigurationsTableName}.organization_uuid`,
+                `${OrganizationSsoConfigurationsTableName}.config`,
+            );
+
+        return rows
+            .map(
+                (
+                    row,
+                ): OrganizationSsoConfigLookup<OrganizationSsoProvider.OKTA> => ({
+                    organizationUuid: row.organization_uuid,
+                    config: this.decryptConfig<OrganizationSsoProvider.OKTA>(
+                        row.config,
+                    ),
+                }),
+            )
+            .find((method) => method.config.oauth2Issuer === oauth2Issuer);
     }
 
     /**

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.test.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.test.ts
@@ -26,6 +26,7 @@ const buildService = () => {
     const organizationSsoModel = {
         findMethod: jest.fn(),
         findEnabledMethodsForEmailDomain: jest.fn(),
+        findEnabledOktaMethodByStoredIssuer: jest.fn(),
         findGoogleMethodsForEmailDomain: jest.fn(),
         upsert: jest.fn(),
         delete: jest.fn(),
@@ -345,6 +346,39 @@ describe('OrganizationSsoService', () => {
             await expect(
                 service.findEnabledMethodsForEmail('user@acme.com'),
             ).resolves.toEqual([ownOrgMethod]);
+        });
+    });
+
+    describe('findEnabledOktaMethodForIssuer', () => {
+        it('normalizes issuer lookup before querying the SSO model', async () => {
+            const { service, organizationSsoModel } = buildService();
+            const method = enabledMethodForOrg(
+                ORG_UUID,
+                OrganizationSsoProvider.OKTA,
+            );
+            organizationSsoModel.findEnabledOktaMethodByStoredIssuer.mockResolvedValue(
+                method,
+            );
+
+            await expect(
+                service.findEnabledOktaMethodForIssuer(
+                    'https://EXAMPLE.okta.com/?from=dashboard',
+                ),
+            ).resolves.toEqual(method);
+            expect(
+                organizationSsoModel.findEnabledOktaMethodByStoredIssuer,
+            ).toHaveBeenCalledWith('https://example.okta.com');
+        });
+
+        it('returns undefined without querying when issuer is invalid', async () => {
+            const { service, organizationSsoModel } = buildService();
+
+            await expect(
+                service.findEnabledOktaMethodForIssuer('not-a-url'),
+            ).resolves.toBeUndefined();
+            expect(
+                organizationSsoModel.findEnabledOktaMethodByStoredIssuer,
+            ).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
@@ -30,6 +30,7 @@ import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel
 import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
 import { OrganizationDomainVerificationModel } from '../../models/OrganizationDomainVerificationModel';
 import {
+    OrganizationSsoConfigLookup,
     OrganizationSsoMethod,
     OrganizationSsoModel,
 } from '../../models/OrganizationSsoModel';
@@ -106,6 +107,18 @@ const toGoogleSummary = (
     emailDomains: method.emailDomains,
     allowPassword: method.allowPassword,
 });
+
+// Okta dashboard tile launches identify the provider with an `iss` URL.
+const normalizeIssuerUrl = (issuer: string) => {
+    try {
+        const url = new URL(issuer);
+        url.hash = '';
+        url.search = '';
+        return url.href.replace(/\/$/, '').toLowerCase();
+    } catch {
+        return undefined;
+    }
+};
 
 export class OrganizationSsoService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
@@ -404,8 +417,13 @@ export class OrganizationSsoService extends BaseService {
             throw new ParameterError('oauth2ClientSecret is required');
         }
 
+        const oauth2Issuer = normalizeIssuerUrl(data.oauth2Issuer);
+        if (!oauth2Issuer) {
+            throw new ParameterError('oauth2Issuer must be a valid URL');
+        }
+
         const config: OktaSsoConfig = {
-            oauth2Issuer: data.oauth2Issuer.trim(),
+            oauth2Issuer,
             oktaDomain: data.oktaDomain.trim(),
             oauth2ClientId: data.oauth2ClientId.trim(),
             oauth2ClientSecret: clientSecret,
@@ -799,6 +817,18 @@ export class OrganizationSsoService extends BaseService {
         const matches = await this.findEnabledMethodsForEmail(email);
         return matches.find(
             (m): m is OrganizationSsoMethod<P> => m.provider === provider,
+        );
+    }
+
+    async findEnabledOktaMethodForIssuer(
+        issuer: string,
+    ): Promise<
+        OrganizationSsoConfigLookup<OrganizationSsoProvider.OKTA> | undefined
+    > {
+        const normalizedIssuer = normalizeIssuerUrl(issuer);
+        if (!normalizedIssuer) return undefined;
+        return this.organizationSsoModel.findEnabledOktaMethodByStoredIssuer(
+            normalizedIssuer,
         );
     }
 }


### PR DESCRIPTION
### Description
- Support Okta dashboard tile launches for org-level Okta SSO by resolving the provider from the `iss` parameter.
- Normalize the incoming issuer in the service layer, then match it against the stored org-level Okta issuer.
- Preserve existing email `login_hint` discovery and env-based fallback behavior.

### Testing
- pnpm -F backend test -- src/controllers/authentication/strategies/oktaStrategy.test.ts --runInBand
- pnpm -F backend test -- src/models/OrganizationSsoModel.test.ts --runInBand
- pnpm -F backend test -- src/services/OrganizationSsoService/OrganizationSsoService.test.ts --runInBand
- pnpm -F backend typecheck:fast
- focused backend lint

Closes: PROD-8236
Closes: #24139
