### PR TITLE
feat(embed): thread session timezone into query resolution

### DIFF
--- a/packages/api-tests/tests/embedTimezone.test.ts
+++ b/packages/api-tests/tests/embedTimezone.test.ts
@@ -214,13 +214,30 @@ describe('Embed dashboard-tile session timezone (?timezone=)', () => {
         expect(totalsResp.body.results.resolvedTimezone).toBe(resolvedTimezone);
     });
 
-    it('rejects an invalid session timezone with a 400', async () => {
+    it('rejects an invalid session timezone with a 400 when timezone support is on', async () => {
         const token = await freshDashboardJwt();
+
+        // Probe the flag: resolvedTimezone is null when EnableTimezoneSupport
+        // is off, in which case the session timezone is gated out before
+        // resolution and never validated.
+        const probe = await executeTile(token, SESSION_TIMEZONE);
+        expect(probe.status).toBe(200);
+        const timezoneSupportEnabled =
+            probe.body.results.resolvedTimezone !== null;
+
         const resp = await executeTile(token, 'Not/AZone', {
             failOnStatusCode: false,
         });
 
-        expect(resp.status).toBe(400);
-        expect(resp.body).toHaveProperty('error');
+        if (timezoneSupportEnabled) {
+            // Flag on: the invalid session timezone reaches the resolver and
+            // is rejected as a ParameterError.
+            expect(resp.status).toBe(400);
+            expect(resp.body).toHaveProperty('error');
+        } else {
+            // Flag off: the session timezone is dropped at the embed boundary,
+            // so the invalid value is inert and the query runs normally.
+            expect(resp.status).toBe(200);
+        }
     });
 });

