### PR TITLE
feat(instance-config): declare group → project access via LD_SETUP_GROUP_PROJECT_ACCESS

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -12,6 +12,7 @@ import { VERSION } from '../version';
 import {
     getFloatArrayFromEnvironmentVariable,
     getFloatFromEnvironmentVariable,
+    getGroupProjectAccessSetupConfig,
     getIntegerFromEnvironmentVariable,
     getMaybeBase64EncodedFromEnvironmentVariable,
     getMultiProjectSetupConfig,
@@ -794,6 +795,136 @@ describe('getUpdateSetupConfig userAttributes', () => {
 
     test('userAttributes is undefined when env var not set', () => {
         expect(getUpdateSetupConfig()?.userAttributes).toBeUndefined();
+    });
+});
+
+describe('getGroupProjectAccessSetupConfig', () => {
+    beforeEach(() => {
+        delete process.env.LD_SETUP_GROUP_PROJECT_ACCESS;
+    });
+
+    test('returns undefined when LD_SETUP_GROUP_PROJECT_ACCESS is not set', () => {
+        expect(getGroupProjectAccessSetupConfig()).toBeUndefined();
+    });
+
+    test('returns undefined when the array is empty', () => {
+        process.env.LD_SETUP_GROUP_PROJECT_ACCESS = '[]';
+        expect(getGroupProjectAccessSetupConfig()).toBeUndefined();
+    });
+
+    test('parses an entry referencing the project by name', () => {
+        process.env.LD_SETUP_GROUP_PROJECT_ACCESS = JSON.stringify([
+            {
+                groupName: 'Core Data Developer',
+                projectName: 'Production',
+                role: 'developer',
+            },
+        ]);
+        expect(getGroupProjectAccessSetupConfig()).toEqual([
+            {
+                groupName: 'Core Data Developer',
+                projectName: 'Production',
+                role: 'developer',
+            },
+        ]);
+    });
+
+    test('parses an entry referencing the project by uuid with a custom role name', () => {
+        process.env.LD_SETUP_GROUP_PROJECT_ACCESS = JSON.stringify([
+            {
+                groupName: 'Data Analyst',
+                projectUuid: 'abc-123',
+                role: 'PII Analyst',
+            },
+        ]);
+        expect(getGroupProjectAccessSetupConfig()).toEqual([
+            {
+                groupName: 'Data Analyst',
+                projectUuid: 'abc-123',
+                role: 'PII Analyst',
+            },
+        ]);
+    });
+
+    test('throws ParseError on malformed JSON', () => {
+        process.env.LD_SETUP_GROUP_PROJECT_ACCESS = '{not json';
+        expect(() => getGroupProjectAccessSetupConfig()).toThrowError(
+            ParseError,
+        );
+    });
+
+    test('throws ParseError when groupName is missing', () => {
+        process.env.LD_SETUP_GROUP_PROJECT_ACCESS = JSON.stringify([
+            { projectName: 'Production', role: 'developer' },
+        ]);
+        expect(() => getGroupProjectAccessSetupConfig()).toThrowError(
+            ParseError,
+        );
+    });
+
+    test('throws ParseError when neither projectName nor projectUuid is given', () => {
+        process.env.LD_SETUP_GROUP_PROJECT_ACCESS = JSON.stringify([
+            { groupName: 'Core Data Developer', role: 'developer' },
+        ]);
+        expect(() => getGroupProjectAccessSetupConfig()).toThrowError(
+            ParseError,
+        );
+    });
+
+    test('accepts both projectName and projectUuid (uuid wins at reconcile time)', () => {
+        process.env.LD_SETUP_GROUP_PROJECT_ACCESS = JSON.stringify([
+            {
+                groupName: 'Core Data Developer',
+                projectName: 'Production',
+                projectUuid: 'abc-123',
+                role: 'developer',
+            },
+        ]);
+        expect(getGroupProjectAccessSetupConfig()).toEqual([
+            {
+                groupName: 'Core Data Developer',
+                projectName: 'Production',
+                projectUuid: 'abc-123',
+                role: 'developer',
+            },
+        ]);
+    });
+
+    test('throws ParseError on a duplicate group/project pair', () => {
+        process.env.LD_SETUP_GROUP_PROJECT_ACCESS = JSON.stringify([
+            {
+                groupName: 'Core Data Developer',
+                projectName: 'Production',
+                role: 'developer',
+            },
+            {
+                groupName: 'Core Data Developer',
+                projectName: 'Production',
+                role: 'editor',
+            },
+        ]);
+        expect(() => getGroupProjectAccessSetupConfig()).toThrowError(
+            'Duplicate group/project pair',
+        );
+    });
+});
+
+describe('getUpdateSetupConfig groupProjectAccess', () => {
+    beforeEach(() => {
+        delete process.env.LD_SETUP_GROUP_PROJECT_ACCESS;
+    });
+
+    test('includes parsed groupProjectAccess from the env var', () => {
+        process.env.LD_SETUP_GROUP_PROJECT_ACCESS = JSON.stringify([
+            { groupName: 'G', projectName: 'P', role: 'developer' },
+        ]);
+        expect(getUpdateSetupConfig()?.groupProjectAccess).toEqual([
+            { groupName: 'G', projectName: 'P', role: 'developer' },
+        ]);
+    });
+
+    test('groupProjectAccess is undefined when env var not set', () => {
+        expect(getUpdateSetupConfig()?.groupProjectAccess).toBeUndefined();
     });
 });
 

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -26,6 +26,7 @@ import {
     SupportedDbtVersions,
     WarehouseTypes,
     WeekDay,
+    type GroupProjectAccessSetupEntry,
     type SchedulerTaskName,
     type UserAttributeSetupEntry,
 } from '@lightdash/common';
@@ -527,6 +528,76 @@ export const getUserAttributesSetupConfig = ():
     return result.data;
 };
 
