### PR TITLE
feat(ai-copilot): hide unsupported writeback reason and align toggles

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.test.tsx
@@ -1,0 +1,102 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { ReviewItemActions } from './ReviewItemActions';
+
+vi.mock('../../hooks/useAiAgentAdmin', () => ({
+    useAiAgentAdminReviewItem: () => ({ data: undefined }),
+    useCreateAiAgentReviewItemWriteback: () => ({
+        isLoading: false,
+        mutate: vi.fn(),
+    }),
+}));
+
+vi.mock('./ProjectContextWritebackModal', () => ({
+    ProjectContextWritebackModal: () => null,
+}));
+
+const makeReviewItem = (
+    overrides: Partial<AiAgentReviewItemSummary> = {},
+): AiAgentReviewItemSummary =>
+    ({
+        uuid: 'review-1',
+        fingerprint: 'review-1',
+        organizationUuid: 'org-1',
+        projectUuid: 'project-1',
+        agentUuid: 'agent-1',
+        title: 'Fallback title',
+        description: 'Fallback description',
+        primaryRootCause: 'product_capability',
+        status: 'open',
+        dismissedReason: null,
+        ownerType: 'unknown',
+        assignedToUserUuid: null,
+        firstSeenAt: new Date('2026-06-10T08:00:00.000Z'),
+        lastSeenAt: new Date('2026-06-10T08:05:00.000Z'),
+        findingCount: 1,
+        statusUpdatedAt: new Date('2026-06-10T08:05:00.000Z'),
+        statusUpdatedByUserUuid: null,
+        linkedIssueUrl: null,
+        linkedPrUrl: null,
+        prState: null,
+        prWritebackStatus: null,
+        prWritebackMessage: null,
+        writebackEligible: false,
+        writebackEligibility: {
+            eligible: false,
+            reason: 'unsupported_root_cause',
+            strategy: null,
+            provider: null,
+        },
+        remediation: null,
+        createdAt: new Date('2026-06-10T08:00:00.000Z'),
+        updatedAt: new Date('2026-06-10T08:05:00.000Z'),
+        latestFinding: {
+            uuid: 'finding-1',
+            promptUuid: 'prompt-1',
+            threadUuid: 'thread-1',
+            projectUuid: 'project-1',
+            agentUuid: 'agent-1',
+            subcategories: [],
+            fixTargets: ['product_capability_ticket'],
+            targetRefs: [],
+            evidenceExcerpts: [],
+            recommendation: null,
+            projectContextEntry: null,
+            createdAt: new Date('2026-06-10T08:00:00.000Z'),
+        },
+        ...overrides,
+    }) as AiAgentReviewItemSummary;
+
+describe('ReviewItemActions', () => {
+    it('does not render the unsupported root cause blocked reason', () => {
+        renderWithProviders(
+            <ReviewItemActions reviewItem={makeReviewItem()} mode="drawer" />,
+        );
+
+        expect(
+            screen.queryByText('No writeback strategy for this root cause'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('still renders other blocked reasons', () => {
+        renderWithProviders(
+            <ReviewItemActions
+                reviewItem={makeReviewItem({
+                    writebackEligibility: {
+                        eligible: false,
+                        reason: 'missing_project',
+                        strategy: null,
+                        provider: null,
+                    },
+                })}
+                mode="drawer"
+            />,
+        );
+
+        expect(
+            screen.getByText('No project is linked to this finding'),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -20,7 +20,10 @@ import {
     useCreateAiAgentReviewItemWriteback,
 } from '../../hooks/useAiAgentAdmin';
 import { ProjectContextWritebackModal } from './ProjectContextWritebackModal';
-import { writebackBlockedReasonLabels } from './reviewItemDetails';
+import {
+    shouldShowWritebackBlockedReason,
+    writebackBlockedReasonLabels,
+} from './reviewItemDetails';
 
 type ReviewItemActionsProps = {
     reviewItem: AiAgentReviewItemSummary;
@@ -52,7 +55,7 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
     const blockedReason = current.writebackEligibility.eligible
         ? null
         : current.writebackEligibility.reason;
-    const blockedReasonLabel = blockedReason
+    const blockedReasonLabel = shouldShowWritebackBlockedReason(blockedReason)
         ? writebackBlockedReasonLabels[blockedReason]
         : null;
     const previewsDiff = current.primaryRootCause === 'project_context';

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.module.css
@@ -27,7 +27,7 @@
 }
 
 .summaryText {
-    max-width: 56ch;
+    max-width: none;
     line-height: 1.55;
 }
 
@@ -35,11 +35,20 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
+    padding: 0;
     font-size: 12px;
     font-weight: 600;
+    line-height: 1.2;
     color: light-dark(
         var(--mantine-color-ldGray-7),
         var(--mantine-color-dark-2)
+    );
+}
+
+.sectionToggle[data-active='true'] {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-dark-0)
     );
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -333,7 +333,9 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                     <Group gap="md" wrap="wrap">
                                         <UnstyledButton
                                             className={styles.sectionToggle}
-                                            data-active={showDetails || undefined}
+                                            data-active={
+                                                showDetails || undefined
+                                            }
                                             onClick={() =>
                                                 setShowDetails((open) => !open)
                                             }
@@ -351,7 +353,9 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                         </UnstyledButton>
                                         <UnstyledButton
                                             className={styles.sectionToggle}
-                                            data-active={showWhy || undefined}
+                                            data-active={
+                                                showWhy || undefined
+                                            }
                                             onClick={() =>
                                                 setShowWhy((open) => !open)
                                             }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -11,6 +11,7 @@ import {
     Text,
     Title,
     Tooltip,
+    UnstyledButton,
     useMantineTheme,
 } from '@mantine-8/core';
 import {
@@ -114,15 +115,12 @@ const ExpandableReviewText = ({
                 {text}
             </Text>
             {canExpand && (
-                <Button
-                    variant="subtle"
-                    color="gray"
-                    size="compact-xs"
-                    px={0}
+                <UnstyledButton
+                    className={styles.sectionToggle}
                     onClick={() => setExpanded((open) => !open)}
                 >
                     {expanded ? 'Show less' : 'Show more'}
-                </Button>
+                </UnstyledButton>
             )}
         </Stack>
     );
@@ -332,53 +330,43 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                         </Box>
                                     </Group>
 
-                                    <Group gap="xs" wrap="wrap">
-                                        <Button
-                                            variant={
-                                                showDetails ? 'light' : 'subtle'
-                                            }
-                                            color="gray"
-                                            size="compact-xs"
-                                            radius="xl"
-                                            rightSection={
-                                                <MantineIcon
-                                                    icon={
-                                                        showDetails
-                                                            ? IconChevronDown
-                                                            : IconChevronRight
-                                                    }
-                                                    size="xs"
-                                                />
-                                            }
+                                    <Group gap="md" wrap="wrap">
+                                        <UnstyledButton
+                                            className={styles.sectionToggle}
+                                            data-active={showDetails || undefined}
                                             onClick={() =>
                                                 setShowDetails((open) => !open)
                                             }
+                                            aria-expanded={showDetails}
                                         >
-                                            Details
-                                        </Button>
-                                        <Button
-                                            variant={
-                                                showWhy ? 'light' : 'subtle'
-                                            }
-                                            color="gray"
-                                            size="compact-xs"
-                                            radius="xl"
-                                            rightSection={
-                                                <MantineIcon
-                                                    icon={
-                                                        showWhy
-                                                            ? IconChevronDown
-                                                            : IconChevronRight
-                                                    }
-                                                    size="xs"
-                                                />
-                                            }
+                                            <span>Details</span>
+                                            <MantineIcon
+                                                icon={
+                                                    showDetails
+                                                        ? IconChevronDown
+                                                        : IconChevronRight
+                                                }
+                                                size="xs"
+                                            />
+                                        </UnstyledButton>
+                                        <UnstyledButton
+                                            className={styles.sectionToggle}
+                                            data-active={showWhy || undefined}
                                             onClick={() =>
                                                 setShowWhy((open) => !open)
                                             }
+                                            aria-expanded={showWhy}
                                         >
-                                            Why flagged
-                                        </Button>
+                                            <span>Why flagged</span>
+                                            <MantineIcon
+                                                icon={
+                                                    showWhy
+                                                        ? IconChevronDown
+                                                        : IconChevronRight
+                                                }
+                                                size="xs"
+                                            />
+                                        </UnstyledButton>
                                     </Group>
 
                                     <Collapse in={showDetails}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -353,9 +353,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                         </UnstyledButton>
                                         <UnstyledButton
                                             className={styles.sectionToggle}
-                                            data-active={
-                                                showWhy || undefined
-                                            }
+                                            data-active={showWhy || undefined}
                                             onClick={() =>
                                                 setShowWhy((open) => !open)
                                             }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -47,6 +47,13 @@ export const writebackBlockedReasonLabels: Record<
     writeback_in_progress: 'Writeback is already in progress',
 };
 
+export const shouldShowWritebackBlockedReason = (
+    reason: AiAgentReviewItemWritebackBlockedReason | null,
+): reason is Exclude<
+    AiAgentReviewItemWritebackBlockedReason,
+    'unsupported_root_cause'
+> => reason !== null && reason !== 'unsupported_root_cause';
+
 const actionLabels: Record<AiAgentRecommendationAction, string> = {
     update_semantic_yaml: 'Update semantic layer',
     update_agent_instructions: 'Update instructions',


### PR DESCRIPTION
## Summary
- Hide the writeback-blocked message when the only reason is `unsupported_root_cause`
- Convert the drawer text controls to unstyled inline toggles so `Details`, `Why flagged`, and `Show more` align cleanly
- Let the reasoning copy use the full summary width once the blocked-reason line is gone
- Add unit coverage for the blocked-reason suppression

## Testing
- Added unit tests for `ReviewItemActions`
- Existing sidebar behavior test kept intact
- Not run (not requested)