### PR TITLE
fix(ai): reject mismatched repos for writeback previews

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.test.ts
@@ -42,6 +42,7 @@ const githubProject = (): AnyType => ({
     projectUuid: PROJECT,
     dbtConnection: {
         type: DbtProjectType.GITHUB,
+        repository: 'acme/analytics',
     },
 });
 
@@ -51,6 +52,7 @@ const makeGithubClient = (): jest.Mocked<WritebackPreviewGithubClient> =>
         getPullRequest: jest.fn().mockResolvedValue({
             state: 'open',
             headRef: 'feature/writeback',
+            headRepoFullName: 'acme/analytics',
         }),
         createPullRequestComment: jest.fn().mockResolvedValue(undefined),
     }) as AnyType;
@@ -140,5 +142,53 @@ describe('WritebackPreviewService.createPreviewForPullRequest', () => {
             }),
             expect.anything(),
         );
+    });
+
+    it('returns null when the PR URL repo does not match the project repo', async () => {
+        const githubClient = makeGithubClient();
+        const projectService = {
+            createPreview: jest.fn(),
+        };
+        const service = buildService({
+            githubClient,
+            projectService: projectService as AnyType,
+        });
+
+        const result = await service.createPreviewForPullRequest({
+            user: userWithSourceCodeAccess(true),
+            projectUuid: PROJECT,
+            prUrl: 'https://github.com/acme/other-repo/pull/42',
+        });
+
+        expect(result).toBeNull();
+        expect(githubClient.getPullRequest).not.toHaveBeenCalled();
+        expect(githubClient.createPullRequestComment).not.toHaveBeenCalled();
+        expect(projectService.createPreview).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the PR branch comes from a fork', async () => {
+        const githubClient = makeGithubClient();
+        githubClient.getPullRequest.mockResolvedValue({
+            state: 'open',
+            headRef: 'feature/writeback',
+            headRepoFullName: 'fork/analytics',
+        });
+        const projectService = {
+            createPreview: jest.fn(),
+        };
+        const service = buildService({
+            githubClient,
+            projectService: projectService as AnyType,
+        });
+
+        const result = await service.createPreviewForPullRequest({
+            user: userWithSourceCodeAccess(true),
+            projectUuid: PROJECT,
+            prUrl: PR_URL,
+        });
+
+        expect(result).toBeNull();
+        expect(githubClient.createPullRequestComment).not.toHaveBeenCalled();
+        expect(projectService.createPreview).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.test.ts
@@ -15,6 +15,16 @@ const ORG = 'org-1';
 const PROJECT = 'project-1';
 const PR_URL = 'https://github.com/acme/analytics/pull/42';
 
+const openPullRequest = () => ({
+    state: 'open' as const,
+    merged: false,
+    headRef: 'feature/writeback',
+    headRepoFullName: 'acme/analytics',
+    mergeable: true,
+    mergeableState: 'clean',
+    draft: false,
+});
+
 const userWithSourceCodeAccess = (canViewSourceCode: boolean): SessionUser => {
     const { build, can } = new AbilityBuilder<MemberAbility>(Ability);
     if (canViewSourceCode) {
@@ -49,11 +59,7 @@ const githubProject = (): AnyType => ({
 const makeGithubClient = (): jest.Mocked<WritebackPreviewGithubClient> =>
     ({
         getInstallationToken: jest.fn().mockResolvedValue('installation-token'),
-        getPullRequest: jest.fn().mockResolvedValue({
-            state: 'open',
-            headRef: 'feature/writeback',
-            headRepoFullName: 'acme/analytics',
-        }),
+        getPullRequest: jest.fn().mockResolvedValue(openPullRequest()),
         createPullRequestComment: jest.fn().mockResolvedValue(undefined),
     }) as AnyType;
 
@@ -169,8 +175,7 @@ describe('WritebackPreviewService.createPreviewForPullRequest', () => {
     it('returns null when the PR branch comes from a fork', async () => {
         const githubClient = makeGithubClient();
         githubClient.getPullRequest.mockResolvedValue({
-            state: 'open',
-            headRef: 'feature/writeback',
+            ...openPullRequest(),
             headRepoFullName: 'fork/analytics',
         });
         const projectService = {

--- a/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.ts
@@ -45,6 +45,19 @@ const parseGithubPullRequestUrl = (
     return { owner: match[1], repo: match[2], pullNumber: Number(match[3]) };
 };
 
+const parseProjectRepository = (
+    repository: string | undefined,
+): { owner: string; repo: string } | null => {
+    if (!repository) {
+        return null;
+    }
+    const [owner, repo] = repository.split('/');
+    if (!owner || !repo) {
+        return null;
+    }
+    return { owner, repo };
+};
+
 /**
  * Creates Lightdash preview projects for writeback PRs server-side, instead of
  * relying on the customer repo's CI to deploy one and post its URL as a PR
@@ -121,6 +134,22 @@ export class WritebackPreviewService extends BaseService {
             if (project.dbtConnection.type !== DbtProjectType.GITHUB) {
                 return null;
             }
+            const configuredRepo = parseProjectRepository(
+                project.dbtConnection.repository,
+            );
+            const expectedRepo = configuredRepo
+                ? `${configuredRepo.owner}/${configuredRepo.repo}`.toLowerCase()
+                : null;
+            if (
+                !configuredRepo ||
+                expectedRepo !==
+                    `${parsed.owner}/${parsed.repo}`.toLowerCase()
+            ) {
+                this.logger.warn(
+                    `Refusing to create writeback preview for ${prUrl}: it does not match project ${projectUuid}'s configured repository`,
+                );
+                return null;
+            }
             if (!user.organizationUuid) {
                 return null;
             }
@@ -142,6 +171,18 @@ export class WritebackPreviewService extends BaseService {
                 token,
             });
             if (pullRequest.state !== 'open') {
+                return null;
+            }
+            if (
+                !pullRequest.headRepoFullName ||
+                pullRequest.headRepoFullName.toLowerCase() !== expectedRepo
+            ) {
+                this.logger.warn(
+                    `Refusing to create writeback preview for ${prUrl}: head branch is from ${
+                        pullRequest.headRepoFullName ??
+                        'an unknown repository'
+                    }, not ${expectedRepo}`,
+                );
                 return null;
             }
 

--- a/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.ts
@@ -142,8 +142,7 @@ export class WritebackPreviewService extends BaseService {
                 : null;
             if (
                 !configuredRepo ||
-                expectedRepo !==
-                    `${parsed.owner}/${parsed.repo}`.toLowerCase()
+                expectedRepo !== `${parsed.owner}/${parsed.repo}`.toLowerCase()
             ) {
                 this.logger.warn(
                     `Refusing to create writeback preview for ${prUrl}: it does not match project ${projectUuid}'s configured repository`,
@@ -179,8 +178,7 @@ export class WritebackPreviewService extends BaseService {
             ) {
                 this.logger.warn(
                     `Refusing to create writeback preview for ${prUrl}: head branch is from ${
-                        pullRequest.headRepoFullName ??
-                        'an unknown repository'
+                        pullRequest.headRepoFullName ?? 'an unknown repository'
                     }, not ${expectedRepo}`,
                 );
                 return null;


### PR DESCRIPTION
## Summary
- refuse writeback preview creation when the PR URL repo does not match the project's configured GitHub repo
- refuse writeback preview creation for fork-based PRs whose head branch does not live in the project repo
- cover both guards in `WritebackPreviewService` tests

## Testing
- not run: `pnpm -F backend test -- --runTestsByPath src/ee/services/AiWritebackService/WritebackPreviewService.test.ts` (`node_modules` missing in this worktree)