### PR TITLE
fix(frontend): render temporal metric cells in resolved tz in results grid (GLITCH-491)

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/timezone_test.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/timezone_test.yml
@@ -52,6 +52,9 @@ models:
             count:
               type: count
               description: Total number of events
+            max_event_ts:
+              type: max
+              description: Latest event timestamp (defined metric, tz formatting test)
       - name: event_timestamp_raw_utc
         description: >
           Same instants as event_timestamp, but the dimension opts out of

--- a/packages/frontend/src/hooks/useColumns.test.tsx
+++ b/packages/frontend/src/hooks/useColumns.test.tsx
@@ -1,6 +1,8 @@
 import {
+    DimensionType,
     FieldType,
     MetricType,
+    TableCalculationType,
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
@@ -8,7 +10,11 @@ import { MantineProvider } from '@mantine-8/core';
 import { type CellContext } from '@tanstack/react-table';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
-import { formatCellContent, getFormattedValueCell } from './useColumns';
+import {
+    formatCellContent,
+    formatResultsTableCell,
+    getFormattedValueCell,
+} from './useColumns';
 
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
@@ -341,6 +347,92 @@ describe('getFormattedValueCell - Bar Chart Display', () => {
         // Should have the default color (#5470c6)
         const style = barElement?.getAttribute('style') || '';
         expect(style).toContain('background');
+    });
+});
+
+describe('formatResultsTableCell - temporal metric timezone (GLITCH-491)', () => {
+    const maxTsMetric = {
+        name: 'max_event_ts',
+        table: 'timezone_test',
+        fieldType: FieldType.METRIC,
+        type: MetricType.MAX,
+        label: 'Max event ts',
+        sql: 'event_timestamp',
+        tableLabel: 'Timezone test',
+        hidden: false,
+    };
+
+    test('formats a MAX(timestamp) metric cell in the resolved project timezone', () => {
+        const data = {
+            value: {
+                raw: '2025-01-15T17:00:00.000Z',
+                formatted: '2025-01-16, 02:00:00:000 (+09:00)',
+            },
+        };
+        const result = formatResultsTableCell(
+            data,
+            maxTsMetric,
+            undefined,
+            'Asia/Tokyo',
+        );
+        expect(result).toBe('2025-01-16, 02:00:00:000 (+09:00)');
+    });
+
+    test('does not coerce a non-temporal metric — timezone is ignored', () => {
+        const countMetric = {
+            ...maxTsMetric,
+            name: 'count',
+            type: MetricType.COUNT,
+        };
+        const data = { value: { raw: 5000, formatted: '5,000' } };
+        expect(
+            formatResultsTableCell(
+                data,
+                countMetric,
+                undefined,
+                'Pacific/Pago_Pago',
+            ),
+        ).toBe('5,000');
+    });
+
+    test('DATE/TIMESTAMP dimensions use the backend-formatted value unchanged', () => {
+        const tsDimension = {
+            name: 'event_timestamp',
+            table: 'timezone_test',
+            fieldType: FieldType.DIMENSION,
+            type: DimensionType.TIMESTAMP,
+            label: 'Event timestamp',
+            sql: 'event_timestamp',
+            tableLabel: 'Timezone test',
+            hidden: false,
+        };
+        const data = {
+            value: {
+                raw: '2025-01-15T17:00:00.000Z',
+                formatted: 'BACKEND_VALUE',
+            },
+        };
+        expect(
+            formatResultsTableCell(data, tsDimension, undefined, 'Asia/Tokyo'),
+        ).toBe('BACKEND_VALUE');
+    });
+
+    test('temporal table calculations also render in the resolved timezone', () => {
+        const tsTableCalc = {
+            name: 'ts_calc',
+            displayName: 'Ts calc',
+            sql: '${TABLE}.event_timestamp',
+            type: TableCalculationType.TIMESTAMP,
+        };
+        const data = {
+            value: {
+                raw: '2025-01-15T17:00:00.000Z',
+                formatted: '2025-01-16, 02:00:00:000 (+09:00)',
+            },
+        };
+        expect(
+            formatResultsTableCell(data, tsTableCalc, undefined, 'Asia/Tokyo'),
+        ).toBe('2025-01-16, 02:00:00:000 (+09:00)');
     });
 });
 

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -52,6 +52,7 @@ import {
     selectCustomDimensions,
     selectMetricOverrides,
     selectParameters,
+    selectTimezone,
     selectSorts,
     selectTableCalculations,
     selectTableName,
@@ -85,6 +86,36 @@ export const formatCellContent = (
 
     // Use backend-formatted value by default
     return data.value.formatted ?? '-';
+};
+
+// Results-grid cell value. DATE/TIMESTAMP dimensions use the backend
+// pre-formatted value (already in the resolved project tz) to avoid re-parsing
+// UTC strings on the frontend. Everything else (metrics, table calculations,
+// numbers) is formatted on the frontend to support metric overrides / parameter
+// formats — and is passed the resolved `timezone` so temporal metrics render in
+// the project timezone, not the browser's.
+export const formatResultsTableCell = (
+    data: { value: ResultValue } | undefined,
+    item:
+        | Field
+        | AdditionalMetric
+        | TableCalculation
+        | CustomDimension
+        | undefined,
+    parameters: ParametersValuesMap | undefined,
+    timezone: string | undefined,
+): string => {
+    if (!data) return '-';
+
+    if (
+        isField(item) &&
+        (item.type === DimensionType.DATE ||
+            item.type === DimensionType.TIMESTAMP)
+    ) {
+        return data.value.formatted;
+    }
+
+    return formatItemValue(item, data.value.raw, false, parameters, timezone);
 };
 
 const isBarDisplay = (
@@ -407,6 +438,7 @@ export const useColumns = (): TableColumn[] => {
     const resultsFields = query.data?.fields;
 
     const parameters = useExplorerSelector(selectParameters);
+    const timezone = useExplorerSelector(selectTimezone);
 
     const { data: exploreData } = useExplore(tableName, {
         refetchOnMount: false,
@@ -568,31 +600,13 @@ export const useColumns = (): TableColumn[] => {
                     ),
                     cell: (
                         info: CellContext<ResultRow, { value: ResultValue }>,
-                    ) => {
-                        const cellValue = info.getValue();
-                        if (!cellValue) return '-';
-                        // Use item from meta to ensure we get the latest version with overrides
-                        const currentItem = info.column.columnDef.meta?.item;
-
-                        // For DATE and TIMESTAMP types, use the pre-formatted value from backend
-                        // to avoid timezone issues when re-parsing UTC date strings on the frontend
-                        if (
-                            isField(currentItem) &&
-                            (currentItem.type === DimensionType.DATE ||
-                                currentItem.type === DimensionType.TIMESTAMP)
-                        ) {
-                            return cellValue.value.formatted;
-                        }
-
-                        // For everything else (metrics, numbers, etc.), format on frontend
-                        // to support metric overrides and other client-side formatting
-                        return formatItemValue(
-                            currentItem,
-                            cellValue.value.raw,
-                            false,
+                    ) =>
+                        formatResultsTableCell(
+                            info.getValue(),
+                            info.column.columnDef.meta?.item,
                             parameters,
-                        );
-                    },
+                            timezone,
+                        ),
                     footer: () =>
                         totals?.[fieldId]
                             ? formatItemValue(
@@ -600,6 +614,7 @@ export const useColumns = (): TableColumn[] => {
                                   totals[fieldId],
                                   false,
                                   parameters,
+                                  timezone,
                               )
                             : null,
                     meta: {
@@ -669,5 +684,6 @@ export const useColumns = (): TableColumn[] => {
         totals,
         exploreData,
         parameters,
+        timezone,
     ]);
 };


### PR DESCRIPTION
Closes: GLITCH-491
Relates: GLITCH-485

### Description:

Follow-up to GLITCH-485 (#24137, merged). That fix made the backend format `MIN`/`MAX`-of-timestamp metrics in the resolved project timezone — but the explore **Results grid** still rendered temporal **metrics** in the **browser's** timezone, so the parent ticket's AC ("…in the results table and chart tooltips") was only half met.

**Root cause** — `useColumns.tsx` returned the backend pre-formatted value only for DATE/TIMESTAMP **dimensions**; a `MAX`-of-timestamp metric (`type = MetricType.MAX`) fell into the "everything else" branch and was re-formatted from `raw` **without** the resolved timezone → it rendered in the browser's local zone.

### Fix

- Extracted the inline results-grid cell into an exported `formatResultsTableCell(data, item, parameters, timezone)`.
- Threaded the resolved query timezone (`selectTimezone`, already used by other formatting hooks) into the cell **and** the footer/totals, and into the columns `useMemo` deps.
- Keeps the client-side re-format path (metric overrides / parameter formats) — it just gives it the timezone it was missing.

### Verified (project tz `Asia/Tokyo`), `MAX(event_timestamp)` beside its raw dimension

| Surface | Before | After |
|---|---|---|
| Results grid — MAX metric | `… (+01:00)` browser-local | `… (+09:00)` ✅ matches dimension |
| Results grid — dimension | `… (+09:00)` | `… (+09:00)` (unchanged) |
| Chart table-viz / tooltip | `… (+09:00)` | `… (+09:00)` (unchanged) |

### Containment

The timezone is only *read* by `formatItemValue`'s temporal branches, so:
- **Unaffected:** numeric/string metrics, MAX/MIN over non-temporal columns, DATE-only metrics (calendar-value gate), and DATE/TIMESTAMP dimensions (short-circuit to backend value).
- **Now in project tz (the fix):** `MAX`/`MIN` over TIMESTAMP, `MetricType.TIMESTAMP` metrics, and temporal **table calculations** — all had the same browser-local bug, so no regression.

### Tests

`useColumns.test.tsx` — `formatResultsTableCell`: a `MAX(timestamp)` renders in the resolved tz; a number metric is unaffected; a DATE/TIMESTAMP dimension uses the backend value unchanged; a temporal table calc renders in the resolved tz. Full suite green; typecheck + oxlint clean.

Also adds a defined `max(event_timestamp)` metric to the `timezone_test` demo model (purpose-built for tz testing) to exercise this end-to-end.

Gated by the same timezone feature flag as the rest of Phase 2 (resolved tz is UTC when off → no visible change).
