### PR TITLE
feat(ai): durable verification footer — resolve review item by preview thread, mark as done in-thread

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -1010,6 +1010,124 @@ export const getCommitDiff = async ({
     }
 };
 
+const PR_DIFF_MAX_FILES = 20;
+const PR_DIFF_MAX_FILE_BYTES = 200_000;
+
+export type PullRequestDiffFile = {
+    path: string;
+    status: string;
+    additions: number;
+    deletions: number;
+    before: string;
+    after: string;
+};
+
+// Structured per-file before/after contents — used for side-by-side diff
+// rendering, unlike getPullRequestDiff which returns the raw unified diff.
+export const getPullRequestDiffFiles = async ({
+    owner,
+    repo,
+    pullNumber,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    pullNumber: number;
+    installationId?: string;
+    token?: string;
+}): Promise<{
+    files: PullRequestDiffFile[];
+    totalAdditions: number;
+    totalDeletions: number;
+    truncated: boolean;
+}> => {
+    const { octokit, headers } = getOctokit(installationId, token);
+
+    try {
+        const pr = await octokit.rest.pulls.get({
+            owner,
+            repo,
+            pull_number: pullNumber,
+            headers,
+        });
+        const baseSha = pr.data.base.sha;
+        const headSha = pr.data.head.sha;
+
+        const filesResponse = await octokit.rest.pulls.listFiles({
+            owner,
+            repo,
+            pull_number: pullNumber,
+            per_page: 100,
+            headers,
+        });
+
+        const allFiles = filesResponse.data;
+        const includedFiles = allFiles.slice(0, PR_DIFF_MAX_FILES);
+
+        const fetchContents = async (
+            path: string,
+            ref: string,
+        ): Promise<string> => {
+            try {
+                const response = await octokit.rest.repos.getContent({
+                    owner,
+                    repo,
+                    path,
+                    ref,
+                    headers,
+                });
+                if (
+                    !Array.isArray(response.data) &&
+                    response.data.type === 'file' &&
+                    'content' in response.data
+                ) {
+                    const content = Buffer.from(
+                        response.data.content,
+                        'base64',
+                    ).toString('utf-8');
+                    return content.length > PR_DIFF_MAX_FILE_BYTES
+                        ? `${content.slice(0, PR_DIFF_MAX_FILE_BYTES)}\n… (truncated)`
+                        : content;
+                }
+                return '';
+            } catch {
+                // Missing on this ref (added/removed file) — empty side.
+                return '';
+            }
+        };
+
+        const files = await Promise.all(
+            includedFiles.map(async (file) => {
+                const isAdded = file.status === 'added';
+                const isRemoved = file.status === 'removed';
+                const beforePath = file.previous_filename ?? file.filename;
+                const [before, after] = await Promise.all([
+                    isAdded ? '' : fetchContents(beforePath, baseSha),
+                    isRemoved ? '' : fetchContents(file.filename, headSha),
+                ]);
+                return {
+                    path: file.filename,
+                    status: file.status,
+                    additions: file.additions,
+                    deletions: file.deletions,
+                    before,
+                    after,
+                };
+            }),
+        );
+
+        return {
+            files,
+            totalAdditions: allFiles.reduce((acc, f) => acc + f.additions, 0),
+            totalDeletions: allFiles.reduce((acc, f) => acc + f.deletions, 0),
+            truncated: allFiles.length > includedFiles.length,
+        };
+    } catch (e) {
+        throw new UnexpectedGitError(getErrorMessage(e));
+    }
+};
+
 export const createPullRequestComment = async ({
     owner,
     repo,

--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -3,6 +3,7 @@ import {
     AiAgentAdminSort,
     AiAgentReviewItemStatus,
     ApiAiAgentAdminConversationsResponse,
+    ApiAiAgentReviewItemPrDiffResponse,
     ApiAiAgentReviewItemResponse,
     ApiAiAgentReviewItemsResponse,
     ApiAiAgentReviewSignalsResponse,
@@ -183,6 +184,53 @@ export class AiAgentAdminController extends BaseController {
                 toSessionUser(req.account),
                 fingerprint,
             ),
+        };
+    }
+
+    /**
+     * Get the file diff of the pull request linked to a review item
+     * @summary Get AI agent review item PR diff
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/review-items/{fingerprint}/pr-diff')
+    @OperationId('getAiAgentReviewItemPrDiff')
+    async getReviewItemPrDiff(
+        @Request() req: express.Request,
+        @Path() fingerprint: string,
+    ): Promise<ApiAiAgentReviewItemPrDiffResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().getReviewItemPrDiff(
+                toSessionUser(req.account),
+                fingerprint,
+            ),
+        };
+    }
+
+    /**
+     * Get the review item linked to a remediation preview work thread
+     * @summary Get AI agent review item by preview thread
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/review-items/by-preview-thread/{threadUuid}')
+    @OperationId('getAiAgentReviewItemByPreviewThread')
+    async getReviewItemByPreviewThread(
+        @Request() req: express.Request,
+        @Path() threadUuid: string,
+    ): Promise<ApiAiAgentReviewItemResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentAdminService().getReviewItemByPreviewThread(
+                    toSessionUser(req.account),
+                    threadUuid,
+                ),
         };
     }
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1217,6 +1217,35 @@ export class AiAgentReviewClassifierModel {
         return row ? mapReviewRemediation(row) : null;
     }
 
+    async findReviewRemediationByPreviewThread(args: {
+        organizationUuid: string;
+        previewThreadUuid: string;
+    }): Promise<AiAgentReviewRemediation | null> {
+        const row = (await this.database<AiAgentReviewRemediationTable>(
+            `${AiAgentReviewRemediationTableName} as remediation`,
+        )
+            .leftJoin(
+                `${PullRequestsTableName} as pull_request`,
+                'pull_request.pull_request_uuid',
+                'remediation.pull_request_uuid',
+            )
+            .where('remediation.organization_uuid', args.organizationUuid)
+            .where('remediation.preview_thread_uuid', args.previewThreadUuid)
+            .orderBy('remediation.updated_at', 'desc')
+            .select<ReviewRemediationRow>(
+                'remediation.*',
+                {
+                    linked_pr_url: 'pull_request.pr_url',
+                },
+                this.database.raw(
+                    '(extract(epoch from (now() - remediation.updated_at)) * 1000)::float8 as updated_at_age_ms',
+                ),
+            )
+            .first()) as ReviewRemediationRow | undefined;
+
+        return row ? mapReviewRemediation(row) : null;
+    }
+
     async createReviewRemediation(
         args: CreateReviewRemediationArgs,
     ): Promise<AiAgentReviewRemediation> {

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -3,6 +3,7 @@ import {
     AiAgentAdminConversationsSummary,
     AiAgentAdminFilters,
     AiAgentAdminSort,
+    AiAgentReviewItemPrDiff,
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
     AiAgentReviewRemediationPreviewJobPayload,
@@ -38,6 +39,7 @@ import {
     getInstallationToken,
     getPullRequest,
     getPullRequestComments,
+    getPullRequestDiffFiles,
 } from '../../clients/github/Github';
 import { type LightdashConfig } from '../../config/parseConfig';
 import { isUniqueConstraintViolation } from '../../database/errors';
@@ -1507,6 +1509,77 @@ export class AiAgentAdminService extends BaseService {
         message: string;
     }): Promise<void> {
         await this.aiAgentReviewClassifierModel.failReviewItemWriteback(args);
+    }
+
+    async getReviewItemPrDiff(
+        user: SessionUser,
+        fingerprint: string,
+    ): Promise<AiAgentReviewItemPrDiff> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const reviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
+        if (!reviewItem?.linkedPrUrl) {
+            throw new NotFoundError(
+                'No pull request is linked to this review item',
+            );
+        }
+        const parsed = parsePullRequestUrl(reviewItem.linkedPrUrl);
+        if (!parsed) {
+            throw new NotFoundError(
+                'The linked pull request is not a GitHub pull request',
+            );
+        }
+
+        const installationId =
+            await this.githubAppInstallationsModel.getInstallationId(
+                organizationUuid,
+            );
+        const diff = await getPullRequestDiffFiles({
+            owner: parsed.owner,
+            repo: parsed.repo,
+            pullNumber: parsed.pullNumber,
+            installationId,
+        });
+
+        return {
+            prUrl: reviewItem.linkedPrUrl,
+            ...diff,
+        };
+    }
+
+    // Resolves the review item a preview work thread belongs to, so the
+    // thread page can show the verification context without relying on
+    // query params surviving navigation.
+    async getReviewItemByPreviewThread(
+        user: SessionUser,
+        previewThreadUuid: string,
+    ): Promise<AiAgentReviewItemSummary> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const remediation =
+            await this.aiAgentReviewClassifierModel.findReviewRemediationByPreviewThread(
+                {
+                    organizationUuid,
+                    previewThreadUuid,
+                },
+            );
+        if (!remediation) {
+            throw new NotFoundError('No review item is linked to this thread');
+        }
+
+        return this.getReviewItem(user, remediation.fingerprint);
     }
 
     async getReviewItem(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1953,6 +1953,19 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmbedWriteActions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                spaceUuid: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string' },
+                serviceAccountUserUuid: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CreateEmbedJwt: {
         dataType: 'refAlias',
         type: {
@@ -1973,6 +1986,7 @@ const models: TsoaRoute.Models = {
                     nestedProperties: {},
                     additionalProperties: { dataType: 'string' },
                 },
+                writeActions: { ref: 'EmbedWriteActions' },
                 content: {
                     dataType: 'union',
                     subSchemas: [
@@ -12460,11 +12474,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12522,11 +12536,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12563,11 +12577,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13870,11 +13884,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14116,11 +14130,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14135,11 +14149,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14154,11 +14168,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -19548,6 +19562,15 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'refAlias', ref: 'CiCheck' },
                     required: true,
                 },
+                state: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['open'] },
+                        { dataType: 'enum', enums: ['closed'] },
+                    ],
+                    required: true,
+                },
+                merged: { dataType: 'boolean', required: true },
                 mergeState: { ref: 'CiMergeState', required: true },
                 overall: { ref: 'CiCheckState', required: true },
                 provider: { ref: 'CiProviderType', required: true },
@@ -19570,6 +19593,112 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ClosePullRequestResult: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                state: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['open'] },
+                        { dataType: 'enum', enums: ['closed'] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiClosePullRequestResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ClosePullRequestResult', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ClosePullRequestRequestBody: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { prUrl: { dataType: 'string', required: true } },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiPullRequestDiffResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                diff: { dataType: 'string', required: true },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MergePullRequestResult: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                sha: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                merged: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiMergePullRequestResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'MergePullRequestResult', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MergePullRequestRequestBody: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                sha: { dataType: 'string' },
+                prUrl: { dataType: 'string', required: true },
             },
             validators: {},
         },
@@ -20745,6 +20874,61 @@ const models: TsoaRoute.Models = {
     ApiAiAgentReviewItemResponse: {
         dataType: 'refAlias',
         type: { ref: 'ApiSuccess_AiAgentReviewItemSummary_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemPrDiffFile: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                after: { dataType: 'string', required: true },
+                before: { dataType: 'string', required: true },
+                deletions: { dataType: 'double', required: true },
+                additions: { dataType: 'double', required: true },
+                status: { dataType: 'string', required: true },
+                path: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemPrDiff: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                truncated: { dataType: 'boolean', required: true },
+                totalDeletions: { dataType: 'double', required: true },
+                totalAdditions: { dataType: 'double', required: true },
+                files: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentReviewItemPrDiffFile',
+                    },
+                    required: true,
+                },
+                prUrl: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiAgentReviewItemPrDiff_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiAgentReviewItemPrDiff', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentReviewItemPrDiffResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiAgentReviewItemPrDiff_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UpdateAiAgentReviewItemStatus: {
@@ -28361,7 +28545,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28371,7 +28555,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28381,7 +28565,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28394,7 +28578,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -29049,7 +29233,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29059,7 +29243,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29069,7 +29253,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29082,7 +29266,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -50438,6 +50622,208 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiWritebackController_closeWritebackPullRequest: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ClosePullRequestRequestBody',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/ai-writeback/close-pull-request',
+        ...fetchMiddlewares<RequestHandler>(AiWritebackController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiWritebackController.prototype.closeWritebackPullRequest,
+        ),
+
+        async function AiWritebackController_closeWritebackPullRequest(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiWritebackController_closeWritebackPullRequest,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiWritebackController>(
+                        AiWritebackController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'closeWritebackPullRequest',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiWritebackController_getPullRequestDiff: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        prUrl: {
+            in: 'query',
+            name: 'prUrl',
+            required: true,
+            dataType: 'string',
+        },
+        commitSha: { in: 'query', name: 'commitSha', dataType: 'string' },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/ai-writeback/ci-diff',
+        ...fetchMiddlewares<RequestHandler>(AiWritebackController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiWritebackController.prototype.getPullRequestDiff,
+        ),
+
+        async function AiWritebackController_getPullRequestDiff(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiWritebackController_getPullRequestDiff,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiWritebackController>(
+                        AiWritebackController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getPullRequestDiff',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiWritebackController_mergeWritebackPullRequest: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'MergePullRequestRequestBody',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/ai-writeback/merge-pull-request',
+        ...fetchMiddlewares<RequestHandler>(AiWritebackController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiWritebackController.prototype.mergeWritebackPullRequest,
+        ),
+
+        async function AiWritebackController_mergeWritebackPullRequest(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiWritebackController_mergeWritebackPullRequest,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiWritebackController>(
+                        AiWritebackController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'mergeWritebackPullRequest',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsAiWritebackController_listProjectFiles: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -50766,6 +51152,128 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getReviewItem',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getReviewItemPrDiff: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        fingerprint: {
+            in: 'path',
+            name: 'fingerprint',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/review-items/:fingerprint/pr-diff',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getReviewItemPrDiff,
+        ),
+
+        async function AiAgentAdminController_getReviewItemPrDiff(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getReviewItemPrDiff,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getReviewItemPrDiff',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getReviewItemByPreviewThread: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/review-items/by-preview-thread/:threadUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getReviewItemByPreviewThread,
+        ),
+
+        async function AiAgentAdminController_getReviewItemByPreviewThread(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getReviewItemByPreviewThread,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getReviewItemByPreviewThread',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1994,6 +1994,21 @@
                     }
                 ]
             },
+            "EmbedWriteActions": {
+                "properties": {
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string"
+                    },
+                    "serviceAccountUserUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["spaceUuid"],
+                "type": "object"
+            },
             "CreateEmbedJwt": {
                 "properties": {
                     "exp": {
@@ -2024,6 +2039,9 @@
                             "type": "string"
                         },
                         "type": "object"
+                    },
+                    "writeActions": {
+                        "$ref": "#/components/schemas/EmbedWriteActions"
                     },
                     "content": {
                         "anyOf": [
@@ -14023,8 +14041,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14082,8 +14100,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14107,6 +14125,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -20036,6 +20067,15 @@
                         },
                         "type": "array"
                     },
+                    "state": {
+                        "type": "string",
+                        "enum": ["open", "closed"],
+                        "description": "Whether the PR is open or closed. A closed-but-not-merged PR is terminal\ntoo, so the card shows \"Closed\" and offers neither merge nor close."
+                    },
+                    "merged": {
+                        "type": "boolean",
+                        "description": "Whether the PR is already merged. Once merged the provider's\n`mergeState` is no longer meaningful, so consumers show a terminal\n\"Merged\" state and suppress the merge action."
+                    },
                     "mergeState": {
                         "$ref": "#/components/schemas/CiMergeState",
                         "description": "Whether the PR can actually be merged per the repo's policy — resolved\nfrom the provider, NOT inferred from `overall`. Drives the merge-\nreadiness verdict so a failing-but-not-required check doesn't read as\n\"blocked\"."
@@ -20048,7 +20088,14 @@
                         "$ref": "#/components/schemas/CiProviderType"
                     }
                 },
-                "required": ["checks", "mergeState", "overall", "provider"],
+                "required": [
+                    "checks",
+                    "state",
+                    "merged",
+                    "mergeState",
+                    "overall",
+                    "provider"
+                ],
                 "type": "object",
                 "description": "The CI checks for a pull request, plus a single rolled-up state for an\nat-a-glance summary. `checks` is empty when the ref has no CI configured."
             },
@@ -20071,6 +20118,108 @@
                 "required": ["results", "status"],
                 "type": "object",
                 "description": "CI checks for a PR, or null when CI status can't be resolved (project isn't\nconnected to a supported provider, no app installation, PR not found, etc.) —\ndistinct from a resolved result with an empty `checks` array (\"no CI runs\")."
+            },
+            "ClosePullRequestResult": {
+                "properties": {
+                    "state": {
+                        "type": "string",
+                        "enum": ["open", "closed"]
+                    }
+                },
+                "required": ["state"],
+                "type": "object",
+                "description": "Outcome of closing a pull request."
+            },
+            "ApiClosePullRequestResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ClosePullRequestResult"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ClosePullRequestRequestBody": {
+                "properties": {
+                    "prUrl": {
+                        "type": "string",
+                        "description": "The PR/MR URL of the write-back pull request to close."
+                    }
+                },
+                "required": ["prUrl"],
+                "type": "object",
+                "description": "Body for closing a write-back pull request from the chat PR card."
+            },
+            "ApiPullRequestDiffResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "diff": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["diff"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object",
+                "description": "The raw unified diff of a write-back pull request (or a single pinned commit\nwithin it), for the chat card's diff viewer. Null when it can't be resolved\n(unsupported source control, no app installation, PR not found, diff too\nlarge for the provider to return)."
+            },
+            "MergePullRequestResult": {
+                "properties": {
+                    "sha": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The resulting merge commit SHA, when the provider returns one."
+                    },
+                    "merged": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["sha", "merged"],
+                "type": "object",
+                "description": "Outcome of a pull request merge."
+            },
+            "ApiMergePullRequestResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/MergePullRequestResult"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "MergePullRequestRequestBody": {
+                "properties": {
+                    "sha": {
+                        "type": "string",
+                        "description": "The commit the card is pinned to. When set the merge only proceeds if the\nPR's head still points at this SHA, so a user never merges a commit they\nhaven't seen (a later turn may have pushed a newer head)."
+                    },
+                    "prUrl": {
+                        "type": "string",
+                        "description": "The PR/MR URL of the write-back pull request to merge."
+                    }
+                },
+                "required": ["prUrl"],
+                "type": "object",
+                "description": "Body for merging a write-back pull request from the chat PR card."
             },
             "ProjectFiles": {
                 "properties": {
@@ -21195,6 +21344,88 @@
             },
             "ApiAiAgentReviewItemResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewItemSummary_"
+            },
+            "AiAgentReviewItemPrDiffFile": {
+                "properties": {
+                    "after": {
+                        "type": "string"
+                    },
+                    "before": {
+                        "type": "string"
+                    },
+                    "deletions": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "additions": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "after",
+                    "before",
+                    "deletions",
+                    "additions",
+                    "status",
+                    "path"
+                ],
+                "type": "object"
+            },
+            "AiAgentReviewItemPrDiff": {
+                "properties": {
+                    "truncated": {
+                        "type": "boolean"
+                    },
+                    "totalDeletions": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "totalAdditions": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "files": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentReviewItemPrDiffFile"
+                        },
+                        "type": "array"
+                    },
+                    "prUrl": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "truncated",
+                    "totalDeletions",
+                    "totalAdditions",
+                    "files",
+                    "prUrl"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiAgentReviewItemPrDiff_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemPrDiff"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentReviewItemPrDiffResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewItemPrDiff_"
             },
             "UpdateAiAgentReviewItemStatus": {
                 "properties": {
@@ -29138,22 +29369,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -29713,22 +29944,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -38676,7 +38907,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3143.1",
+        "version": "0.3144.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -45524,6 +45755,86 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/aiAgents/admin/review-items/{fingerprint}/pr-diff": {
+            "get": {
+                "operationId": "getAiAgentReviewItemPrDiff",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemPrDiffResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the file diff of the pull request linked to a review item",
+                "summary": "Get AI agent review item PR diff",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "fingerprint",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/aiAgents/admin/review-items/by-preview-thread/{threadUuid}": {
+            "get": {
+                "operationId": "getAiAgentReviewItemByPreviewThread",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the review item linked to a remediation preview work thread",
+                "summary": "Get AI agent review item by preview thread",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "threadUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/aiAgents/admin/review-items/{fingerprint}/writeback": {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -656,6 +656,26 @@ export type AiAgentReviewItemWritebackPreview =
 export type ApiAiAgentReviewItemWritebackPreviewResponse =
     ApiSuccess<AiAgentReviewItemWritebackPreview>;
 
+export type AiAgentReviewItemPrDiffFile = {
+    path: string;
+    status: string;
+    additions: number;
+    deletions: number;
+    before: string;
+    after: string;
+};
+
+export type AiAgentReviewItemPrDiff = {
+    prUrl: string;
+    files: AiAgentReviewItemPrDiffFile[];
+    totalAdditions: number;
+    totalDeletions: number;
+    truncated: boolean;
+};
+
+export type ApiAiAgentReviewItemPrDiffResponse =
+    ApiSuccess<AiAgentReviewItemPrDiff>;
+
 export type AiAgentReviewSignalSummary = {
     uuid: string;
     runUuid: string;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -11,6 +11,7 @@ import type {
     ApiAiAgentEvaluationRunSummaryListResponse,
     ApiAiAgentEvaluationSummaryListResponse,
     ApiAiAgentProjectThreadSummaryListResponse,
+    ApiAiAgentReviewItemPrDiffResponse,
     ApiAiAgentReviewItemWritebackPreviewResponse,
     ApiAiAgentThreadCreateResponse,
     ApiAiAgentThreadGenerateTitleResponse,
@@ -1096,6 +1097,7 @@ type ApiResults =
     | Account
     | ApiAiAgentAdminConversationsResponse['results']
     | ApiAiAgentReviewItemWritebackPreviewResponse['results']
+    | ApiAiAgentReviewItemPrDiffResponse['results']
     | ApiAiAgentEvaluationSummaryListResponse['results']
     | ApiAiAgentEvaluationResponse['results']
     | ApiAiAgentEvaluationRunResponse['results']

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectContextDiffPreview.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectContextDiffPreview.tsx
@@ -2,30 +2,13 @@ import { Paper, Text, useComputedColorScheme } from '@mantine-8/core';
 import {
     MultiFileDiff,
     Virtualizer,
-    type WorkerInitializationRenderOptions,
     WorkerPoolContextProvider,
-    type WorkerPoolOptions,
 } from '@pierre/diffs/react';
-// Vite resolves this to the bundled worker URL.
-// oxlint-disable-next-line import/default
-import DiffsWorkerUrl from '@pierre/diffs/worker/worker.js?worker&url';
 import { type CSSProperties, type FC } from 'react';
-
-// Tokenize with both Pierre themes; the diff renders via CSS `light-dark()`. We
-// pin the host's `color-scheme` to Mantine's computed scheme below so the diff
-// follows the app's light/dark toggle rather than the OS preference.
-const HIGHLIGHTER_OPTIONS: WorkerInitializationRenderOptions = {
-    theme: { dark: 'pierre-dark', light: 'pierre-light' },
-    langs: ['yaml'],
-    preferredHighlighter: 'shiki-wasm',
-};
-
-const POOL_OPTIONS: WorkerPoolOptions = {
-    poolSize: 2,
-    workerFactory() {
-        return new Worker(DiffsWorkerUrl, { type: 'module' });
-    },
-};
+import {
+    PIERRE_HIGHLIGHTER_OPTIONS,
+    PIERRE_POOL_OPTIONS,
+} from './pierreDiffConfig';
 
 type ProjectContextDiffPreviewProps = {
     fileName: string;
@@ -57,8 +40,8 @@ export const ProjectContextDiffPreview: FC<ProjectContextDiffPreviewProps> = ({
 
     return (
         <WorkerPoolContextProvider
-            poolOptions={POOL_OPTIONS}
-            highlighterOptions={HIGHLIGHTER_OPTIONS}
+            poolOptions={PIERRE_POOL_OPTIONS}
+            highlighterOptions={PIERRE_HIGHLIGHTER_OPTIONS}
         >
             <Paper
                 withBorder

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -65,7 +65,7 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
         current.remediation?.previewProjectUuid &&
         current.remediation.previewAgentUuid &&
         current.remediation.previewThreadUuid
-            ? `/projects/${current.remediation.previewProjectUuid}/ai-agents/${current.remediation.previewAgentUuid}/threads/${current.remediation.previewThreadUuid}?reviewItem=${encodeURIComponent(current.fingerprint)}`
+            ? `/projects/${current.remediation.previewProjectUuid}/ai-agents/${current.remediation.previewAgentUuid}/threads/${current.remediation.previewThreadUuid}`
             : null;
     const remediationError =
         current.remediation?.status === 'failed'

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffModal.tsx
@@ -1,0 +1,114 @@
+import { type AiAgentReviewItemPrDiff } from '@lightdash/common';
+import {
+    Center,
+    Loader,
+    Paper,
+    Stack,
+    Text,
+    useComputedColorScheme,
+} from '@mantine-8/core';
+import {
+    MultiFileDiff,
+    Virtualizer,
+    WorkerPoolContextProvider,
+} from '@pierre/diffs/react';
+import { IconGitPullRequest } from '@tabler/icons-react';
+import { type CSSProperties, type FC } from 'react';
+import MantineModal from '../../../../../components/common/MantineModal';
+import {
+    PIERRE_HIGHLIGHTER_OPTIONS,
+    PIERRE_POOL_OPTIONS,
+} from './pierreDiffConfig';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    diff: AiAgentReviewItemPrDiff | undefined;
+    isLoading: boolean;
+};
+
+export const ReviewPrDiffModal: FC<Props> = ({
+    opened,
+    onClose,
+    diff,
+    isLoading,
+}) => {
+    const colorScheme = useComputedColorScheme('light');
+
+    // Pierre's <Virtualizer> IS the scroll viewport its virtualizer tracks —
+    // each file gets its own so off-screen rows render as you scroll.
+    const viewportStyle = {
+        maxHeight: '70vh',
+        overflow: 'auto',
+        colorScheme,
+        '--diffs-font-size': '11px',
+        '--diffs-line-height': '17px',
+    } as CSSProperties;
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Pull request changes"
+            icon={IconGitPullRequest}
+            size="80vw"
+        >
+            {isLoading || !diff ? (
+                <Center py="xl">
+                    <Loader size="md" color="gray" />
+                </Center>
+            ) : (
+                <WorkerPoolContextProvider
+                    poolOptions={PIERRE_POOL_OPTIONS}
+                    highlighterOptions={PIERRE_HIGHLIGHTER_OPTIONS}
+                >
+                    <Stack gap="md">
+                        {diff.truncated && (
+                            <Text fz="xs" c="dimmed">
+                                Showing the first {diff.files.length} changed
+                                files — open the PR for the full change set.
+                            </Text>
+                        )}
+                        {diff.files.map((file) => (
+                            <Paper
+                                key={file.path}
+                                withBorder
+                                radius="md"
+                                style={{ overflow: 'hidden' }}
+                            >
+                                <Virtualizer style={viewportStyle}>
+                                    <MultiFileDiff
+                                        oldFile={{
+                                            name: file.path,
+                                            contents: file.before,
+                                        }}
+                                        newFile={{
+                                            name: file.path,
+                                            contents: file.after,
+                                        }}
+                                        // color-scheme must sit on the diff host
+                                        // itself to override its `:host` default.
+                                        style={{ colorScheme }}
+                                        renderHeaderMetadata={() => (
+                                            <Text fz="xs" c="ldGray.6">
+                                                +{file.additions} −
+                                                {file.deletions}
+                                            </Text>
+                                        )}
+                                        options={{
+                                            diffStyle: 'split',
+                                            theme:
+                                                colorScheme === 'dark'
+                                                    ? 'pierre-dark'
+                                                    : 'pierre-light',
+                                        }}
+                                    />
+                                </Virtualizer>
+                            </Paper>
+                        ))}
+                    </Stack>
+                </WorkerPoolContextProvider>
+            )}
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.module.css
@@ -1,0 +1,65 @@
+.gutter {
+    width: 19.5rem;
+    flex-shrink: 0;
+    height: 100%;
+    overflow-y: auto;
+    padding: var(--mantine-spacing-md);
+}
+
+.card {
+    border-radius: var(--mantine-radius-lg);
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldGray-3));
+    box-shadow: var(--mantine-shadow-sm);
+    padding: var(--mantine-spacing-md);
+    background-image: linear-gradient(
+        160deg,
+        rgba(99, 102, 241, 0.04),
+        rgba(217, 70, 239, 0.02) 45%,
+        rgba(34, 197, 94, 0.04)
+    );
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-ldGray-0)
+    );
+}
+
+.cardResolved {
+    border-color: light-dark(
+        var(--mantine-color-green-3),
+        var(--mantine-color-green-9)
+    );
+    background-image: linear-gradient(
+        160deg,
+        rgba(34, 197, 94, 0.09),
+        rgba(16, 185, 129, 0.03) 60%,
+        rgba(99, 102, 241, 0.05)
+    );
+}
+
+.row {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    width: 100%;
+    padding: 6px var(--mantine-spacing-xs);
+    margin: 0 calc(var(--mantine-spacing-xs) * -1);
+    border-radius: var(--mantine-radius-sm);
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldGray-9)
+    );
+    text-decoration: none;
+}
+
+.row:hover {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-ldGray-2)
+    );
+}
+
+.rowLabel {
+    flex: 1;
+    min-width: 0;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
@@ -1,0 +1,238 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import {
+    Anchor,
+    Button,
+    Divider,
+    Group,
+    Loader,
+    Stack,
+    Text,
+    UnstyledButton,
+} from '@mantine-8/core';
+import {
+    IconArrowUpRight,
+    IconCircleCheck,
+    IconCircleCheckFilled,
+    IconFileDiff,
+    IconGitPullRequest,
+    IconMessages,
+    IconRefresh,
+} from '@tabler/icons-react';
+import { useState, type FC, type ReactNode } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiAgentReviewItemPrDiff } from '../../hooks/useAiAgentAdmin';
+import { ReviewPrDiffModal } from './ReviewPrDiffModal';
+import styles from './ReviewVerificationPanel.module.css';
+
+type Props = {
+    reviewItem: AiAgentReviewItemSummary;
+    canRetry: boolean;
+    isBusy: boolean;
+    isResolving: boolean;
+    onRetry: () => void;
+    onMarkDone: () => void;
+};
+
+const getPrNumber = (prUrl: string): string | null => {
+    const match = prUrl.match(/\/pull\/(\d+)/);
+    return match ? match[1] : null;
+};
+
+const Row: FC<{
+    icon: typeof IconFileDiff;
+    label: string;
+    trailing?: ReactNode;
+}> = ({ icon, label, trailing }) => (
+    <>
+        <MantineIcon icon={icon} size="md" color="ldGray.7" />
+        <Text fz="sm" fw={500} truncate className={styles.rowLabel}>
+            {label}
+        </Text>
+        {trailing}
+    </>
+);
+
+export const ReviewVerificationPanel: FC<Props> = ({
+    reviewItem,
+    canRetry,
+    isBusy,
+    isResolving,
+    onRetry,
+    onMarkDone,
+}) => {
+    const [diffOpened, setDiffOpened] = useState(false);
+    const remediation = reviewItem.remediation ?? null;
+    const linkedPrUrl = remediation?.linkedPrUrl ?? null;
+    const prNumber = linkedPrUrl ? getPrNumber(linkedPrUrl) : null;
+    const isResolved = reviewItem.status === 'resolved';
+    const sourceThreadUrl =
+        remediation &&
+        `/projects/${remediation.sourceProjectUuid}/ai-agents/${remediation.sourceAgentUuid}/threads/${remediation.sourceThreadUuid}`;
+
+    const { data: prDiff, isLoading: isLoadingPrDiff } =
+        useAiAgentReviewItemPrDiff(reviewItem.fingerprint, {
+            enabled: !!linkedPrUrl,
+        });
+
+    return (
+        <div className={styles.gutter}>
+            <Stack
+                gap="sm"
+                className={`${styles.card} ${
+                    isResolved ? styles.cardResolved : ''
+                }`}
+            >
+                {isResolved ? (
+                    <Group gap="xs" wrap="nowrap">
+                        <MantineIcon
+                            icon={IconCircleCheckFilled}
+                            color="green.7"
+                            size="lg"
+                        />
+                        <Text fz="sm" fw={600}>
+                            Verified
+                        </Text>
+                    </Group>
+                ) : (
+                    <Text fz="sm" fw={600} c="dimmed">
+                        Verification
+                    </Text>
+                )}
+
+                <Text fz="sm" fw={600} lineClamp={2}>
+                    {reviewItem.title}
+                </Text>
+
+                <Stack gap={2}>
+                    {linkedPrUrl && (
+                        <UnstyledButton
+                            className={styles.row}
+                            onClick={() => setDiffOpened(true)}
+                        >
+                            <Row
+                                icon={IconFileDiff}
+                                label="Changes"
+                                trailing={
+                                    isLoadingPrDiff ? (
+                                        <Loader size={12} color="gray" />
+                                    ) : prDiff ? (
+                                        <Text fz="sm" fw={600}>
+                                            <Text
+                                                span
+                                                fz="sm"
+                                                fw={600}
+                                                c="green.8"
+                                            >
+                                                +{prDiff.totalAdditions}
+                                            </Text>{' '}
+                                            <Text
+                                                span
+                                                fz="sm"
+                                                fw={600}
+                                                c="red.8"
+                                            >
+                                                −{prDiff.totalDeletions}
+                                            </Text>
+                                        </Text>
+                                    ) : undefined
+                                }
+                            />
+                        </UnstyledButton>
+                    )}
+
+                    {linkedPrUrl && (
+                        <Anchor
+                            className={styles.row}
+                            href={linkedPrUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            underline="never"
+                        >
+                            <Row
+                                icon={IconGitPullRequest}
+                                label={
+                                    prNumber
+                                        ? `Pull request #${prNumber}`
+                                        : 'Pull request'
+                                }
+                                trailing={
+                                    <MantineIcon
+                                        icon={IconArrowUpRight}
+                                        size="sm"
+                                        color="dimmed"
+                                    />
+                                }
+                            />
+                        </Anchor>
+                    )}
+
+                    {sourceThreadUrl && (
+                        <Anchor
+                            className={styles.row}
+                            component={Link}
+                            to={sourceThreadUrl}
+                            target="_blank"
+                            underline="never"
+                        >
+                            <Row
+                                icon={IconMessages}
+                                label="Where it was flagged"
+                                trailing={
+                                    <MantineIcon
+                                        icon={IconArrowUpRight}
+                                        size="sm"
+                                        color="dimmed"
+                                    />
+                                }
+                            />
+                        </Anchor>
+                    )}
+
+                    {!isResolved && canRetry && (
+                        <UnstyledButton
+                            className={styles.row}
+                            disabled={isBusy}
+                            onClick={onRetry}
+                        >
+                            <Row icon={IconRefresh} label="Retry question" />
+                        </UnstyledButton>
+                    )}
+                </Stack>
+
+                <Divider />
+
+                {isResolved ? (
+                    <Anchor
+                        component={Link}
+                        to="/generalSettings/ai/reviews"
+                        fz="sm"
+                        fw={500}
+                    >
+                        Back to reviews
+                    </Anchor>
+                ) : (
+                    <Button
+                        size="xs"
+                        color="green"
+                        fullWidth
+                        loading={isResolving}
+                        onClick={onMarkDone}
+                        leftSection={
+                            <MantineIcon icon={IconCircleCheck} size="sm" />
+                        }
+                    >
+                        Mark as done
+                    </Button>
+                )}
+            </Stack>
+
+            <ReviewPrDiffModal
+                opened={diffOpened}
+                onClose={() => setDiffOpened(false)}
+                diff={prDiff}
+                isLoading={isLoadingPrDiff}
+            />
+        </div>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/pierreDiffConfig.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/pierreDiffConfig.ts
@@ -1,0 +1,22 @@
+import {
+    type WorkerInitializationRenderOptions,
+    type WorkerPoolOptions,
+} from '@pierre/diffs/react';
+// Vite resolves this to the bundled worker URL.
+// oxlint-disable-next-line import/default
+import DiffsWorkerUrl from '@pierre/diffs/worker/worker.js?worker&url';
+
+// Tokenize with both Pierre themes; diffs render via CSS `light-dark()` and
+// hosts pin `color-scheme` to Mantine's computed scheme.
+export const PIERRE_HIGHLIGHTER_OPTIONS: WorkerInitializationRenderOptions = {
+    theme: { dark: 'pierre-dark', light: 'pierre-light' },
+    langs: ['yaml', 'sql', 'markdown', 'json'],
+    preferredHighlighter: 'shiki-wasm',
+};
+
+export const PIERRE_POOL_OPTIONS: WorkerPoolOptions = {
+    poolSize: 2,
+    workerFactory() {
+        return new Worker(DiffsWorkerUrl, { type: 'module' });
+    },
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -4,6 +4,7 @@ import {
     type AiAgentReviewItemSummary,
     type AiAgentReviewItemStatus,
     type ApiAiAgentAdminConversationsResponse,
+    type ApiAiAgentReviewItemPrDiffResponse,
     type ApiAiAgentReviewItemResponse,
     type ApiAiAgentReviewItemsResponse,
     type ApiAiAgentReviewItemWritebackPreviewResponse,
@@ -217,6 +218,63 @@ export const useAiAgentAdminReviewItem = (
     });
 };
 
+const getAiAgentReviewItemPrDiff = async (fingerprint: string) => {
+    return lightdashApi<ApiAiAgentReviewItemPrDiffResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items/${encodeURIComponent(
+            fingerprint,
+        )}/pr-diff`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useAiAgentReviewItemPrDiff = (
+    fingerprint: string,
+    options?: { enabled?: boolean },
+) => {
+    return useQuery<ApiAiAgentReviewItemPrDiffResponse['results'], ApiError>({
+        queryKey: ['ai-agent-admin-review-item-pr-diff', fingerprint],
+        queryFn: () => getAiAgentReviewItemPrDiff(fingerprint),
+        enabled: options?.enabled ?? true,
+        retry: false,
+        // Each fetch costs ~2 GitHub API calls per changed file — keep it warm.
+        staleTime: 5 * 60_000,
+    });
+};
+
+const getAiAgentReviewItemByPreviewThread = async (threadUuid: string) => {
+    return lightdashApi<ApiAiAgentReviewItemResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items/by-preview-thread/${encodeURIComponent(
+            threadUuid,
+        )}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+// Resolves the review item a preview work thread belongs to. Most threads
+// are not linked to one — a 404 means "regular thread", not an error.
+export const useAiAgentReviewItemByPreviewThread = (
+    threadUuid: string | undefined,
+    options?: { enabled?: boolean },
+) => {
+    return useQuery<ApiAiAgentReviewItemResponse['results'] | null, ApiError>({
+        queryKey: ['ai-agent-admin-review-item-by-preview-thread', threadUuid],
+        queryFn: async () => {
+            try {
+                return await getAiAgentReviewItemByPreviewThread(threadUuid!);
+            } catch (error) {
+                if ((error as ApiError).error?.statusCode === 404) return null;
+                throw error;
+            }
+        },
+        enabled: (options?.enabled ?? true) && !!threadUuid,
+        retry: false,
+    });
+};
+
 const getAiAgentReviewItemWritebackPreview = async (fingerprint: string) => {
     return lightdashApi<
         ApiAiAgentReviewItemWritebackPreviewResponse['results']
@@ -277,6 +335,9 @@ export const useUpdateAiAgentReviewItemStatus = () => {
             updateCachedReviewItemLists(queryClient, updatedItem);
             void queryClient.invalidateQueries({
                 queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
+            });
+            void queryClient.invalidateQueries({
+                queryKey: ['ai-agent-admin-review-item-by-preview-thread'],
             });
         },
         onError: ({ error }) => {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,21 +1,9 @@
-import {
-    Alert,
-    Button,
-    Center,
-    Group,
-    Loader,
-    Stack,
-    Text,
-} from '@mantine-8/core';
-import {
-    IconCircleCheck,
-    IconGitPullRequest,
-    IconRefresh,
-} from '@tabler/icons-react';
+import { subject } from '@casl/ability';
+import { Box, Center, Flex, Loader } from '@mantine-8/core';
 import { useCallback, useMemo } from 'react';
-import { useOutletContext, useParams, useSearchParams } from 'react-router';
-import MantineIcon from '../../../components/common/MantineIcon';
+import { useOutletContext, useParams } from 'react-router';
 import useApp from '../../../providers/App/useApp';
+import { ReviewVerificationPanel } from '../../features/aiCopilot/components/Admin/ReviewVerificationPanel';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import {
@@ -23,7 +11,7 @@ import {
     mergeContentMentionSuggestionItems,
 } from '../../features/aiCopilot/components/ChatElements/contentMentions';
 import {
-    useAiAgentAdminReviewItem,
+    useAiAgentReviewItemByPreviewThread,
     useUpdateAiAgentReviewItemStatus,
 } from '../../features/aiCopilot/hooks/useAiAgentAdmin';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
@@ -51,8 +39,6 @@ import { type AgentContext } from './AgentPage';
 
 const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const { agentUuid, threadUuid, projectUuid, promptUuid } = useParams();
-    const [searchParams] = useSearchParams();
-    const reviewFingerprint = searchParams.get('reviewItem');
     const { user } = useApp();
 
     const {
@@ -135,11 +121,16 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         threadUuid!,
         refetch,
     );
-    const { data: reviewItem } = useAiAgentAdminReviewItem(
-        reviewFingerprint ?? '',
-        {
-            enabled: !!reviewFingerprint,
-        },
+    const isOrgAdmin =
+        user.data?.ability.can(
+            'manage',
+            subject('Organization', {
+                organizationUuid: user.data?.organizationUuid,
+            }),
+        ) ?? false;
+    const { data: reviewItem } = useAiAgentReviewItemByPreviewThread(
+        threadUuid,
+        { enabled: isOrgAdmin },
     );
     const updateReviewItemStatus = useUpdateAiAgentReviewItemStatus();
 
@@ -245,15 +236,8 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
             toolHints,
         });
     };
-    const isBusy = isCreatingMessage || isStreaming || isPending;
-    const reviewRemediation = reviewItem?.remediation ?? null;
-    const reviewRemediationForThread =
-        reviewRemediation?.previewThreadUuid === threadUuid
-            ? reviewRemediation
-            : null;
-    const retryPrompt = reviewRemediationForThread?.retryPrompt ?? null;
-    const linkedPrUrl = reviewRemediationForThread?.linkedPrUrl ?? null;
-    const isReviewFixed = reviewItem?.status === 'resolved';
+    const isBusy = Boolean(isCreatingMessage || isStreaming || isPending);
+    const retryPrompt = reviewItem?.remediation?.retryPrompt ?? null;
     const handleRetryOriginalQuestion = () => {
         if (!retryPrompt) return;
         handleSubmit({
@@ -262,7 +246,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         });
     };
     const handleMarkFixed = () => {
-        if (!reviewItem || isReviewFixed) return;
+        if (!reviewItem || reviewItem.status === 'resolved') return;
         updateReviewItemStatus.mutate({
             fingerprint: reviewItem.fingerprint,
             body: {
@@ -281,115 +265,61 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     }
 
     return (
-        <AgentChatDisplay
-            thread={thread}
-            agentName={agentQuery.data?.name ?? 'AI'}
-            enableAutoScroll={true}
-            promptUuid={promptUuid}
-            debug={debug}
-            projectUuid={projectUuid}
-            agentUuid={agentUuid}
-            showAddToEvalsButton={canManage}
-            onDashboardLinkClick={handleDashboardLinkClick}
-        >
-            <Stack gap="xs">
-                {reviewItem && retryPrompt && (
-                    <Alert color="gray" variant="light" px="md" py="sm">
-                        <Group justify="space-between" align="center" gap="sm">
-                            <Stack gap={2}>
-                                <Text fz="sm" fw={600}>
-                                    {reviewItem.title}
-                                </Text>
-                                <Text fz="xs" c="dimmed">
-                                    Retry the original question in this preview,
-                                    then mark the review fixed when the answer
-                                    behaves as expected.
-                                </Text>
-                            </Stack>
-                            <Group gap="xs" wrap="nowrap">
-                                {linkedPrUrl && (
-                                    <Button
-                                        component="a"
-                                        href={linkedPrUrl}
-                                        target="_blank"
-                                        size="xs"
-                                        variant="subtle"
-                                        color="gray"
-                                        leftSection={
-                                            <MantineIcon
-                                                icon={IconGitPullRequest}
-                                                size="sm"
-                                            />
-                                        }
-                                    >
-                                        View PR
-                                    </Button>
-                                )}
-                                <Button
-                                    size="xs"
-                                    variant="default"
-                                    disabled={inputDisabled || isBusy}
-                                    onClick={handleRetryOriginalQuestion}
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconRefresh}
-                                            size="sm"
-                                        />
-                                    }
-                                >
-                                    Retry question
-                                </Button>
-                                <Button
-                                    size="xs"
-                                    color="green"
-                                    variant={isReviewFixed ? 'light' : 'filled'}
-                                    disabled={isReviewFixed}
-                                    loading={updateReviewItemStatus.isLoading}
-                                    onClick={handleMarkFixed}
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconCircleCheck}
-                                            size="sm"
-                                        />
-                                    }
-                                >
-                                    {isReviewFixed ? 'Fixed' : 'Mark fixed'}
-                                </Button>
-                            </Group>
-                        </Group>
-                    </Alert>
-                )}
-                <AgentChatInput
-                    disabled={inputDisabled}
-                    disabledReason={inputDisabledReason}
-                    loading={isBusy}
-                    onSubmit={handleSubmit}
-                    placeholder={`Ask ${agent.name} anything about your data...`}
-                    messageCount={thread.messages?.length || 0}
+        <Flex h="100%" gap={0} wrap="nowrap" align="stretch">
+            <Box flex={1} miw={0} h="100%">
+                <AgentChatDisplay
+                    thread={thread}
+                    agentName={agentQuery.data?.name ?? 'AI'}
+                    enableAutoScroll={true}
+                    promptUuid={promptUuid}
+                    debug={debug}
                     projectUuid={projectUuid}
                     agentUuid={agentUuid}
-                    threadUuid={threadUuid}
-                    contentMentionPriorityItems={contentMentionItems}
-                    latestAssistantMessageUuid={
-                        [...(thread.messages ?? [])]
-                            .reverse()
-                            .find((m) => m.role === 'assistant')?.uuid
-                    }
-                    sqlMode={sqlModeAvailable ? sqlMode : undefined}
-                    onSqlModeChange={
-                        sqlModeAvailable && threadUuid
-                            ? (enabled) =>
-                                  dispatch(
-                                      setThreadSqlMode({
-                                          threadUuid,
-                                          enabled,
-                                      }),
-                                  )
-                            : undefined
-                    }
+                    showAddToEvalsButton={canManage}
+                    onDashboardLinkClick={handleDashboardLinkClick}
+                >
+                    <AgentChatInput
+                        disabled={inputDisabled}
+                        disabledReason={inputDisabledReason}
+                        loading={isBusy}
+                        onSubmit={handleSubmit}
+                        placeholder={`Ask ${agent.name} anything about your data...`}
+                        messageCount={thread.messages?.length || 0}
+                        projectUuid={projectUuid}
+                        agentUuid={agentUuid}
+                        threadUuid={threadUuid}
+                        contentMentionPriorityItems={contentMentionItems}
+                        latestAssistantMessageUuid={
+                            [...(thread.messages ?? [])]
+                                .reverse()
+                                .find((m) => m.role === 'assistant')?.uuid
+                        }
+                        sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                        onSqlModeChange={
+                            sqlModeAvailable && threadUuid
+                                ? (enabled) =>
+                                      dispatch(
+                                          setThreadSqlMode({
+                                              threadUuid,
+                                              enabled,
+                                          }),
+                                      )
+                                : undefined
+                        }
+                    />
+                </AgentChatDisplay>
+            </Box>
+            {reviewItem && (
+                <ReviewVerificationPanel
+                    reviewItem={reviewItem}
+                    canRetry={!!retryPrompt && !inputDisabled}
+                    isBusy={isBusy}
+                    isResolving={updateReviewItemStatus.isLoading}
+                    onRetry={handleRetryOriginalQuestion}
+                    onMarkDone={handleMarkFixed}
                 />
-            </Stack>
-        </AgentChatDisplay>
+            )}
+        </Flex>
     );
 };
 


### PR DESCRIPTION
Closes: ZAP-479

## What this does

Makes the verification loop closeable from inside the preview work thread, with a codex-style context panel. Builds on #24190.

### Durable thread → review item resolution

The thread page previously discovered its review context from a `?reviewItem=<fingerprint>` query param, which died on refresh or in-app navigation. New admin endpoint `GET /aiAgents/admin/review-items/by-preview-thread/{threadUuid}` resolves the review item from the remediation's stored `preview_thread_uuid`, so the verification UI survives any navigation. Org-admin gated; the frontend only issues the lookup for org admins and treats 404 as "regular thread". The now-dead query param is removed from the Test fix link.

### Verification panel (codex-style right rail)

`ReviewVerificationPanel` renders beside the chat on remediation preview threads:

- Finding title under a "Verification" header, on a card with a subtle gradient wash (green-shifted once resolved).
- Icon rows: **Changes +N −N** (opens the diff modal), **Pull request #N** (external link), **Where it was flagged** (links to the source thread), **Retry question**.
- **Mark as done** resolves the review item via the existing status mutation (`resolvedByUserUuid` recorded); the panel flips to a "Verified" state with a Back-to-reviews link, and the admin table reflects it through existing cache updates.

### PR diff modal (@pierre/diffs)

New endpoint `GET …/review-items/{fingerprint}/pr-diff` fetches the linked PR's changed files with before/after contents from GitHub (base/head refs via the org installation token; capped at 20 files / 200KB per file). The modal renders split-view syntax-highlighted diffs per file using the same Pierre worker setup as the project-context preview — now extracted to a shared `pierreDiffConfig.ts`. The hook caches for 5 minutes since each fetch costs ~2 GitHub API calls per changed file.

## Who is affected

Org admins opening remediation preview threads. Non-admins and regular threads see no change (no lookup is issued / 404 → no panel). The old query-param flow is removed — `Test fix` links keep working since resolution is now by thread.

## Testing

Live on local dev against a real writeback PR: panel resolves by thread UUID (404 for unlinked threads), Changes row shows +31 −2 from the GitHub diff, modal renders 3 YAML file diffs split-view, Mark as done flips the finding to resolved in the table. Backend suites pass; frontend typecheck/lint clean.

Relates: (Linear ticket TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)