### PR TITLE
feat(embed): support per-session timezone via ?timezone= URL param

### DIFF
--- a/docs/timezones/draft-user-documentation.md
+++ b/docs/timezones/draft-user-documentation.md
@@ -268,12 +268,13 @@ For most schedules, the cleanest setup is:
 
 ## Embedded charts
 
-When you embed a Lightdash chart in another product, the embed has no user — there's no profile timezone to fall back to. Embedded charts use:
+When you embed a Lightdash chart in another product, the embed has no user — there's no profile timezone to fall back to. Embedded sessions resolve their timezone as:
 
-1. The chart's pin, if set.
-2. Otherwise, the project timezone.
+1. The `?timezone=<IANA>` param on the embed page URL, if present. This is a per-session override the host sets when building the URL (e.g. `…/embed/<projectUuid>?timezone=America/Los_Angeles#<token>`), and it wins over the chart pin.
+2. Otherwise, the chart's pin, if set.
+3. Otherwise, the project timezone.
 
-If you need an embed in a specific timezone, pin the chart explicitly before embedding.
+For multi-tenant embeds, set `?timezone=` per session to render each tenant in its own zone — you don't need a separate chart per timezone. An unrecognised timezone value is rejected rather than silently ignored.
 
 ## Custom SQL with `${ldQueryTimezone}`
 

--- a/docs/timezones/timezone-handling.md
+++ b/docs/timezones/timezone-handling.md
@@ -13,14 +13,15 @@ Lightdash has two timezone settings. They look similar but solve different probl
 | **Data timezone**    | Warehouse   | "What timezone are my NTZ timestamps stored in?" | Warehouse connection → Advanced settings |
 | **Project timezone** | Application | "What timezone should my users see data in?"     | Project settings → Timezone              |
 
-In addition, two display-layer overrides sit on top of the project timezone:
+In addition, three overrides sit on top of the project timezone (the session timezone applies only to embedded sessions):
 
 | Override               | Scope              | Wins over project? | Where configured                  |
 | ---------------------- | ------------------ | ------------------ | --------------------------------- |
+| **Session timezone**   | Per embed session  | ✅ (wins over chart, user, project) | Embed page URL `?timezone=<IANA>` |
 | **User timezone**      | Per viewer         | ✅                 | Profile settings → Default timezone |
 | **Chart timezone**     | Per saved chart    | ✅ (also wins over user) | Explorer header → Timezone picker |
 
-Resolution order: `chart → user → project → server default ('UTC')`. A viewer with no profile preference falls through to the project. A viewer with a profile timezone sees their zone on charts that don't pin one. See [User-level timezone](#user-level-timezone) below.
+Resolution order: `session (embed URL) → chart → user → project → server default ('UTC')`. A viewer with no profile preference falls through to the project. A viewer with a profile timezone sees their zone on charts that don't pin one. An embedding host can pin a single session to a zone via the `?timezone=` URL param, which outranks even the chart pin. See [User-level timezone](#user-level-timezone) below.
 
 Two flags gate timezone behavior:
 
@@ -61,7 +62,7 @@ metricQuery.timezone  →  user.timezone  →  project.queryTimezone  →  confi
 - An author can still "pin" a chart to a specific zone via the Explorer timezone picker — that fixed zone then wins for every viewer.
 - Charts without a pinned zone fall through per-viewer, so each reader sees their own zone.
 
-Resolution happens server-side in [`resolveQueryTimezone`](../../packages/common/src/utils/resolveQueryTimezone.ts). Anonymous viewers (embeds / JWT) and service accounts have no profile timezone — the helper `getAccountUserTimezone(account)` returns `null` for them, so they fall through to the project default.
+Resolution happens server-side in [`resolveQueryTimezone`](../../packages/common/src/utils/resolveQueryTimezone.ts). Anonymous viewers (embeds / JWT) and service accounts have no profile timezone — the helper `getAccountUserTimezone(account)` returns `null` for them. Embedded sessions can still set a per-session query timezone via the `?timezone=<IANA>` embed URL param, which is threaded in as the top-priority `sessionTimezone` argument and outranks the chart pin; absent that param they fall through to the project default.
 
 **Worker / retrieval paths** (queued warehouse execution, pre-aggregate workers, results pagination, downloads, ready-results fetch) don't re-resolve the timezone. `executePreparedAsyncQuery` stamps the resolved chart > user > project timezone onto `metricQuery.timezone` before persisting the query history snapshot, so any method that receives a `queryUuid` reads it back directly as `queryHistory.metricQuery.timezone` — no resolver helper, no project lookup, no flag check.
 
