### PR TITLE
feat(ai-writeback): run writeback compile with project's dbt version

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -2,9 +2,12 @@ import { Ability, AbilityBuilder } from '@casl/ability';
 import {
     AnyType,
     DbtProjectType,
+    DbtVersionOptionLatest,
     FeatureFlags,
     ForbiddenError,
+    getLatestSupportDbtVersion,
     PullRequestProvider,
+    SupportedDbtVersions,
     WarehouseTypes,
     type MemberAbility,
     type SessionUser,
@@ -20,6 +23,7 @@ import {
 } from '../../../clients/github/Github';
 import { AiWritebackService } from './AiWritebackService';
 import {
+    COMPILE_WRAPPER_PATH,
     PR_DESCRIPTION_CLOSE,
     PR_DESCRIPTION_OPEN,
     PR_TITLE_CLOSE,
@@ -260,7 +264,9 @@ describe('AiWritebackService.prepareTurn', () => {
         } as AnyType;
     };
 
-    const githubProject = (): AnyType => ({
+    const githubProject = (
+        dbtVersion: AnyType = SupportedDbtVersions.V1_9,
+    ): AnyType => ({
         organizationUuid: ORG,
         name: 'Analytics',
         dbtConnection: {
@@ -271,6 +277,7 @@ describe('AiWritebackService.prepareTurn', () => {
             project_sub_path: '/',
         },
         warehouseConnection: { type: WarehouseTypes.POSTGRES },
+        dbtVersion,
     });
 
     const gitlabProject = (): AnyType => ({
@@ -345,6 +352,53 @@ describe('AiWritebackService.prepareTurn', () => {
             existingRow: null,
             isResume: false,
             warehouseType: WarehouseTypes.POSTGRES,
+            dbtVersion: SupportedDbtVersions.V1_9,
+        });
+    });
+
+    it('resolves the project `latest` dbt version to the newest supported version', async () => {
+        const service = buildService({
+            featureFlagModel: {
+                get: jest.fn().mockResolvedValue({ enabled: true }),
+            } as AnyType,
+            projectModel: {
+                get: jest
+                    .fn()
+                    .mockResolvedValue(
+                        githubProject(DbtVersionOptionLatest.LATEST),
+                    ),
+            } as AnyType,
+            aiWritebackThreadModel: {
+                findByAiThreadUuid: jest.fn().mockResolvedValue(null),
+            } as AnyType,
+        });
+        await expect(
+            prepareTurn(service, userWithOrg(true)),
+        ).resolves.toMatchObject({
+            dbtVersion: getLatestSupportDbtVersion(),
+        });
+    });
+
+    it('clamps a project pinned below the supported range to the oldest installed version', async () => {
+        const service = buildService({
+            featureFlagModel: {
+                get: jest.fn().mockResolvedValue({ enabled: true }),
+            } as AnyType,
+            projectModel: {
+                get: jest
+                    .fn()
+                    .mockResolvedValue(
+                        githubProject(SupportedDbtVersions.V1_5),
+                    ),
+            } as AnyType,
+            aiWritebackThreadModel: {
+                findByAiThreadUuid: jest.fn().mockResolvedValue(null),
+            } as AnyType,
+        });
+        await expect(
+            prepareTurn(service, userWithOrg(true)),
+        ).resolves.toMatchObject({
+            dbtVersion: SupportedDbtVersions.V1_8,
         });
     });
 
@@ -466,6 +520,7 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
                         project_sub_path: '/',
                     },
                     warehouseConnection: null,
+                    dbtVersion: SupportedDbtVersions.V1_9,
                 }),
             } as AnyType,
             githubAppInstallationsModel: {
@@ -531,6 +586,15 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
         expect(createPullRequest).toHaveBeenCalledTimes(1);
         expect(sandbox.kill).toHaveBeenCalledTimes(1);
         expect(sandbox.pause).not.toHaveBeenCalled();
+
+        // The compile wrapper pins `dbt` to the project's version venv (V1_9)
+        // and still strips secrets from the compile child's environment.
+        const wrapperWrite = (sandbox.files.write as jest.Mock).mock.calls.find(
+            ([path]) => path === COMPILE_WRAPPER_PATH,
+        );
+        expect(wrapperWrite).toBeDefined();
+        expect(wrapperWrite[1]).toContain('PATH="/usr/local/dbt1.9/bin:$PATH"');
+        expect(wrapperWrite[1]).toContain('-u ANTHROPIC_API_KEY');
     });
 
     it('skips the PR when the agent exits non-zero', async () => {

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -9,6 +9,7 @@ import {
     ParameterError,
     PullRequestProvider,
     PullRequestSource,
+    SupportedDbtVersions,
     WarehouseTypes,
     type AiWritebackRunResult,
     type AiWritebackStep,
@@ -78,6 +79,7 @@ import type {
 } from './types';
 import {
     classifyToolStep,
+    dbtSandboxVenvBin,
     extractPrMetadata,
     formatWritebackStep,
     interpretAgentEvent,
@@ -85,6 +87,7 @@ import {
     parsePullNumber,
     progressTextForStage,
     resolvePrMetadataValue,
+    resolveSandboxDbtVersion,
     resolveSandboxTemplateRef,
     splitStreamBuffer,
     summarizeToolInput,
@@ -607,6 +610,7 @@ export class AiWritebackService extends BaseService {
                 recordStep,
                 skillKey,
                 warehouseType: turn.warehouseType,
+                dbtVersion: turn.dbtVersion,
             });
 
             const {
@@ -801,6 +805,12 @@ export class AiWritebackService extends BaseService {
         // connection — the agent then gets `shared.md` only.
         const warehouseType = project.warehouseConnection?.type ?? null;
 
+        // Resolve to a concrete, sandbox-installed version here so downstream
+        // (the compile wrapper's PATH prefix) always maps to an installed venv:
+        // `latest` becomes the newest version and pins older than the supported
+        // range clamp up. Never re-resolved downstream.
+        const dbtVersion = resolveSandboxDbtVersion(project.dbtVersion);
+
         return {
             organizationUuid: user.organizationUuid,
             projectName: project.name,
@@ -809,6 +819,7 @@ export class AiWritebackService extends BaseService {
             existingRow,
             isResume: existingRow !== null,
             warehouseType,
+            dbtVersion,
         };
     }
 
@@ -1060,6 +1071,7 @@ export class AiWritebackService extends BaseService {
         recordStep,
         skillKey,
         warehouseType,
+        dbtVersion,
     }: {
         sandbox: Sandbox;
         systemPrompt: string;
@@ -1069,6 +1081,7 @@ export class AiWritebackService extends BaseService {
         recordStep: (step: AiWritebackStep) => void;
         skillKey: WarehouseSkillKey | null;
         warehouseType: WarehouseTypes | null;
+        dbtVersion: SupportedDbtVersions;
     }): Promise<{ stdout: string; exitCode: number }> {
         await sandbox.files.write(SYSTEM_PROMPT_PATH, systemPrompt);
         await sandbox.files.write(PROMPT_PATH, prompt);
@@ -1082,6 +1095,12 @@ export class AiWritebackService extends BaseService {
         const unsetFlags = COMPILE_STRIPPED_ENV_VARS.map(
             (name) => `-u ${name}`,
         ).join(' ');
+        // Prepend the project's dbt-version venv bin to PATH so the bare `dbt`
+        // the Lightdash CLI invokes resolves to the version the project is
+        // configured to use (the image installs every supported version in its
+        // own venv). `lightdash` still resolves via the inherited PATH. This is
+        // the only place `dbt` runs — the agent is allowlisted to this wrapper.
+        const dbtBin = dbtSandboxVenvBin(dbtVersion);
         // Time each compile and append `<elapsedMs> <exitCode>` to a log we read
         // after the run. We drop `exec` (one extra shell frame) so the timing
         // can be recorded after the child returns; secrets are still stripped via
@@ -1090,7 +1109,7 @@ export class AiWritebackService extends BaseService {
             COMPILE_WRAPPER_PATH,
             `#!/usr/bin/env bash\n` +
                 `__ld_start=$(date +%s%3N)\n` +
-                `env ${unsetFlags} lightdash compile "$@"\n` +
+                `env ${unsetFlags} PATH="${dbtBin}:$PATH" lightdash compile "$@"\n` +
                 `__ld_code=$?\n` +
                 `echo "$(( $(date +%s%3N) - __ld_start )) $__ld_code" >> ${COMPILE_TIMINGS_PATH}\n` +
                 `exit $__ld_code\n`,

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -1,6 +1,13 @@
 // Where the repo is cloned inside the sandbox, and where the agent runs.
 export const CWD = '/home/user/repo';
 
+// Each supported dbt version is installed in its own venv at
+// `${DBT_VENV_BIN_PREFIX}<X.Y>/bin` in the sandbox image (see
+// sandboxes/ai-writeback/e2b.Dockerfile). The compile wrapper prepends the
+// project's venv bin to PATH so the bare `dbt` the Lightdash CLI invokes
+// resolves to the project's configured version. See `dbtSandboxVenvBin`.
+export const DBT_VENV_BIN_PREFIX = '/usr/local/dbt';
+
 export const PROMPT_PATH = '/tmp/prompt.txt';
 export const SYSTEM_PROMPT_PATH = '/tmp/system_prompt.txt';
 

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -1,6 +1,7 @@
 import type {
     PullRequestProvider,
     SessionUser,
+    SupportedDbtVersions,
     WarehouseTypes,
 } from '@lightdash/common';
 import type { AiWritebackFailureStage } from '../../../analytics/LightdashAnalytics';
@@ -117,6 +118,13 @@ export type TurnContext = {
      * warehouse slicing. `null` when the project has no warehouse connection.
      */
     warehouseType: WarehouseTypes | null;
+    /**
+     * The project's configured dbt version, resolved to a concrete version
+     * (`latest` is resolved to the newest supported version here, never passed
+     * downstream). The compile wrapper prepends this version's venv bin to PATH
+     * so the agent compiles with the version the project actually uses.
+     */
+    dbtVersion: SupportedDbtVersions;
 };
 
 export type AppliedChanges = {

--- a/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
@@ -1,7 +1,10 @@
 import {
     DbtProjectType,
+    DbtVersionOptionLatest,
+    getLatestSupportDbtVersion,
     ParameterError,
     PullRequestProvider,
+    SupportedDbtVersions,
     type DbtGithubProjectConfig,
     type DbtGitlabProjectConfig,
     type DbtProjectConfig,
@@ -20,6 +23,7 @@ import {
     buildNoreplyEmail,
     buildUserCoAuthorTrailer,
     classifyToolStep,
+    dbtSandboxVenvBin,
     extractPrMetadata,
     formatWritebackStep,
     interpretAgentEvent,
@@ -31,6 +35,7 @@ import {
     parsePullRequestUrl,
     progressTextForStage,
     resolvePrMetadataValue,
+    resolveSandboxDbtVersion,
     resolveSandboxTemplateRef,
     splitStreamBuffer,
     summarizeToolInput,
@@ -606,5 +611,58 @@ describe('resolveSandboxTemplateRef', () => {
 
     it('omits the tag separator when the tag is empty', () => {
         expect(resolveSandboxTemplateRef({ name: 'tpl', tag: '' })).toBe('tpl');
+    });
+});
+
+describe('dbtSandboxVenvBin', () => {
+    it.each([
+        [SupportedDbtVersions.V1_4, '/usr/local/dbt1.4/bin'],
+        [SupportedDbtVersions.V1_5, '/usr/local/dbt1.5/bin'],
+        [SupportedDbtVersions.V1_6, '/usr/local/dbt1.6/bin'],
+        [SupportedDbtVersions.V1_7, '/usr/local/dbt1.7/bin'],
+        [SupportedDbtVersions.V1_8, '/usr/local/dbt1.8/bin'],
+        [SupportedDbtVersions.V1_9, '/usr/local/dbt1.9/bin'],
+        [SupportedDbtVersions.V1_10, '/usr/local/dbt1.10/bin'],
+        [SupportedDbtVersions.V1_11, '/usr/local/dbt1.11/bin'],
+    ])('maps %s to its venv bin dir', (version, expected) => {
+        expect(dbtSandboxVenvBin(version)).toBe(expected);
+    });
+
+    it('covers every supported dbt version', () => {
+        // Guards against a new SupportedDbtVersions member being added without a
+        // corresponding case above.
+        const covered = [
+            SupportedDbtVersions.V1_4,
+            SupportedDbtVersions.V1_5,
+            SupportedDbtVersions.V1_6,
+            SupportedDbtVersions.V1_7,
+            SupportedDbtVersions.V1_8,
+            SupportedDbtVersions.V1_9,
+            SupportedDbtVersions.V1_10,
+            SupportedDbtVersions.V1_11,
+        ];
+        expect(new Set(covered)).toEqual(
+            new Set(Object.values(SupportedDbtVersions)),
+        );
+    });
+});
+
+describe('resolveSandboxDbtVersion', () => {
+    it.each([
+        // Below the supported range → clamped up to the oldest installed (1.8).
+        [SupportedDbtVersions.V1_4, SupportedDbtVersions.V1_8],
+        [SupportedDbtVersions.V1_7, SupportedDbtVersions.V1_8],
+        // In range → returned unchanged.
+        [SupportedDbtVersions.V1_8, SupportedDbtVersions.V1_8],
+        [SupportedDbtVersions.V1_9, SupportedDbtVersions.V1_9],
+        [SupportedDbtVersions.V1_11, SupportedDbtVersions.V1_11],
+    ])('clamps %s to %s', (input, expected) => {
+        expect(resolveSandboxDbtVersion(input)).toBe(expected);
+    });
+
+    it('resolves `latest` to the newest supported version', () => {
+        expect(resolveSandboxDbtVersion(DbtVersionOptionLatest.LATEST)).toBe(
+            getLatestSupportDbtVersion(),
+        );
     });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -3,12 +3,16 @@ import {
     DbtProjectType,
     ParameterError,
     PullRequestProvider,
+    resolveDbtVersion,
+    SupportedDbtVersions,
     type AiWritebackStep,
     type DbtProjectConfig,
+    type DbtVersionOption,
 } from '@lightdash/common';
 import type { AiWritebackFailureStage } from '../../../analytics/LightdashAnalytics';
 import {
     COMPILE_WRAPPER_PATH,
+    DBT_VENV_BIN_PREFIX,
     PR_DESCRIPTION_CLOSE,
     PR_DESCRIPTION_OPEN,
     PR_TITLE_CLOSE,
@@ -510,3 +514,39 @@ export const resolveSandboxTemplateRef = ({
     name: string;
     tag: string;
 }): string => (tag ? `${name}:${tag}` : name);
+
+/**
+ * Oldest dbt version installed in the sandbox image (see
+ * sandboxes/ai-writeback/e2b.Dockerfile). We support 1.8+ only: 1.4–1.7 are
+ * end-of-life and don't support the image's Python. Projects pinned below this
+ * are clamped to it by `resolveSandboxDbtVersion`.
+ */
+export const SANDBOX_MIN_DBT_VERSION = SupportedDbtVersions.V1_8;
+
+/**
+ * Resolve a project's `DbtVersionOption` to a concrete version that is actually
+ * installed in the sandbox: `latest` resolves to the newest supported version,
+ * and anything older than `SANDBOX_MIN_DBT_VERSION` clamps up to it (rather than
+ * pointing PATH at a venv the image doesn't contain). `SupportedDbtVersions` is
+ * declared in ascending order, so an enum-index comparison gives the clamp.
+ */
+export const resolveSandboxDbtVersion = (
+    option: DbtVersionOption,
+): SupportedDbtVersions => {
+    const resolved = resolveDbtVersion(option);
+    const order = Object.values(SupportedDbtVersions);
+    return order.indexOf(resolved) < order.indexOf(SANDBOX_MIN_DBT_VERSION)
+        ? SANDBOX_MIN_DBT_VERSION
+        : resolved;
+};
+
+/**
+ * Absolute path to the `bin` directory of the sandbox venv for a given dbt
+ * version. `SupportedDbtVersions` values are `v<major>.<minor>` (e.g. `v1.10`)
+ * and the image installs each version at `${DBT_VENV_BIN_PREFIX}<major>.<minor>`
+ * (e.g. `/usr/local/dbt1.10`), so we drop the leading `v`. The compile wrapper
+ * prepends this to PATH so the bare `dbt` resolves to the project's version.
+ * Callers must pass a sandbox-installed version (see `resolveSandboxDbtVersion`).
+ */
+export const dbtSandboxVenvBin = (version: SupportedDbtVersions): string =>
+    `${DBT_VENV_BIN_PREFIX}${version.slice(1)}/bin`;

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -3,10 +3,8 @@ import {
     DbtProjectConfig,
     DbtProjectType,
     DbtVersionOption,
-    DbtVersionOptionLatest,
-    getLatestSupportDbtVersion,
     ParameterError,
-    SupportedDbtVersions,
+    resolveDbtVersion,
 } from '@lightdash/common';
 import { warehouseClientFromCredentials } from '@lightdash/warehouses';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
@@ -37,10 +35,7 @@ export const projectAdapterFromConfig = async (
     const configType = config.type;
     Logger.debug(`Initialize project adaptor of type ${configType}`);
 
-    const dbtVersion: SupportedDbtVersions =
-        dbtVersionOption === DbtVersionOptionLatest.LATEST
-            ? getLatestSupportDbtVersion()
-            : dbtVersionOption;
+    const dbtVersion = resolveDbtVersion(dbtVersionOption);
 
     switch (config.type) {
         case DbtProjectType.DBT:

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -178,6 +178,7 @@ export {
     mergeWarehouseCredentials,
     normalizeWarehouseCredentials,
     ProjectType,
+    resolveDbtVersion,
     sensitiveCredentialsFieldNames,
     SnowflakeAuthenticationType,
     stripDucklakeNestedSensitive,

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -741,6 +741,14 @@ export const getLatestSupportDbtVersion = (): SupportedDbtVersions => {
     return versions[versions.length - 1];
 };
 
+/** Resolve a `DbtVersionOption` to a concrete version (`latest` → newest). */
+export const resolveDbtVersion = (
+    option: DbtVersionOption,
+): SupportedDbtVersions =>
+    option === DbtVersionOptionLatest.LATEST
+        ? getLatestSupportDbtVersion()
+        : option;
+
 export const DefaultSupportedDbtVersion = DbtVersionOptionLatest.LATEST;
 
 export interface DbtProjectCompilerBase extends DbtProjectConfigBase {

--- a/sandboxes/ai-writeback/e2b.Dockerfile
+++ b/sandboxes/ai-writeback/e2b.Dockerfile
@@ -11,12 +11,62 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir \
-        dbt-core \
-        dbt-bigquery \
-        dbt-snowflake \
-        dbt-postgres \
-        dbt-duckdb
+# Install the supported dbt versions, each in its own venv at /usr/local/dbt<X.Y>.
+# We support dbt 1.8+ only: 1.8 is where dbt-core decoupled from adapters (and is
+# the first version to support Python 3.12), and 1.4–1.7 are end-of-life. Pins
+# mirror the production `dockerfile`. The writeback compile wrapper prepends the
+# project's venv bin to PATH at run time, so the bare `dbt` the Lightdash CLI
+# invokes resolves to the project's configured version (projects pinned below
+# 1.8 are clamped to 1.8 — see `resolveSandboxDbtVersion`). The default `dbt`
+# symlink points at the latest version for any incidental use.
+RUN python3 -m venv /usr/local/dbt1.8 \
+    && /usr/local/dbt1.8/bin/pip install --no-cache-dir \
+        "dbt-core~=1.8.0" \
+        "dbt-postgres~=1.8.0" \
+        "dbt-redshift~=1.8.0" \
+        "dbt-snowflake~=1.8.0" \
+        "dbt-bigquery~=1.8.0" \
+        "dbt-databricks~=1.8.0" \
+        "dbt-trino~=1.8.0" \
+        "dbt-clickhouse~=1.8.0" \
+        "dbt-duckdb~=1.8.0" \
+    && python3 -m venv /usr/local/dbt1.9 \
+    && /usr/local/dbt1.9/bin/pip install --no-cache-dir \
+        "dbt-core~=1.9.0" \
+        "dbt-postgres~=1.9.0" \
+        "dbt-redshift~=1.9.0" \
+        "dbt-snowflake~=1.9.0" \
+        "dbt-bigquery~=1.9.0" \
+        "dbt-databricks~=1.9.0" \
+        "dbt-trino~=1.9.0" \
+        "dbt-clickhouse~=1.9.0" \
+        "dbt-athena~=1.9.0" \
+        "dbt-duckdb~=1.9.0" \
+    && python3 -m venv /usr/local/dbt1.10 \
+    && /usr/local/dbt1.10/bin/pip install --no-cache-dir \
+        "dbt-core~=1.10.0" \
+        "dbt-postgres~=1.10.0" \
+        "dbt-redshift~=1.10.0" \
+        "dbt-snowflake~=1.10.0" \
+        "dbt-bigquery~=1.10.0" \
+        "dbt-databricks~=1.10.0" \
+        "dbt-trino~=1.10.0" \
+        "dbt-clickhouse~=1.9.0" \
+        "dbt-athena~=1.10.0" \
+        "dbt-duckdb~=1.10.0" \
+    && python3 -m venv /usr/local/dbt1.11 \
+    && /usr/local/dbt1.11/bin/pip install --no-cache-dir \
+        "dbt-core~=1.11.0" \
+        "dbt-postgres~=1.10.0" \
+        "dbt-redshift~=1.10.0" \
+        "dbt-snowflake~=1.11.0" \
+        "dbt-bigquery~=1.11.0" \
+        "dbt-databricks~=1.11.0" \
+        "dbt-trino~=1.10.0" \
+        "dbt-clickhouse~=1.9.0" \
+        "dbt-athena~=1.10.0" \
+        "dbt-duckdb~=1.10.0" \
+    && ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt
 
 # Socket Firewall (sfw) blocks known-malicious packages at install time.
 # Install it first, then route every npm/pnpm install through it.


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8263/support-multiple-versions-of-dbt

## Summary

The AI writeback sandbox compiled every project with a single dbt version, regardless of the version the project is configured to use. A project pinned to dbt 1.9 could have its post-edit `lightdash compile` validation run under a different version, parsing the project differently (or failing). Now writeback compiles each project with the version set on `project.dbtVersion`.

## Root cause

The writeback agent validates its edits by running a compile wrapper → `lightdash compile` → `execa('dbt', …)`, which invokes the bare `dbt` on `PATH` and auto-detects its version. The sandbox image installed a single, unpinned `dbt-core`:

```dockerfile
RUN pip install --no-cache-dir dbt-core dbt-bigquery dbt-snowflake dbt-postgres dbt-duckdb
```

So `dbt` on `PATH` was always whatever was latest at image-build time. `project.dbtVersion` was never consulted — the version-selection surface simply didn't exist in the sandbox, even though the production backend already installs every version in its own venv and selects per project.

## Fix

Install dbt 1.8–1.11 each in its own venv (`/usr/local/dbt1.8` … `dbt1.11`), mirroring the production `dockerfile`, and prepend the project's venv bin to `PATH` on the compile-wrapper line so the bare `dbt` resolves to the project's version. We support 1.8+ only: 1.8 is where dbt-core decoupled from adapters and the first version to support Python 3.12; 1.4–1.7 are end-of-life. Projects pinned below 1.8 clamp up to 1.8.

```
project.dbtVersion ──resolveSandboxDbtVersion──> concrete, installed version
   v1.5  ──clamp──> v1.8 ┐
   latest ──────────> v1.11 ┼─> dbtSandboxVenvBin ─> /usr/local/dbt<X.Y>/bin
   v1.9  ───────────> v1.9 ┘                              │
                                                          ▼
   compile wrapper:  env -u ANTHROPIC_API_KEY … PATH="/usr/local/dbt1.9/bin:$PATH" lightdash compile
                                                          │
                                                          ▼
                              lightdash compile → execa('dbt') picks that venv
```

- `sandboxes/ai-writeback/e2b.Dockerfile` — install dbt 1.8–1.11 in per-version venvs; default `dbt` → latest.
- `AiWritebackService.ts` — resolve `project.dbtVersion` to a concrete installed version in `prepareTurn`; thread it onto `TurnContext` and into the compile wrapper's `PATH` prefix. Secret-stripping (`env -u`) is unchanged.
- `utils.ts` — `resolveSandboxDbtVersion` (resolve `latest` + clamp below-range up to 1.8) and `dbtSandboxVenvBin` (version → venv bin path).
- `common` — extracted shared `resolveDbtVersion` (resolve `latest`), reused here and in `projectAdapter.ts` which had the same inline logic.

## Test plan

- [x] `pnpm -F backend typecheck:fast` + `pnpm -F common typecheck:fast` + backend/common lint
- [x] `npx jest src/ee/services/AiWritebackService src/projectAdapters` — 137 pass; added: `resolveSandboxDbtVersion` clamp table, `dbtSandboxVenvBin` exhaustiveness, `prepareTurn` resolves `latest`/clamps below-range, and the compile wrapper carries the right `PATH` prefix while still stripping secrets
- [ ] Build the e2b template (`build-sandbox.ts`) and run a writeback turn end-to-end, confirming the compile uses the project's pinned version (the Dockerfile builds remotely, so it isn't build-tested in CI)