### PR TITLE
fix: CSV email attachments use correct filename extension

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -736,7 +736,10 @@ export default class SchedulerTask {
                                 SCHEDULER_POLLING_OPTIONS,
                             );
                         csvUrl = {
-                            filename: ExcelService.generateFileId(chart.name),
+                            filename:
+                                downloadFileType === DownloadFileType.XLSX
+                                    ? ExcelService.generateFileId(chart.name)
+                                    : CsvService.generateFileId(chart.name),
                             path: downloadResult.fileUrl,
                             localPath:
                                 downloadResult.s3FileUrl ??


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2172
Closes: #19052

### Description:

Single-chart scheduled CSV email deliveries hardcoded `ExcelService.generateFileId`, producing filenames ending in `.xlsx` that then got `.csv` appended by the email client, resulting in misleading `.xlsx.csv` names. This now selects the filename generator matching the actual export format, so CSV deliveries produce `csv-<name>-<timestamp>.csv` and XLSX deliveries are unchanged.
