### PR TITLE
feat(ai): verification flow for review remediations — seeded preview runs and pinned thread context

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -278,7 +278,7 @@ export type AiAgentToolResultTable = Knex.CompositeTableType<
 
 export const AiPromptContextTableName = 'ai_prompt_context';
 
-export type AiPromptContextEntityType = 'chart' | 'dashboard';
+export type AiPromptContextEntityType = 'chart' | 'dashboard' | 'thread';
 
 export type DbAiPromptContext = {
     ai_prompt_context_uuid: string;

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -2535,6 +2535,79 @@ export class AiAgentModel {
         };
     }
 
+    async findPinnedThreadContextUuids(threadUuid: string): Promise<string[]> {
+        const rows = await this.database(AiPromptContextTableName)
+            .join(
+                AiPromptTableName,
+                `${AiPromptContextTableName}.ai_prompt_uuid`,
+                `${AiPromptTableName}.ai_prompt_uuid`,
+            )
+            .where(`${AiPromptTableName}.ai_thread_uuid`, threadUuid)
+            .where(`${AiPromptContextTableName}.entity_type`, 'thread')
+            .distinct<{ entity_uuid: string }[]>(
+                `${AiPromptContextTableName}.entity_uuid`,
+            );
+        return rows.map((row) => row.entity_uuid);
+    }
+
+    async findThreadOwnership({
+        organizationUuid,
+        threadUuid,
+    }: {
+        organizationUuid: string;
+        threadUuid: string;
+    }): Promise<
+        | {
+              threadUuid: string;
+              projectUuid: string;
+              agentUuid: string | null;
+              ownerUserUuid: string | null;
+          }
+        | undefined
+    > {
+        const row = await this.database(AiThreadTableName)
+            .joinRaw(
+                `left join lateral (
+                    select created_by_user_uuid
+                    from ${AiPromptTableName}
+                    where ${AiPromptTableName}.ai_thread_uuid = ${AiThreadTableName}.ai_thread_uuid
+                    order by created_at asc
+                    limit 1
+                ) as first_prompt on true`,
+            )
+            .leftJoin(
+                AiWebAppThreadTableName,
+                `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiWebAppThreadTableName}.ai_thread_uuid`,
+            )
+            .where(`${AiThreadTableName}.ai_thread_uuid`, threadUuid)
+            .where(`${AiThreadTableName}.organization_uuid`, organizationUuid)
+            .select<
+                {
+                    ai_thread_uuid: string;
+                    project_uuid: string;
+                    agent_uuid: string | null;
+                    owner_user_uuid: string | null;
+                }[]
+            >(
+                `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.project_uuid`,
+                `${AiThreadTableName}.agent_uuid`,
+                this.database.raw(
+                    `COALESCE(first_prompt.created_by_user_uuid, ${AiWebAppThreadTableName}.user_uuid) as owner_user_uuid`,
+                ),
+            )
+            .first();
+
+        if (!row) return undefined;
+        return {
+            threadUuid: row.ai_thread_uuid,
+            projectUuid: row.project_uuid,
+            agentUuid: row.agent_uuid,
+            ownerUserUuid: row.owner_user_uuid,
+        };
+    }
+
     async findThreads({
         organizationUuid,
         agentUuid,
@@ -4504,6 +4577,27 @@ export class AiAgentModel {
         });
     }
 
+    // Atomic thread+prompt creation — a failed prompt insert rolls back the
+    // thread, so no promptless (unfetchable) thread is ever left behind.
+    async createWebAppThreadWithPrompt({
+        thread,
+        prompt,
+    }: {
+        thread: CreateWebAppThread;
+        prompt: Omit<CreateWebAppPrompt, 'threadUuid'>;
+    }): Promise<{ threadUuid: string; promptUuid: string }> {
+        return this.database.transaction(async (trx) => {
+            const threadUuid = await this.createWebAppThread(thread, {
+                db: trx,
+            });
+            const promptUuid = await this.createWebAppPrompt(
+                { ...prompt, threadUuid },
+                { db: trx },
+            );
+            return { threadUuid, promptUuid };
+        });
+    }
+
     private static async insertPromptContext(
         trx: Knex.Transaction,
         promptUuid: string,
@@ -4592,6 +4686,41 @@ export class AiAgentModel {
             ).map((r) => [r.dashboard_uuid, r] as const),
         );
 
