### PR TITLE
chore: add more verbose logs when data apps fail

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -77,6 +77,10 @@ import type { SpacePermissionService } from '../../../services/SpaceService/Spac
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { getModel } from '../ai/models';
 import {
+    classifyClaudeCliFailure,
+    ClaudeGenerationError,
+} from './claudeCliFailure';
+import {
     buildClaudeCodeEnv,
     claudeCodeAllowedHosts,
     describeClaudeCodeEnv,
@@ -1521,18 +1525,49 @@ export class AppGenerateService extends BaseService {
                 return { durationMs, responseText, toolCallCount };
             }
 
-            this.logger.debug(
-                `App ${appUuid}: Claude stderr (tail): ${AppGenerateService.truncateEnd(result.stderr, 4000)}`,
+            const stderrTail = AppGenerateService.truncateEnd(
+                result.stderr,
+                4000,
             );
-            this.logger.debug(
-                `App ${appUuid}: Claude stdout (tail): ${AppGenerateService.truncateEnd(result.stdout, 4000)}`,
+            const stdoutTail = AppGenerateService.truncateEnd(
+                result.stdout,
+                4000,
             );
 
             if (attempt >= AppGenerateService.MAX_GENERATION_ATTEMPTS) {
-                throw new Error(
-                    `Claude generation failed (exit ${result.exitCode}): ${result.stderr}`,
+                // On final failure, promote stderr+stdout to info so the
+                // upstream API error (often emitted to stdout in
+                // stream-json mode) is captured in production logs.
+                const classification = classifyClaudeCliFailure(
+                    result.stderr,
+                    result.stdout,
                 );
+                this.logger.info(
+                    `App ${appUuid}: Claude failure (category=${classification.category}, exit=${result.exitCode})`,
+                );
+                this.logger.info(
+                    `App ${appUuid}: Claude stderr (tail): ${stderrTail}`,
+                );
+                this.logger.info(
+                    `App ${appUuid}: Claude stdout (tail): ${stdoutTail}`,
+                );
+                const message = `Claude generation failed (exit ${result.exitCode}): ${result.stderr}`;
+                if (classification.category === 'unknown') {
+                    throw new Error(message);
+                }
+                throw new ClaudeGenerationError({
+                    message,
+                    userMessage: classification.userMessage,
+                    category: classification.category,
+                });
             }
+
+            this.logger.debug(
+                `App ${appUuid}: Claude stderr (tail): ${stderrTail}`,
+            );
+            this.logger.debug(
+                `App ${appUuid}: Claude stdout (tail): ${stdoutTail}`,
+            );
 
             this.logger.warn(
                 `App ${appUuid}: Claude generation failed (exit ${result.exitCode}), retrying (attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
@@ -2372,14 +2407,21 @@ export class AppGenerateService extends BaseService {
                 this.logger.error(
                     `App ${appUuid}: generation failed after ${totalMs}ms: ${getErrorMessage(error)}`,
                 );
-                // In Bedrock mode a generation failure is often the model not
-                // being enabled in the configured region (the call fails before
-                // any tool use) — point operators at that instead of the generic
-                // "try rephrasing".
-                const userMessage =
-                    claudeCodeEnv.CLAUDE_CODE_USE_BEDROCK === '1'
-                        ? 'Failed to generate the app. If this keeps happening, check that the selected model is enabled in your AWS Bedrock region (see server logs).'
-                        : 'Failed to generate app code. Try rephrasing your request.';
+                // Prefer a classified upstream-API message (quota /
+                // rate-limit / auth / overloaded). Otherwise fall back to
+                // the existing branches: Bedrock failures are often the
+                // model not being enabled in the configured region — point
+                // operators at that instead of the generic "try rephrasing".
+                let userMessage: string;
+                if (error instanceof ClaudeGenerationError) {
+                    userMessage = error.userMessage;
+                } else if (claudeCodeEnv.CLAUDE_CODE_USE_BEDROCK === '1') {
+                    userMessage =
+                        'Failed to generate the app. If this keeps happening, check that the selected model is enabled in your AWS Bedrock region (see server logs).';
+                } else {
+                    userMessage =
+                        'Failed to generate app code. Try rephrasing your request.';
+                }
                 const marked = await this.markError(
                     appUuid,
                     version,

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCliFailure.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCliFailure.test.ts
@@ -1,0 +1,82 @@
+import { classifyClaudeCliFailure } from './claudeCliFailure';
+
+describe('classifyClaudeCliFailure', () => {
+    test('classifies Anthropic credit-balance error from stdout', () => {
+        const stdout = JSON.stringify({
+            type: 'result',
+            subtype: 'error',
+            error: 'Your credit balance is too low to access the Claude API. Please go to Plans & Billing to upgrade or purchase credits.',
+        });
+        const result = classifyClaudeCliFailure('', stdout);
+        expect(result.category).toBe('quota');
+        if (result.category !== 'unknown') {
+            expect(result.userMessage).toMatch(/out of credits/i);
+        }
+    });
+
+    test('classifies insufficient_quota error from stderr', () => {
+        const result = classifyClaudeCliFailure(
+            'API Error 400: insufficient_quota',
+            '',
+        );
+        expect(result.category).toBe('quota');
+    });
+
+    test('classifies Anthropic rate_limit_error', () => {
+        const result = classifyClaudeCliFailure(
+            '',
+            '{"error":{"type":"rate_limit_error","message":"Number of request tokens has exceeded your per-minute rate limit"}}',
+        );
+        expect(result.category).toBe('rate_limit');
+    });
+
+    test('classifies Bedrock ThrottlingException as rate_limit', () => {
+        const result = classifyClaudeCliFailure(
+            'ThrottlingException: Too many requests',
+            '',
+        );
+        expect(result.category).toBe('rate_limit');
+    });
+
+    test('classifies Anthropic invalid_api_key as auth', () => {
+        const result = classifyClaudeCliFailure(
+            '',
+            '{"error":{"type":"authentication_error","message":"invalid_api_key: x-api-key header"}}',
+        );
+        expect(result.category).toBe('auth');
+    });
+
+    test('classifies Bedrock AccessDeniedException as auth', () => {
+        const result = classifyClaudeCliFailure(
+            'AccessDeniedException: not authorized to invoke this model',
+            '',
+        );
+        expect(result.category).toBe('auth');
+    });
+
+    test('classifies Anthropic overloaded_error', () => {
+        const result = classifyClaudeCliFailure(
+            '',
+            '{"error":{"type":"overloaded_error","message":"Overloaded"}}',
+        );
+        expect(result.category).toBe('overloaded');
+    });
+
+    test('returns unknown for empty output', () => {
+        const result = classifyClaudeCliFailure('', '');
+        expect(result).toEqual({ category: 'unknown' });
+    });
+
+    test('returns unknown for a generic crash with no matching signature', () => {
+        const result = classifyClaudeCliFailure(
+            'Error: ENOENT: no such file or directory',
+            '',
+        );
+        expect(result).toEqual({ category: 'unknown' });
+    });
+
+    test('is case-insensitive', () => {
+        const result = classifyClaudeCliFailure('CREDIT BALANCE TOO LOW', '');
+        expect(result.category).toBe('quota');
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCliFailure.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCliFailure.ts
@@ -1,0 +1,86 @@
+export type ClaudeCliFailureCategory =
+    | 'quota'
+    | 'rate_limit'
+    | 'auth'
+    | 'overloaded'
+    | 'unknown';
+
+export type ClaudeCliFailureClassification =
+    | {
+          category: Exclude<ClaudeCliFailureCategory, 'unknown'>;
+          userMessage: string;
+      }
+    | { category: 'unknown' };
+
+/**
+ * Classifies a Claude CLI non-zero exit by scanning its stdout + stderr
+ * for known upstream-API error signatures. The CLI emits its `result`
+ * event (including failure messages) to stdout in stream-json mode, so
+ * stderr alone is often empty — both streams must be searched.
+ */
+export function classifyClaudeCliFailure(
+    stderr: string,
+    stdout: string,
+): ClaudeCliFailureClassification {
+    const haystack = `${stderr}\n${stdout}`.toLowerCase();
+
+    if (/credit balance|insufficient_quota/.test(haystack)) {
+        return {
+            category: 'quota',
+            userMessage:
+                "Couldn't generate the app — the AI provider account is out of credits.",
+        };
+    }
+    if (/rate.?limit|throttlingexception/.test(haystack)) {
+        return {
+            category: 'rate_limit',
+            userMessage:
+                "Couldn't generate the app — the AI provider is rate-limiting requests. Try again in a few minutes.",
+        };
+    }
+    if (
+        /invalid_api_key|authentication_error|accessdeniedexception/.test(
+            haystack,
+        )
+    ) {
+        return {
+            category: 'auth',
+            userMessage:
+                "Couldn't generate the app — the AI provider rejected the API credentials.",
+        };
+    }
+    if (/overloaded_error|serviceunavailableexception/.test(haystack)) {
+        return {
+            category: 'overloaded',
+            userMessage:
+                'The AI provider is temporarily overloaded. Try again in a few minutes.',
+        };
+    }
+
+    return { category: 'unknown' };
+}
+
+/**
+ * Thrown by the generation step when retries are exhausted AND the
+ * failure was classified as a known upstream-API condition. Carries a
+ * user-facing message so the outer pipeline can surface a meaningful
+ * explanation instead of the generic "Try rephrasing" fallback. Unknown
+ * failures throw a plain Error so the caller's default branch handles
+ * them.
+ */
+export class ClaudeGenerationError extends Error {
+    readonly userMessage: string;
+
+    readonly category: Exclude<ClaudeCliFailureCategory, 'unknown'>;
+
+    constructor(opts: {
+        message: string;
+        userMessage: string;
+        category: Exclude<ClaudeCliFailureCategory, 'unknown'>;
+    }) {
+        super(opts.message);
+        this.name = 'ClaudeGenerationError';
+        this.userMessage = opts.userMessage;
+        this.category = opts.category;
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

- When a data-app generation failed because of an upstream API
    condition (out of credits, rate limit, bad credentials,
    provider overloaded), the user only ever saw "Failed to generate
    app code. Try rephrasing your request." — and the root-cause API
    error wasn't recoverable from production logs because the
    Claude CLI's stderr+stdout tails were logged at `debug` level.
  - A recent customer incident was hard to diagnose for
    exactly this reason: the CLI exited within 1–15s with
    toolCalls=0 and empty stderr (the upstream error landed in
    stdout via stream-json), and the user-facing "rephrase" message
    pointed them away from the real issue (an exhausted Anthropic
    account).
  - Now classifies the failure by scanning both stderr and stdout
    for known signatures and surfaces a meaningful user message:
    - `quota` ("credit balance", "insufficient_quota")
    - `rate_limit` ("rate_limit_error", "ThrottlingException")
    - `auth` ("invalid_api_key", "authentication_error",
      "AccessDeniedException")
    - `overloaded` ("overloaded_error",
      "ServiceUnavailableException")
  - On final failure (after retries exhausted), promotes
    stderr+stdout tails and the classified category from `debug` to
    `info` so the root cause is visible in production logs without
    enabling debug capture per-namespace.
  - Retries are unchanged — classified failures still go through
    the existing 3-attempt loop. Faster short-circuit for
    known-unrecoverable categories was considered and deferred
    (less code, longer wait on a doomed retry, but simpler).