--- a/packages/api-tests/tests/embedTimezone.test.ts
+++ b/packages/api-tests/tests/embedTimezone.test.ts
@@ -1,0 +1,226 @@
+import { SEED_PROJECT, UpdateEmbed } from '@lightdash/common';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { ApiClient, Body } from '../helpers/api-client';
+import { login } from '../helpers/auth';
+
+const EMBED_API_PREFIX = `/api/v1/embed/${SEED_PROJECT.project_uuid}`;
+const SESSION_TIMEZONE = 'America/Los_Angeles';
+
+type EmbedConfig = {
+    dashboardUuids?: string[];
+    allowAllDashboards?: boolean;
+    chartUuids?: string[];
+    allowAllCharts?: boolean;
+};
+
+type DashboardTile = {
+    uuid: string;
+    type: string;
+    properties: { savedChartUuid?: string | null };
+};
+
+type ExecuteTileResponse = {
+    queryUuid: string;
+    resolvedTimezone: string | null;
+};
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+async function getEmbedConfig(client: ApiClient) {
+    return client.get<Body<EmbedConfig>>(`${EMBED_API_PREFIX}/config`);
+}
+
+async function updateEmbedConfig(client: ApiClient, body: UpdateEmbed) {
+    return client.patch<Body<unknown>>(`${EMBED_API_PREFIX}/config`, body);
+}
+
+async function waitForEmbedConfigWithDashboards(
+    client: ApiClient,
+    expectedDashboardUuids: string[],
+    maxAttempts = 10,
+    delayMs = 500,
+): Promise<void> {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const resp = await getEmbedConfig(client);
+        if (resp.status === 200) {
+            const config = resp.body.results;
+            const hasAll = expectedDashboardUuids.every((uuid) =>
+                config.dashboardUuids?.includes(uuid),
+            );
+            if (hasAll) return;
+        }
+        if (attempt >= maxAttempts) {
+            throw new Error(
+                'Embed config did not contain expected dashboards.',
+            );
+        }
+        await delay(delayMs);
+    }
+}
+
+describe('Embed dashboard-tile session timezone (?timezone=)', () => {
+    let admin: ApiClient;
+    let embedEnabled = true;
+    let dashboardUuid: string;
+    let chartTileUuid: string;
+
+    // Fresh JWT each test so it always uses the current embed secret
+    async function freshDashboardJwt(): Promise<string> {
+        const resp = await admin.post<Body<{ url: string }>>(
+            `${EMBED_API_PREFIX}/get-embed-url`,
+            {
+                user: {
+                    externalId: 'tz-user@example.com',
+                    email: 'tz-user@example.com',
+                },
+                content: {
+                    type: 'dashboard',
+                    dashboardUuid,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                },
+                expiresIn: '24h',
+            },
+        );
+        expect(resp.status).toBe(200);
+        return resp.body.results.url.split('#')[1];
+    }
+
+    function embedHeaders(token: string) {
+        return { 'Lightdash-Embed-Token': token };
+    }
+
+    async function executeTile(
+        token: string,
+        timezone: string | undefined,
+        options?: { failOnStatusCode?: boolean },
+    ) {
+        return new ApiClient().post<Body<ExecuteTileResponse>>(
+            `${EMBED_API_PREFIX}/query/dashboard-tile`,
+            {
+                tileUuid: chartTileUuid,
+                dashboardFilters: {
+                    dimensions: [],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                dashboardSorts: [],
+                ...(timezone ? { timezone } : {}),
+            },
+            { headers: embedHeaders(token), ...options },
+        );
+    }
+
+    beforeAll(async () => {
+        admin = await login();
+
+        const configResp = await admin.get<Body<EmbedConfig>>(
+            `${EMBED_API_PREFIX}/config`,
+            { failOnStatusCode: false },
+        );
+        if (configResp.status === 403) {
+            embedEnabled = false;
+            return;
+        }
+        expect(configResp.status).toBe(200);
+        const existingConfig = configResp.body.results;
+
+        const dashboardsResp = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`/api/v1/projects/${SEED_PROJECT.project_uuid}/dashboards`);
+        expect(dashboardsResp.status).toBe(200);
+        const seedDashboard = dashboardsResp.body.results.find(
+            (d) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        dashboardUuid = seedDashboard!.uuid;
+
+        await updateEmbedConfig(admin, {
+            dashboardUuids: [dashboardUuid],
+            allowAllDashboards: false,
+            chartUuids: existingConfig.chartUuids || [],
+            allowAllCharts: true,
+        });
+        await waitForEmbedConfigWithDashboards(admin, [dashboardUuid]);
+
+        const dashboardResp = await admin.get<Body<{ tiles: DashboardTile[] }>>(
+            `/api/v1/dashboards/${dashboardUuid}?projectUuid=${SEED_PROJECT.project_uuid}`,
+        );
+        expect(dashboardResp.status).toBe(200);
+        const chartTile = dashboardResp.body.results.tiles.find(
+            (tile) =>
+                tile.type === 'saved_chart' &&
+                Boolean(tile.properties.savedChartUuid),
+        );
+        expect(chartTile).toBeDefined();
+        chartTileUuid = chartTile!.uuid;
+    });
+
+    beforeEach((ctx) => {
+        if (!embedEnabled) ctx.skip();
+    });
+
+    it('applies the session timezone, overriding the chart pin', async () => {
+        const token = await freshDashboardJwt();
+        const resp = await executeTile(token, SESSION_TIMEZONE);
+
+        expect(resp.status).toBe(200);
+        // resolvedTimezone is the gated display timezone — null when
+        // EnableTimezoneSupport is off. When present, it must reflect the
+        // session timezone we passed, proving it reached the resolver and
+        // won over the chart pin / project default.
+        if (resp.body.results.resolvedTimezone !== null) {
+            expect(resp.body.results.resolvedTimezone).toBe(SESSION_TIMEZONE);
+        }
+    });
+
+    it('totals inherit the session timezone without re-passing it', async () => {
+        const token = await freshDashboardJwt();
+        const tileResp = await executeTile(token, SESSION_TIMEZONE);
+        expect(tileResp.status).toBe(200);
+        const { queryUuid, resolvedTimezone } = tileResp.body.results;
+
+        // Poll the tile query to completion via the v2 results endpoint
+        // (embed token authorises it), then compute totals by queryUuid only.
+        const tileClient = new ApiClient();
+        let ready = false;
+        for (let attempt = 0; attempt < 60 && !ready; attempt++) {
+            const poll = await tileClient.get<Body<{ status: string }>>(
+                `/api/v2/projects/${SEED_PROJECT.project_uuid}/query/${queryUuid}?page=1&pageSize=1`,
+                { headers: embedHeaders(token) },
+            );
+            expect(poll.status).toBe(200);
+            if (poll.body.results.status === 'ready') ready = true;
+            else if (poll.body.results.status === 'error')
+                throw new Error('Tile query failed');
+            else await delay(500);
+        }
+        expect(ready).toBe(true);
+
+        const totalsResp = await new ApiClient().post<
+            Body<{ resolvedTimezone: string | null }>
+        >(
+            `/api/v2/projects/${SEED_PROJECT.project_uuid}/query/${queryUuid}/calculate-total`,
+            { kind: 'columnTotal' },
+            { headers: embedHeaders(token), failOnStatusCode: false },
+        );
+
+        expect(totalsResp.status).toBe(200);
+        // The totals re-query rebuilds from the persisted source metricQuery,
+        // so it must resolve to the same timezone as the originating tile.
+        expect(totalsResp.body.results.resolvedTimezone).toBe(resolvedTimezone);
+    });
+
+    it('rejects an invalid session timezone with a 400', async () => {
+        const token = await freshDashboardJwt();
+        const resp = await executeTile(token, 'Not/AZone', {
+            failOnStatusCode: false,
+        });
+
+        expect(resp.status).toBe(400);
+        expect(resp.body).toHaveProperty('error');
+    });
+});

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -330,6 +330,7 @@ export class EmbedController extends BaseController {
         @Body()
         body: {
             tileUuid: string;
+            timezone?: string;
         } & Pick<
             ExecuteAsyncDashboardChartRequestParams,
             | 'dashboardFilters'
@@ -360,6 +361,7 @@ export class EmbedController extends BaseController {
                 parameters: body.parameters,
                 pivotResults: body.pivotResults,
                 limit: body.limit,
+                timezone: body.timezone,
             });
 
         return {
@@ -610,14 +612,22 @@ export class EmbedController extends BaseController {
             forceRefresh: boolean;
             tableName?: string;
             fieldId?: string;
+            timezone?: string;
         },
     ): Promise<{
         status: 'ok';
         results: FieldValueSearchResult;
     }> {
         this.setStatus(200);
-        const { search, limit, filters, forceRefresh, tableName, fieldId } =
-            body;
+        const {
+            search,
+            limit,
+            filters,
+            forceRefresh,
+            tableName,
+            fieldId,
+            timezone,
+        } = body;
 
         assertEmbeddedAuth(req.account);
 
@@ -631,6 +641,7 @@ export class EmbedController extends BaseController {
             forceRefresh,
             tableName,
             fieldId,
+            timezone,
         });
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1066,10 +1066,12 @@ export class EmbedService extends BaseService {
         parameters,
         pivotResults,
         limit,
+        timezone,
     }: {
         account: AnonymousAccount;
         projectUuid: string;
         tileUuid: string;
+        timezone?: string;
     } & Pick<
         ExecuteAsyncDashboardChartRequestParams,
         | 'dashboardFilters'
@@ -1170,6 +1172,7 @@ export class EmbedService extends BaseService {
             context: QueryExecutionContext.EMBED,
             parameters: combinedParameters,
             pivotResults,
+            sessionTimezone: timezone ?? null,
         });
     }
 
