### PR TITLE
fix: omnibar "Created by" filter loses selection when searching

### DIFF
--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
@@ -101,6 +101,15 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
         );
     }, [filters]);
 
+    const userOptions = useMemo(
+        () =>
+            organizationUsers?.map((user) => ({
+                value: user.userUuid,
+                label: `${user.firstName} ${user.lastName}`,
+            })) || [],
+        [organizationUsers],
+    );
+
     return (
         <Group px="md" py="sm">
             <Menu
@@ -249,20 +258,21 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
                     <Select
                         placeholder="Select a user"
                         searchable
-                        value={filters?.createdByUuid}
+                        // null keeps the Select controlled; if uncontrolled, Mantine resets the search text mid-click
+                        value={filters?.createdByUuid ?? null}
                         clearable
-                        data={
-                            organizationUsers?.map((user) => ({
-                                value: user.userUuid,
-                                label: `${user.firstName} ${user.lastName}`,
-                            })) || []
-                        }
+                        allowDeselect={false}
+                        // keep options inside the Menu so clicking one isn't an outside click that closes it
+                        comboboxProps={{ withinPortal: false }}
+                        data={userOptions}
                         onChange={(value) => {
                             onSearchFilterChange({
                                 ...filters,
                                 createdByUuid: value || undefined,
                             });
-
+                        }}
+                        // onChange doesn't fire when re-selecting the current value
+                        onOptionSubmit={() => {
                             createdByMenuHelpers.close();
                         }}
                     />


### PR DESCRIPTION
## Description

Fixes the omnibar "Created by" filter losing the selection when a user is picked after typing in the dropdown's search input, and the filter being silently cleared when re-selecting the currently selected user.

Two underlying problems in `OmnibarFilters.tsx`:

1. **Lost click after typing**: the Select's options dropdown rendered in a portal, so pressing the mouse on an option registered as an *outside click* for the wrapping `Menu`, which started closing and re-rendered the component. The `data` array was rebuilt inline on every render and `value` was `undefined` when no filter was set, so Mantine treated the Select as uncontrolled and reset its search text on the `data` identity change — between `mousedown` and `mouseup`. The filtered list snapped back to the full list, the option under the cursor was replaced, and the click never landed.
2. **Same-user re-select cleared the filter**: Mantine v8 `Select` defaults `allowDeselect` to `true`, so clicking the already-selected option fires `onChange(null)`.

## Changes

- Pass `value={filters?.createdByUuid ?? null}` so the Select stays controlled (no search reset on `data` changes)
- Memoize the user options so `data` keeps a stable identity
- Render the Select's combobox with `withinPortal: false` so clicking an option isn't an outside click that closes the Menu mid-selection
- Set `allowDeselect={false}` (clearing is still available via the clear button)
- Close the menu in `onOptionSubmit` instead of `onChange`, since `onChange` doesn't fire when re-selecting the current value

## How tested

Verified in the browser with real clicks: selecting a user after searching applies the filter, re-selecting the same user keeps it, switching users via search works, selecting from the unfiltered list works, and the dropdown renders without clipping inside the menu.

Closes: PROD-8256
Closes: #24174