### PR TITLE
refactor(changesets): stop applying changesets to explores and catalog

### DIFF
--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -33,7 +33,6 @@ import { Knex } from 'knex';
 import path from 'path';
 import { lightdashConfig } from '../../../config/lightdashConfig';
 import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
-import { ChangesetModel } from '../../../models/ChangesetModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { ProjectParametersModel } from '../../../models/ProjectParametersModel';
 import { TagsModel } from '../../../models/TagsModel';
@@ -272,12 +271,10 @@ export async function seed(knex: Knex): Promise<void> {
             projectUuid,
         });
 
-        const changesetModel = new ChangesetModel({ database: knex });
         const projectModel = new ProjectModel({
             database: knex,
             lightdashConfig,
             encryptionUtil: enc,
-            changesetModel,
         });
 
         await projectModel.saveExploresToCache(

--- a/packages/backend/src/database/seeds/development/10_pop_test_charts.ts
+++ b/packages/backend/src/database/seeds/development/10_pop_test_charts.ts
@@ -18,7 +18,6 @@ import {
 import { Knex } from 'knex';
 import { v4 as uuidv4 } from 'uuid';
 import { lightdashConfig } from '../../../config/lightdashConfig';
-import { ChangesetModel } from '../../../models/ChangesetModel';
 import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../../models/SavedChartModel';
@@ -612,12 +611,10 @@ export async function seed(knex: Knex): Promise<void> {
     });
 
     const encryptionUtil = new EncryptionUtil({ lightdashConfig });
-    const changesetModel = new ChangesetModel({ database: knex });
     const projectModel = new ProjectModel({
         database: knex,
         lightdashConfig,
         encryptionUtil,
-        changesetModel,
     });
 
     const [user] = await knex('users').where(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4352,7 +4352,6 @@ export class AiAgentService extends BaseService {
             agent.projectUuid,
             'name',
             originalChangeset.changes.map((c) => c.entityTableName),
-            { applyChangeset: false },
         );
 
         await this.changesetModel.revertChange(changeUuid, agent.projectUuid);

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -765,7 +765,6 @@ export class CatalogModel {
         context,
         fullTextSearchOperator = 'AND',
         filteredExplores,
-        changeset,
         hasTimeDimension,
         tags,
     }: {
@@ -780,7 +779,6 @@ export class CatalogModel {
         context: CatalogSearchContext;
         fullTextSearchOperator?: 'OR' | 'AND';
         filteredExplores?: Explore[];
-        changeset?: ChangesetWithChanges;
         hasTimeDimension?: boolean;
         tags?: string[];
     }): Promise<KnexPaginatedData<CatalogItem[]>> {
@@ -1276,14 +1274,6 @@ export class CatalogModel {
                             );
                         }
 
-                        if (changeset) {
-                            const exploreWithChanges =
-                                ChangesetUtils.applyChangeset(changeset, {
-                                    // we need to clone the explore to avoid mutating the original explore object
-                                    [explore.name]: structuredClone(explore),
-                                })[explore.name] as Explore; // at this point we know the explore is valid
-                            explore = exploreWithChanges;
-                        }
                         return parseCatalog({
                             ...item,
                             explore,

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -530,7 +530,6 @@ export class ModelRepository
             () =>
                 new ProjectModel({
                     database: this.database,
-                    changesetModel: this.getChangesetModel(),
                     lightdashConfig: this.lightdashConfig,
                     encryptionUtil: this.utils.getEncryptionUtil(),
                 }),

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -33,7 +33,6 @@ import {
     SpaceUserAccessTableName,
 } from '../../database/entities/spaces';
 import { ServiceAccountsTableName } from '../../ee/database/entities/serviceAccounts';
-import { ChangesetModel } from '../ChangesetModel';
 import { ProjectModel } from './ProjectModel';
 import {
     CompletePostgresCredentials,
@@ -68,7 +67,6 @@ describe('ProjectModel', () => {
 
     const model = new ProjectModel({
         database,
-        changesetModel: new ChangesetModel({ database }),
         lightdashConfig: lightdashConfigMock,
         encryptionUtil: encryptionUtilMock,
     });

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -3,7 +3,6 @@ import {
     AnyType,
     AthenaAuthenticationType,
     BigqueryAuthenticationType,
-    ChangesetUtils,
     CompiledTable,
     CreateProject,
     CreateProjectOptionalCredentials,
@@ -124,14 +123,12 @@ import Logger from '../../logging/logger';
 import { wrapSentryTransaction, wrapSentryTransactionSync } from '../../utils';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { generateUniqueSpaceSlug } from '../../utils/SlugUtils';
-import { ChangesetModel } from '../ChangesetModel';
 import Transaction = Knex.Transaction;
 
 export type ProjectModelArguments = {
     database: Knex;
     lightdashConfig: LightdashConfig;
     encryptionUtil: EncryptionUtil;
-    changesetModel: ChangesetModel;
 };
 
 const CACHED_EXPLORES_PG_LOCK_NAMESPACE = 1;
@@ -188,14 +185,11 @@ export class ProjectModel {
 
     protected lightdashConfig: LightdashConfig;
 
-    protected changesetModel: ChangesetModel;
-
     private encryptionUtil: EncryptionUtil;
 
     constructor(args: ProjectModelArguments) {
         this.database = args.database;
         this.lightdashConfig = args.lightdashConfig;
-        this.changesetModel = args.changesetModel;
         this.encryptionUtil = args.encryptionUtil;
     }
 
@@ -1309,7 +1303,6 @@ export class ProjectModel {
         projectUuid: string,
         key: 'name' | 'uuid',
         exploreNamesWithDuplicates?: string[],
-        { applyChangeset = true }: { applyChangeset?: boolean } = {},
     ): Promise<{ [exploreNameOrUuid: string]: Explore | ExploreError }> {
         // dedupe values
         const exploreNames = exploreNamesWithDuplicates
@@ -1322,11 +1315,6 @@ export class ProjectModel {
                 exploreNames,
             },
             async (span) => {
-                const changeset =
-                    await this.changesetModel.findActiveChangesetWithChangesByProjectUuid(
-                        projectUuid,
-                    );
-
                 const query = this.database(CachedExploreTableName)
                     .select('explore', 'cached_explore_uuid')
                     .where('project_uuid', projectUuid);
@@ -1336,7 +1324,7 @@ export class ProjectModel {
                 const explores = await query;
                 span.setAttribute('foundExplores', !!explores.length);
 
-                let finalExplores = wrapSentryTransactionSync(
+                const finalExplores = wrapSentryTransactionSync(
                     'ProjectModel.findExploresFromCache.convertExplores',
                     { exploresCount: explores.length },
                     () =>
@@ -1355,13 +1343,6 @@ export class ProjectModel {
                             {},
                         ),
                 );
-
-                if (changeset && applyChangeset) {
-                    finalExplores = ChangesetUtils.applyChangeset(
-                        changeset,
-                        finalExplores,
-                    );
-                }
 
                 return finalExplores;
             },

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -280,12 +280,6 @@ export class CatalogService<
         fullTextSearchOperator?: 'OR' | 'AND';
         filteredExplores?: Explore[];
     }): Promise<KnexPaginatedData<CatalogItem[]>> {
-        const changeset = args.filteredExplores
-            ? // Do not pass changeset as we expect `filteredExplores` to have changeset already applied
-              undefined
-            : await this.changesetModel.findActiveChangesetWithChangesByProjectUuid(
-                  args.projectUuid,
-              );
         return wrapSentryTransaction(
             'CatalogService.searchCatalog',
             {
@@ -305,7 +299,6 @@ export class CatalogService<
                     () =>
                         this.catalogModel.search({
                             projectUuid: args.projectUuid,
-                            changeset,
                             catalogSearch: args.catalogSearch,
                             paginateArgs: args.paginateArgs,
                             userAttributes: args.userAttributes,

--- a/packages/backend/src/services/ChangesetService.ts
+++ b/packages/backend/src/services/ChangesetService.ts
@@ -220,7 +220,6 @@ export class ChangesetService extends BaseService {
             projectUuid,
             'name',
             originalChangeset.changes.map((c) => c.entityTableName),
-            { applyChangeset: false },
         );
 
         // Delete the change
@@ -272,7 +271,6 @@ export class ChangesetService extends BaseService {
             projectUuid,
             'name',
             changeset.changes.map((change) => change.entityTableName),
-            { applyChangeset: false },
         );
 
         await this.changesetModel.revertChanges({ changeUuids });


### PR DESCRIPTION
Closes: [PROD-8130](https://linear.app/lightdash/issue/PROD-8130/stop-using-changesets-in-charts-and-dashboards)

## Summary

First step of deprecating changesets ([PROD-7968](https://linear.app/lightdash/issue/PROD-7968/deprecate-changesets-in-favour-of-writeback)). Stops applying the active changeset in the two read paths that surface it to users, so changesets no longer alter charts, dashboards, the explorer, or the data catalog. The data is still stored, still shown in the changesets UI, and can still be reverted or written back — this only removes the silent rewrite-on-read.

## Why

Changesets were always a temporary stand-in for full writeback. We're deprecating them in favour of writeback and want to observe whether customers rely on the apply-on-read behaviour before removing the feature wholesale. Removing the read-path application is the smallest reversible step (revert the commit) that disables the effect while leaving the data, UI, and migration bridge intact.

## What changes vs. what stays

```
Removed (changeset application on read):
  ProjectModel.findExploresFromCache        -> serves charts / dashboards / explorer
  CatalogService.searchCatalog -> .search   -> data catalog

Left intact:
  changesets / changes tables               -> data unchanged
  ChangesetController GET .../changesets     -> UI list still populated
  ChangesetService revert*                   -> revert still works
  AiAgentService fromActiveChangeset         -> writeback-from-changeset bridge
```

## Files touched (9)

- `models/ProjectModel/ProjectModel.ts` — drop the active-changeset fetch + apply in `findExploresFromCache`; remove the now-dead `applyChangeset` param and the unused `changesetModel` dependency.
- `models/ModelRepository.ts` — stop injecting `changesetModel` into `ProjectModel`.
- `models/CatalogModel/CatalogModel.ts` — drop the `changeset` param and the per-item `applyChangeset` in `search`.
- `services/CatalogService/CatalogService.ts` — stop fetching/passing the active changeset into `search`.
- `services/ChangesetService.ts`, `ee/services/AiAgentService/AiAgentService.ts` — drop the now-removed `{ applyChangeset: false }` arg from the revert-flow `findExploresFromCache` calls.
- `database/seeds/development/01_initial_user.ts`, `10_pop_test_charts.ts` — drop the `changesetModel` ctor arg + dead import.
- `models/ProjectModel/ProjectModel.test.ts` — drop `changesetModel` from the test ctor.

## Non-trivial bits

- `findExploresFromCache` keeps returning base explores, which is exactly what the revert/writeback callers wanted when they passed `applyChangeset: false` — so dropping the arg is behaviour-preserving for them.
- `ChangesetUtils` / `ChangesetWithChanges` imports stay in `CatalogModel` — still used by the revert reconstruction path, which is intentionally untouched.
- `CatalogService` keeps its `changesetModel` dependency — still used by `indexCatalogUpdates`.

## Test plan

- [x] `pnpm -F backend typecheck:fast`
- [x] `pnpm -F backend lint` (changed files, with custom `--rulesdir`)
- [x] `pnpm -F backend test:dev:nowatch` — 727 passed, 1 skipped (the lone failure was an unrelated jest-worker SIGSEGV; `EmbedService` passes 12/12 in isolation)
- [x] Changeset UI still populated: `GET /api/v1/projects/{uuid}/changesets` returns the active changeset with all its changes
- [x] Writeback-from-changeset intact: `AiWritebackService` suite 127/127; `fromActiveChangeset` branch unmodified and still builds the prompt from the active changeset
- [ ] CI green

## Diff size

9 files, +1 / -49.