+const groupProjectAccessSetupEntrySchema = z
+    .object({
+        groupName: z.string().min(1),
+        projectName: z.string().min(1).optional(),
+        projectUuid: z.string().min(1).optional(),
+        role: z.string().min(1),
+    })
+    .refine((entry) => Boolean(entry.projectName || entry.projectUuid), {
+        message: 'Each entry must specify either projectName or projectUuid',
+    });
+
+const groupProjectAccessSetupSchema = z
+    .array(groupProjectAccessSetupEntrySchema)
+    .refine(
+        (entries) => {
+            const keys = entries.map(
+                (e) => `${e.groupName}::${e.projectUuid ?? e.projectName}`,
+            );
+            return new Set(keys).size === keys.length;
+        },
+        (entries) => {
+            const keys = entries.map(
+                (e) => `${e.groupName}::${e.projectUuid ?? e.projectName}`,
+            );
+            const duplicate = keys.find((k, i) => keys.indexOf(k) !== i);
+            return {
+                message: `Duplicate group/project pair "${duplicate}" in LD_SETUP_GROUP_PROJECT_ACCESS`,
+            };
+        },
+    );
+
+export const getGroupProjectAccessSetupConfig = ():
+    | GroupProjectAccessSetupEntry[]
+    | undefined => {
+    const raw = process.env.LD_SETUP_GROUP_PROJECT_ACCESS;
+    if (!raw) return undefined;
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (e) {
+        throw new ParseError(
+            `Failed to parse LD_SETUP_GROUP_PROJECT_ACCESS: ${getErrorMessage(
+                e,
+            )}`,
+        );
+    }
+
+    if (Array.isArray(parsed) && parsed.length === 0) {
+        return undefined;
+    }
+
+    const result = groupProjectAccessSetupSchema.safeParse(parsed);
+    if (!result.success) {
+        const errorDetails = result.error.errors
+            .map((err) =>
+                err.path.length > 0
+                    ? `  - ${err.path.join('.')}: ${err.message}`
+                    : `  - ${err.message}`,
+            )
+            .join('\n');
+        throw new ParseError(
+            `Invalid LD_SETUP_GROUP_PROJECT_ACCESS:\n${errorDetails}\n\n` +
+                `See https://docs.lightdash.com/self-host/customize-deployment/environment-variables for details.`,
+        );
+    }
+
+    return result.data as GroupProjectAccessSetupEntry[];
+};
+
 const getInitialSetupConfig = (): LightdashConfig['initialSetup'] => {
     const parseCompute = (): CreateDatabricksCredentials['compute'] => {
         // This is a stringified array of objects, in JSON format
@@ -702,6 +773,7 @@ export const getUpdateSetupConfig = (): LightdashConfig['updateSetup'] => {
         },
         projects: getMultiProjectSetupConfig(),
         userAttributes: getUserAttributesSetupConfig(),
+        groupProjectAccess: getGroupProjectAccessSetupConfig(),
         embed: {
             allowAllDashboards:
                 process.env.LD_SETUP_EMBED_ALLOW_ALL_DASHBOARDS === 'true',
@@ -1341,6 +1413,7 @@ export type LightdashConfig = {
         };
         projects?: MultiProjectSetupEntry[];
         userAttributes?: UserAttributeSetupEntry[];
+        groupProjectAccess?: GroupProjectAccessSetupEntry[];
         serviceAccount?: {
             token: string;
             expirationTime: Date | null;

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -526,6 +526,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     encryptionUtil: utils.getEncryptionUtil(),
                     userAttributesModel: models.getUserAttributesModel(),
                     groupsModel: models.getGroupsModel(),
+                    rolesModel: models.getRolesModel(),
                 }),
             asyncQueryService: ({
                 models,

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
@@ -1387,5 +1387,96 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
 
             expect(getGroupProjectAccess).not.toHaveBeenCalled();
         });
+
+        test('updates an existing access to a custom role with the viewer+role_uuid payload', async () => {
+            const updateProjectAccess = jest.fn();
+            service = createMockService({
+                updateSetup: {
+                    organizationUuid: mockOrgUuid,
+                    projects: [],
+                    groupProjectAccess: [
+                        {
+                            groupName: 'Data Analyst',
+                            projectName: 'Production',
+                            role: 'PII Analyst',
+                        },
+                    ],
+                },
+                organizationModel: orgWithSingleUuid,
+                projectModel: {
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockResolvedValue(['proj-1']),
+                    getSummary: jest.fn(),
+                },
+                groupsModel: {
+                    find: jest.fn().mockResolvedValue({
+                        data: [{ uuid: 'grp-2', name: 'Data Analyst' }],
+                    }),
+                    addProjectAccess: jest.fn(),
+                    updateProjectAccess,
+                },
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest
+                        .fn()
+                        .mockResolvedValue([
+                            { roleUuid: 'role-uuid-7', name: 'PII Analyst' },
+                        ]),
+                    getGroupProjectAccess: jest.fn().mockResolvedValue([
+                        {
+                            groupUuid: 'grp-2',
+                            projectUuid: 'proj-1',
+                            roleUuid: 'developer',
+                        },
+                    ]),
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(updateProjectAccess).toHaveBeenCalledWith(
+                { groupUuid: 'grp-2', projectUuid: 'proj-1' },
+                { role: 'viewer', role_uuid: 'role-uuid-7' },
+            );
+        });
+
+        test('skips (no throw) when getSummary rejects for a given projectUuid', async () => {
+            const addProjectAccess = jest.fn();
+            const find = jest.fn();
+            service = createMockService({
+                updateSetup: {
+                    organizationUuid: mockOrgUuid,
+                    projects: [],
+                    groupProjectAccess: [
+                        {
+                            groupName: 'Core Data Developer',
+                            projectUuid: 'missing-proj',
+                            role: 'developer',
+                        },
+                    ],
+                },
+                organizationModel: orgWithSingleUuid,
+                projectModel: {
+                    getDefaultProjectUuidsByName: jest.fn(),
+                    getSummary: jest
+                        .fn()
+                        .mockRejectedValue(new Error('not found')),
+                },
+                groupsModel: {
+                    find,
+                    addProjectAccess,
+                    updateProjectAccess: jest.fn(),
+                },
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest.fn().mockResolvedValue([]),
+                    getGroupProjectAccess: jest.fn().mockResolvedValue([]),
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(addProjectAccess).not.toHaveBeenCalled();
+            expect(find).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
@@ -75,6 +75,7 @@ const createMockService = (overrides: AnyType = {}) => {
     const projectModel = {
         getDefaultProjectUuids: jest.fn(),
         getDefaultProjectUuidsByName: jest.fn(),
+        getSummary: jest.fn(),
         getWithSensitiveFields: jest.fn(),
         update: jest.fn(),
         ...overrides.projectModel,
@@ -108,6 +109,12 @@ const createMockService = (overrides: AnyType = {}) => {
         ...overrides.groupsModel,
     };
 
+    const rolesModel = {
+        getRolesByOrganizationUuid: jest.fn().mockResolvedValue([]),
+        getGroupProjectAccess: jest.fn().mockResolvedValue([]),
+        ...overrides.rolesModel,
+    };
+
     const lightdashConfig = {
         ...lightdashConfigMock,
         updateSetup: overrides.updateSetup || undefined,
@@ -131,6 +138,7 @@ const createMockService = (overrides: AnyType = {}) => {
         encryptionUtil: { encrypt: jest.fn() } as AnyType,
         userAttributesModel: userAttributesModel as AnyType,
         groupsModel: groupsModel as AnyType,
+        rolesModel: rolesModel as AnyType,
     });
 };
 
@@ -1035,6 +1043,349 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
             await service.updateInstanceConfiguration();
 
             expect(find).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('group project access update scenarios', () => {
+        const orgWithSingleUuid = {
+            getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
+        };
+
+        const baseEntry = {
+            groupName: 'Core Data Developer',
+            projectName: 'Production',
+            role: 'developer',
+        };
+
+        test('adds access for a new group resolved by name with a system role', async () => {
+            const addProjectAccess = jest.fn();
+            const updateProjectAccess = jest.fn();
+            service = createMockService({
+                updateSetup: {
+                    organizationUuid: mockOrgUuid,
+                    projects: [],
+                    groupProjectAccess: [baseEntry],
+                },
+                organizationModel: orgWithSingleUuid,
+                projectModel: {
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockResolvedValue(['proj-1']),
+                    getSummary: jest.fn(),
+                },
+                groupsModel: {
+                    find: jest.fn().mockResolvedValue({
+                        data: [{ uuid: 'grp-1', name: 'Core Data Developer' }],
+                    }),
+                    addProjectAccess,
+                    updateProjectAccess,
+                },
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest.fn().mockResolvedValue([]),
+                    getGroupProjectAccess: jest.fn().mockResolvedValue([]),
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(addProjectAccess).toHaveBeenCalledWith({
+                groupUuid: 'grp-1',
+                projectUuid: 'proj-1',
+                role: 'developer',
+            });
+            expect(updateProjectAccess).not.toHaveBeenCalled();
+        });
+
+        test('resolves the project by projectUuid when provided', async () => {
+            const addProjectAccess = jest.fn();
+            const getSummary = jest.fn().mockResolvedValue({});
+            const getDefaultProjectUuidsByName = jest.fn();
+            service = createMockService({
+                updateSetup: {
+                    organizationUuid: mockOrgUuid,
+                    projects: [],
+                    groupProjectAccess: [
+                        {
+                            groupName: 'Core Data Developer',
+                            projectUuid: 'proj-uuid-9',
+                            role: 'editor',
+                        },
+                    ],
+                },
+                organizationModel: orgWithSingleUuid,
+                projectModel: { getSummary, getDefaultProjectUuidsByName },
+                groupsModel: {
+                    find: jest.fn().mockResolvedValue({
+                        data: [{ uuid: 'grp-1', name: 'Core Data Developer' }],
+                    }),
+                    addProjectAccess,
+                    updateProjectAccess: jest.fn(),
+                },
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest.fn().mockResolvedValue([]),
+                    getGroupProjectAccess: jest.fn().mockResolvedValue([]),
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(getSummary).toHaveBeenCalledWith('proj-uuid-9');
+            expect(getDefaultProjectUuidsByName).not.toHaveBeenCalled();
+            expect(addProjectAccess).toHaveBeenCalledWith({
+                groupUuid: 'grp-1',
+                projectUuid: 'proj-uuid-9',
+                role: 'editor',
+            });
+        });
+
+        test('resolves a custom role by name to its uuid', async () => {
+            const addProjectAccess = jest.fn();
+            service = createMockService({
+                updateSetup: {
+                    organizationUuid: mockOrgUuid,
+                    projects: [],
+                    groupProjectAccess: [
+                        {
+                            groupName: 'Data Analyst',
+                            projectName: 'Production',
+                            role: 'PII Analyst',
+                        },
+                    ],
+                },
+                organizationModel: orgWithSingleUuid,
+                projectModel: {
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockResolvedValue(['proj-1']),
+                    getSummary: jest.fn(),
+                },
+                groupsModel: {
+                    find: jest.fn().mockResolvedValue({
+                        data: [{ uuid: 'grp-2', name: 'Data Analyst' }],
+                    }),
+                    addProjectAccess,
+                    updateProjectAccess: jest.fn(),
+                },
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest
+                        .fn()
+                        .mockResolvedValue([
+                            { roleUuid: 'role-uuid-7', name: 'PII Analyst' },
+                        ]),
+                    getGroupProjectAccess: jest.fn().mockResolvedValue([]),
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(addProjectAccess).toHaveBeenCalledWith({
+                groupUuid: 'grp-2',
+                projectUuid: 'proj-1',
+                role: 'role-uuid-7',
+            });
+        });
+
+        test('updates an existing access when the role differs', async () => {
+            const addProjectAccess = jest.fn();
+            const updateProjectAccess = jest.fn();
+            service = createMockService({
+                updateSetup: {
+                    organizationUuid: mockOrgUuid,
+                    projects: [],
+                    groupProjectAccess: [baseEntry], // role: 'developer'
+                },
+                organizationModel: orgWithSingleUuid,
+                projectModel: {
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockResolvedValue(['proj-1']),
+                    getSummary: jest.fn(),
+                },
+                groupsModel: {
+                    find: jest.fn().mockResolvedValue({
+                        data: [{ uuid: 'grp-1', name: 'Core Data Developer' }],
+                    }),
+                    addProjectAccess,
+                    updateProjectAccess,
+                },
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest.fn().mockResolvedValue([]),
+                    getGroupProjectAccess: jest.fn().mockResolvedValue([
+                        {
+                            groupUuid: 'grp-1',
+                            projectUuid: 'proj-1',
+                            roleUuid: 'viewer',
+                        },
+                    ]),
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(updateProjectAccess).toHaveBeenCalledWith(
+                { groupUuid: 'grp-1', projectUuid: 'proj-1' },
+                { role: 'developer', role_uuid: null },
+            );
+            expect(addProjectAccess).not.toHaveBeenCalled();
+        });
+
+        test('is a no-op when the existing role already matches', async () => {
+            const addProjectAccess = jest.fn();
+            const updateProjectAccess = jest.fn();
+            service = createMockService({
+                updateSetup: {
+                    organizationUuid: mockOrgUuid,
+                    projects: [],
+                    groupProjectAccess: [baseEntry], // role: 'developer'
+                },
+                organizationModel: orgWithSingleUuid,
+                projectModel: {
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockResolvedValue(['proj-1']),
+                    getSummary: jest.fn(),
+                },
+                groupsModel: {
+                    find: jest.fn().mockResolvedValue({
+                        data: [{ uuid: 'grp-1', name: 'Core Data Developer' }],
+                    }),
+                    addProjectAccess,
+                    updateProjectAccess,
+                },
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest.fn().mockResolvedValue([]),
+                    getGroupProjectAccess: jest.fn().mockResolvedValue([
+                        {
+                            groupUuid: 'grp-1',
+                            projectUuid: 'proj-1',
+                            roleUuid: 'developer',
+                        },
+                    ]),
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(addProjectAccess).not.toHaveBeenCalled();
+            expect(updateProjectAccess).not.toHaveBeenCalled();
+        });
+
+        test('skips (no throw) when the group is not found', async () => {
+            const addProjectAccess = jest.fn();
+            service = createMockService({
+                updateSetup: {
+                    organizationUuid: mockOrgUuid,
+                    projects: [],
+                    groupProjectAccess: [baseEntry],
+                },
+                organizationModel: orgWithSingleUuid,
+                projectModel: {
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockResolvedValue(['proj-1']),
+                    getSummary: jest.fn(),
+                },
+                groupsModel: {
+                    find: jest.fn().mockResolvedValue({ data: [] }),
+                    addProjectAccess,
+                    updateProjectAccess: jest.fn(),
+                },
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest.fn().mockResolvedValue([]),
+                    getGroupProjectAccess: jest.fn().mockResolvedValue([]),
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(addProjectAccess).not.toHaveBeenCalled();
+        });
+
+        test('skips (no throw) when the project name is not found', async () => {
+            const addProjectAccess = jest.fn();
+            const find = jest.fn();
+            service = createMockService({
+                updateSetup: {
+                    organizationUuid: mockOrgUuid,
+                    projects: [],
+                    groupProjectAccess: [baseEntry],
+                },
+                organizationModel: orgWithSingleUuid,
+                projectModel: {
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockResolvedValue([]),
+                    getSummary: jest.fn(),
+                },
+                groupsModel: {
+                    find,
+                    addProjectAccess,
+                    updateProjectAccess: jest.fn(),
+                },
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest.fn().mockResolvedValue([]),
+                    getGroupProjectAccess: jest.fn().mockResolvedValue([]),
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(addProjectAccess).not.toHaveBeenCalled();
+        });
+
+        test('skips (no throw) when a custom role name is not found', async () => {
+            const addProjectAccess = jest.fn();
+            service = createMockService({
+                updateSetup: {
+                    organizationUuid: mockOrgUuid,
+                    projects: [],
+                    groupProjectAccess: [
+                        {
+                            groupName: 'Data Analyst',
+                            projectName: 'Production',
+                            role: 'Nonexistent Role',
+                        },
+                    ],
+                },
+                organizationModel: orgWithSingleUuid,
+                projectModel: {
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockResolvedValue(['proj-1']),
+                    getSummary: jest.fn(),
+                },
+                groupsModel: {
+                    find: jest.fn().mockResolvedValue({
+                        data: [{ uuid: 'grp-2', name: 'Data Analyst' }],
+                    }),
+                    addProjectAccess,
+                    updateProjectAccess: jest.fn(),
+                },
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest.fn().mockResolvedValue([]),
+                    getGroupProjectAccess: jest.fn().mockResolvedValue([]),
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(addProjectAccess).not.toHaveBeenCalled();
+        });
+
+        test('does nothing when no groupProjectAccess is configured', async () => {
+            const getGroupProjectAccess = jest.fn();
+            service = createMockService({
+                updateSetup: { organizationUuid: mockOrgUuid, projects: [] },
+                organizationModel: orgWithSingleUuid,
+                rolesModel: {
+                    getRolesByOrganizationUuid: jest.fn(),
+                    getGroupProjectAccess,
+                },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(getGroupProjectAccess).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -903,97 +903,111 @@ export class InstanceConfigurationService extends BaseService {
 
         /* eslint-disable no-await-in-loop */
         for (const entry of config.groupProjectAccess) {
-            // Resolve the project — projectUuid wins over projectName.
-            let projectUuid: string | undefined;
-            if (entry.projectUuid) {
-                try {
-                    await this.projectModel.getSummary(entry.projectUuid);
-                    projectUuid = entry.projectUuid;
-                } catch {
-                    projectUuid = undefined;
-                }
-            } else if (entry.projectName) {
-                const [firstUuid] =
-                    await this.projectModel.getDefaultProjectUuidsByName(
-                        entry.projectName,
-                    );
-                projectUuid = firstUuid;
-            }
-
-            if (!projectUuid) {
-                this.logger.warn(
-                    `Update instance: project "${
-                        entry.projectUuid ?? entry.projectName
-                    }" for group "${entry.groupName}" not found; skipping`,
-                );
-            } else {
-                // Resolve the group by name.
-                const { data: groups } = await this.groupsModel.find({
-                    organizationUuid,
-                    name: entry.groupName,
-                });
-                const group = groups.find((g) => g.name === entry.groupName);
-
-                if (!group) {
-                    this.logger.warn(
-                        `Update instance: group "${entry.groupName}" not found (not yet synced?); skipping`,
-                    );
-                } else {
-                    // Resolve the role: system role as-is, else custom role by name.
-                    let resolvedRole: string | undefined;
-                    if (isSystemRole(entry.role)) {
-                        resolvedRole = entry.role;
-                    } else {
-                        const customRole = customRoles.find(
-                            (r) => r.name === entry.role,
-                        );
-                        if (!customRole) {
-                            this.logger.warn(
-                                `Update instance: role "${entry.role}" for group "${entry.groupName}" not found as a system or custom role; skipping`,
-                            );
-                        } else {
-                            resolvedRole = customRole.roleUuid;
-                        }
-                    }
-
-                    if (resolvedRole !== undefined) {
-                        // Upsert (non-destructive): add if absent, update if role differs.
-                        const existingAccess =
-                            await this.rolesModel.getGroupProjectAccess(
-                                projectUuid,
-                            );
-                        const existing = existingAccess.find(
-                            (a) => a.groupUuid === group.uuid,
-                        );
-
-                        if (!existing) {
-                            await this.groupsModel.addProjectAccess({
-                                groupUuid: group.uuid,
-                                projectUuid,
-                                role: resolvedRole,
-                            });
-                            this.logger.info(
-                                `Update instance: Added "${entry.role}" access for group "${entry.groupName}" on project ${projectUuid}`,
-                            );
-                        } else if (existing.roleUuid !== resolvedRole) {
-                            await this.groupsModel.updateProjectAccess(
-                                { groupUuid: group.uuid, projectUuid },
-                                isSystemRole(resolvedRole)
-                                    ? { role: resolvedRole, role_uuid: null }
-                                    : {
-                                          role: ProjectMemberRole.VIEWER,
-                                          role_uuid: resolvedRole,
-                                      },
-                            );
-                            this.logger.info(
-                                `Update instance: Updated group "${entry.groupName}" access on project ${projectUuid} to "${entry.role}"`,
-                            );
-                        }
-                    }
-                }
-            }
+            await this.reconcileGroupProjectAccessEntry(
+                entry,
+                organizationUuid,
+                customRoles,
+            );
         }
         /* eslint-enable no-await-in-loop */
+    }
+
+    /**
+     * Reconcile a single LD_SETUP_GROUP_PROJECT_ACCESS entry. Resolves project,
+     * group and role; any that can't be resolved are warned-and-skipped (never
+     * fatal). Adds access when absent, updates it when the role differs, and is
+     * a no-op when it already matches.
+     */
+    private async reconcileGroupProjectAccessEntry(
+        entry: NonNullable<
+            NonNullable<LightdashConfig['updateSetup']>['groupProjectAccess']
+        >[number],
+        organizationUuid: string,
+        customRoles: Awaited<
+            ReturnType<RolesModel['getRolesByOrganizationUuid']>
+        >,
+    ) {
+        // Resolve the project — projectUuid wins over projectName.
+        let projectUuid: string | undefined;
+        if (entry.projectUuid) {
+            try {
+                await this.projectModel.getSummary(entry.projectUuid);
+                projectUuid = entry.projectUuid;
+            } catch {
+                projectUuid = undefined;
+            }
+        } else if (entry.projectName) {
+            const [firstUuid] =
+                await this.projectModel.getDefaultProjectUuidsByName(
+                    entry.projectName,
+                );
+            projectUuid = firstUuid;
+        }
+        if (!projectUuid) {
+            this.logger.warn(
+                `Update instance: project "${
+                    entry.projectUuid ?? entry.projectName
+                }" for group "${entry.groupName}" not found; skipping`,
+            );
+            return;
+        }
+
+        // Resolve the group by name.
+        const { data: groups } = await this.groupsModel.find({
+            organizationUuid,
+            name: entry.groupName,
+        });
+        const group = groups.find((g) => g.name === entry.groupName);
+        if (!group) {
+            this.logger.warn(
+                `Update instance: group "${entry.groupName}" not found (not yet synced?); skipping`,
+            );
+            return;
+        }
+
+        // Resolve the role: system role as-is, else custom role by name.
+        let resolvedRole: string;
+        if (isSystemRole(entry.role)) {
+            resolvedRole = entry.role;
+        } else {
+            const customRole = customRoles.find((r) => r.name === entry.role);
+            if (!customRole) {
+                this.logger.warn(
+                    `Update instance: role "${entry.role}" for group "${entry.groupName}" not found as a system or custom role; skipping`,
+                );
+                return;
+            }
+            resolvedRole = customRole.roleUuid;
+        }
+
+        // Upsert (non-destructive): add if absent, update if role differs.
+        const existingAccess =
+            await this.rolesModel.getGroupProjectAccess(projectUuid);
+        const existing = existingAccess.find((a) => a.groupUuid === group.uuid);
+
+        if (!existing) {
+            await this.groupsModel.addProjectAccess({
+                groupUuid: group.uuid,
+                projectUuid,
+                role: resolvedRole,
+            });
+            this.logger.info(
+                `Update instance: Added "${entry.role}" access for group "${entry.groupName}" on project ${projectUuid}`,
+            );
+        } else if (existing.roleUuid !== resolvedRole) {
+            await this.groupsModel.updateProjectAccess(
+                { groupUuid: group.uuid, projectUuid },
+                isSystemRole(resolvedRole)
+                    ? { role: resolvedRole, role_uuid: null }
+                    : {
+                          role: ProjectMemberRole.VIEWER,
+                          role_uuid: resolvedRole,
+                      },
+            );
+            this.logger.info(
+                `Update instance: Updated group "${entry.groupName}" access on project ${projectUuid} to "${entry.role}"`,
+            );
+        }
     }
 
     async updateInstanceConfiguration() {

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -7,9 +7,11 @@ import {
     DbtProjectConfig,
     DbtVersionOptionLatest,
     isGitProjectType,
+    isSystemRole,
     NotFoundError,
     OrganizationMemberRole,
     ParameterError,
+    ProjectMemberRole,
     ProjectType,
     RequestMethod,
     ServiceAccountScope,
@@ -31,6 +33,7 @@ import { GroupsModel } from '../../models/GroupsModel';
 import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { RolesModel } from '../../models/RolesModel';
 import { UserAttributesModel } from '../../models/UserAttributesModel';
 import { UserModel } from '../../models/UserModel';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
@@ -53,6 +56,7 @@ type InstanceConfigurationServiceArguments = {
     encryptionUtil: EncryptionUtil; // For encrypting embed secrets
     userAttributesModel: UserAttributesModel; // For declaring user attributes as config
     groupsModel: GroupsModel; // For resolving attribute group mappings by name
+    rolesModel: RolesModel; // For resolving custom roles by name + existing group access
 };
 
 export class InstanceConfigurationService extends BaseService {
@@ -84,6 +88,8 @@ export class InstanceConfigurationService extends BaseService {
 
     private readonly groupsModel: GroupsModel;
 
+    private readonly rolesModel: RolesModel;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -99,6 +105,7 @@ export class InstanceConfigurationService extends BaseService {
         encryptionUtil,
         userAttributesModel,
         groupsModel,
+        rolesModel,
     }: InstanceConfigurationServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -116,6 +123,7 @@ export class InstanceConfigurationService extends BaseService {
         this.encryptionUtil = encryptionUtil;
         this.userAttributesModel = userAttributesModel;
         this.groupsModel = groupsModel;
+        this.rolesModel = rolesModel;
     }
 
     async initializeInstance() {
@@ -864,6 +872,130 @@ export class InstanceConfigurationService extends BaseService {
         /* eslint-enable no-await-in-loop */
     }
 
+    /**
+     * Reconcile group → project role assignments declared via
+     * LD_SETUP_GROUP_PROJECT_ACCESS. For each entry resolves the project (by
+     * uuid or name), the group (by name) and the role (system role string, or a
+     * custom role resolved by name to its uuid), then upserts the group's
+     * project access. Anything that can't be resolved yet (e.g. SCIM groups or
+     * custom roles not yet synced) is skipped with a warning and reconciled on a
+     * later deploy — never fatal. Accesses not listed are left untouched
+     * (non-destructive).
+     */
+    private async updateGroupProjectAccessConfiguration(
+        config: NonNullable<LightdashConfig['updateSetup']>,
+    ) {
+        if (
+            !config.groupProjectAccess ||
+            config.groupProjectAccess.length === 0
+        ) {
+            this.logger.debug(
+                `Update instance: No group project access config found, skipping`,
+            );
+            return;
+        }
+
+        const organizationUuid = await this.getSingleOrg();
+        const customRoles = await this.rolesModel.getRolesByOrganizationUuid(
+            organizationUuid,
+            'user',
+        );
+
+        /* eslint-disable no-await-in-loop */
+        for (const entry of config.groupProjectAccess) {
+            // Resolve the project — projectUuid wins over projectName.
+            let projectUuid: string | undefined;
+            if (entry.projectUuid) {
+                try {
+                    await this.projectModel.getSummary(entry.projectUuid);
+                    projectUuid = entry.projectUuid;
+                } catch {
+                    projectUuid = undefined;
+                }
+            } else if (entry.projectName) {
+                const [firstUuid] =
+                    await this.projectModel.getDefaultProjectUuidsByName(
+                        entry.projectName,
+                    );
+                projectUuid = firstUuid;
+            }
+
+            if (!projectUuid) {
+                this.logger.warn(
+                    `Update instance: project "${
+                        entry.projectUuid ?? entry.projectName
+                    }" for group "${entry.groupName}" not found; skipping`,
+                );
+            } else {
+                // Resolve the group by name.
+                const { data: groups } = await this.groupsModel.find({
+                    organizationUuid,
+                    name: entry.groupName,
+                });
+                const group = groups.find((g) => g.name === entry.groupName);
+
+                if (!group) {
+                    this.logger.warn(
+                        `Update instance: group "${entry.groupName}" not found (not yet synced?); skipping`,
+                    );
+                } else {
+                    // Resolve the role: system role as-is, else custom role by name.
+                    let resolvedRole: string | undefined;
+                    if (isSystemRole(entry.role)) {
+                        resolvedRole = entry.role;
+                    } else {
+                        const customRole = customRoles.find(
+                            (r) => r.name === entry.role,
+                        );
+                        if (!customRole) {
+                            this.logger.warn(
+                                `Update instance: role "${entry.role}" for group "${entry.groupName}" not found as a system or custom role; skipping`,
+                            );
+                        } else {
+                            resolvedRole = customRole.roleUuid;
+                        }
+                    }
+
+                    if (resolvedRole !== undefined) {
+                        // Upsert (non-destructive): add if absent, update if role differs.
+                        const existingAccess =
+                            await this.rolesModel.getGroupProjectAccess(
+                                projectUuid,
+                            );
+                        const existing = existingAccess.find(
+                            (a) => a.groupUuid === group.uuid,
+                        );
+
+                        if (!existing) {
+                            await this.groupsModel.addProjectAccess({
+                                groupUuid: group.uuid,
+                                projectUuid,
+                                role: resolvedRole,
+                            });
+                            this.logger.info(
+                                `Update instance: Added "${entry.role}" access for group "${entry.groupName}" on project ${projectUuid}`,
+                            );
+                        } else if (existing.roleUuid !== resolvedRole) {
+                            await this.groupsModel.updateProjectAccess(
+                                { groupUuid: group.uuid, projectUuid },
+                                isSystemRole(resolvedRole)
+                                    ? { role: resolvedRole, role_uuid: null }
+                                    : {
+                                          role: ProjectMemberRole.VIEWER,
+                                          role_uuid: resolvedRole,
+                                      },
+                            );
+                            this.logger.info(
+                                `Update instance: Updated group "${entry.groupName}" access on project ${projectUuid} to "${entry.role}"`,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        /* eslint-enable no-await-in-loop */
+    }
+
     async updateInstanceConfiguration() {
         const config = this.lightdashConfig.updateSetup;
         if (!config) {
@@ -889,5 +1021,7 @@ export class InstanceConfigurationService extends BaseService {
         await this.updateOrganizationDefaultRole(config);
 
         await this.updateUserAttributesConfiguration(config);
+
+        await this.updateGroupProjectAccessConfiguration(config);
     }
 }

--- a/packages/common/src/types/projectGroupAccess.ts
+++ b/packages/common/src/types/projectGroupAccess.ts
@@ -19,6 +19,19 @@ export type DeleteProjectGroupAccess = Pick<
     'projectUuid' | 'groupUuid'
 >;
 
+/**
+ * One entry in the `LD_SETUP_GROUP_PROJECT_ACCESS` instance-config env var. The
+ * group is referenced by name (and the project optionally by name) because
+ * SCIM-synced groups are created by the IdP, so their UUIDs aren't known at
+ * deploy time. `role` is a system role (e.g. "developer") or a custom role name.
+ */
+export type GroupProjectAccessSetupEntry = {
+    groupName: string;
+    projectName?: string;
+    projectUuid?: string;
+    role: string;
+};
+
 export type ApiCreateProjectGroupAccess = {
     status: 'ok';
     results: ProjectGroupAccess;


### PR DESCRIPTION
## Summary

Adds a new `LD_SETUP_GROUP_PROJECT_ACCESS` instance-config env var so self-hosted deployments can declare **group → project role assignments** at deploy time, reconciled on every deploy. This is the project-access equivalent of `LD_SETUP_USER_ATTRIBUTES` (#24100) and mirrors its implementation.

Motivation: instances using SCIM-synced groups (e.g. OKTA → Lightdash) previously had to re-apply group → project role mappings via the UI/API after every deploy, because SCIM group UUIDs aren't known at deploy time. This lets those mappings be declared once and reconciled automatically.

### Config shape

`LD_SETUP_GROUP_PROJECT_ACCESS` is a JSON array. Each entry:

```json
[
  { "groupName": "Core Data Developer", "projectName": "Production", "role": "developer" },
  { "groupName": "Data Analyst", "projectUuid": "abc-123", "role": "PII Analyst" }
]
```

- `groupName` — required; resolved by name (SCIM-compatible).
- `projectName` **or** `projectUuid` — at least one required; `projectUuid` wins if both are given.
- `role` — a system role (`viewer`/`interactive_viewer`/`editor`/`developer`/`admin`) **or** a custom role name (resolved to its role UUID).

### Behaviour

- Runs in `InstanceConfigurationService.updateInstanceConfiguration()` (every deploy), EE-gated via the EE app arguments (group access + custom roles are EE features).
- **Non-destructive**: adds access when absent, updates it when the role differs, no-op when it already matches. Group accesses **not** listed in config are left untouched — nothing is ever removed.
- **Never fatal**: an entry whose group, project, or custom role can't be resolved yet (e.g. not yet synced from the IdP) is logged at `warn` and skipped, then reconciled on a later deploy. Malformed JSON / schema errors throw at parse time (config-author error, before boot).

## How it works

1. `getGroupProjectAccessSetupConfig()` (`parseConfig.ts`) parses + zod-validates the env var into `updateSetup.groupProjectAccess`.
2. `updateGroupProjectAccessConfiguration()` resolves each entry's project (by uuid or name), group (by name) and role (system role as-is, or custom role by name → uuid), then upserts via `GroupsModel.addProjectAccess` / `updateProjectAccess`, using `RolesModel.getGroupProjectAccess` to decide add-vs-update.

## Test plan

- [x] Unit tests for parsing/validation (`parseConfig.test.ts`): unset/empty → undefined, name & uuid forms, custom role, malformed JSON → error, missing `groupName`, neither/both project refs, duplicate group/project pair.
- [x] Unit tests for reconciliation (`InstanceConfigurationService.test.ts`): add new (system role), resolve by `projectUuid`, resolve custom role by name, update on role change (system + custom payloads), no-op when unchanged, warn-and-skip on missing group / project / custom role, no-op when env unset.
- [x] `parseConfig.test.ts` + `InstanceConfigurationService.test.ts` green (153/153); common + backend typecheck and lint clean for the touched files.

## Follow-up (not in this PR)

- Document `LD_SETUP_GROUP_PROJECT_ACCESS` in the environment-variables reference (separate docs repo), as was done for `LD_SETUP_USER_ATTRIBUTES`.

Closes: PROD-8262
Closes: #24179

🤖 Generated with [Claude Code](https://claude.com/claude-code)