@@ -1981,6 +1984,7 @@ export class EmbedService extends BaseService {
         forceRefresh,
         tableName: fallbackTableName,
         fieldId: fallbackFieldId,
+        timezone: sessionTimezoneParam,
     }: {
         account: AnonymousAccount;
         projectUuid: string;
@@ -1991,6 +1995,7 @@ export class EmbedService extends BaseService {
         forceRefresh: boolean;
         tableName?: string;
         fieldId?: string;
+        timezone?: string;
     }): Promise<FieldValueSearchResult> {
         const { dashboardUuids, allowAllDashboards, user } =
             await this.embedModel.get(projectUuid);
@@ -2084,7 +2089,7 @@ export class EmbedService extends BaseService {
         const projectTimezone =
             await this.projectService.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone({
-            sessionTimezone: null,
+            sessionTimezone: sessionTimezoneParam ?? null,
             metricQuery,
             projectTimezone,
             userTimezone: null,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1157,6 +1157,14 @@ export class EmbedService extends BaseService {
             dashboardParameters,
         );
 
+        // The session timezone only takes effect when timezone support is
+        // enabled for the org; otherwise it is dropped so the param is inert.
+        const isTimezoneSupportEnabled =
+            await this.projectService.isTimezoneSupportEnabled({
+                userUuid: user?.userUuid ?? account.user.id,
+                organizationUuid,
+            });
+
         // Execute using AsyncQueryService method with embed context
         return this.asyncQueryService.executeAsyncDashboardChartQuery({
             account,
@@ -1172,7 +1180,9 @@ export class EmbedService extends BaseService {
             context: QueryExecutionContext.EMBED,
             parameters: combinedParameters,
             pivotResults,
-            sessionTimezone: timezone ?? null,
+            sessionTimezone: isTimezoneSupportEnabled
+                ? (timezone ?? null)
+                : null,
         });
     }
 
@@ -2086,20 +2096,25 @@ export class EmbedService extends BaseService {
                 filters,
             });
 
-        const projectTimezone =
-            await this.projectService.getQueryTimezoneForProject(projectUuid);
-        const timezone = resolveQueryTimezone({
-            sessionTimezone: sessionTimezoneParam ?? null,
-            metricQuery,
-            projectTimezone,
-            userTimezone: null,
-            isUserTimezoneEnabled: false,
-        });
         const useTimezoneAwareDateTrunc =
             await this.projectService.isTimezoneSupportEnabled({
                 userUuid: user?.userUuid ?? account.user.id,
                 organizationUuid: dashboard.organizationUuid,
             });
+
+        const projectTimezone =
+            await this.projectService.getQueryTimezoneForProject(projectUuid);
+        const timezone = resolveQueryTimezone({
+            // Gated like the tile path: the session timezone is dropped unless
+            // timezone support is enabled, leaving the param inert.
+            sessionTimezone: useTimezoneAwareDateTrunc
+                ? (sessionTimezoneParam ?? null)
+                : null,
+            metricQuery,
+            projectTimezone,
+            userTimezone: null,
+            isUserTimezoneEnabled: false,
+        });
 
         const { rows, cacheMetadata } = await this._runEmbedQuery({
             projectUuid: dashboard.projectUuid,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12741,7 +12741,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12749,7 +12749,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12764,7 +12768,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12772,11 +12776,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -13081,13 +13081,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -13114,13 +13114,13 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: [
                                                                 'not_found',
                                                             ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13172,6 +13172,130 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
                                                                 explore: {
                                                                     dataType:
                                                                         'nestedObjectLiteral',
@@ -13206,130 +13330,6 @@ const models: TsoaRoute.Models = {
                                                                         },
                                                                     required: true,
                                                                 },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            },
-                                                                    },
-                                                                    required: true,
-                                                                },
                                                                 status: {
                                                                     dataType:
                                                                         'enum',
@@ -13358,17 +13358,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -13493,6 +13493,14 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                uuid: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13502,14 +13510,6 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                             },
                                         },
                                         {
@@ -13591,27 +13591,6 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
-                                                prAction: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['opened'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['updated'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 steps: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13672,6 +13651,27 @@ const models: TsoaRoute.Models = {
                                                                         },
                                                                     },
                                                             },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
+                                                prAction: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['opened'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['updated'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13763,6 +13763,10 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13772,10 +13776,6 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                             },
                                         },
                                         {
@@ -13825,14 +13825,14 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13872,25 +13872,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -13980,6 +13961,13 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
+                                                                                    'dimension',
+                                                                                ],
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
                                                                                     'metric',
                                                                                 ],
                                                                             },
@@ -13987,8 +13975,20 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    null,
                                                                                 ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
                                                                             },
                                                                             {
                                                                                 dataType:
@@ -40922,6 +40922,7 @@ export function RegisterRoutes(app: Router) {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        timezone: { dataType: 'string' },
                         tileUuid: { dataType: 'string', required: true },
                     },
                 },