+        const threadUuids = context.flatMap((c) =>
+            c.type === 'thread' ? [c.threadUuid] : [],
+        );
+        const threadLookup = new Map(
+            (
+                await trx(AiThreadTableName)
+                    .leftJoin(
+                        AiPromptTableName,
+                        `${AiThreadTableName}.ai_thread_uuid`,
+                        `${AiPromptTableName}.ai_thread_uuid`,
+                    )
+                    .whereIn(`${AiThreadTableName}.ai_thread_uuid`, threadUuids)
+                    .distinctOn(`${AiThreadTableName}.ai_thread_uuid`)
+                    .orderBy([
+                        { column: `${AiThreadTableName}.ai_thread_uuid` },
+                        {
+                            column: `${AiPromptTableName}.created_at`,
+                            order: 'asc',
+                            nulls: 'last',
+                        },
+                    ])
+                    .select<
+                        {
+                            ai_thread_uuid: string;
+                            title: string | null;
+                            first_prompt: string | null;
+                        }[]
+                    >({
+                        ai_thread_uuid: `${AiThreadTableName}.ai_thread_uuid`,
+                        title: `${AiThreadTableName}.title`,
+                        first_prompt: `${AiPromptTableName}.prompt`,
+                    })
+            ).map((r) => [r.ai_thread_uuid, r] as const),
+        );
+
         const rows = context.map((ctx) => {
             switch (ctx.type) {
                 case 'chart': {
@@ -4615,6 +4744,17 @@ export class AiAgentModel {
                         pinned_version_uuid:
                             dashboard?.dashboard_version_uuid ?? null,
                         display_name: dashboard?.name ?? null,
+                    };
+                }
+                case 'thread': {
+                    const thread = threadLookup.get(ctx.threadUuid);
+                    return {
+                        ai_prompt_uuid: promptUuid,
+                        entity_type: 'thread' as AiPromptContextEntityType,
+                        entity_uuid: ctx.threadUuid,
+                        pinned_version_uuid: ctx.promptUuid ?? null,
+                        display_name:
+                            thread?.title ?? thread?.first_prompt ?? null,
                     };
                 }
                 default:
@@ -4725,6 +4865,13 @@ export class AiAgentModel {
                     dashboardSlug:
                         dashboardSlugByUuid.get(row.entity_uuid) ?? null,
                     pinnedVersionUuid: row.pinned_version_uuid,
+                    displayName: row.display_name,
+                };
+            case 'thread':
+                return {
+                    type: 'thread',
+                    threadUuid: row.entity_uuid,
+                    promptUuid: row.pinned_version_uuid,
                     displayName: row.display_name,
                 };
             default:

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -2,6 +2,7 @@ import {
     AiAgentEvalRunJobPayload,
     AiAgentReviewClassifierJobPayload,
     AiAgentReviewRemediationPreviewJobPayload,
+    AiAgentReviewRemediationRunJobPayload,
     AiAgentReviewWritebackJobPayload,
     AppGeneratePipelineJobPayload,
     EE_SCHEDULER_TASKS,
@@ -101,6 +102,22 @@ export class CommercialSchedulerClient extends SchedulerClient {
                 runAt,
                 maxAttempts: 1,
                 jobKey: `ai-agent-review-remediation-preview:${payload.remediationUuid}`,
+            },
+        );
+        return { jobId };
+    }
+
+    async aiAgentReviewRemediationRun(
+        payload: AiAgentReviewRemediationRunJobPayload,
+    ) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN,
+            payload,
+            {
+                runAt: new Date(),
+                maxAttempts: 1,
+                jobKey: `ai-agent-review-remediation-run:${payload.remediationUuid}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -23,6 +23,7 @@ import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgen
 import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
 
 const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const AI_AGENT_REVIEW_REMEDIATION_RUN_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 const AI_AGENT_REVIEW_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
@@ -102,6 +103,46 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             ) => {
                 await this.aiAgentAdminService.pollReviewRemediationPreview(
                     payload,
+                );
+            },
+            [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.aiAgentService.executeReviewRemediationRun(
+                                payload,
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    AI_AGENT_REVIEW_REMEDIATION_RUN_TIMEOUT_MS,
+                    async (job, e) => {
+                        // The preview stays usable on failure — the admin can
+                        // still retry the question manually from the thread.
+                        await this.schedulerService.logSchedulerJob({
+                            task: EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                error: getErrorMessage(e),
+                                projectUuid: payload.projectUuid,
+                                organizationUuid: payload.organizationUuid,
+                                createdByUserUuid: payload.userUuid,
+                                agentUuid: payload.agentUuid,
+                                threadUuid: payload.threadUuid,
+                                remediationUuid: payload.remediationUuid,
+                                fingerprint: payload.fingerprint,
+                            },
+                        });
+                    },
                 );
             },
             [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: async (

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -143,9 +143,10 @@ const makeService = ({
     new AiAgentAdminService({
         analytics: { track: jest.fn() },
         aiAgentModel: {
-            createWebAppThread: jest
-                .fn()
-                .mockResolvedValue(PREVIEW_THREAD_UUID),
+            createWebAppThreadWithPrompt: jest.fn().mockResolvedValue({
+                threadUuid: PREVIEW_THREAD_UUID,
+                promptUuid: 'prompt-uuid-1',
+            }),
             updateThreadTitle: jest.fn().mockResolvedValue(undefined),
             ...aiAgentModel,
         },
@@ -195,6 +196,9 @@ const makeService = ({
             aiAgentReviewRemediationPreview: jest
                 .fn()
                 .mockResolvedValue(undefined),
+            aiAgentReviewRemediationRun: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
             ...schedulerClient,
         },
         userModel: {},
@@ -411,12 +415,18 @@ describe('AiAgentAdminService.pollReviewRemediationPreview', () => {
         jest.clearAllMocks();
     });
 
-    it('creates a preview work thread and links it to the remediation', async () => {
+    it('creates a seeded preview work thread and links it to the remediation', async () => {
         const aiAgentModel = {
-            createWebAppThread: jest
-                .fn()
-                .mockResolvedValue(PREVIEW_THREAD_UUID),
+            createWebAppThreadWithPrompt: jest.fn().mockResolvedValue({
+                threadUuid: PREVIEW_THREAD_UUID,
+                promptUuid: 'prompt-uuid-1',
+            }),
             updateThreadTitle: jest.fn().mockResolvedValue(undefined),
+        };
+        const schedulerClient = {
+            aiAgentReviewRemediationRun: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
         };
         const aiAgentReviewClassifierModel = {
             getReviewRemediation: jest
@@ -441,6 +451,7 @@ describe('AiAgentAdminService.pollReviewRemediationPreview', () => {
             aiAgentModel,
             aiAgentReviewClassifierModel,
             projectModel,
+            schedulerClient,
         });
         (getPullRequestComments as jest.Mock).mockResolvedValue([
             `Preview ready: ${SITE_URL}/projects/${PREVIEW_PROJECT_UUID}/tables`,
@@ -461,12 +472,27 @@ describe('AiAgentAdminService.pollReviewRemediationPreview', () => {
             previewProjectUuid: PREVIEW_PROJECT_UUID,
             aiAgentUuid: AGENT_UUID,
         });
-        expect(aiAgentModel.createWebAppThread).toHaveBeenCalledWith({
-            organizationUuid: ORGANIZATION_UUID,
-            projectUuid: PREVIEW_PROJECT_UUID,
-            userUuid: USER_UUID,
-            createdFrom: 'web_app',
-            agentUuid: PREVIEW_AGENT_UUID,
+        expect(aiAgentModel.createWebAppThreadWithPrompt).toHaveBeenCalledWith({
+            thread: {
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PREVIEW_PROJECT_UUID,
+                userUuid: USER_UUID,
+                createdFrom: 'web_app',
+                agentUuid: PREVIEW_AGENT_UUID,
+            },
+            prompt: {
+                createdByUserUuid: USER_UUID,
+                prompt: expect.stringContaining(
+                    "Re-run the user's original question",
+                ),
+                context: [
+                    {
+                        type: 'thread',
+                        threadUuid: THREAD_UUID,
+                        promptUuid: PROMPT_UUID,
+                    },
+                ],
+            },
         });
         expect(aiAgentModel.updateThreadTitle).toHaveBeenCalledWith({
             threadUuid: PREVIEW_THREAD_UUID,
@@ -481,6 +507,118 @@ describe('AiAgentAdminService.pollReviewRemediationPreview', () => {
             previewAgentUuid: PREVIEW_AGENT_UUID,
             previewThreadUuid: PREVIEW_THREAD_UUID,
         });
+        expect(
+            schedulerClient.aiAgentReviewRemediationRun,
+        ).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PREVIEW_PROJECT_UUID,
+            userUuid: USER_UUID,
+            fingerprint: 'fingerprint-1',
+            remediationUuid: REMEDIATION_UUID,
+            agentUuid: PREVIEW_AGENT_UUID,
+            threadUuid: PREVIEW_THREAD_UUID,
+        });
+    });
+
+    it('falls back to the flagged prompt text when the verification prompt fails to seed', async () => {
+        const aiAgentModel = {
+            createWebAppThreadWithPrompt: jest
+                .fn()
+                .mockRejectedValueOnce(new Error('context insert failed'))
+                .mockResolvedValue({
+                    threadUuid: PREVIEW_THREAD_UUID,
+                    promptUuid: 'prompt-uuid-1',
+                }),
+            updateThreadTitle: jest.fn().mockResolvedValue(undefined),
+        };
+        const schedulerClient = {
+            aiAgentReviewRemediationRun: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
+        };
+        const service = makeService({ aiAgentModel, schedulerClient });
+        (getPullRequestComments as jest.Mock).mockResolvedValue([
+            `Preview ready: ${SITE_URL}/projects/${PREVIEW_PROJECT_UUID}/tables`,
+        ]);
+
+        await service.pollReviewRemediationPreview({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            userUuid: USER_UUID,
+            fingerprint: 'fingerprint-1',
+            remediationUuid: REMEDIATION_UUID,
+            prUrl: 'https://github.com/acme/dbt/pull/42',
+            startedAt: Date.now(),
+        });
+
+        expect(
+            aiAgentModel.createWebAppThreadWithPrompt,
+        ).toHaveBeenLastCalledWith({
+            thread: expect.objectContaining({
+                projectUuid: PREVIEW_PROJECT_UUID,
+            }),
+            prompt: {
+                createdByUserUuid: USER_UUID,
+                prompt: 'Show revenue',
+            },
+        });
+        expect(schedulerClient.aiAgentReviewRemediationRun).toHaveBeenCalled();
+    });
+
+    it('links no preview thread when seeding fails and there is no retry prompt', async () => {
+        const aiAgentModel = {
+            createWebAppThreadWithPrompt: jest
+                .fn()
+                .mockRejectedValue(new Error('context insert failed')),
+            updateThreadTitle: jest.fn().mockResolvedValue(undefined),
+        };
+        const schedulerClient = {
+            aiAgentReviewRemediationRun: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
+        };
+        const aiAgentReviewClassifierModel = {
+            getReviewRemediation: jest
+                .fn()
+                .mockResolvedValue(makeRemediation({ retryPrompt: null })),
+            getReviewItem: jest
+                .fn()
+                .mockResolvedValue(makeReviewItem({ title: 'Review revenue' })),
+            setReviewRemediationPreviewThread: jest
+                .fn()
+                .mockResolvedValue(undefined),
+            updateReviewRemediationStatus: jest
+                .fn()
+                .mockResolvedValue(undefined),
+        };
+        const service = makeService({
+            aiAgentModel,
+            aiAgentReviewClassifierModel,
+            schedulerClient,
+        });
+        (getPullRequestComments as jest.Mock).mockResolvedValue([
+            `Preview ready: ${SITE_URL}/projects/${PREVIEW_PROJECT_UUID}/tables`,
+        ]);
+
+        await service.pollReviewRemediationPreview({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            userUuid: USER_UUID,
+            fingerprint: 'fingerprint-1',
+            remediationUuid: REMEDIATION_UUID,
+            prUrl: 'https://github.com/acme/dbt/pull/42',
+            startedAt: Date.now(),
+        });
+
+        expect(
+            aiAgentReviewClassifierModel.setReviewRemediationPreviewThread,
+        ).not.toHaveBeenCalled();
+        expect(aiAgentModel.createWebAppThreadWithPrompt).toHaveBeenCalledTimes(
+            1,
+        );
+        expect(
+            schedulerClient.aiAgentReviewRemediationRun,
+        ).not.toHaveBeenCalled();
     });
 
     it('marks remediation failed when no preview URL is published in time', async () => {

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -1153,22 +1153,21 @@ export class AiAgentAdminService extends BaseService {
                         },
                     );
                 }
-                if (plan.strategy === 'prompt') {
-                    await setProgress('Creating preview environment…');
-                    const preview =
-                        await this.writebackPreviewService.createPreviewForPullRequest(
-                            { user, projectUuid, prUrl },
-                        );
-                    if (preview) {
-                        terminalMessage = `Opened pull request · Preview: ${preview.previewUrl}`;
-                        if (remediationUuid && pullRequest) {
-                            await this.setReviewRemediationPreviewFromProject({
-                                organizationUuid,
-                                remediationUuid,
-                                previewProjectUuid: preview.previewProjectUuid,
-                                userUuid,
-                            });
-                        }
+                // Both strategies verify against the PR's head branch in a preview env.
+                await setProgress('Creating preview environment…');
+                const preview =
+                    await this.writebackPreviewService.createPreviewForPullRequest(
+                        { user, projectUuid, prUrl },
+                    );
+                if (preview) {
+                    terminalMessage = `Opened pull request · Preview: ${preview.previewUrl}`;
+                    if (remediationUuid && pullRequest) {
+                        await this.setReviewRemediationPreviewFromProject({
+                            organizationUuid,
+                            remediationUuid,
+                            previewProjectUuid: preview.previewProjectUuid,
+                            userUuid,
+                        });
                     }
                 }
                 await setTerminal('completed', terminalMessage);
@@ -1264,6 +1263,18 @@ export class AiAgentAdminService extends BaseService {
         }
     }
 
+    private static buildReviewVerificationPrompt(
+        linkedPrUrl: string | null,
+    ): string {
+        return [
+            `A fix for this project was just applied from a pull request${
+                linkedPrUrl ? ` (${linkedPrUrl})` : ''
+            }. The conversation where the original question went wrong is attached as context.`,
+            '',
+            "Re-run the user's original question end-to-end against this project. Then compare the outcome with the attached conversation and state clearly whether the issue is resolved. Point out anything that still looks wrong.",
+        ].join('\n');
+    }
+
     private async createReviewRemediationPreviewThread({
         remediation,
         organizationUuid,
@@ -1277,13 +1288,56 @@ export class AiAgentAdminService extends BaseService {
         previewAgentUuid: string;
         userUuid: string;
     }): Promise<string> {
-        const threadUuid = await this.aiAgentModel.createWebAppThread({
+        // Seed the thread with a verification prompt that pins the source
+        // conversation as context — the agent re-runs the original question
+        // against the fixed project and reports whether the issue is
+        // resolved. Thread and prompt are created atomically; on failure the
+        // whole creation is retried with the flagged prompt's text verbatim.
+        const thread = {
             organizationUuid,
             projectUuid: previewProjectUuid,
             userUuid,
-            createdFrom: 'web_app',
+            createdFrom: 'web_app' as const,
             agentUuid: previewAgentUuid,
-        });
+        };
+        let threadUuid: string;
+        try {
+            ({ threadUuid } =
+                await this.aiAgentModel.createWebAppThreadWithPrompt({
+                    thread,
+                    prompt: {
+                        createdByUserUuid: userUuid,
+                        prompt: AiAgentAdminService.buildReviewVerificationPrompt(
+                            remediation.linkedPrUrl,
+                        ),
+                        context: [
+                            {
+                                type: 'thread',
+                                threadUuid: remediation.sourceThreadUuid,
+                                promptUuid: remediation.sourcePromptUuid,
+                            },
+                        ],
+                    },
+                }));
+        } catch (error) {
+            this.logger.warn(
+                `Failed to seed review verification prompt, falling back to the flagged prompt text: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            if (!remediation.retryPrompt) {
+                throw error;
+            }
+            ({ threadUuid } =
+                await this.aiAgentModel.createWebAppThreadWithPrompt({
+                    thread,
+                    prompt: {
+                        createdByUserUuid: userUuid,
+                        prompt: remediation.retryPrompt,
+                    },
+                }));
+        }
+
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
                 organizationUuid,
@@ -1334,14 +1388,25 @@ export class AiAgentAdminService extends BaseService {
             return;
         }
 
-        const previewThreadUuid =
-            await this.createReviewRemediationPreviewThread({
-                remediation,
-                organizationUuid,
-                previewProjectUuid,
-                previewAgentUuid,
-                userUuid,
-            });
+        let previewThreadUuid: string;
+        try {
+            previewThreadUuid = await this.createReviewRemediationPreviewThread(
+                {
+                    remediation,
+                    organizationUuid,
+                    previewProjectUuid,
+                    previewAgentUuid,
+                    userUuid,
+                },
+            );
+        } catch (error) {
+            this.logger.warn(
+                `Failed to create review verification thread: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            return;
+        }
 
         await this.aiAgentReviewClassifierModel.setReviewRemediationPreviewThread(
             {
@@ -1352,6 +1417,16 @@ export class AiAgentAdminService extends BaseService {
                 previewThreadUuid,
             },
         );
+
+        await this.schedulerClient.aiAgentReviewRemediationRun({
+            organizationUuid,
+            projectUuid: previewProjectUuid,
+            userUuid,
+            fingerprint: remediation.fingerprint,
+            remediationUuid,
+            agentUuid: previewAgentUuid,
+            threadUuid: previewThreadUuid,
+        });
     }
 
     async pollReviewRemediationPreview(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -10,6 +10,7 @@ import {
     AiAgentNotFoundError,
     AiAgentProjectThreadSummary,
     AiAgentReviewClassifierEventType,
+    AiAgentReviewRemediationRunJobPayload,
     AiAgentSummary,
     AiAgentThread,
     AiAgentThreadFilters,
@@ -542,7 +543,10 @@ export class AiAgentService extends BaseService {
             context?.filter((item) => item.type === 'chart').length ?? 0;
         const pinnedDashboardCount =
             context?.filter((item) => item.type === 'dashboard').length ?? 0;
-        const pinnedContextCount = pinnedChartCount + pinnedDashboardCount;
+        const pinnedThreadCount =
+            context?.filter((item) => item.type === 'thread').length ?? 0;
+        const pinnedContextCount =
+            pinnedChartCount + pinnedDashboardCount + pinnedThreadCount;
 
         return {
             hasPinnedContext: pinnedContextCount > 0,
@@ -561,10 +565,23 @@ export class AiAgentService extends BaseService {
 
         const seen = new Set<string>();
         const deduped = context.filter((item) => {
-            const key =
-                item.type === 'chart'
-                    ? `chart:${item.chartUuid}`
-                    : `dashboard:${item.dashboardUuid}`;
+            let key: string;
+            switch (item.type) {
+                case 'chart':
+                    key = `chart:${item.chartUuid}`;
+                    break;
+                case 'dashboard':
+                    key = `dashboard:${item.dashboardUuid}`;
+                    break;
+                case 'thread':
+                    key = `thread:${item.threadUuid}`;
+                    break;
+                default:
+                    return assertUnreachable(
+                        item,
+                        'Unknown AiPromptContextItemInput type',
+                    );
+            }
             if (seen.has(key)) return false;
             seen.add(key);
             return true;
@@ -586,6 +603,10 @@ export class AiAgentService extends BaseService {
                     );
                 }
 
+                if (item.type === 'thread') {
+                    return this.validateThreadContextAccess(user, item);
+                }
+
                 return this.dashboardService.hasAccess(
                     'view',
                     { user, projectUuid: agent.projectUuid },
@@ -595,6 +616,43 @@ export class AiAgentService extends BaseService {
         );
 
         return deduped;
+    }
+
+    // A pinned thread may live in another project (e.g. verifying a fix in a
+    // preview environment against the original conversation), so access is
+    // checked against the source thread's own agent.
+    private async validateThreadContextAccess(
+        user: SessionUser,
+        item: { threadUuid: string },
+    ): Promise<void> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        const ownership = await this.aiAgentModel.findThreadOwnership({
+            organizationUuid,
+            threadUuid: item.threadUuid,
+        });
+        if (!ownership || !ownership.agentUuid) {
+            throw new NotFoundError(`Thread not found: ${item.threadUuid}`);
+        }
+        const threadAgent = await this.aiAgentModel.getAgent({
+            organizationUuid,
+            agentUuid: ownership.agentUuid,
+        });
+        if (!threadAgent) {
+            throw new NotFoundError(`Thread not found: ${item.threadUuid}`);
+        }
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            threadAgent,
+            ownership.ownerUserUuid ?? '',
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to attach this conversation as context',
+            );
+        }
     }
 
     constructor(dependencies: AiAgentServiceDependencies) {
@@ -4572,6 +4630,12 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 }
                 case 'dashboard':
                     return `- Dashboard "${name}" (dashboardSlug: ${item.dashboardSlug ?? '(slug unavailable)'})`;
+                case 'thread':
+                    return `- Conversation "${name}" (threadUuid: ${item.threadUuid}${
+                        item.promptUuid
+                            ? `, the referenced turn is promptUuid: ${item.promptUuid}`
+                            : ''
+                    }) — a previous conversation attached as reference. Read it with the readPinnedThread tool. It may predate recent project changes, so verify any claims it contains against the current project instead of trusting them.`;
                 default:
                     return assertUnreachable(
                         item,
@@ -5490,6 +5554,28 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             describeWarehouseTable,
             listKnowledgeDocuments,
             getKnowledgeDocumentContent,
+            // Only conversations pinned as context on this thread are
+            // readable — the pin is the capability grant.
+            readPinnedThread: async ({ threadUuid }) => {
+                const pinnedThreadUuids =
+                    await this.aiAgentModel.findPinnedThreadContextUuids(
+                        prompt.threadUuid,
+                    );
+                if (!pinnedThreadUuids.includes(threadUuid)) {
+                    throw new ForbiddenError(
+                        'This conversation is not attached as context on this thread',
+                    );
+                }
+                const messages = await this.aiAgentModel.findThreadMessages({
+                    organizationUuid: user.organizationUuid!,
+                    threadUuid,
+                });
+                return messages.map((message) => ({
+                    role: message.role,
+                    message: message.message ?? '',
+                    createdAt: message.createdAt,
+                }));
+            },
             getSavedChart,
             getPrompt,
             sendFile,
@@ -9338,6 +9424,24 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             completedAt: new Date(),
         });
         await this.aiAgentModel.checkAndUpdateEvalRunCompletion(evalRunUuid);
+    }
+
+    async executeReviewRemediationRun({
+        userUuid,
+        organizationUuid,
+        agentUuid,
+        threadUuid,
+    }: AiAgentReviewRemediationRunJobPayload): Promise<void> {
+        const sessionUser = await this.userModel.findSessionUserAndOrgByUuid(
+            userUuid,
+            organizationUuid,
+        );
+
+        await this.generateAgentThreadResponse(sessionUser, {
+            agentUuid,
+            threadUuid,
+            autoApproveSql: true,
+        });
     }
 
     async executeEvalResult({

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -32,6 +32,7 @@ import { getListWarehouseTables } from '../tools/listWarehouseTables';
 import { getLoadProjectContext } from '../tools/loadProjectContext';
 import { getLoadSkill } from '../tools/loadSkill';
 import { getReadContent } from '../tools/readContent';
+import { getReadPinnedThread } from '../tools/readPinnedThread';
 import { getRepoShell } from '../tools/repoShell';
 import { getRunContentQuery } from '../tools/runContentQuery';
 import { getRunSavedChart } from '../tools/runSavedChart';
@@ -312,6 +313,10 @@ const getAgentTools = (
         getKnowledgeDocumentContent: dependencies.getKnowledgeDocumentContent,
     });
 
+    const readPinnedThread = getReadPinnedThread({
+        readPinnedThread: dependencies.readPinnedThread,
+    });
+
     const loadSkill =
         args.availableSkills.length > 0
             ? getLoadSkill({
@@ -348,6 +353,7 @@ const getAgentTools = (
         getProjectInfo,
         listKnowledgeDocuments,
         getKnowledgeDocumentContent,
+        readPinnedThread,
         ...(enableContentTools
             ? {
                   readContent,

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -191,6 +191,8 @@ export class Compaction {
                 return `chart ${item.displayName ?? item.chartUuid} (${item.chartUuid})`;
             case 'dashboard':
                 return `dashboard ${item.displayName ?? item.dashboardUuid} (${item.dashboardUuid})`;
+            case 'thread':
+                return `conversation ${item.displayName ?? item.threadUuid} (${item.threadUuid})`;
             default:
                 return assertUnreachable(
                     item,

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -6588,6 +6588,7 @@ exports[`AI agent tool contracts matches the shared agent tool definition names 
   "describeWarehouseTable",
   "listKnowledgeDocuments",
   "getKnowledgeDocumentContent",
+  "readPinnedThread",
   "findCharts",
   "findDashboards",
   "generateBarVizConfig",

--- a/packages/backend/src/ee/services/ai/tools/readPinnedThread.tsx
+++ b/packages/backend/src/ee/services/ai/tools/readPinnedThread.tsx
@@ -1,0 +1,62 @@
+import { readPinnedThreadToolDefinition } from '@lightdash/common';
+import { tool } from 'ai';
+import type { ReadPinnedThreadFn } from '../types/aiAgentDependencies';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+import { xmlBuilder } from '../xmlBuilder';
+
+type Dependencies = {
+    readPinnedThread: ReadPinnedThreadFn;
+};
+
+const toolDefinition = readPinnedThreadToolDefinition.for('agent');
+
+const MAX_MESSAGE_CHARS = 4_000;
+const MAX_TRANSCRIPT_CHARS = 40_000;
+
+export const getReadPinnedThread = ({ readPinnedThread }: Dependencies) =>
+    tool({
+        ...toolDefinition,
+        execute: async ({ threadUuid }) => {
+            try {
+                const messages = await readPinnedThread({ threadUuid });
+
+                let budget = MAX_TRANSCRIPT_CHARS;
+                const bounded = messages.map((message) => {
+                    const truncated = message.message.slice(
+                        0,
+                        Math.max(0, Math.min(MAX_MESSAGE_CHARS, budget)),
+                    );
+                    budget -= truncated.length;
+                    return { ...message, message: truncated };
+                });
+
+                return {
+                    result: (
+                        <conversation threadUuid={threadUuid}>
+                            {bounded.map((message, index) => (
+                                <message
+                                    role={message.role}
+                                    index={index}
+                                    createdAt={message.createdAt}
+                                >
+                                    {message.message}
+                                </message>
+                            ))}
+                        </conversation>
+                    ).toString(),
+                    metadata: {
+                        status: 'success',
+                        messageCount: messages.length,
+                    },
+                };
+            } catch (e) {
+                return {
+                    result: toolErrorHandler(
+                        e,
+                        'Error reading pinned conversation.',
+                    ),
+                    metadata: { status: 'error' },
+                };
+            }
+        },
+    });

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -34,6 +34,7 @@ import {
     ListWarehouseTablesFn,
     LoadAgentSkillFn,
     ReadContentFn,
+    ReadPinnedThreadFn,
     RecordSqlApprovalFn,
     RepoShellFn,
     RunAsyncQueryFn,
@@ -146,6 +147,7 @@ export type AiAgentDependencies = {
     describeWarehouseTable: DescribeWarehouseTableFn;
     listKnowledgeDocuments: ListKnowledgeDocumentsFn;
     getKnowledgeDocumentContent: GetKnowledgeDocumentContentFn;
+    readPinnedThread: ReadPinnedThreadFn;
     getSavedChart: GetSavedChartFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -403,6 +403,14 @@ export type GetKnowledgeDocumentContentFn = (args: {
     documentUuid: string;
 }) => Promise<AiAgentDocumentContent>;
 
+export type ReadPinnedThreadFn = (args: { threadUuid: string }) => Promise<
+    {
+        role: 'user' | 'assistant';
+        message: string;
+        createdAt: string;
+    }[]
+>;
+
 export type WaitForSqlApprovalFn = (
     toolCallId: string,
     timeoutMs?: number,

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -41,6 +41,7 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     describeWarehouseTable: 'describe_warehouse_table',
     listKnowledgeDocuments: 'list_knowledge_documents',
     getKnowledgeDocumentContent: 'get_knowledge_document_content',
+    readPinnedThread: 'read_pinned_thread',
     generateDashboard: 'generate_dashboard',
     improveContext: 'improve_context',
     listProjects: 'list_projects',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1953,19 +1953,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    EmbedWriteActions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                spaceUuid: { dataType: 'string', required: true },
-                userUuid: { dataType: 'string' },
-                serviceAccountUserUuid: { dataType: 'string' },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CreateEmbedJwt: {
         dataType: 'refAlias',
         type: {
@@ -1986,7 +1973,6 @@ const models: TsoaRoute.Models = {
                     nestedProperties: {},
                     additionalProperties: { dataType: 'string' },
                 },
-                writeActions: { ref: 'EmbedWriteActions' },
                 content: {
                     dataType: 'union',
                     subSchemas: [
@@ -12223,6 +12209,33 @@ const models: TsoaRoute.Models = {
                         },
                     },
                 },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        displayName: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        promptUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        threadUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['thread'],
+                            required: true,
+                        },
+                    },
+                },
             ],
             validators: {},
         },
@@ -12418,6 +12431,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['describeWarehouseTable'] },
                 { dataType: 'enum', enums: ['listKnowledgeDocuments'] },
                 { dataType: 'enum', enums: ['getKnowledgeDocumentContent'] },
+                { dataType: 'enum', enums: ['readPinnedThread'] },
             ],
             validators: {},
         },
@@ -12446,11 +12460,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -12508,11 +12522,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -12549,11 +12563,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12568,11 +12582,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13615,6 +13629,11 @@ const models: TsoaRoute.Models = {
                                                                     'nestedObjectLiteral',
                                                                 nestedProperties:
                                                                     {
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
                                                                         kind: {
                                                                             dataType:
                                                                                 'union',
@@ -13656,11 +13675,6 @@ const models: TsoaRoute.Models = {
                                                                                         ],
                                                                                     },
                                                                                 ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
                                                                             required: true,
                                                                         },
                                                                     },
@@ -13856,11 +13870,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13921,11 +13935,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14102,11 +14116,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14121,11 +14135,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14140,11 +14154,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14533,6 +14547,24 @@ const models: TsoaRoute.Models = {
                         type: {
                             dataType: 'enum',
                             enums: ['dashboard'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        promptUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                        },
+                        threadUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['thread'],
                             required: true,
                         },
                     },
@@ -19516,15 +19548,6 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'refAlias', ref: 'CiCheck' },
                     required: true,
                 },
