### PR TITLE
fix(ai): unblock server-side agent runs — pass autoApproveSql to runSql, guard empty cloneThread update

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -6980,18 +6980,20 @@ export class AiAgentModel {
                 { db: trx },
             );
 
-            await trx(AiThreadTableName)
-                .where('ai_thread_uuid', newThreadUuid)
-                .update({
-                    ...(shareSourceThreadShareUuid && {
-                        share_source_thread_share_uuid:
-                            shareSourceThreadShareUuid,
-                    }),
-                    ...(copyTitle && {
-                        title: sourceThread.title,
-                        title_generated_at: sourceThread.title_generated_at,
-                    }),
-                });
+            if (shareSourceThreadShareUuid || copyTitle) {
+                await trx(AiThreadTableName)
+                    .where('ai_thread_uuid', newThreadUuid)
+                    .update({
+                        ...(shareSourceThreadShareUuid && {
+                            share_source_thread_share_uuid:
+                                shareSourceThreadShareUuid,
+                        }),
+                        ...(copyTitle && {
+                            title: sourceThread.title,
+                            title_generated_at: sourceThread.title_generated_at,
+                        }),
+                    });
+            }
 
             // Clone thread artifacts and get mapping
             const artifactMapping = await this.cloneThreadArtifacts({

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -234,6 +234,8 @@ const getAgentTools = (
               waitForSqlApproval: dependencies.waitForSqlApproval,
               recordSqlApproval: dependencies.recordSqlApproval,
               maxQueryLimit: args.runSqlMaxLimit,
+              autoApproveSql: args.autoApproveSql,
+              autoApproveSqlUserUuid: args.autoApproveSqlUserUuid,
           })
         : null;
 


### PR DESCRIPTION
## Problem

Two bugs that break **server-side agent runs** (evals, and the upcoming review-remediation verification runs):

1. `agentV2.ts` constructed the `runSql` tool **without passing `autoApproveSql`/`autoApproveSqlUserUuid`**, so the flag set by non-interactive callers (`generateAgentThreadResponse(..., { autoApproveSql: true })` — used by evals) never reached the tool. Every server-side run that used SQL sat through the full 5-minute approval timeout and answered "the SQL was not approved".
2. `AiAgentModel.cloneThread` issued an unconditional thread-row update that is **empty** when neither `shareSourceThreadShareUuid` nor `copyTitle` is set — exactly what the eval thread-clone path passes — making knex throw `Empty .update() call detected`.

## Fix

- Pass `autoApproveSql`/`autoApproveSqlUserUuid` from agent args into `getRunSql`.
- Guard the clone's thread-row update behind `shareSourceThreadShareUuid || copyTitle`.

## Who is affected

- Eval runs with SQL-mode agents stop timing out and produce real answers; recorded SQL approvals for auto-approved runs now carry the triggering user. Interactive (web/Slack) approval flows are untouched — `autoApproveSql` is only ever set by non-interactive callers.
- Thread-clone-based eval prompts stop crashing. Share-link clones (which pass `copyTitle`) behave exactly as before.

## Testing

Verified live on local dev: a server-side run with `autoApproveSql: true` executed `runSql` immediately (no 5-minute wait) and answered; verified via a direct model call that clones without share/title no longer throw.

Relates: (Linear ticket TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)