@@ -41434,6 +41435,7 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                timezone: { dataType: 'string' },
                 fieldId: { dataType: 'string' },
                 tableName: { dataType: 'string' },
                 forceRefresh: { dataType: 'boolean', required: true },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12432,11 +12432,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12494,11 +12494,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14158,16 +14158,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -14315,19 +14315,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "status",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14337,8 +14337,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
-                                                            "not_found"
+                                                            "not_found",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -14368,6 +14368,66 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "false",
+                                                                                        "not_applicable",
+                                                                                        "true"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "description",
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldFilterType",
+                                                                                "fieldValueType",
+                                                                                "fieldType",
+                                                                                "table",
+                                                                                "label",
+                                                                                "name",
+                                                                                "fieldId"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "joinedTables": {
@@ -14394,66 +14454,6 @@
                                                                         ],
                                                                         "type": "object"
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
-                                                                                "fieldValueType",
-                                                                                "fieldFilterType",
-                                                                                "description",
-                                                                                "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
-                                                                                "label",
-                                                                                "name"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -14464,8 +14464,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "explore",
                                                                     "fields",
+                                                                    "explore",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14478,10 +14478,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -14489,8 +14489,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "exploreLabel",
                                                                                 "reason",
+                                                                                "exploreLabel",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -14573,6 +14573,12 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "uuid": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
@@ -14580,36 +14586,21 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "uuid": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "slug",
-                                                    "status",
                                                     "uuid",
