### PR TITLE
feat(common): add sessionTimezone slot to resolveQueryTimezone

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1448,6 +1448,7 @@ export class EmbedService extends BaseService {
         const projectTimezone =
             await this.projectService.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone({
+            sessionTimezone: null,
             metricQuery: metricQueryWithDashboardOverrides,
             projectTimezone,
             userTimezone: null,
@@ -2082,6 +2083,7 @@ export class EmbedService extends BaseService {
         const projectTimezone =
             await this.projectService.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone({
+            sessionTimezone: null,
             metricQuery,
             projectTimezone,
             userTimezone: null,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2822,6 +2822,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
         });
         const resolvedTimezone = resolveQueryTimezone({
+            sessionTimezone: null,
             metricQuery,
             projectTimezone,
             userTimezone,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3858,6 +3858,7 @@ export class ProjectService extends BaseService {
             organizationUuid: account.organization.organizationUuid,
         });
         const timezone = resolveQueryTimezone({
+            sessionTimezone: null,
             metricQuery,
             projectTimezone,
             userTimezone: getAccountUserTimezone(account),
@@ -4547,6 +4548,7 @@ export class ProjectService extends BaseService {
                     organizationUuid: account.organization.organizationUuid,
                 });
                 const resolvedTimezone = resolveQueryTimezone({
+                    sessionTimezone: null,
                     metricQuery,
                     projectTimezone,
                     userTimezone: getAccountUserTimezone(account),
@@ -4895,6 +4897,7 @@ export class ProjectService extends BaseService {
                                 account.organization.organizationUuid,
                         });
                     const timezone = resolveQueryTimezone({
+                        sessionTimezone: null,
                         metricQuery: metricQueryWithLimit,
                         projectTimezone,
                         userTimezone: getAccountUserTimezone(account),
@@ -5502,6 +5505,7 @@ export class ProjectService extends BaseService {
             await this.getQueryTimezoneForProject(projectUuid);
         const isUserTimezoneEnabled = await this.isUserTimezoneEnabled(user);
         const timezone = resolveQueryTimezone({
+            sessionTimezone: null,
             metricQuery,
             projectTimezone,
             userTimezone: user.timezone,

--- a/packages/common/src/utils/resolveQueryTimezone.test.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.test.ts
@@ -18,6 +18,7 @@ describe('resolveQueryTimezone', () => {
     it('returns metricQuery.timezone when set', () => {
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: { timezone: 'America/New_York' },
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: null,
@@ -29,6 +30,7 @@ describe('resolveQueryTimezone', () => {
     it('falls back to project timezone when metricQuery.timezone is undefined', () => {
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: { timezone: undefined },
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: null,
@@ -40,6 +42,7 @@ describe('resolveQueryTimezone', () => {
     it('falls back to project timezone when timezone field is missing', () => {
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: {},
                 projectTimezone: 'Europe/London',
                 userTimezone: null,
@@ -51,6 +54,7 @@ describe('resolveQueryTimezone', () => {
     it('accepts UTC', () => {
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: {},
                 projectTimezone: 'UTC',
                 userTimezone: null,
@@ -62,6 +66,7 @@ describe('resolveQueryTimezone', () => {
     it('uses user timezone when chart timezone is absent and the flag is on', () => {
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: {},
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: 'Asia/Tokyo',
@@ -73,6 +78,7 @@ describe('resolveQueryTimezone', () => {
     it('ignores user timezone when the flag is off, falling back to project', () => {
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: {},
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: 'Asia/Tokyo',
@@ -84,6 +90,7 @@ describe('resolveQueryTimezone', () => {
     it('chart timezone takes precedence over user timezone', () => {
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: { timezone: 'America/New_York' },
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: 'Asia/Tokyo',
@@ -95,6 +102,7 @@ describe('resolveQueryTimezone', () => {
     it('chart timezone still applies when the user-timezone flag is off', () => {
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: { timezone: 'America/New_York' },
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: 'Asia/Tokyo',
@@ -106,6 +114,7 @@ describe('resolveQueryTimezone', () => {
     it('falls back to project when user timezone is null', () => {
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: {},
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: null,
@@ -117,6 +126,7 @@ describe('resolveQueryTimezone', () => {
     it('throws on invalid metricQuery timezone', () => {
         expect(() =>
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: { timezone: "'; DROP TABLE users; --" },
                 projectTimezone: 'UTC',
                 userTimezone: null,
@@ -128,6 +138,7 @@ describe('resolveQueryTimezone', () => {
     it('throws on invalid project timezone', () => {
         expect(() =>
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: {},
                 projectTimezone: 'Not/A/Timezone',
                 userTimezone: null,
@@ -139,6 +150,7 @@ describe('resolveQueryTimezone', () => {
     it('throws on invalid user timezone', () => {
         expect(() =>
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: {},
                 projectTimezone: 'UTC',
                 userTimezone: "UTC'; DROP TABLE users; --",
@@ -150,10 +162,59 @@ describe('resolveQueryTimezone', () => {
     it('throws on timezone with SQL injection attempt', () => {
         expect(() =>
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: { timezone: "UTC' OR '1'='1" },
                 projectTimezone: 'UTC',
                 userTimezone: null,
                 isUserTimezoneEnabled: true,
+            }),
+        ).toThrow('Invalid timezone');
+    });
+
+    it('sessionTimezone wins over chart pin, user, and project', () => {
+        expect(
+            resolveQueryTimezone({
+                sessionTimezone: 'America/Los_Angeles',
+                metricQuery: { timezone: 'Europe/London' },
+                projectTimezone: 'UTC',
+                userTimezone: 'Asia/Tokyo',
+                isUserTimezoneEnabled: true,
+            }),
+        ).toBe('America/Los_Angeles');
+    });
+
+    it('falls back to chart pin when sessionTimezone is null', () => {
+        expect(
+            resolveQueryTimezone({
+                sessionTimezone: null,
+                metricQuery: { timezone: 'Europe/London' },
+                projectTimezone: 'UTC',
+                userTimezone: null,
+                isUserTimezoneEnabled: false,
+            }),
+        ).toBe('Europe/London');
+    });
+
+    it('falls back to project when sessionTimezone and pin are absent', () => {
+        expect(
+            resolveQueryTimezone({
+                sessionTimezone: null,
+                metricQuery: {},
+                projectTimezone: 'America/New_York',
+                userTimezone: null,
+                isUserTimezoneEnabled: false,
+            }),
+        ).toBe('America/New_York');
+    });
+
+    it('throws ParameterError for an invalid sessionTimezone', () => {
+        expect(() =>
+            resolveQueryTimezone({
+                sessionTimezone: 'Not/AZone',
+                metricQuery: {},
+                projectTimezone: 'UTC',
+                userTimezone: null,
+                isUserTimezoneEnabled: false,
             }),
         ).toThrow('Invalid timezone');
     });
@@ -180,6 +241,7 @@ describe('getAccountUserTimezone', () => {
 
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: {},
                 projectTimezone,
                 userTimezone: getAccountUserTimezone(account),
@@ -189,6 +251,7 @@ describe('getAccountUserTimezone', () => {
 
         expect(
             resolveQueryTimezone({
+                sessionTimezone: null,
                 metricQuery: {},
                 projectTimezone,
                 userTimezone: getAccountUserTimezone(account),

--- a/packages/common/src/utils/resolveQueryTimezone.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.ts
@@ -17,13 +17,14 @@ export function getAccountUserTimezone(account: Account): string | null {
 
 /**
  * Resolves the effective timezone for a query using the hierarchy:
- *   metricQuery.timezone → user timezone → project timezone → 'UTC'
+ *   sessionTimezone → metricQuery.timezone → user timezone → project timezone → 'UTC'
  *
  * The project timezone (from getQueryTimezoneForProject) already handles
  * the project → config → 'UTC' fallback. The chart-level override sits on
  * top, and the user's profile timezone slots between the two so a viewer
  * with a personal preference sees their zone whenever the chart doesn't
- * pin one.
+ * pin one. The session timezone is a host-controlled per-session override
+ * (e.g. an embed URL `?timezone=` param) that outranks even the chart pin.
  *
  * The user layer is only applied when isUserTimezoneEnabled is true. When the
  * EnableUserTimezones flag is off, stored preferences are ignored so every
@@ -34,11 +35,13 @@ export function getAccountUserTimezone(account: Account): string | null {
  * is interpolated into warehouse SQL strings (e.g., AT TIME ZONE '...').
  */
 export function resolveQueryTimezone({
+    sessionTimezone,
     metricQuery,
     projectTimezone,
     userTimezone,
     isUserTimezoneEnabled,
 }: {
+    sessionTimezone: string | null;
     metricQuery: Pick<MetricQuery, 'timezone'>;
     projectTimezone: string;
     userTimezone: string | null;
@@ -46,7 +49,10 @@ export function resolveQueryTimezone({
 }): string {
     const effectiveUserTimezone = isUserTimezoneEnabled ? userTimezone : null;
     const timezone =
-        metricQuery.timezone ?? effectiveUserTimezone ?? projectTimezone;
+        sessionTimezone ??
+        metricQuery.timezone ??
+        effectiveUserTimezone ??
+        projectTimezone;
 
     if (!isValidTimezone(timezone)) {
         throw new ParameterError(`Invalid timezone: ${timezone}`);


### PR DESCRIPTION
Part 1 of 3 of the embed per-session timezone stack.

Adds a new highest-priority `sessionTimezone` slot to the shared `resolveQueryTimezone` resolver so a per-session override can outrank the chart pin, user timezone, and project default. This is a pure foundation: every existing call site passes `sessionTimezone: null`, so there is no behaviour change.

Precedence is now `sessionTimezone ?? metricQuery.timezone (chart pin) ?? user timezone ?? project timezone`. Invalid timezones still throw `ParameterError` via the existing `isValidTimezone` check.

Unit tests cover the new precedence (session wins over pin, user, and project) and the invalid-throw.

Relates: GLITCH-488