-                state: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['open'] },
-                        { dataType: 'enum', enums: ['closed'] },
-                    ],
-                    required: true,
-                },
-                merged: { dataType: 'boolean', required: true },
                 mergeState: { ref: 'CiMergeState', required: true },
                 overall: { ref: 'CiCheckState', required: true },
                 provider: { ref: 'CiProviderType', required: true },
@@ -19547,112 +19570,6 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ClosePullRequestResult: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                state: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['open'] },
-                        { dataType: 'enum', enums: ['closed'] },
-                    ],
-                    required: true,
-                },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiClosePullRequestResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'ClosePullRequestResult', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ClosePullRequestRequestBody: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { prUrl: { dataType: 'string', required: true } },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiPullRequestDiffResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'union',
-                    subSchemas: [
-                        {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                diff: { dataType: 'string', required: true },
-                            },
-                        },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    MergePullRequestResult: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                sha: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                merged: { dataType: 'boolean', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiMergePullRequestResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'MergePullRequestResult', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    MergePullRequestRequestBody: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                sha: { dataType: 'string' },
-                prUrl: { dataType: 'string', required: true },
             },
             validators: {},
         },
@@ -25434,6 +25351,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'enum',
                     enums: ['aiAgentReviewRemediationPreview'],
                 },