-                                                    "name"
+                                                    "name",
+                                                    "slug",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
                                             {
                                                 "properties": {
-                                                    "prAction": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "opened",
-                                                            "updated",
-                                                            null
-                                                        ],
-                                                        "nullable": true
-                                                    },
                                                     "steps": {
                                                         "items": {
                                                             "properties": {
@@ -14634,6 +14625,15 @@
                                                             "type": "object"
                                                         },
                                                         "type": "array",
+                                                        "nullable": true
+                                                    },
+                                                    "prAction": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "opened",
+                                                            "updated",
+                                                            null
+                                                        ],
                                                         "nullable": true
                                                     },
                                                     "prUrl": {
@@ -14676,6 +14676,9 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
@@ -14683,16 +14686,13 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
+                                                    "name",
                                                     "slug",
-                                                    "status",
-                                                    "name"
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14702,8 +14702,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
                                                             "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -14715,10 +14715,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -14758,17 +14754,21 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
+                                                                "nullable": true
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
-                                                            "type"
+                                                            "type",
+                                                            "searchQuery"
                                                         ],
                                                         "type": "object"
                                                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13995,8 +13995,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14054,8 +14054,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -38600,7 +38600,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3135.0",
+        "version": "0.3137.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2802,12 +2802,14 @@ export class AsyncQueryService extends ProjectService {
         organizationUuid,
         userUuid,
         userTimezone,
+        sessionTimezone,
         metricQuery,
     }: {
         projectUuid: string | null;
         organizationUuid: string;
         userUuid: string;
         userTimezone: string | null;
+        sessionTimezone: string | null;
         metricQuery: MetricQuery;
     }): Promise<{
         resolvedTimezone: string;
@@ -2822,7 +2824,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
         });
         const resolvedTimezone = resolveQueryTimezone({
-            sessionTimezone: null,
+            sessionTimezone,
             metricQuery,
             projectTimezone,
             userTimezone,
@@ -3196,6 +3198,7 @@ export class AsyncQueryService extends ProjectService {
         userAttributeOverrides,
         materializationRole,
         columnTimezone,
+        sessionTimezone,
         applyDateZoomToFilters,
     }: Pick<
         ExecuteAsyncMetricQueryArgs,
@@ -3211,6 +3214,7 @@ export class AsyncQueryService extends ProjectService {
         explore: Explore;
         pivotConfiguration?: PivotConfiguration;
         columnTimezone?: string;
+        sessionTimezone?: string | null;
         /**
          * Opt-in: rewrite WHERE filter LHS to use the zoom-grain dimension
          * for the filter that targets the zoom-rewritten field. Only the
@@ -3249,6 +3253,7 @@ export class AsyncQueryService extends ProjectService {
                 materializationRole !== undefined
                     ? null
                     : getAccountUserTimezone(account),
+            sessionTimezone: sessionTimezone ?? null,
             metricQuery,
         });
 
@@ -4765,6 +4770,7 @@ export class AsyncQueryService extends ProjectService {
         limit,
         parameters,
         pivotResults,
+        sessionTimezone,
     }: ExecuteAsyncDashboardChartQueryArgs): Promise<ApiExecuteAsyncDashboardChartQueryResults> {
         assertIsAccountWithOrg(account);
 
@@ -4951,6 +4957,7 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             pivotConfiguration,
             columnTimezone: getColumnTimezone(warehouseCredentials),
+            sessionTimezone,
         });
 
         const routingDecision = this.getPreAggregationRoutingDecision({

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -95,6 +95,7 @@ export type ExecuteAsyncDashboardChartQueryArgs = CommonAsyncQueryArgs & {
     dateZoom?: DateZoom;
     limit?: number | null | undefined;
     pivotResults?: boolean;
+    sessionTimezone?: string | null;
 };
 
 export type ExecuteAsyncUnderlyingDataQueryArgs = CommonAsyncQueryArgs & {


### PR DESCRIPTION
Part 2 of 3 of the embed per-session timezone stack. Stacked on #24181.

Threads the embed session timezone from the request body into query timezone resolution:
* `resolveTimezoneContext` → `prepareMetricQueryAsyncQueryArgs` → `executeAsyncDashboardChartQuery` (dashboard tile render path)
* `EmbedService.searchFilterValues` (filter-value autocomplete direct resolver call)
* adds an optional `timezone` field to the `/query/dashboard-tile` and `/filter/:filterUuid/search` embed request bodies

Totals and subtotals need no change. They re-query from the persisted `metricQuery.timezone` on the originating tile query, so they inherit the session timezone automatically.

The session timezone is gated at the `EmbedService` boundary on `EnableTimezoneSupport`: when the flag is off the param is dropped to null before resolution, so it is fully inert (not resolved, not validated). The gate lives in `EmbedService`, the single source of the URL param, rather than in the shared resolver, so the non-embed call sites stay untouched. When the flag is on, the session timezone overrides the chart pin and an invalid value returns a 400.

API behaviour test (`packages/api-tests`) covers: the tile resolves to the session timezone, totals inherit it without re-passing, and an invalid timezone returns 400 when timezone support is on (and is inert when off).

Relates: GLITCH-488

test-all