### PR TITLE
feat(timezones): default saved charts to project timezone (GLITCH-459)

### DIFF
--- a/packages/api-tests/tests/userTimezone.test.ts
+++ b/packages/api-tests/tests/userTimezone.test.ts
@@ -8,12 +8,11 @@ import {
 } from '../helpers/timezone-test';
 
 /**
- * User-level timezone (PROD-7528) tests.
+ * User-level timezone tests, updated for the GLITCH-459 model.
  *
- * Verifies the resolution chain `chart > user > project`:
- *  - When a chart doesn't pin a timezone, the viewer's profile timezone
- *    (`users.timezone`) is used for grouping/filtering.
- *  - When a chart pins a timezone, it overrides the viewer's profile.
+ * Resolution now defaults to the **project** timezone; the viewer's profile
+ * timezone (`users.timezone`) is only used when the query explicitly sets
+ * `timezone: 'user_timezone'`. An IANA zone is an override that wins over both.
  *
  * Uses the same `timezone_test` fixture as `queryTimezone.test.ts`. Asia/Tokyo
  * (+9) shifts events into Jan 15/16/17 — distinct from the UTC layout
@@ -21,7 +20,7 @@ import {
  *
  * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true and the EnableUserTimezones
  * flag enabled (LIGHTDASH_ENABLE_FEATURE_FLAGS=enable-user-timezones) in the
- * environment — user-level resolution is gated on the latter.
+ * environment — `user_timezone` resolution is gated on the latter.
  */
 
 const DIMENSION_KEY = 'timezone_test_event_timestamp_day';
@@ -41,15 +40,35 @@ describe('User-level timezone', () => {
         await updateUserTimezone(admin, null);
     });
 