@@ -415,7 +416,6 @@ The only remaining hole is NTZ-style columns storing non-UTC data on warehouses 
 | Gap                                                              | Description                                                                                                                                                                                                                                                                           | Impact                                                                                                                                            |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **BigQuery/Athena: no session timezone**                         | These warehouses have no session-timezone plumbing, so the data-timezone setting is inert. NTZ-style columns (BigQuery `DATETIME`, Athena bare `TIMESTAMP`) can't be rebased from their stored zone to UTC                                                                           | Data timezone setting has no effect (UI field is hidden); NTZ columns holding non-UTC data can't be normalized                                    |
-| **Embeds: no per-session timezone**                              | Embedded sessions (signed JWT / iframe) can't carry a per-viewer timezone. The embed path resolves with `userTimezone: null`, and there's no `timezone` field on the embed JWT nor a `?timezone=` URL param, so every embedded session falls back to the project timezone             | Multi-tenant embeds can't render each tenant in its own zone; only the single project timezone applies, short of building separate per-zone charts |
 | **SQL Runner / SQL charts: timestamps serialized as ISO `Z` regardless of actual type** | SQL Runner and SQL-based charts bypass `formatRows` and serialize every timestamp via a JS `Date` → ISO 8601 `Z` string. A TZ-aware timestamp is collapsed to the UTC instant with its offset dropped (verified on Postgres: `timestamptz` `12:00:00+00` shows `12:00:00.000Z` even with the session at Pacific/Pago_Pago, where the warehouse's own `::text` renders `01:00:00-11`; and on Snowflake: a `CONVERT_TIMEZONE` result of `08:00:00 -04:00` shows `12:00:00.000Z`, identical to the unconverted value, so the conversion looks inert). A naive `timestamp` — including a user's own `AT TIME ZONE` result — is stamped `Z` as if UTC (`08:00:00` NY wall-clock shows as `08:00:00.000Z`). Raw-output is by design; the `Z` mislabeling is a faithfulness bug. | Timestamps don't reflect the project/data timezone and misrepresent their own zone; a user's in-SQL conversion is hidden or mislabeled, and casting to text (`::text` / `to_char`) is the only faithful workaround. Tracked as GLITCH-489 (v3); see also GLITCH-462 / GLITCH-466. |
 
 ---

--- a/docs/timezones/timezone-questions.md
+++ b/docs/timezones/timezone-questions.md
@@ -90,13 +90,14 @@ So we *carry* the metadata. But we *re-derive* on top of it in five places (the 
 `packages/common/src/utils/resolveQueryTimezone.ts`:
 
 ```
-metricQuery.timezone   (per-chart pin)
-  → user.timezone     (profile preference, if any)
-    → project.queryTimezone
-      → 'UTC'
+sessionTimezone        (embed ?timezone= URL param, embed sessions only)
+  → metricQuery.timezone   (per-chart pin)
+    → user.timezone     (profile preference, if any)
+      → project.queryTimezone
+        → 'UTC'
 ```
 
-This is the same order documented in [`timezone-handling.md:23`](./timezone-handling.md). Anonymous viewers (embeds, JWT, service accounts) skip the user layer (`getAccountUserTimezone(account)` returns null for them).
+This is the same order documented in [`timezone-handling.md:23`](./timezone-handling.md). Anonymous viewers (embeds, JWT, service accounts) skip the user layer (`getAccountUserTimezone(account)` returns null for them); embedded sessions may set the top-priority `sessionTimezone` via the `?timezone=` URL param.
 
 ### Per-content choice between a pinned TZ and a viewer TZ?
 
@@ -118,7 +119,7 @@ This is the same order documented in [`timezone-handling.md:23`](./timezone-hand
 
 1. **`scheduler.timezone`** — when to send. A separate field on the scheduler row (`SchedulerClient.ts:872`). Used purely for cron parsing. Has nothing to do with query semantics.
 2. **Query TZ for the scheduled report** — resolved via the normal chain, but the *user* is the schedule owner (or an impersonated account), so their profile TZ applies.
-3. **Embed TZ** — embed viewers are anonymous; their `getAccountUserTimezone` returns null, so they fall through to the project default. Embed JWTs do not currently surface a user-TZ override.
+3. **Embed TZ** — embed viewers are anonymous; their `getAccountUserTimezone` returns null. An embedded session can carry a per-session query TZ via the `?timezone=<IANA>` embed URL param, threaded in as the top-priority `sessionTimezone` argument (wins over the chart pin); absent that param it falls through to the project default. The signed JWT itself still has no timezone field.
 
 **Why this matters**: an admin in NY sets up a daily 9am Pacific delivery (`scheduler.timezone = America/Los_Angeles`). The report queries fire at 9am PT but compute "last 7 days" in NY because that's the schedule owner's TZ. The recipient in Singapore reads numbers bracketed by NY midnight. This is the kind of cross-tz confusion that warrants explicit documentation. **We don't have a doc for this.**
 
@@ -135,7 +136,7 @@ This is the same order documented in [`timezone-handling.md:23`](./timezone-hand
 **Surface consistency**:
 - **Interactive queries**: Node `moment()` in the resolved query TZ.
 - **Scheduled queries**: same path, but the resolution chain runs with the schedule owner's user.
-- **Embed queries**: same path, but `getAccountUserTimezone` returns null so it falls through to project TZ.
+- **Embed queries**: same path, but `getAccountUserTimezone` returns null, so it falls through to project TZ unless the `?timezone=` embed URL param sets a per-session timezone.
 - **SQL Runner / user-written SQL**: `CURRENT_TIMESTAMP` runs on the warehouse against whatever session TZ we set. **Inconsistent with the rest** — a user who writes `WHERE created_at > NOW()` in SQL Runner does NOT get the same boundary as `IN_THE_CURRENT` in Explore.
 
 The fix is to expose the resolved TZ to user SQL as a template variable. Flagged in [`timezone-review.md` section H](./timezone-review.md#h-no-sql-side-surface-for-the-resolved-tz).

--- a/docs/timezones/timezones-v2-design.md
+++ b/docs/timezones/timezones-v2-design.md
@@ -138,8 +138,8 @@ Minimum affordance: a distinguishing icon for TZ-immune vs TZ-sensitive dimensio
 27. **The schedule's cron TZ is separate from the query's TZ; they don't interact.**
     ✅ Structurally separate.
 
-28. **Scheduled-report queries resolve TZ via the schedule owner's profile; embed queries fall through to project.**
-    ✅ Implemented; ❌ `gap-schedule-doc` *[qol]* — not documented for customers.
+28. **Scheduled-report queries resolve TZ via the schedule owner's profile; embed queries fall through to project unless a `?timezone=` URL param sets a per-session override.**
+    ⚠️ Implemented (embed `?timezone=` session override per GLITCH-488); `gap-schedule-doc` *[qol]* — scheduled-delivery TZ interaction not documented for customers.
 
 ---
 

--- a/docs/timezones/whats-new.md
+++ b/docs/timezones/whats-new.md
@@ -10,6 +10,7 @@ Short summary of how v2 changes user-facing behavior vs. today's published docs 
 - **Day-grain dimensions return real `DATE`** in warehouse output, not `TIMESTAMP` at project-TZ midnight. Cleaner exports, downstream tools see the right type. (GLITCH-452)
 - **Dimension picker shows TZ-sensitivity** — an icon + tooltip naming the anchor zone, so users can tell which dimensions move when the chart TZ changes. (GLITCH-458)
 - **`dataTimezone` gets a connection-setup preview** so misconfiguration is caught before it produces silent wrong numbers. (GLITCH-454)
+- **Embedded sessions can set their own timezone** via a `?timezone=<IANA>` URL param, so multi-tenant embeds render each tenant in its own zone without separate per-zone charts. (GLITCH-488)
 
 ## Bug fixes that may shift numbers
 

--- a/packages/e2e/cypress/e2e/app/embed.cy.ts
+++ b/packages/e2e/cypress/e2e/app/embed.cy.ts
@@ -115,7 +115,7 @@ describe('Embedded dashboard', () => {
 
                     cy.intercept(
                         'POST',
-                        `${EMBED_API_PREFIX}/query/dashboard-tile`,
+                        `${EMBED_API_PREFIX}/query/dashboard-tile*`,
                     ).as('tileQuery');
 
                     // The session timezone is set via ?timezone= before the JWT
@@ -149,7 +149,7 @@ describe('Embedded dashboard', () => {
 
                     cy.intercept(
                         'POST',
-                        `${EMBED_API_PREFIX}/query/dashboard-tile`,
+                        `${EMBED_API_PREFIX}/query/dashboard-tile*`,
                     ).as('tileQuery');
 
                     cy.visit(resp.body.results.url);

--- a/packages/e2e/cypress/e2e/app/embed.cy.ts
+++ b/packages/e2e/cypress/e2e/app/embed.cy.ts
@@ -101,6 +101,67 @@ describe('Embedded dashboard', () => {
         });
     });
 
+    it('forwards the ?timezone= session override into embed tile queries', () => {
+        getJaffleDashboard().then((dashboardsResp) => {
+            const dashboardUuid = dashboardsResp.body.results.data[0]?.uuid;
+
+            updateEmbedConfigDashboards([dashboardUuid]).then((updateResp) => {
+                expect(updateResp.status).to.eq(200);
+
+                getEmbedUrl({
+                    content: { type: 'dashboard', dashboardUuid },
+                }).then((resp) => {
+                    cy.logout();
+
+                    cy.intercept(
+                        'POST',
+                        `${EMBED_API_PREFIX}/query/dashboard-tile`,
+                    ).as('tileQuery');
+
+                    // The session timezone is set via ?timezone= before the JWT
+                    // hash; the frontend should forward it in the request body.
+                    const embedUrl = new URL(resp.body.results.url);
+                    embedUrl.searchParams.set(
+                        'timezone',
+                        'America/Los_Angeles',
+                    );
+                    cy.visit(embedUrl.toString());
+
+                    cy.wait('@tileQuery')
+                        .its('request.body.timezone')
+                        .should('eq', 'America/Los_Angeles');
+                });
+            });
+        });
+    });
+
+    it('omits the timezone from embed tile queries when ?timezone= is absent', () => {
+        getJaffleDashboard().then((dashboardsResp) => {
+            const dashboardUuid = dashboardsResp.body.results.data[0]?.uuid;
+
+            updateEmbedConfigDashboards([dashboardUuid]).then((updateResp) => {
+                expect(updateResp.status).to.eq(200);
+
+                getEmbedUrl({
+                    content: { type: 'dashboard', dashboardUuid },
+                }).then((resp) => {
+                    cy.logout();
+
+                    cy.intercept(
+                        'POST',
+                        `${EMBED_API_PREFIX}/query/dashboard-tile`,
+                    ).as('tileQuery');
+
+                    cy.visit(resp.body.results.url);
+
+                    cy.wait('@tileQuery')
+                        .its('request.body')
+                        .should('not.have.property', 'timezone');
+                });
+            });
+        });
+    });
+
     // todo: move to unit test
     it.skip('I can use "Explore from here" in embedded dashboard and view the correct elements', () => {
         getJaffleDashboard().then((dashboardsResp) => {

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -46,8 +46,12 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
 
     // Parse theme params from URL once on mount (before hash is stripped)
     const [embedThemeParams] = useState(parseEmbedThemeParams);
-    // Parse the session timezone (?timezone=) once on mount, alongside the theme
-    const [embedTimezone] = useState(parseEmbedTimezoneParam);
+    // Parse the session timezone (?timezone=) once on mount, alongside the theme.
+    // Only the direct/iframe embed owns its URL; in SDK mode window.location is
+    // the host app's URL, so we must not scrape ?timezone= from it.
+    const [embedTimezone] = useState(() =>
+        encodedToken ? null : parseEmbedTimezoneParam(),
+    );
     const embed = getFromInMemoryStorage<InMemoryEmbed>(EMBED_KEY);
     const { data: account, isLoading } = useAccount();
     const ability = useAbilityContext();

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -13,6 +13,7 @@ import { LightdashEventType } from '../../features/embed/events/types';
 import { useEmbedEventEmitter } from '../../features/embed/hooks/useEmbedEventEmitter';
 import EmbedProviderContext from './context';
 import { parseEmbedThemeParams } from './parseEmbedThemeParams';
+import { parseEmbedTimezoneParam } from './parseEmbedTimezoneParam';
 import { EMBED_KEY, type EmbedMode, type InMemoryEmbed } from './types';
 
 type Props = {
@@ -45,6 +46,8 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
 
     // Parse theme params from URL once on mount (before hash is stripped)
     const [embedThemeParams] = useState(parseEmbedThemeParams);
+    // Parse the session timezone (?timezone=) once on mount, alongside the theme
+    const [embedTimezone] = useState(parseEmbedTimezoneParam);
     const embed = getFromInMemoryStorage<InMemoryEmbed>(EMBED_KEY);
     const { data: account, isLoading } = useAccount();
     const ability = useAbilityContext();
@@ -112,6 +115,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
             mode,
             theme: embedThemeParams.theme,
             backgroundColor: embedThemeParams.backgroundColor,
+            timezone: embedTimezone,
         };
     }, [
         embed?.projectUuid,
@@ -128,6 +132,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         mode,
         embedThemeParams.theme,
         embedThemeParams.backgroundColor,
+        embedTimezone,
     ]);
 
     return (

--- a/packages/frontend/src/ee/providers/Embed/context.ts
+++ b/packages/frontend/src/ee/providers/Embed/context.ts
@@ -15,6 +15,7 @@ const EmbedProviderContext = createContext<EmbedContext>({
     mode: 'direct',
     theme: 'light',
     backgroundColor: null,
+    timezone: null,
 });
 
 export default EmbedProviderContext;

--- a/packages/frontend/src/ee/providers/Embed/parseEmbedTimezoneParam.ts
+++ b/packages/frontend/src/ee/providers/Embed/parseEmbedTimezoneParam.ts
@@ -1,0 +1,9 @@
+/**
+ * Parses the embed `?timezone=` URL param (IANA string) from the current URL
+ * query string, parsed once on mount alongside the theme params. The raw value
+ * is sent as-is; the backend validates and hard-errors on an invalid zone.
+ */
+export function parseEmbedTimezoneParam(): string | null {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('timezone');
+}

--- a/packages/frontend/src/ee/providers/Embed/parseEmbedTimezoneParam.ts
+++ b/packages/frontend/src/ee/providers/Embed/parseEmbedTimezoneParam.ts
@@ -1,9 +1,12 @@
 /**
  * Parses the embed `?timezone=` URL param (IANA string) from the current URL
- * query string, parsed once on mount alongside the theme params. The raw value
- * is sent as-is; the backend validates and hard-errors on an invalid zone.
+ * query string, parsed once on mount alongside the theme params. An empty or
+ * whitespace-only value is treated as absent (null) so a malformed templated
+ * URL falls through to the chart pin / project default instead of erroring; a
+ * non-empty value is sent as-is and the backend validates it.
  */
 export function parseEmbedTimezoneParam(): string | null {
     const params = new URLSearchParams(window.location.search);
-    return params.get('timezone');
+    const timezone = params.get('timezone')?.trim();
+    return timezone ? timezone : null;
 }

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -39,4 +39,6 @@ export interface EmbedContext {
     theme: EmbedTheme;
     // Custom background color for the embed, set via ?backgroundColor=<css-color> URL param
     backgroundColor: string | null;
+    // Session query timezone (IANA), set via ?timezone=<IANA> URL param; overrides the chart pin
+    timezone: string | null;
 }

--- a/packages/frontend/src/ee/providers/Embed/useEmbed.ts
+++ b/packages/frontend/src/ee/providers/Embed/useEmbed.ts
@@ -32,6 +32,7 @@ function useEmbed(): EmbedContext {
             mode: 'direct',
             theme: 'light',
             backgroundColor: null,
+            timezone: null,
         };
     }
 

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -11,6 +11,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo } from 'react';
 import { lightdashApi } from '../../api';
+import useEmbed from '../../ee/providers/Embed/useEmbed';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../providers/Dashboard/useDashboardTileStatusContext';
 import { convertDateDashboardFilters } from '../../utils/dateFilter';
@@ -36,6 +37,7 @@ const postEmbedDashboardTileQuery = async (
     projectUuid: string,
     data: {
         tileUuid: string;
+        timezone?: string;
     } & Pick<
         ExecuteAsyncDashboardChartRequestParams,
         | 'dashboardFilters'
@@ -101,6 +103,8 @@ export const useDashboardChartReadyQuery = (
             ?.join(',') || '';
 
     const projectUuid = useDashboardContext((c) => c.projectUuid);
+    // Session timezone from the embed URL (?timezone=); null for non-embed views
+    const embedTimezone = useEmbed().timezone;
     const chartQuery = useSavedQuery({
         uuidOrSlug: chartUuid ?? undefined,
         projectUuid,
@@ -178,6 +182,7 @@ export const useDashboardChartReadyQuery = (
             isZoomLikelyApplied ? granularity : null,
             invalidateCache,
             chartParameterValues,
+            embedTimezone,
         ],
         [
             chartQuery.data?.projectUuid,
@@ -193,6 +198,7 @@ export const useDashboardChartReadyQuery = (
             granularity,
             invalidateCache,
             chartParameterValues,
+            embedTimezone,
         ],
     );
 
@@ -225,6 +231,7 @@ export const useDashboardChartReadyQuery = (
                           invalidateCache,
                           parameters: parameterValues,
                           pivotResults: true,
+                          timezone: embedTimezone ?? undefined,
                       },
                   )
                 : await executeAsyncDashboardChartQuery(

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -11,7 +11,6 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo } from 'react';
 import { lightdashApi } from '../../api';
-import useEmbed from '../../ee/providers/Embed/useEmbed';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../providers/Dashboard/useDashboardTileStatusContext';
 import { convertDateDashboardFilters } from '../../utils/dateFilter';
@@ -19,6 +18,7 @@ import { useExplore } from '../useExplore';
 import { useQueryRetryConfig } from '../useQueryRetry';
 import { useSavedQuery } from '../useSavedQuery';
 import useSearchParams from '../useSearchParams';
+import { useSessionTimezone } from '../useSessionTimezone';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
 const executeAsyncDashboardChartQuery = async (
@@ -103,8 +103,7 @@ export const useDashboardChartReadyQuery = (
             ?.join(',') || '';
 
     const projectUuid = useDashboardContext((c) => c.projectUuid);
-    // Session timezone from the embed URL (?timezone=); null for non-embed views
-    const embedTimezone = useEmbed().timezone;
+    const sessionTimezone = useSessionTimezone();
     const chartQuery = useSavedQuery({
         uuidOrSlug: chartUuid ?? undefined,
         projectUuid,
@@ -182,7 +181,7 @@ export const useDashboardChartReadyQuery = (
             isZoomLikelyApplied ? granularity : null,
             invalidateCache,
             chartParameterValues,
-            embedTimezone,
+            sessionTimezone,
         ],
         [
             chartQuery.data?.projectUuid,
@@ -198,7 +197,7 @@ export const useDashboardChartReadyQuery = (
             granularity,
             invalidateCache,
             chartParameterValues,
-            embedTimezone,
+            sessionTimezone,
         ],
     );
 
@@ -231,7 +230,7 @@ export const useDashboardChartReadyQuery = (
                           invalidateCache,
                           parameters: parameterValues,
                           pivotResults: true,
-                          timezone: embedTimezone ?? undefined,
+                          timezone: sessionTimezone ?? undefined,
                       },
                   )
                 : await executeAsyncDashboardChartQuery(

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -19,6 +19,7 @@ import { useDebounce } from 'react-use';
 import { lightdashApi } from '../api';
 import useEmbed from '../ee/providers/Embed/useEmbed';
 import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
+import { useSessionTimezone } from './useSessionTimezone';
 
 export const MAX_AUTOCOMPLETE_RESULTS = 50;
 
@@ -218,7 +219,8 @@ export const useFieldValues = (
     useQueryOptions?: UseQueryOptions<FieldValueSearchResult, ApiError>,
     parameterValues?: ParametersValuesMap,
 ) => {
-    const { embedToken, timezone: embedTimezone } = useEmbed();
+    const { embedToken } = useEmbed();
+    const sessionTimezone = useSessionTimezone();
     const { data: resultsCacheFlag } = useServerFeatureFlag(
         FeatureFlags.ResultsCacheEnabled,
     );
@@ -278,7 +280,7 @@ export const useFieldValues = (
         debouncedSearch,
         parameterValues,
         useAsyncPath ? 'v2' : 'v1',
-        embedTimezone,
+        sessionTimezone,
     ];
 
     const query = useQuery<FieldValueSearchResult, ApiError>(
@@ -294,7 +296,7 @@ export const useFieldValues = (
                     filters,
                     tableName,
                     fieldId,
-                    timezone: embedTimezone,
+                    timezone: sessionTimezone,
                 });
             }
             if (useAsyncPath) {

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -52,6 +52,7 @@ const getEmbedFilterValues = async (options: {
     filters: AndFilterGroup | undefined;
     tableName: string | undefined;
     fieldId: string | undefined;
+    timezone: string | null;
 }) => {
     return lightdashApi<FieldValueSearchResult>({
         url: `/embed/${options.projectId}/filter/${options.filterId}/search`,
@@ -63,6 +64,7 @@ const getEmbedFilterValues = async (options: {
             forceRefresh: options.forceRefresh,
             tableName: options.tableName,
             fieldId: options.fieldId,
+            timezone: options.timezone ?? undefined,
         }),
     });
 };
@@ -216,7 +218,7 @@ export const useFieldValues = (
     useQueryOptions?: UseQueryOptions<FieldValueSearchResult, ApiError>,
     parameterValues?: ParametersValuesMap,
 ) => {
-    const { embedToken } = useEmbed();
+    const { embedToken, timezone: embedTimezone } = useEmbed();
     const { data: resultsCacheFlag } = useServerFeatureFlag(
         FeatureFlags.ResultsCacheEnabled,
     );
@@ -276,6 +278,7 @@ export const useFieldValues = (
         debouncedSearch,
         parameterValues,
         useAsyncPath ? 'v2' : 'v1',
+        embedTimezone,
     ];
 
     const query = useQuery<FieldValueSearchResult, ApiError>(
@@ -291,6 +294,7 @@ export const useFieldValues = (
                     filters,
                     tableName,
                     fieldId,
+                    timezone: embedTimezone,
                 });
             }
             if (useAsyncPath) {

--- a/packages/frontend/src/hooks/useSessionTimezone.ts
+++ b/packages/frontend/src/hooks/useSessionTimezone.ts
@@ -1,0 +1,19 @@
+import useEmbed from '../ee/providers/Embed/useEmbed';
+
+/**
+ * The timezone for the current viewing session, or null when none is set.
+ *
+ * "Session" means the timezone chosen for *how this view is being looked at
+ * right now*, independent of any single piece of content. Today its only
+ * source is the embed `?timezone=` URL param; non-embed views return null.
+ *
+ * This is deliberately NOT:
+ *   - user timezone    — a per-account preference
+ *   - chart timezone   — pinned on a saved chart
+ *   - project timezone — project default
+ *
+ * Consumers should treat null as "no session override, fall back to the
+ * usual server-side resolution". Future non-embed sources of a session
+ * timezone should be resolved here so every consumer picks them up.
+ */
+export const useSessionTimezone = (): string | null => useEmbed().timezone;


### PR DESCRIPTION
Part 3 of 3 of the embed per-session timezone stack. Stacked on #24182. Completes the feature.

Frontend wiring for the embed `?timezone=<IANA>` URL param:
* parses `?timezone=` once on mount and exposes it on the embed context (sibling to the existing theme params)
* includes it in the dashboard tile-render and filter-value-search request bodies, and in their query keys so changing the URL timezone refetches

With this merged, an embedding host can set `…/embed/<projectUuid>?timezone=America/Los_Angeles#<token>` and the session renders dashboard tiles, inherited totals and subtotals, and filter autocomplete in that timezone (when `EnableTimezoneSupport` is on), overriding the chart pin. An invalid value surfaces as a 400.

### Tests
**`EnableTimezoneSupport: true`, `?timezone=America/Los_Angeles`**
<img width="1200" height="1133" alt="embed-2-timezone-la" src="https://github.com/user-attachments/assets/c05bdc1c-936e-4499-8b8a-3b0755780356" />

**`EnableTimezoneSupport: false`, `?timezone=America/Los_Angeles`**
<img width="1200" height="1133" alt="embed-5-flag-off-timezone-inert" src="https://github.com/user-attachments/assets/e7d4b5ed-f7ae-4525-8f99-a18e50ff668b" />


test-all

Closes: GLITCH-488