+                { dataType: 'enum', enums: ['aiAgentReviewRemediationRun'] },
                 { dataType: 'enum', enums: ['embedArtifactVersion'] },
                 { dataType: 'enum', enums: ['generateArtifactQuestion'] },
                 { dataType: 'enum', enums: ['appGeneratePipeline'] },
@@ -28443,7 +28361,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28453,7 +28371,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28463,7 +28381,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28476,7 +28394,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -29131,7 +29049,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29141,7 +29059,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29151,7 +29069,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29164,7 +29082,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -50508,208 +50426,6 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getPullRequestCiChecks',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiWritebackController_closeWritebackPullRequest: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        projectUuid: {
-            in: 'path',
-            name: 'projectUuid',
-            required: true,
-            dataType: 'string',
-        },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'ClosePullRequestRequestBody',
-        },
-    };
-    app.post(
-        '/api/v1/ee/projects/:projectUuid/ai-writeback/close-pull-request',
-        ...fetchMiddlewares<RequestHandler>(AiWritebackController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiWritebackController.prototype.closeWritebackPullRequest,
-        ),
-
-        async function AiWritebackController_closeWritebackPullRequest(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiWritebackController_closeWritebackPullRequest,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<AiWritebackController>(
-                        AiWritebackController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'closeWritebackPullRequest',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiWritebackController_getPullRequestDiff: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        projectUuid: {
-            in: 'path',
-            name: 'projectUuid',
-            required: true,
-            dataType: 'string',
-        },
-        prUrl: {
-            in: 'query',
-            name: 'prUrl',
-            required: true,
-            dataType: 'string',
-        },
-        commitSha: { in: 'query', name: 'commitSha', dataType: 'string' },
-    };
-    app.get(
-        '/api/v1/ee/projects/:projectUuid/ai-writeback/ci-diff',
-        ...fetchMiddlewares<RequestHandler>(AiWritebackController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiWritebackController.prototype.getPullRequestDiff,
-        ),
-
-        async function AiWritebackController_getPullRequestDiff(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiWritebackController_getPullRequestDiff,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<AiWritebackController>(
-                        AiWritebackController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'getPullRequestDiff',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiWritebackController_mergeWritebackPullRequest: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        projectUuid: {
-            in: 'path',
-            name: 'projectUuid',
-            required: true,
-            dataType: 'string',
-        },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'MergePullRequestRequestBody',
-        },
-    };
-    app.post(
-        '/api/v1/ee/projects/:projectUuid/ai-writeback/merge-pull-request',
-        ...fetchMiddlewares<RequestHandler>(AiWritebackController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiWritebackController.prototype.mergeWritebackPullRequest,
-        ),
-
-        async function AiWritebackController_mergeWritebackPullRequest(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiWritebackController_mergeWritebackPullRequest,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<AiWritebackController>(
-                        AiWritebackController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'mergeWritebackPullRequest',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1994,21 +1994,6 @@
                     }
                 ]
             },
-            "EmbedWriteActions": {
-                "properties": {
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "userUuid": {
-                        "type": "string"
-                    },
-                    "serviceAccountUserUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": ["spaceUuid"],
-                "type": "object"
-            },
             "CreateEmbedJwt": {
                 "properties": {
                     "exp": {
@@ -2039,9 +2024,6 @@
                             "type": "string"
                         },
                         "type": "object"
-                    },
-                    "writeActions": {
-                        "$ref": "#/components/schemas/EmbedWriteActions"
                     },
                     "content": {
                         "anyOf": [
@@ -13773,6 +13755,33 @@
                             "type"
                         ],
                         "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "displayName": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "promptUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "threadUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["thread"],
+                                "nullable": false
+                            }
+                        },
+                        "required": [
+                            "displayName",
+                            "promptUuid",
+                            "threadUuid",
+                            "type"
+                        ],
+                        "type": "object"
                     }
                 ]
             },
@@ -13993,7 +14002,8 @@
                     "listWarehouseTables",
                     "describeWarehouseTable",
                     "listKnowledgeDocuments",
-                    "getKnowledgeDocumentContent"
+                    "getKnowledgeDocumentContent",
+                    "readPinnedThread"
                 ],
                 "description": "Exclude from T those types that are assignable to U"
             },