-    it('applies the viewer profile timezone when the chart has no pinned timezone', async () => {
+    it('defaults to the project timezone, ignoring the viewer profile, when no timezone is set', async () => {
         await updateUserTimezone(admin, 'Asia/Tokyo');
 
-        // No `timezone` on the metric query → chain falls through to the
-        // user's profile (Asia/Tokyo). Expected Tokyo grouping per the
-        // `timezone_test` fixture: Jan 15=5, Jan 16=4, Jan 17=1.
+        // No `timezone` on the metric query → resolves to the project default
+        // (UTC), NOT the viewer's Tokyo profile. Expected UTC grouping per the
+        // `timezone_test` fixture: Jan 15=6, Jan 16=4.
         const rows = await runTimezoneTestQuery(admin, {
             dimensions: DIMENSIONS,
             metrics: METRICS,
+        });
+
+        expect(rows).toHaveLength(2);
+        expect(getRowCount(rows, '2024-01-15', DIMENSION_KEY, METRIC_KEY)).toBe(
+            6,
+        );
+        expect(getRowCount(rows, '2024-01-16', DIMENSION_KEY, METRIC_KEY)).toBe(
+            4,
+        );
+    });
+
+    it('uses the viewer profile timezone when the query sets user_timezone', async () => {
+        await updateUserTimezone(admin, 'Asia/Tokyo');
+
+        // `timezone: 'user_timezone'` → the viewer's profile (Asia/Tokyo).
+        // Expected Tokyo grouping: Jan 15=5, Jan 16=4, Jan 17=1.
+        const rows = await runTimezoneTestQuery(admin, {
+            dimensions: DIMENSIONS,
+            metrics: METRICS,
+            timezone: 'user_timezone',
         });
 
         expect(rows).toHaveLength(3);
@@ -64,11 +83,12 @@ describe('User-level timezone', () => {
         );
     });
 
-    it('chart-pinned timezone overrides the viewer profile timezone', async () => {
+    it('an override zone wins over the viewer profile timezone', async () => {
         await updateUserTimezone(admin, 'Asia/Tokyo');
 
-        // Chart pins America/New_York → should win over the viewer's Tokyo
-        // preference. Expected NY grouping: Jan 14=1, Jan 15=6, Jan 16=3.
+        // An explicit America/New_York override → should win over both the
+        // viewer's Tokyo preference and the project default. Expected NY
+        // grouping: Jan 14=1, Jan 15=6, Jan 16=3.
         const rows = await runTimezoneTestQuery(admin, {
             dimensions: DIMENSIONS,
             metrics: METRICS,

--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -16,6 +16,7 @@ import {
     PivotSortAnchor,
     TableCalculationTemplate,
     TableCalculationType,
+    TimezoneSetting,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 
@@ -105,7 +106,7 @@ export type DbSavedChartVersion = {
     pivot_dimensions: string[] | null;
     parameters: AnyType | null; // JSONB
     updated_by_user_uuid: string | null;
-    timezone: string | null;
+    timezone: TimezoneSetting;
 };
 
 export type SavedChartVersionsTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/migrations/20260610120000_default_saved_chart_timezone_to_project.ts
+++ b/packages/backend/src/database/migrations/20260610120000_default_saved_chart_timezone_to_project.ts
@@ -1,0 +1,101 @@
+import { TimezoneSetting } from '@lightdash/common';
+import { Knex } from 'knex';
+
+const TABLE = 'saved_queries_versions';
+const COLUMN = 'timezone';
+const PROJECT_TIMEZONE_SETTING = 'project_timezone';
+const USER_TIMEZONE_SETTING = 'user_timezone';
+const NOT_NULL_CHECK = 'saved_queries_versions_timezone_not_null';
+const BATCH_SIZE = 10000;
+
+// Repurposes the nullable `timezone` column into the single timezone-setting
+// column ('project_timezone' | 'user_timezone' | <IANA zone>), NOT NULL with a
+// 'project_timezone' default. saved_queries_versions has millions of rows on
+// large instances, so runs outside a transaction and avoids any long write
+// lock; every step is idempotent so a partial run can be re-applied.
+export const config = { transaction: false };
+
+export async function up(knex: Knex): Promise<void> {
+    // Session setting — no schema-builder equivalent.
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        // New rows default to the project-timezone setting.
+        await knex.schema.alterTable(TABLE, (table) => {
+            table
+                .text(COLUMN)
+                .defaultTo(PROJECT_TIMEZONE_SETTING)
+                .alter({ alterNullable: false, alterType: false });
+        });
+
+        // Existing NULLs (charts that deferred resolution) become the default;
+        // existing IANA zones are left as-is (still an override). BATCH_SIZE limits how
+        // many rows ONE pass updates (to bound the lock/WAL per statement), NOT the
+        // total. Each pass re-selects the *remaining* NULLs and flips them to a
+        // non-NULL value, so the candidate set shrinks every pass; we repeat until
+        // a pass updates 0 rows, i.e. no NULLs are left.
+        console.log(
+            `Backfilling null ${COLUMN} to ${PROJECT_TIMEZONE_SETTING}...`,
+        );
+        let updatedInPass: number;
+        let totalUpdated = 0;
+        do {
+            // eslint-disable-next-line no-await-in-loop
+            updatedInPass = await knex(TABLE)
+                .update({ [COLUMN]: PROJECT_TIMEZONE_SETTING })
+                .whereIn(
+                    'ctid',
+                    knex(TABLE)
+                        .select('ctid')
+                        .whereNull(COLUMN)
+                        .limit(BATCH_SIZE),
+                );
+            totalUpdated += updatedInPass;
+            console.log(
+                `  ...backfilled ${updatedInPass} rows this pass (${totalUpdated} total)`,
+            );
+        } while (updatedInPass > 0);
+
+        // Enforce NOT NULL. A plain SET NOT NULL would full-scan the (multi-
+        // million row) table under an ACCESS EXCLUSIVE lock, blocking reads and
+        // writes. Instead: add a CHECK NOT VALID (instant), VALIDATE it (only a
+        // non-blocking SHARE UPDATE EXCLUSIVE lock), then SET NOT NULL is instant
+        // because PG trusts the validated CHECK; finally drop the redundant CHECK.
+        // (NOT VALID / VALIDATE have no knex schema-builder equivalent.)
+        const existingCheck = await knex('pg_constraint')
+            .where('conname', NOT_NULL_CHECK)
+            .first();
+        if (!existingCheck) {
+            await knex.raw(
+                `ALTER TABLE ?? ADD CONSTRAINT ?? CHECK (?? IS NOT NULL) NOT VALID`,
+                [TABLE, NOT_NULL_CHECK, COLUMN],
+            );
+        }
+        console.log(`Validating ${NOT_NULL_CHECK}...`);
+        await knex.raw(`ALTER TABLE ?? VALIDATE CONSTRAINT ??`, [
+            TABLE,
+            NOT_NULL_CHECK,
+        ]);
+        await knex.schema.alterTable(TABLE, (table) => {
+            table.dropNullable(COLUMN);
+        });
+        // IF EXISTS keeps the drop idempotent on a re-applied run.
+        await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+            TABLE,
+            NOT_NULL_CHECK,
+        ]);
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // Drops both NOT NULL and the default (the nullable, default-less builder).
+    await knex.schema.alterTable(TABLE, (table) => {
+        table.text(COLUMN).alter({ alterType: false });
+    });
+    // Restore v1-compatible data: keyword settings revert to NULL (no pin).
+    // The column is nullable again here; type the row so null is accepted.
+    await knex<{ timezone: TimezoneSetting | null }>(TABLE)
+        .whereIn(COLUMN, [PROJECT_TIMEZONE_SETTING, USER_TIMEZONE_SETTING])
+        .update({ timezone: null });
+}

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -958,6 +958,7 @@ export class EmbedService extends BaseService {
                 context: QueryExecutionContext.EMBED,
                 warehouseClient,
                 metricQuery,
+                resolvedTimezone: timezone,
                 query: compiledQuery.query,
                 queryTags,
                 invalidateCache: false,
@@ -1454,12 +1455,12 @@ export class EmbedService extends BaseService {
             userTimezone: null,
             isUserTimezoneEnabled: false,
         });
-
         const isTimezoneSupportEnabled =
             await this.projectService.isTimezoneSupportEnabled({
                 userUuid: user?.userUuid ?? account.user.id,
                 organizationUuid,
             });
+
         const displayTimezone = isTimezoneSupportEnabled ? timezone : undefined;
 
         const { rows, cacheMetadata, fields } = await this._runEmbedQuery({
@@ -2089,7 +2090,6 @@ export class EmbedService extends BaseService {
             userTimezone: null,
             isUserTimezoneEnabled: false,
         });
-
         const useTimezoneAwareDateTrunc =
             await this.projectService.isTimezoneSupportEnabled({
                 userUuid: user?.userUuid ?? account.user.id,

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -42,7 +42,8 @@ import {
     Space,
     TableCalculation,
     TimeFrames,
-    TimeZone,
+    TimezoneSetting,
+    toTimezoneSetting,
     UpdatedByUser,
     UpdateMultipleSavedChart,
     UpdateSavedChart,
@@ -111,7 +112,7 @@ type DbSavedChartDetails = {
     last_name: string;
     pinned_list_uuid: string;
     dashboard_uuid: string | null;
-    timezone: TimeZone | null;
+    timezone: TimezoneSetting;
     color_palette_uuid: string | null;
 };
 
@@ -238,7 +239,7 @@ const createSavedChartVersion = async (
                 chart_config: chartConfig.config,
                 parameters: parameters ? JSON.stringify(parameters) : null,
                 updated_by_user_uuid: updatedByUser?.userUuid || null,
-                timezone: timezone || null,
+                timezone: toTimezoneSetting(timezone),
             })
             .returning('*');
         await createSavedChartVersionFields(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4634,11 +4634,13 @@ export class ProjectService extends BaseService {
         warehouseClient,
         query,
         metricQuery,
+        resolvedTimezone,
         queryTags,
         invalidateCache,
     }: {
         projectUuid: string;
         userUuid: string | null;
+        resolvedTimezone: string;
         user: Pick<
             LightdashUser,
             'userUuid' | 'organizationUuid' | 'organizationName'
@@ -4657,8 +4659,15 @@ export class ProjectService extends BaseService {
             'ProjectService.getResultsFromCacheOrWarehouse',
             {},
             async (span) => {
-                const hashParts = [projectUuid, userUuid, query];
-                if (metricQuery.timezone) hashParts.push(metricQuery.timezone);
+                // Key on the resolved timezone (not the raw setting) so the
+                // cache reflects project/user fallbacks and invalidates when the
+                // project timezone changes.
+                const hashParts = [
+                    projectUuid,
+                    userUuid,
+                    query,
+                    resolvedTimezone,
+                ];
                 const queryHash = buildCacheHash(hashParts);
 
                 span.setAttribute('queryHash', queryHash);
@@ -5011,6 +5020,7 @@ export class ProjectService extends BaseService {
                             context,
                             warehouseClient,
                             metricQuery: metricQueryWithLimit,
+                            resolvedTimezone: timezone,
                             query,
                             queryTags,
                             invalidateCache,
@@ -5532,8 +5542,13 @@ export class ProjectService extends BaseService {
 
         const userUuid = getCacheUserUuid(warehouseCredentials, user.userUuid);
 
-        const hashParts = [projectUuid, userUuid, 'cache_autocomplete', query];
-        if (metricQuery.timezone) hashParts.push(metricQuery.timezone);
+        const hashParts = [
+            projectUuid,
+            userUuid,
+            'cache_autocomplete',
+            query,
+            timezone,
+        ];
         const queryHash = buildCacheHash(hashParts);
 
         if (!forceRefresh && isUserCacheEnabled) {

--- a/packages/common/src/types/timezone.ts
+++ b/packages/common/src/types/timezone.ts
@@ -37,3 +37,36 @@ export enum TimeZone {
 
 export const isTimeZone = (timezone: string): timezone is TimeZone =>
     Object.values(TimeZone).includes(timezone as TimeZone);
+
+/**
+ * Sentinel values for a query's timezone setting. Anything that is not one of
+ * these keywords is treated as an override IANA zone.
+ */
+export const PROJECT_TIMEZONE_SETTING = 'project_timezone';
+export const USER_TIMEZONE_SETTING = 'user_timezone';
+
+/**
+ * A query/saved-chart timezone setting: the project-default keyword, the
+ * per-user keyword, or an override IANA zone. The `string` arm keeps the union
+ * from collapsing while still accepting any valid zone (resolved/profile/project
+ * zones aren't limited to the TimeZone dropdown set).
+ */
+export type TimezoneSetting =
+    | typeof PROJECT_TIMEZONE_SETTING
+    | typeof USER_TIMEZONE_SETTING
+    | TimeZone;
+
+/**
+ * Narrows an untrusted timezone string into a persisted TimezoneSetting. Keeps
+ * the keywords and any supported TimeZone; anything else (an unsupported zone)
+ * falls back to the project default rather than storing an arbitrary string.
+ */
+export function toTimezoneSetting(value: string | undefined): TimezoneSetting {
+    if (!value || value === PROJECT_TIMEZONE_SETTING) {
+        return PROJECT_TIMEZONE_SETTING;
+    }
+    if (value === USER_TIMEZONE_SETTING) {
+        return USER_TIMEZONE_SETTING;
+    }
+    return isTimeZone(value) ? value : PROJECT_TIMEZONE_SETTING;
+}

--- a/packages/common/src/utils/resolveQueryTimezone.test.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.test.ts
@@ -15,43 +15,36 @@ const anonymousAccount = (): Account =>
     }) as unknown as Account;
 
 describe('resolveQueryTimezone', () => {
-    it('returns metricQuery.timezone when set', () => {
+    it('default project_timezone resolves to project for everyone, ignoring viewer profile', () => {
+        const args = {
+            sessionTimezone: null,
+            metricQuery: { timezone: 'project_timezone' },
+            projectTimezone: 'Australia/Brisbane',
+            isUserTimezoneEnabled: true,
+        };
         expect(
-            resolveQueryTimezone({
-                sessionTimezone: null,
-                metricQuery: { timezone: 'America/New_York' },
-                projectTimezone: 'Australia/Brisbane',
-                userTimezone: null,
-                isUserTimezoneEnabled: true,
-            }),
-        ).toBe('America/New_York');
-    });
-
-    it('falls back to project timezone when metricQuery.timezone is undefined', () => {
-        expect(
-            resolveQueryTimezone({
-                sessionTimezone: null,
-                metricQuery: { timezone: undefined },
-                projectTimezone: 'Australia/Brisbane',
-                userTimezone: null,
-                isUserTimezoneEnabled: true,
-            }),
+            resolveQueryTimezone({ ...args, userTimezone: 'Asia/Tokyo' }),
         ).toBe('Australia/Brisbane');
+        expect(resolveQueryTimezone({ ...args, userTimezone: null })).toBe(
+            'Australia/Brisbane',
+        );
     });
 
-    it('falls back to project timezone when timezone field is missing', () => {
+    it('absent setting defaults to project, ignoring the viewer profile', () => {
+        // Only an explicit `user_timezone` uses the viewer's profile; absent
+        // resolves to project (deterministic) like `project_timezone`.
         expect(
             resolveQueryTimezone({
                 sessionTimezone: null,
                 metricQuery: {},
                 projectTimezone: 'Europe/London',
-                userTimezone: null,
+                userTimezone: 'Asia/Tokyo',
                 isUserTimezoneEnabled: true,
             }),
         ).toBe('Europe/London');
     });
 
-    it('accepts UTC', () => {
+    it('accepts UTC as the project timezone', () => {
         expect(
             resolveQueryTimezone({
                 sessionTimezone: null,
@@ -63,11 +56,11 @@ describe('resolveQueryTimezone', () => {
         ).toBe('UTC');
     });
 
-    it('uses user timezone when chart timezone is absent and the flag is on', () => {
+    it('user_timezone resolves to the viewer profile when EnableUserTimezones is on', () => {
         expect(
             resolveQueryTimezone({
                 sessionTimezone: null,
-                metricQuery: {},
+                metricQuery: { timezone: 'user_timezone' },
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: 'Asia/Tokyo',
                 isUserTimezoneEnabled: true,
@@ -75,11 +68,11 @@ describe('resolveQueryTimezone', () => {
         ).toBe('Asia/Tokyo');
     });
 
-    it('ignores user timezone when the flag is off, falling back to project', () => {
+    it('user_timezone falls through to project when EnableUserTimezones is off', () => {
         expect(
             resolveQueryTimezone({
                 sessionTimezone: null,
-                metricQuery: {},
+                metricQuery: { timezone: 'user_timezone' },
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: 'Asia/Tokyo',
                 isUserTimezoneEnabled: false,
@@ -87,35 +80,11 @@ describe('resolveQueryTimezone', () => {
         ).toBe('Australia/Brisbane');
     });
 
-    it('chart timezone takes precedence over user timezone', () => {
+    it('user_timezone falls through to project when the viewer has no profile', () => {
         expect(
             resolveQueryTimezone({
                 sessionTimezone: null,
-                metricQuery: { timezone: 'America/New_York' },
-                projectTimezone: 'Australia/Brisbane',
-                userTimezone: 'Asia/Tokyo',
-                isUserTimezoneEnabled: true,
-            }),
-        ).toBe('America/New_York');
-    });
-
-    it('chart timezone still applies when the user-timezone flag is off', () => {
-        expect(
-            resolveQueryTimezone({
-                sessionTimezone: null,
-                metricQuery: { timezone: 'America/New_York' },
-                projectTimezone: 'Australia/Brisbane',
-                userTimezone: 'Asia/Tokyo',
-                isUserTimezoneEnabled: false,
-            }),
-        ).toBe('America/New_York');
-    });
-
-    it('falls back to project when user timezone is null', () => {
-        expect(
-            resolveQueryTimezone({
-                sessionTimezone: null,
-                metricQuery: {},
+                metricQuery: { timezone: 'user_timezone' },
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: null,
                 isUserTimezoneEnabled: true,
@@ -123,7 +92,67 @@ describe('resolveQueryTimezone', () => {
         ).toBe('Australia/Brisbane');
     });
 
-    it('throws on invalid metricQuery timezone', () => {
+    it('an override IANA zone wins over project and user profile', () => {
+        expect(
+            resolveQueryTimezone({
+                sessionTimezone: null,
+                metricQuery: { timezone: 'America/New_York' },
+                projectTimezone: 'Australia/Brisbane',
+                userTimezone: 'Asia/Tokyo',
+                isUserTimezoneEnabled: true,
+            }),
+        ).toBe('America/New_York');
+    });
+
+    it('an override zone applies even when the user-timezone flag is off', () => {
+        expect(
+            resolveQueryTimezone({
+                sessionTimezone: null,
+                metricQuery: { timezone: 'America/New_York' },
+                projectTimezone: 'Australia/Brisbane',
+                userTimezone: 'Asia/Tokyo',
+                isUserTimezoneEnabled: false,
+            }),
+        ).toBe('America/New_York');
+    });
+
+    it('sessionTimezone wins over override, user, and project', () => {
+        expect(
+            resolveQueryTimezone({
+                sessionTimezone: 'America/Los_Angeles',
+                metricQuery: { timezone: 'Europe/London' },
+                projectTimezone: 'UTC',
+                userTimezone: 'Asia/Tokyo',
+                isUserTimezoneEnabled: true,
+            }),
+        ).toBe('America/Los_Angeles');
+    });
+
+    it('falls back to the override when sessionTimezone is null', () => {
+        expect(
+            resolveQueryTimezone({
+                sessionTimezone: null,
+                metricQuery: { timezone: 'Europe/London' },
+                projectTimezone: 'UTC',
+                userTimezone: null,
+                isUserTimezoneEnabled: false,
+            }),
+        ).toBe('Europe/London');
+    });
+
+    it('falls back to project when sessionTimezone and setting are absent', () => {
+        expect(
+            resolveQueryTimezone({
+                sessionTimezone: null,
+                metricQuery: {},
+                projectTimezone: 'America/New_York',
+                userTimezone: null,
+                isUserTimezoneEnabled: false,
+            }),
+        ).toBe('America/New_York');
+    });
+
+    it('throws on invalid override timezone', () => {
         expect(() =>
             resolveQueryTimezone({
                 sessionTimezone: null,
@@ -147,11 +176,11 @@ describe('resolveQueryTimezone', () => {
         ).toThrow('Invalid timezone');
     });
 
-    it('throws on invalid user timezone', () => {
+    it('throws on invalid viewer timezone', () => {
         expect(() =>
             resolveQueryTimezone({
                 sessionTimezone: null,
-                metricQuery: {},
+                metricQuery: { timezone: 'user_timezone' },
                 projectTimezone: 'UTC',
                 userTimezone: "UTC'; DROP TABLE users; --",
                 isUserTimezoneEnabled: true,
@@ -159,7 +188,7 @@ describe('resolveQueryTimezone', () => {
         ).toThrow('Invalid timezone');
     });
 
-    it('throws on timezone with SQL injection attempt', () => {
+    it('throws on an override timezone with a SQL injection attempt', () => {
         expect(() =>
             resolveQueryTimezone({
                 sessionTimezone: null,
@@ -171,43 +200,7 @@ describe('resolveQueryTimezone', () => {
         ).toThrow('Invalid timezone');
     });
 
-    it('sessionTimezone wins over chart pin, user, and project', () => {
-        expect(
-            resolveQueryTimezone({
-                sessionTimezone: 'America/Los_Angeles',
-                metricQuery: { timezone: 'Europe/London' },
-                projectTimezone: 'UTC',
-                userTimezone: 'Asia/Tokyo',
-                isUserTimezoneEnabled: true,
-            }),
-        ).toBe('America/Los_Angeles');
-    });
-
-    it('falls back to chart pin when sessionTimezone is null', () => {
-        expect(
-            resolveQueryTimezone({
-                sessionTimezone: null,
-                metricQuery: { timezone: 'Europe/London' },
-                projectTimezone: 'UTC',
-                userTimezone: null,
-                isUserTimezoneEnabled: false,
-            }),
-        ).toBe('Europe/London');
-    });
-
-    it('falls back to project when sessionTimezone and pin are absent', () => {
-        expect(
-            resolveQueryTimezone({
-                sessionTimezone: null,
-                metricQuery: {},
-                projectTimezone: 'America/New_York',
-                userTimezone: null,
-                isUserTimezoneEnabled: false,
-            }),
-        ).toBe('America/New_York');
-    });
-
-    it('throws ParameterError for an invalid sessionTimezone', () => {
+    it('throws on an invalid sessionTimezone', () => {
         expect(() =>
             resolveQueryTimezone({
                 sessionTimezone: 'Not/AZone',
@@ -235,14 +228,14 @@ describe('getAccountUserTimezone', () => {
         expect(getAccountUserTimezone(anonymousAccount())).toBeNull();
     });
 
-    it('resolves to project timezone when the flag is off and to user timezone when on', () => {
+    it('feeds user_timezone resolution: project when the flag is off, profile when on', () => {
         const account = registeredAccount('Asia/Tokyo');
         const projectTimezone = 'Australia/Brisbane';
 
         expect(
             resolveQueryTimezone({
                 sessionTimezone: null,
-                metricQuery: {},
+                metricQuery: { timezone: 'user_timezone' },
                 projectTimezone,
                 userTimezone: getAccountUserTimezone(account),
                 isUserTimezoneEnabled: false,
@@ -252,7 +245,7 @@ describe('getAccountUserTimezone', () => {
         expect(
             resolveQueryTimezone({
                 sessionTimezone: null,
-                metricQuery: {},
+                metricQuery: { timezone: 'user_timezone' },
                 projectTimezone,
                 userTimezone: getAccountUserTimezone(account),
                 isUserTimezoneEnabled: true,

--- a/packages/common/src/utils/resolveQueryTimezone.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.ts
@@ -1,6 +1,10 @@
 import { type Account } from '../types/auth';
 import { ParameterError } from '../types/errors';
 import { type MetricQuery } from '../types/metricQuery';
+import {
+    PROJECT_TIMEZONE_SETTING,
+    USER_TIMEZONE_SETTING,
+} from '../types/timezone';
 import { isValidTimezone } from './scheduler';
 
 /**
@@ -16,23 +20,22 @@ export function getAccountUserTimezone(account: Account): string | null {
 }
 
 /**
- * Resolves the effective timezone for a query using the hierarchy:
- *   sessionTimezone → metricQuery.timezone → user timezone → project timezone → 'UTC'
+ * Resolves the effective timezone for a query.
  *
- * The project timezone (from getQueryTimezoneForProject) already handles
- * the project → config → 'UTC' fallback. The chart-level override sits on
- * top, and the user's profile timezone slots between the two so a viewer
- * with a personal preference sees their zone whenever the chart doesn't
- * pin one. The session timezone is a host-controlled per-session override
- * (e.g. an embed URL `?timezone=` param) that outranks even the chart pin.
+ * `sessionTimezone` is a host-controlled per-session override (e.g. an embed URL
+ * `?timezone=` param) that outranks everything. Otherwise the resolution is
+ * driven by the metricQuery.timezone setting:
+ *   - `project_timezone` (what saved charts store by default) or **absent** → the
+ *     project TZ for every viewer, tracking project-TZ changes, so the chart is
+ *     deterministic across its audience. This replaces the old "unpinned charts
+ *     fall through to the viewer's profile" behaviour.
+ *   - `user_timezone` → the viewer's profile TZ when `isUserTimezoneEnabled`,
+ *     else the project TZ.
+ *   - any other value → an override IANA zone, frozen regardless of viewer/project.
  *
- * The user layer is only applied when isUserTimezoneEnabled is true. When the
- * EnableUserTimezones flag is off, stored preferences are ignored so every
- * user falls back to the project timezone — gating here, at the single
- * chokepoint, covers every source of userTimezone (account profile or session).
- *
- * Validates the resolved timezone to prevent SQL injection — the result
- * is interpolated into warehouse SQL strings (e.g., AT TIME ZONE '...').
+ * Whether the resolved zone is actually applied to the query is gated by the
+ * calling service (EnableTimezoneSupport). The result is validated to prevent
+ * SQL injection — it is interpolated into warehouse SQL (e.g. AT TIME ZONE '...').
  */
 export function resolveQueryTimezone({
     sessionTimezone,
@@ -47,12 +50,21 @@ export function resolveQueryTimezone({
     userTimezone: string | null;
     isUserTimezoneEnabled: boolean;
 }): string {
-    const effectiveUserTimezone = isUserTimezoneEnabled ? userTimezone : null;
-    const timezone =
-        sessionTimezone ??
-        metricQuery.timezone ??
-        effectiveUserTimezone ??
-        projectTimezone;
+    const setting = metricQuery.timezone;
+
+    let timezone: string;
+    if (sessionTimezone) {
+        // Host/session override (e.g. embed `?timezone=`) — outranks everything.
+        timezone = sessionTimezone;
+    } else if (setting === USER_TIMEZONE_SETTING) {
+        // userTimezone may be null (no profile) → fall back to project.
+        timezone =
+            (isUserTimezoneEnabled ? userTimezone : null) ?? projectTimezone;
+    } else if (!setting || setting === PROJECT_TIMEZONE_SETTING) {
+        timezone = projectTimezone;
+    } else {
+        timezone = setting; // override IANA zone
+    }
 
     if (!isValidTimezone(timezone)) {
         throw new ParameterError(`Invalid timezone: ${timezone}`);


### PR DESCRIPTION
Closes: GLITCH-459

### Description:

Saved charts now default to the **project timezone for every viewer** (deterministic, and they track later project-TZ changes) instead of resolving per-viewer, gated behind the `EnableTimezoneSupport` flag. The single `timezone` column on `saved_queries_versions` is repurposed to store the setting — `project_timezone` (default) | `user_timezone` | an override IANA zone — as `NOT NULL DEFAULT 'project_timezone'`, via a safe online migration (batched backfill + validated `CHECK` before `SET NOT NULL`) since the table can hold millions of rows. `resolveQueryTimezone` now resolves `override → user profile (when EnableUserTimezones is on) → project → UTC`, and the sync cache keys are keyed on the resolved zone so a project-TZ change invalidates them.