@@ -14013,8 +14023,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14072,8 +14082,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14097,19 +14107,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -14622,6 +14619,9 @@
                                                     "steps": {
                                                         "items": {
                                                             "properties": {
+                                                                "label": {
+                                                                    "type": "string"
+                                                                },
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
@@ -14631,14 +14631,11 @@
                                                                         "compile",
                                                                         "stage"
                                                                     ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
                                                                 }
                                                             },
                                                             "required": [
-                                                                "kind",
-                                                                "label"
+                                                                "label",
+                                                                "kind"
                                                             ],
                                                             "type": "object"
                                                         },
@@ -15194,6 +15191,24 @@
                             }
                         },
                         "required": ["dashboardUuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "promptUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "threadUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["thread"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["threadUuid", "type"],
                         "type": "object"
                     }
                 ]
@@ -20021,15 +20036,6 @@
                         },
                         "type": "array"
                     },
-                    "state": {
-                        "type": "string",
-                        "enum": ["open", "closed"],
-                        "description": "Whether the PR is open or closed. A closed-but-not-merged PR is terminal\ntoo, so the card shows \"Closed\" and offers neither merge nor close."
-                    },
-                    "merged": {
-                        "type": "boolean",
-                        "description": "Whether the PR is already merged. Once merged the provider's\n`mergeState` is no longer meaningful, so consumers show a terminal\n\"Merged\" state and suppress the merge action."
-                    },
                     "mergeState": {
                         "$ref": "#/components/schemas/CiMergeState",
                         "description": "Whether the PR can actually be merged per the repo's policy — resolved\nfrom the provider, NOT inferred from `overall`. Drives the merge-\nreadiness verdict so a failing-but-not-required check doesn't read as\n\"blocked\"."
@@ -20042,14 +20048,7 @@
                         "$ref": "#/components/schemas/CiProviderType"
                     }
                 },
-                "required": [
-                    "checks",
-                    "state",
-                    "merged",
-                    "mergeState",
-                    "overall",
-                    "provider"
-                ],
+                "required": ["checks", "mergeState", "overall", "provider"],
                 "type": "object",
                 "description": "The CI checks for a pull request, plus a single rolled-up state for an\nat-a-glance summary. `checks` is empty when the ref has no CI configured."
             },
@@ -20072,108 +20071,6 @@
                 "required": ["results", "status"],
                 "type": "object",
                 "description": "CI checks for a PR, or null when CI status can't be resolved (project isn't\nconnected to a supported provider, no app installation, PR not found, etc.) —\ndistinct from a resolved result with an empty `checks` array (\"no CI runs\")."
-            },
-            "ClosePullRequestResult": {
-                "properties": {
-                    "state": {
-                        "type": "string",
-                        "enum": ["open", "closed"]
-                    }
-                },
-                "required": ["state"],
-                "type": "object",
-                "description": "Outcome of closing a pull request."
-            },
-            "ApiClosePullRequestResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/ClosePullRequestResult"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ClosePullRequestRequestBody": {
-                "properties": {
-                    "prUrl": {
-                        "type": "string",
-                        "description": "The PR/MR URL of the write-back pull request to close."
-                    }
-                },
-                "required": ["prUrl"],
-                "type": "object",
-                "description": "Body for closing a write-back pull request from the chat PR card."
-            },
-            "ApiPullRequestDiffResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "diff": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["diff"],
-                        "type": "object",
-                        "nullable": true
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object",
-                "description": "The raw unified diff of a write-back pull request (or a single pinned commit\nwithin it), for the chat card's diff viewer. Null when it can't be resolved\n(unsupported source control, no app installation, PR not found, diff too\nlarge for the provider to return)."
-            },
-            "MergePullRequestResult": {
-                "properties": {
-                    "sha": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The resulting merge commit SHA, when the provider returns one."
-                    },
-                    "merged": {
-                        "type": "boolean"
-                    }
-                },
-                "required": ["sha", "merged"],
-                "type": "object",
-                "description": "Outcome of a pull request merge."
-            },
-            "ApiMergePullRequestResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/MergePullRequestResult"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "MergePullRequestRequestBody": {
-                "properties": {
-                    "sha": {
-                        "type": "string",
-                        "description": "The commit the card is pinned to. When set the merge only proceeds if the\nPR's head still points at this SHA, so a user never merges a commit they\nhaven't seen (a later turn may have pushed a newer head)."
-                    },
-                    "prUrl": {
-                        "type": "string",
-                        "description": "The PR/MR URL of the write-back pull request to merge."
-                    }
-                },
-                "required": ["prUrl"],
-                "type": "object",
-                "description": "Body for merging a write-back pull request from the chat PR card."
             },
             "ProjectFiles": {
                 "properties": {
@@ -25993,6 +25890,7 @@
                     "aiAgentReviewClassifier",
                     "aiAgentReviewWriteback",
                     "aiAgentReviewRemediationPreview",
+                    "aiAgentReviewRemediationRun",
                     "embedArtifactVersion",
                     "generateArtifactQuestion",
                     "appGeneratePipeline",
@@ -29240,22 +29138,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -29815,22 +29713,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -38778,7 +38676,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3141.0",
+        "version": "0.3143.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -179,6 +179,16 @@ const getTagsForTask: {
         'ai_agent_review.remediation_uuid': payload.remediationUuid,
     }),
 
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid,
+        'agent.uuid': payload.agentUuid,
+        'thread.uuid': payload.threadUuid,
+        'ai_agent_review.fingerprint': payload.fingerprint,
+        'ai_agent_review.remediation_uuid': payload.remediationUuid,
+    }),
+
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -100,6 +100,12 @@ export type AiPromptContextItemInput =
           type: 'dashboard';
           dashboardUuid: string;
           dashboardSlug?: string | null;
+      }
+    | {
+          type: 'thread';
+          threadUuid: string;
+          // The turn the reference points at (e.g. a flagged prompt).
+          promptUuid?: string | null;
       };
 
 export type AiPromptContextInput = AiPromptContextItemInput[];
@@ -119,6 +125,12 @@ export type AiPromptContextItem =
           dashboardUuid: string;
           dashboardSlug: string | null;
           pinnedVersionUuid: string | null;
+          displayName: string | null;
+      }
+    | {
+          type: 'thread';
+          threadUuid: string;
+          promptUuid: string | null;
           displayName: string | null;
       };
 
@@ -193,6 +205,13 @@ export type AiAgentReviewRemediationPreviewJobPayload = TraceTaskBase & {
     remediationUuid: string;
     prUrl: string;
     startedAt: number;
+};
+
+export type AiAgentReviewRemediationRunJobPayload = TraceTaskBase & {
+    fingerprint: string;
+    remediationUuid: string;
+    agentUuid: string;
+    threadUuid: string;
 };
 
 export type EmbedArtifactVersionJobPayload = TraceTaskBase & {

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -19,6 +19,7 @@ export * from './toolDescribeWarehouseTableArgs';
 export * from './toolFindChartsArgs';
 export * from './toolGetKnowledgeDocumentContentArgs';
 export * from './toolListKnowledgeDocumentsArgs';
+export * from './toolReadPinnedThreadArgs';
 export * from './toolCreateContentArgs';
 export * from './toolListContentArgs';
 export * from './toolFindContentArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -166,6 +166,11 @@ import {
     toolReadContentOutputSchema,
 } from './toolReadContentArgs';
 import {
+    TOOL_READ_PINNED_THREAD_DESCRIPTION,
+    toolReadPinnedThreadArgsSchema,
+    toolReadPinnedThreadOutputSchema,
+} from './toolReadPinnedThreadArgs';
+import {
     TOOL_REPO_SHELL_DESCRIPTION,
     toolRepoShellArgsSchema,
     toolRepoShellOutputSchema,
@@ -623,6 +628,15 @@ export const getKnowledgeDocumentContentToolDefinition = defineTool({
     agent: { outputSchema: toolGetKnowledgeDocumentContentOutputSchema },
 });
 
+export const readPinnedThreadToolDefinition = defineTool({
+    name: 'readPinnedThread',
+    title: 'Read pinned conversation',
+    description: TOOL_READ_PINNED_THREAD_DESCRIPTION,
+    availability: ['agent'],
+    inputSchema: toolReadPinnedThreadArgsSchema,
+    agent: { outputSchema: toolReadPinnedThreadOutputSchema },
+});
+
 /** @deprecated Legacy agent tool kept for historical tool calls. */
 export const findChartsToolDefinition = defineTool({
     name: 'findCharts',
@@ -860,6 +874,7 @@ type AgentToolDefinitionsByName = {
     describeWarehouseTable: typeof describeWarehouseTableToolDefinition;
     listKnowledgeDocuments: typeof listKnowledgeDocumentsToolDefinition;
     getKnowledgeDocumentContent: typeof getKnowledgeDocumentContentToolDefinition;
+    readPinnedThread: typeof readPinnedThreadToolDefinition;
     findCharts: typeof findChartsToolDefinition;
     findDashboards: typeof findDashboardsToolDefinition;
     generateBarVizConfig: typeof generateBarVizConfigToolDefinition;
@@ -900,6 +915,7 @@ export const agentToolDefinitionsByName: AgentToolDefinitionsByName = {
     describeWarehouseTable: describeWarehouseTableToolDefinition,
     listKnowledgeDocuments: listKnowledgeDocumentsToolDefinition,
     getKnowledgeDocumentContent: getKnowledgeDocumentContentToolDefinition,
+    readPinnedThread: readPinnedThreadToolDefinition,
     findCharts: findChartsToolDefinition,
     findDashboards: findDashboardsToolDefinition,
     generateBarVizConfig: generateBarVizConfigToolDefinition,
@@ -942,6 +958,7 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     describeWarehouseTableToolDefinition,
     listKnowledgeDocumentsToolDefinition,
     getKnowledgeDocumentContentToolDefinition,
+    readPinnedThreadToolDefinition,
     findChartsToolDefinition,
     findDashboardsToolDefinition,
     generateBarVizConfigToolDefinition,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolReadPinnedThreadArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolReadPinnedThreadArgs.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { createToolSchema } from '../toolSchemaBuilder';
+
+export const TOOL_READ_PINNED_THREAD_DESCRIPTION = `Tool: read_pinned_thread
+
+Purpose:
+Read the transcript of a previous conversation that was attached to this thread as context. Use it to understand what the user was trying to achieve in that conversation before answering.
+
+When to use:
+- A message in this thread lists a Conversation as attached context and you need its content.
+- You were asked to verify or follow up on something that happened in the attached conversation.
+
+Do NOT use:
+- For threads that are not attached as context — only pinned conversations are readable.
+- Repeatedly for the same threadUuid in one turn — the transcript does not change between calls.
+
+Important:
+The attached conversation may predate recent project changes. Verify any claims it contains (available fields, metrics, query results) against the current project instead of trusting them.
+
+Parameters:
+- threadUuid: The uuid of the attached conversation, taken from the context note in this thread.
+`;
+
+export const toolReadPinnedThreadArgsSchema = createToolSchema()
+    .extend({
+        threadUuid: z
+            .string()
+            .uuid()
+            .describe('Uuid of the pinned conversation to read.'),
+    })
+    .build();
+
+export const toolReadPinnedThreadOutputSchema = z.object({
+    result: z.string(),
+    metadata: z.discriminatedUnion('status', [
+        z.object({
+            status: z.literal('success'),
+            messageCount: z.number(),
+        }),
+        z.object({
+            status: z.literal('error'),
+        }),
+    ]),
+});
+
+export type ToolReadPinnedThreadArgs = z.infer<
+    typeof toolReadPinnedThreadArgsSchema
+>;
+
+export type ToolReadPinnedThreadOutput = z.infer<
+    typeof toolReadPinnedThreadOutputSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -47,6 +47,7 @@ export const ToolNameSchema = z.enum([
     'describeWarehouseTable',
     'listKnowledgeDocuments',
     'getKnowledgeDocumentContent',
+    'readPinnedThread',
 ]);
 
 export type ToolName = z.infer<typeof ToolNameSchema>;
@@ -94,6 +95,7 @@ export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     describeWarehouseTable: 'Describing warehouse table',
     listKnowledgeDocuments: 'Listing knowledge documents',
     getKnowledgeDocumentContent: 'Reading knowledge document',
+    readPinnedThread: 'Reading pinned conversation',
 });
 
 // after-tool-call messages
@@ -135,6 +137,7 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         describeWarehouseTable: 'Described warehouse table',
         listKnowledgeDocuments: 'Listed knowledge documents',
         getKnowledgeDocumentContent: 'Read knowledge document',
+        readPinnedThread: 'Read pinned conversation',
     });
 
 export const AVAILABLE_VISUALIZATION_TYPES = VisualizationTools;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -3,6 +3,7 @@ import {
     type AiAgentEvalRunJobPayload,
     type AiAgentReviewClassifierJobPayload,
     type AiAgentReviewRemediationPreviewJobPayload,
+    type AiAgentReviewRemediationRunJobPayload,
     type AiAgentReviewWritebackJobPayload,
     type ChartReference,
     type DataAppClaudeModel,
@@ -66,6 +67,7 @@ export const EE_SCHEDULER_TASKS = {
     AI_AGENT_REVIEW_CLASSIFIER: 'aiAgentReviewClassifier',
     AI_AGENT_REVIEW_WRITEBACK: 'aiAgentReviewWriteback',
     AI_AGENT_REVIEW_REMEDIATION_PREVIEW: 'aiAgentReviewRemediationPreview',
+    AI_AGENT_REVIEW_REMEDIATION_RUN: 'aiAgentReviewRemediationRun',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
@@ -154,6 +156,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: AiAgentReviewRemediationPreviewJobPayload;
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
@@ -166,6 +169,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: AiAgentReviewRemediationPreviewJobPayload;
+    [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -12,6 +12,7 @@ import { ContentReferenceLink } from './ContentReferenceLink';
 import {
     buildContentReferenceSegments,
     getPromptContextItemHref,
+    getPromptContextItemKey,
 } from './contentReferenceUtils';
 
 type Props = {
@@ -34,11 +35,7 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
     );
     const remainingContext = message.context.filter((item) => {
         if (!hasInlineReferences) return true;
-        const key =
-            item.type === 'chart'
-                ? `chart:${item.chartUuid}`
-                : `dashboard:${item.dashboardUuid}`;
-        return !matchedKeys.has(key);
+        return !matchedKeys.has(getPromptContextItemKey(item));
     });
 
     return (
@@ -77,11 +74,7 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                 >
                     {remainingContext.map((item, idx) => (
                         <PinnedContextCard
-                            key={`${item.type}-${
-                                item.type === 'chart'
-                                    ? item.chartUuid
-                                    : item.dashboardUuid
-                            }-${idx}`}
+                            key={`${getPromptContextItemKey(item)}-${idx}`}
                             item={item}
                             projectUuid={projectUuid}
                         />
@@ -119,10 +112,12 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                                     kind={segment.item.type}
                                     rel="noreferrer"
                                     target="_blank"
-                                    to={getPromptContextItemHref(
-                                        segment.item,
-                                        projectUuid,
-                                    )}
+                                    to={
+                                        getPromptContextItemHref(
+                                            segment.item,
+                                            projectUuid,
+                                        ) ?? undefined
+                                    }
                                 >
                                     {segment.label}
                                 </ContentReferenceLink>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
@@ -4,6 +4,7 @@ import {
     IconArrowRight,
     IconChartBar,
     IconLayoutDashboard,
+    IconMessages,
     type Icon,
 } from '@tabler/icons-react';
 import { type AnchorHTMLAttributes, type ReactNode } from 'react';
@@ -12,7 +13,7 @@ import MantineIcon from '../../../../../components/common/MantineIcon';
 import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
 import styles from './ContentLink.module.css';
 
-type ContentReferenceKind = 'artifact' | 'chart' | 'dashboard';
+type ContentReferenceKind = 'artifact' | 'chart' | 'dashboard' | 'thread';
 
 type Props = {
     chartKind?: ChartKind;
@@ -48,6 +49,12 @@ const getIconMeta = ({
                 color: 'indigo.6',
                 fill: 'indigo.1',
                 icon: IconChartBar,
+            };
+        case 'thread':
+            return {
+                color: 'violet.7',
+                fill: 'violet.4',
+                icon: IconMessages,
             };
         case 'chart':
         default:

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -312,6 +312,7 @@ export const ToolCallDescription: FC<{
         case 'editDbtProject':
         case 'setupPreviewDeploy':
         case 'runSavedChart':
+        case 'readPinnedThread':
             return <> </>;
         default:
             return assertUnreachable(toolName, `Unknown tool name ${toolName}`);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
@@ -10,6 +10,7 @@ import {
     IconDatabase,
     IconFileCode,
     IconFileText,
+    IconMessages,
     IconFolders,
     IconLayoutDashboard,
     IconBook2,
@@ -67,6 +68,7 @@ export const getToolIcon = (toolName: AiAgentToolName) => {
             describeWarehouseTable: IconDatabase,
             listKnowledgeDocuments: IconBooks,
             getKnowledgeDocumentContent: IconFileText,
+            readPinnedThread: IconMessages,
         };
 
     return isToolName(toolName) ? iconMap[toolName] : IconPlugConnected;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     ChartSourceType,
     ContentType,
     type AiPromptContextInput,
@@ -36,6 +37,7 @@ import suggestionStyles from '../../../../../components/common/SuggestionList/Su
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import styles from './AgentChatInput.module.css';
 import { ContentMentionNodeView } from './ContentMentionNodeView';
+import { getPromptContextItemKey } from './contentReferenceUtils';
 
 const CONTENT_MENTION_NAME = 'contentMention';
 const MIN_CONTENT_SEARCH_QUERY_LENGTH = 2;
@@ -173,10 +175,21 @@ const getContentMentionIconSpec = (contentType: string): DOMOutputSpec => [
     },
 ];
 
-const getContextKey = (item: AiPromptContextInput[number]) =>
-    item.type === 'chart'
-        ? `chart:${item.chartUuid}`
-        : `dashboard:${item.dashboardUuid}`;
+const getContextKey = (item: AiPromptContextInput[number]) => {
+    switch (item.type) {
+        case 'chart':
+            return `chart:${item.chartUuid}`;
+        case 'dashboard':
+            return `dashboard:${item.dashboardUuid}`;
+        case 'thread':
+            return `thread:${item.threadUuid}`;
+        default:
+            return assertUnreachable(
+                item,
+                'Unknown AiPromptContextItemInput type',
+            );
+    }
+};
 
 const normalizeSearchText = (value: string) =>
     value
@@ -230,10 +243,7 @@ export const mergeAiPromptContextItems = (
     const merged = contextGroups
         .flatMap((context) => context ?? [])
         .filter((item) => {
-            const key =
-                item.type === 'chart'
-                    ? `chart:${item.chartUuid}`
-                    : `dashboard:${item.dashboardUuid}`;
+            const key = getPromptContextItemKey(item);
             if (seen.has(key)) return false;
             seen.add(key);
             return true;
@@ -259,26 +269,31 @@ export const contextItemsToContentMentionSuggestions = (
     context: AiPromptContextItem[],
     group: ContentMentionGroup,
 ): ContentMentionSuggestionItem[] =>
-    context.map((item) =>
-        item.type === 'chart'
-            ? {
-                  id: `${group}:chart:${item.chartUuid}`,
-                  label: item.displayName ?? item.chartSlug ?? 'Chart',
-                  contentType: ContentType.CHART,
-                  uuid: item.chartUuid,
-                  slug: item.chartSlug,
-                  chartKind: item.chartKind,
-                  group,
-              }
-            : {
-                  id: `${group}:dashboard:${item.dashboardUuid}`,
-                  label: item.displayName ?? item.dashboardSlug ?? 'Dashboard',
-                  contentType: ContentType.DASHBOARD,
-                  uuid: item.dashboardUuid,
-                  slug: item.dashboardSlug,
-                  group,
-              },
-    );
+    context.flatMap((item) => {
+        if (item.type === 'chart') {
+            return {
+                id: `${group}:chart:${item.chartUuid}`,
+                label: item.displayName ?? item.chartSlug ?? 'Chart',
+                contentType: ContentType.CHART,
+                uuid: item.chartUuid,
+                slug: item.chartSlug,
+                chartKind: item.chartKind,
+                group,
+            };
+        }
+        if (item.type === 'dashboard') {
+            return {
+                id: `${group}:dashboard:${item.dashboardUuid}`,
+                label: item.displayName ?? item.dashboardSlug ?? 'Dashboard',
+                contentType: ContentType.DASHBOARD,
+                uuid: item.dashboardUuid,
+                slug: item.dashboardSlug,
+                group,
+            };
+        }
+        // Threads are reference-only context — not mentionable content.
+        return [];
+    });
 
 const summaryContentToSuggestion = (
     item: SummaryContent,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -1,4 +1,4 @@
-import { type AiPromptContextItem } from '@lightdash/common';
+import { assertUnreachable, type AiPromptContextItem } from '@lightdash/common';
 
 export type ContentReferenceSegment =
     | {
@@ -12,24 +12,50 @@ export type ContentReferenceSegment =
           label: string;
       };
 
-const getPromptContextItemKey = (item: AiPromptContextItem) =>
-    item.type === 'chart'
-        ? `chart:${item.chartUuid}`
-        : `dashboard:${item.dashboardUuid}`;
+export const getPromptContextItemKey = (item: AiPromptContextItem) => {
+    switch (item.type) {
+        case 'chart':
+            return `chart:${item.chartUuid}`;
+        case 'dashboard':
+            return `dashboard:${item.dashboardUuid}`;
+        case 'thread':
+            return `thread:${item.threadUuid}`;
+        default:
+            return assertUnreachable(item, 'Unknown AiPromptContextItem type');
+    }
+};
 
 const getPromptContextItemLabel = (item: AiPromptContextItem) => {
     if (item.displayName) return item.displayName;
-    if (item.type === 'chart') return item.chartSlug ?? 'Chart';
-    return item.dashboardSlug ?? 'Dashboard';
+    switch (item.type) {
+        case 'chart':
+            return item.chartSlug ?? 'Chart';
+        case 'dashboard':
+            return item.dashboardSlug ?? 'Dashboard';
+        case 'thread':
+            return 'Conversation';
+        default:
+            return assertUnreachable(item, 'Unknown AiPromptContextItem type');
+    }
 };
 
 export const getPromptContextItemHref = (
     item: AiPromptContextItem,
     projectUuid: string,
-) =>
-    item.type === 'chart'
-        ? `/projects/${projectUuid}/saved/${item.chartUuid}`
-        : `/projects/${projectUuid}/dashboards/${item.dashboardUuid}`;
+): string | null => {
+    switch (item.type) {
+        case 'chart':
+            return `/projects/${projectUuid}/saved/${item.chartUuid}`;
+        case 'dashboard':
+            return `/projects/${projectUuid}/dashboards/${item.dashboardUuid}`;
+        // A pinned thread can live in another project, so there is no
+        // reliable in-project URL to offer.
+        case 'thread':
+            return null;
+        default:
+            return assertUnreachable(item, 'Unknown AiPromptContextItem type');
+    }
+};
 
 export const buildContentReferenceSegments = (
     message: string,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -37,6 +37,7 @@ import {
     mergeAiPromptContextInput,
     mergeAiPromptContextItems,
 } from '../ChatElements/contentMentions';
+import { getPromptContextItemKey } from '../ChatElements/contentReferenceUtils';
 import { PinnedContextCard } from '../PinnedContextCard/PinnedContextCard';
 import styles from './AiAgentsLauncher.module.css';
 import { PanelHeader } from './PanelHeader';
@@ -241,11 +242,7 @@ const NewThreadPanel: FC<{
                         <Group gap="xs" wrap="wrap">
                             {previewItems.map((item) => (
                                 <PinnedContextCard
-                                    key={`${item.type}-${
-                                        item.type === 'chart'
-                                            ? item.chartUuid
-                                            : item.dashboardUuid
-                                    }`}
+                                    key={getPromptContextItemKey(item)}
                                     item={item}
                                     projectUuid={projectUuid}
                                 />

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -8,9 +8,9 @@ type Props = {
 };
 
 type ItemMeta = {
-    kind: 'chart' | 'dashboard';
+    kind: 'chart' | 'dashboard' | 'thread';
     label: string;
-    href: string;
+    href: string | null;
 };
 
 const getItemMeta = (
@@ -30,6 +30,14 @@ const getItemMeta = (
                 label: item.displayName ?? 'Dashboard',
                 href: `/projects/${projectUuid}/dashboards/${item.dashboardUuid}`,
             };
+        // A pinned thread can live in another project, so there is no
+        // reliable in-project URL to offer.
+        case 'thread':
+            return {
+                kind: 'thread',
+                label: item.displayName ?? 'Conversation',
+                href: null,
+            };
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
@@ -41,8 +49,9 @@ export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
         <ContentReferenceLink
             kind={meta.kind}
             rel="noreferrer"
-            to={meta.href}
-            target="_blank"
+            to={meta.href ?? undefined}
+            target={meta.href ? '_blank' : undefined}
+            showArrow={meta.href !== null}
         >
             {meta.label}
         </ContentReferenceLink>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -28,6 +28,7 @@ import type {
     ApiSuccessEmpty,
     ApiUpdateAiAgent,
 } from '@lightdash/common';
+import { assertUnreachable } from '@lightdash/common';
 import { nanoid } from '@reduxjs/toolkit';
 import {
     useInfiniteQuery,
@@ -528,23 +529,40 @@ export const useAiAgentThread = (
  */
 const toOptimisticContextItem = (
     item: AiPromptContextItemInput,
-): AiPromptContextItem =>
-    item.type === 'chart'
-        ? {
-              type: 'chart',
-              chartUuid: item.chartUuid,
-              chartSlug: item.chartSlug ?? null,
-              displayName: null,
-              pinnedVersionUuid: null,
-              chartKind: null,
-              runtimeOverrides: item.runtimeOverrides ?? null,
-          }
-        : {
-              ...item,
-              dashboardSlug: item.dashboardSlug ?? null,
-              displayName: null,
-              pinnedVersionUuid: null,
-          };
+): AiPromptContextItem => {
+    switch (item.type) {
+        case 'chart':
+            return {
+                type: 'chart',
+                chartUuid: item.chartUuid,
+                chartSlug: item.chartSlug ?? null,
+                displayName: null,
+                pinnedVersionUuid: null,
+                chartKind: null,
+                runtimeOverrides: item.runtimeOverrides ?? null,
+            };
+        case 'dashboard':
+            return {
+                type: 'dashboard',
+                dashboardUuid: item.dashboardUuid,
+                dashboardSlug: item.dashboardSlug ?? null,
+                displayName: null,
+                pinnedVersionUuid: null,
+            };
+        case 'thread':
+            return {
+                type: 'thread',
+                threadUuid: item.threadUuid,
+                promptUuid: item.promptUuid ?? null,
+                displayName: null,
+            };
+        default:
+            return assertUnreachable(
+                item,
+                'Unknown AiPromptContextItemInput type',
+            );
+    }
+};
 
 const createOptimisticMessages = (
     threadUuid: string,

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -29,6 +29,7 @@ import {
     mergeAiPromptContextInput,
     mergeAiPromptContextItems,
 } from '../../features/aiCopilot/components/ChatElements/contentMentions';
+import { getPromptContextItemKey } from '../../features/aiCopilot/components/ChatElements/contentReferenceUtils';
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
 import { DefaultAgentButton } from '../../features/aiCopilot/components/DefaultAgentButton/DefaultAgentButton';
 import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
@@ -327,11 +328,7 @@ const AiAgentNewThreadPage: FC = () => {
                             <Group gap="xs" wrap="wrap">
                                 {previewItems.map((item) => (
                                     <PinnedContextCard
-                                        key={`${item.type}-${
-                                            item.type === 'chart'
-                                                ? item.chartUuid
-                                                : item.dashboardUuid
-                                        }`}
+                                        key={getPromptContextItemKey(item)}
                                         item={item}
                                         projectUuid={projectUuid}
                                     />


### PR DESCRIPTION
## What this does

Closes the gap between "a writeback PR opened a preview environment" and "an admin can actually verify the fix there". Builds on #24188 (promptless threads fetchable) and #24189 (server-side runs work).

### 1. Seeded verification run in the preview thread

When a remediation preview becomes ready, the pre-created work thread is now seeded with a **verification prompt** and the agent **re-runs it server-side before the admin opens the preview**:

- New EE scheduler task `aiAgentReviewRemediationRun` (mirrors the eval-run job) executes `generateAgentThreadResponse` with `autoApproveSql` on the preview agent.
- The prompt instructs the agent to re-run the user's original question end-to-end, compare with the pre-fix conversation, and state whether the issue is resolved.
- Fallbacks: if seeding fails, seed the flagged prompt's verbatim text; if there's no prompt text either, leave the thread empty (the existing Retry banner remains the manual path).

### 2. `thread` pinned-context type + `readPinnedThread` tool

The verification prompt references the original conversation via a new **pinned context type** (`{ type: 'thread', threadUuid, promptUuid }`) rather than copying it:

- The context note tells the agent the attached conversation **predates the fix** and must be re-verified — avoiding anchoring on stale answers/tool results (a verbatim replay would carry "that metric doesn't exist" claims into history).
- New agent tool `readPinnedThread` returns a bounded transcript. **Capability-scoped: only threads pinned as context on the current thread are readable** — the pin is the grant.
- Public API validation (`validatePromptContextAccess`): a thread can only be pinned by someone with access to that thread via its own agent (owner or agent-manager), org-scoped. Cross-project pinning is allowed precisely for the preview-env case.
- No DB migration needed — `ai_prompt_context.entity_type` is plain text.
- Frontend renders thread context chips (violet conversation icon, no link since the thread may live in another project); thread items are excluded from mention suggestions.

### 3. Preview environments for project_context PRs

Preview creation was gated to the sandbox (semantic-layer) writeback strategy. project_context PRs (deterministic GitHub-API merge) target the same repo, so the gate is removed — both strategies get a preview + seeded verification run.

## Who is affected

- Admin "Test fix" flow: lands on a thread that already contains the verification verdict instead of an empty chat.
- Any user can now pin a conversation as prompt context via the API (validated as above); the UI exposes no picker yet, so reach is effectively the remediation flow.
- Eval/share thread flows: untouched (clone behavior preserved exactly).

## Testing

Live end-to-end on local dev: created a failing source conversation, created the verification thread with the pinned source via the public API (validation exercised; inaccessible thread → 404), enqueued the run job — the agent called `readPinnedThread` first, re-ran discovery + query, and answered with a before/after comparison table concluding "The issue is resolved." Backend (157) and frontend aiCopilot (61) suites pass; tool contract snapshot updated.

Relates: (Linear ticket TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update (Jun 11):** Replaced the predecessor PR (#24188, now closed) with atomicity at the source. Thread + seeded prompt are now created in a single transaction (`createWebAppThreadWithPrompt`) — a failed seed rolls back the thread, so a promptless (unfetchable) thread can never exist. The fallback retries the whole creation with the flagged prompt's text; if both attempts fail, no preview thread is linked and the agent run is skipped (warn-logged, remediation continues without verification). This removes the need for #24188's nullable `firstMessage` API change, lateral-join query rewrite, and index migration.

**Who's affected:** only the review-remediation verification flow (this PR's own feature). The regular web-app thread creation path is unchanged; no public API types change.
