### PR TITLE
fix(formatting): apply project tz to custom-format timestamps

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1190,56 +1190,6 @@ describe('Formatting', () => {
             ).toEqual('2024-01-14 20:00:00');
         });
 
-        test('formatItemValue shifts a custom-format MAX timestamp metric into the project tz from a Date OR an ISO string (GLITCH-492)', () => {
-            const maxMetric = {
-                ...metric,
-                type: MetricType.MAX,
-                format: 'yyyy-mm-dd hh:mm:ss',
-            };
-            const isoString = '2024-01-14T20:00:00.000Z';
-            const asDate = new Date(isoString); // 15:00 in NY (EST)
-
-            const fromDate = formatItemValue(
-                maxMetric,
-                asDate,
-                false,
-                undefined,
-                'America/New_York',
-            );
-            const fromString = formatItemValue(
-                maxMetric,
-                isoString,
-                false,
-                undefined,
-                'America/New_York',
-            );
-
-            expect(fromDate).toEqual('2024-01-14 15:00:00');
-            expect(fromString).toEqual(fromDate);
-        });
-
-        test('formatItemValue shifts a CUSTOM-format MAX timestamp metric into the project tz (GLITCH-492)', () => {
-            const maxMetric = {
-                ...metric,
-                type: MetricType.MAX,
-                formatOptions: {
-                    type: CustomFormatType.CUSTOM,
-                    custom: 'yyyy-mm-dd hh:mm:ss',
-                },
-            };
-            const value = new Date('2024-01-14T20:00:00.000Z'); // 15:00 in NY (EST)
-
-            expect(
-                formatItemValue(
-                    maxMetric,
-                    value,
-                    false,
-                    undefined,
-                    'America/New_York',
-                ),
-            ).toEqual('2024-01-14 15:00:00');
-        });
-
         test('formatItemValue shifts a parameterized custom-format timestamp into the project tz (GLITCH-492)', () => {
             const tsWithFormat = {
                 ...dimension,

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1149,6 +1149,47 @@ describe('Formatting', () => {
             ).toEqual('2018-10-31');
         });
 
+        test('formatItemValue shifts a custom-format timestamp into the project tz (GLITCH-492)', () => {
+            // A TIMESTAMP field with a custom date format expression must still
+            // render in the project timezone — the expression controls HOW the
+            // value is rendered, not WHICH zone it is rendered in.
+            const tsWithFormat = {
+                ...dimension,
+                type: DimensionType.TIMESTAMP,
+                format: 'yyyy-mm-dd hh:mm:ss',
+            };
+            const value = new Date('2024-01-14T20:00:00.000Z'); // 15:00 in NY (EST)
+
+            expect(
+                formatItemValue(
+                    tsWithFormat,
+                    value,
+                    false,
+                    undefined,
+                    'America/New_York',
+                ),
+            ).toEqual('2024-01-14 15:00:00');
+        });
+
+        test('formatItemValue custom-format timestamp stays UTC when flag is off (GLITCH-492)', () => {
+            // Flag-off orgs receive no timezone (the API sends a null
+            // resolvedTimezone), and an explicit UTC project must also not
+            // shift — output stays bit-identical to the raw value.
+            const tsWithFormat = {
+                ...dimension,
+                type: DimensionType.TIMESTAMP,
+                format: 'yyyy-mm-dd hh:mm:ss',
+            };
+            const value = new Date('2024-01-14T20:00:00.000Z');
+
+            expect(
+                formatItemValue(tsWithFormat, value, false, undefined),
+            ).toEqual('2024-01-14 20:00:00');
+            expect(
+                formatItemValue(tsWithFormat, value, false, undefined, 'UTC'),
+            ).toEqual('2024-01-14 20:00:00');
+        });
+
         describe('formatItemValue timestamp handling', () => {
             const mockTimestampField = {
                 type: DimensionType.TIMESTAMP,

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1229,6 +1229,32 @@ describe('Formatting', () => {
             ).toEqual('2024-01-14 20:00:00');
         });
 
+        test('formatItemValue does not shift a calendar DATE with a CUSTOM format (GLITCH-492)', () => {
+            // A bare calendar date has no instant — applying the project tz
+            // would drag it across midnight (off-by-one in negative offsets).
+            // The CUSTOM-format branch must honour the same calendar guard as
+            // the default DATE render.
+            const dateWithCustom = {
+                ...dimension,
+                type: DimensionType.DATE,
+                formatOptions: {
+                    type: CustomFormatType.CUSTOM,
+                    custom: 'yyyy-mm-dd',
+                },
+            };
+            const value = new Date('2024-01-15T00:00:00.000Z');
+
+            expect(
+                formatItemValue(
+                    dateWithCustom,
+                    value,
+                    false,
+                    undefined,
+                    'America/New_York',
+                ),
+            ).toEqual('2024-01-15');
+        });
+
         describe('formatItemValue timestamp handling', () => {
             const mockTimestampField = {
                 type: DimensionType.TIMESTAMP,

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1190,6 +1190,95 @@ describe('Formatting', () => {
             ).toEqual('2024-01-14 20:00:00');
         });
 
+        test('formatItemValue shifts a custom-format MAX timestamp metric into the project tz from a Date OR an ISO string (GLITCH-492)', () => {
+            const maxMetric = {
+                ...metric,
+                type: MetricType.MAX,
+                format: 'yyyy-mm-dd hh:mm:ss',
+            };
+            const isoString = '2024-01-14T20:00:00.000Z';
+            const asDate = new Date(isoString); // 15:00 in NY (EST)
+
+            const fromDate = formatItemValue(
+                maxMetric,
+                asDate,
+                false,
+                undefined,
+                'America/New_York',
+            );
+            const fromString = formatItemValue(
+                maxMetric,
+                isoString,
+                false,
+                undefined,
+                'America/New_York',
+            );
+
+            expect(fromDate).toEqual('2024-01-14 15:00:00');
+            expect(fromString).toEqual(fromDate);
+        });
+
+        test('formatItemValue shifts a CUSTOM-format MAX timestamp metric into the project tz (GLITCH-492)', () => {
+            const maxMetric = {
+                ...metric,
+                type: MetricType.MAX,
+                formatOptions: {
+                    type: CustomFormatType.CUSTOM,
+                    custom: 'yyyy-mm-dd hh:mm:ss',
+                },
+            };
+            const value = new Date('2024-01-14T20:00:00.000Z'); // 15:00 in NY (EST)
+
+            expect(
+                formatItemValue(
+                    maxMetric,
+                    value,
+                    false,
+                    undefined,
+                    'America/New_York',
+                ),
+            ).toEqual('2024-01-14 15:00:00');
+        });
+
+        test('formatItemValue shifts a parameterized custom-format timestamp into the project tz (GLITCH-492)', () => {
+            const tsWithFormat = {
+                ...dimension,
+                type: DimensionType.TIMESTAMP,
+                format: '${ld.parameters.style=="long"?"yyyy-mm-dd hh:mm:ss":"yyyy-mm-dd"}',
+            };
+            const value = new Date('2024-01-14T20:00:00.000Z'); // 15:00 in NY (EST)
+
+            expect(
+                formatItemValue(
+                    tsWithFormat,
+                    value,
+                    false,
+                    { style: 'long' },
+                    'America/New_York',
+                ),
+            ).toEqual('2024-01-14 15:00:00');
+        });
+
+        test('formatItemValue custom-format timestamp respects skipTimezoneConversion (GLITCH-492)', () => {
+            const tsWithFormat = {
+                ...dimension,
+                type: DimensionType.TIMESTAMP,
+                skipTimezoneConversion: true,
+                format: 'yyyy-mm-dd hh:mm:ss',
+            };
+            const value = new Date('2024-01-14T20:00:00.000Z');
+
+            expect(
+                formatItemValue(
+                    tsWithFormat,
+                    value,
+                    false,
+                    undefined,
+                    'America/New_York',
+                ),
+            ).toEqual('2024-01-14 20:00:00');
+        });
+
         describe('formatItemValue timestamp handling', () => {
             const mockTimestampField = {
                 type: DimensionType.TIMESTAMP,
@@ -1769,6 +1858,28 @@ describe('Formatting', () => {
             // Test larger values
             expect(formatItemValue(mockMetric, 1024)).toEqual('1.00KiB');
             expect(formatItemValue(mockMetric, 3072)).toEqual('3.00KiB');
+        });
+
+        test('formatValueWithExpression ignores the incidental runtime timezone for date expressions (#19759)', () => {
+            const previousTz = process.env.TZ;
+            process.env.TZ = 'America/New_York';
+
+            try {
+                const value = new Date('2024-11-01T00:00:00.000Z');
+
+                // Even when the host runtime is non-UTC, a date expression
+                // with no project timezone should render the raw UTC wall-clock
+                // rather than drifting into the machine-local zone.
+                expect(
+                    formatValueWithExpression('d mmm yyyy hh:mm:ss', value),
+                ).toEqual('1 Nov 2024 00:00:00');
+            } finally {
+                if (previousTz === undefined) {
+                    delete process.env.TZ;
+                } else {
+                    process.env.TZ = previousTz;
+                }
+            }
         });
     });
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1103,12 +1103,18 @@ export function formatItemValue(
                 customFormat.custom &&
                 isMomentInput(value)
             ) {
+                // Mirror the default DATE branch: calendar days never shift,
+                // only real instants do. (isCalendarValueDimension is false for
+                // any TIMESTAMP, so this is a no-op there.)
+                const customExpressionTimezone = isCalendarValueDimension(item)
+                    ? undefined
+                    : effectiveTimezone;
                 try {
                     return formatValueWithExpression(
                         customFormat.custom,
                         value,
                         separatorToNumfmtLocale(customFormat.separator),
-                        effectiveTimezone,
+                        customExpressionTimezone,
                     );
                 } catch {
                     // Fall through to the default date/timestamp render.

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -229,7 +229,9 @@ export const toIsoWithProjectOffset = (
 
 // TIMESTAMPs and TIMESTAMP-base DATE intervals shift; calendar DATEs and
 // dims with `skipTimezoneConversion` stay put. Used by spreadsheet exports.
-export const shouldShiftItemTimezone = (item: Item | undefined): boolean => {
+export const shouldShiftItemTimezone = (
+    item: Item | AdditionalMetric | undefined,
+): boolean => {
     if (!isField(item)) return false;
     if (isDimension(item) && item.skipTimezoneConversion) return false;
     if (item.type === DimensionType.TIMESTAMP) return true;
@@ -607,6 +609,7 @@ export function formatValueWithExpression(
     expression: string,
     value: unknown,
     locale?: string,
+    timezone?: string,
 ) {
     try {
         let sanitizedValue = value;
@@ -663,11 +666,15 @@ export function formatValueWithExpression(
             if (!isMomentInput(sanitizedValue)) {
                 return 'NaT';
             }
-            return formatWithExpression(
-                expression,
-                moment(sanitizedValue).toDate(),
-                { ignoreTimezone: true },
-            );
+            // Shift into the project tz then relabel wall-clock as UTC so
+            // numfmt's `ignoreTimezone` renders it verbatim. Gated like
+            // formatTimestamp (`if (timezone)`).
+            const dateForExpression = timezone
+                ? moment.utc(sanitizedValue).tz(timezone).utc(true).toDate()
+                : moment(sanitizedValue).toDate();
+            return formatWithExpression(expression, dateForExpression, {
+                ignoreTimezone: true,
+            });
         }
 
         // format text
@@ -1023,6 +1030,12 @@ export function formatItemValue(
                 getEffectiveSeparator(item),
             );
 
+            // Only shift genuinely timezone-shiftable temporal fields, so
+            // calendar DATEs and skipTimezoneConversion fields stay put.
+            const expressionTimezone = shouldShiftItemTimezone(item)
+                ? timezone
+                : undefined;
+
             // Check if format uses parameter placeholders
             const hasParameterPlaceholders =
                 item.format.includes(
@@ -1043,6 +1056,7 @@ export function formatItemValue(
                             formatExpression,
                             value,
                             separatorLocale,
+                            expressionTimezone,
                         );
                         return result;
                     } catch (error) {
@@ -1061,6 +1075,7 @@ export function formatItemValue(
                     item.format,
                     value,
                     separatorLocale,
+                    expressionTimezone,
                 );
                 return result;
             } catch (error) {
@@ -1093,6 +1108,7 @@ export function formatItemValue(
                         customFormat.custom,
                         value,
                         separatorToNumfmtLocale(customFormat.separator),
+                        effectiveTimezone,
                     );
                 } catch {
                     // Fall through to the default date/timestamp render.

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1023,6 +1023,13 @@ export function formatItemValue(
     if (value === null) return '∅';
     if (value === undefined) return '-';
     if (item) {
+        const isTimestampMetricResult =
+            'type' in item &&
+            (item.type === MetricType.MAX || item.type === MetricType.MIN) &&
+            (value instanceof Date || isTimestampString(value));
+        const shouldShiftExpressionTimezone =
+            shouldShiftItemTimezone(item) || isTimestampMetricResult;
+
         if (hasValidFormatExpression(item)) {
             // A field-level separator localises the ECMA-376 expression, which
             // numfmt otherwise renders with US separators regardless of locale.
@@ -1031,8 +1038,9 @@ export function formatItemValue(
             );
 
             // Only shift genuinely timezone-shiftable temporal fields, so
-            // calendar DATEs and skipTimezoneConversion fields stay put.
-            const expressionTimezone = shouldShiftItemTimezone(item)
+            // calendar DATEs stay put, while MIN/MAX timestamp metrics follow
+            // the same project-tz render path as their default formatter.
+            const expressionTimezone = shouldShiftExpressionTimezone
                 ? timezone
                 : undefined;
 
@@ -1091,6 +1099,9 @@ export function formatItemValue(
                 isDimension(item) && item.skipTimezoneConversion
                     ? undefined
                     : timezone;
+            const customExpressionTimezone = shouldShiftExpressionTimezone
+                ? effectiveTimezone
+                : undefined;
 
             // Date/Timestamp table calculations may carry a CUSTOM format
             // expression (e.g. "mmmm d, yyyy"). The default switch path
@@ -1098,7 +1109,8 @@ export function formatItemValue(
             // it, so honour the custom expression first.
             if (
                 (type === TableCalculationType.DATE ||
-                    type === TableCalculationType.TIMESTAMP) &&
+                    type === TableCalculationType.TIMESTAMP ||
+                    isTimestampMetricResult) &&
                 customFormat?.type === CustomFormatType.CUSTOM &&
                 customFormat.custom &&
                 isMomentInput(value)
@@ -1108,7 +1120,7 @@ export function formatItemValue(
                         customFormat.custom,
                         value,
                         separatorToNumfmtLocale(customFormat.separator),
-                        effectiveTimezone,
+                        customExpressionTimezone,
                     );
                 } catch {
                     // Fall through to the default date/timestamp render.

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1023,13 +1023,6 @@ export function formatItemValue(
     if (value === null) return '∅';
     if (value === undefined) return '-';
     if (item) {
-        const isTimestampMetricResult =
-            'type' in item &&
-            (item.type === MetricType.MAX || item.type === MetricType.MIN) &&
-            (value instanceof Date || isTimestampString(value));
-        const shouldShiftExpressionTimezone =
-            shouldShiftItemTimezone(item) || isTimestampMetricResult;
-
         if (hasValidFormatExpression(item)) {
             // A field-level separator localises the ECMA-376 expression, which
             // numfmt otherwise renders with US separators regardless of locale.
@@ -1038,9 +1031,8 @@ export function formatItemValue(
             );
 
             // Only shift genuinely timezone-shiftable temporal fields, so
-            // calendar DATEs stay put, while MIN/MAX timestamp metrics follow
-            // the same project-tz render path as their default formatter.
-            const expressionTimezone = shouldShiftExpressionTimezone
+            // calendar DATEs and skipTimezoneConversion fields stay put.
+            const expressionTimezone = shouldShiftItemTimezone(item)
                 ? timezone
                 : undefined;
 
@@ -1099,9 +1091,6 @@ export function formatItemValue(
                 isDimension(item) && item.skipTimezoneConversion
                     ? undefined
                     : timezone;
-            const customExpressionTimezone = shouldShiftExpressionTimezone
-                ? effectiveTimezone
-                : undefined;
 
             // Date/Timestamp table calculations may carry a CUSTOM format
             // expression (e.g. "mmmm d, yyyy"). The default switch path
@@ -1109,8 +1098,7 @@ export function formatItemValue(
             // it, so honour the custom expression first.
             if (
                 (type === TableCalculationType.DATE ||
-                    type === TableCalculationType.TIMESTAMP ||
-                    isTimestampMetricResult) &&
+                    type === TableCalculationType.TIMESTAMP) &&
                 customFormat?.type === CustomFormatType.CUSTOM &&
                 customFormat.custom &&
                 isMomentInput(value)
@@ -1120,7 +1108,7 @@ export function formatItemValue(
                         customFormat.custom,
                         value,
                         separatorToNumfmtLocale(customFormat.separator),
-                        customExpressionTimezone,
+                        effectiveTimezone,
                     );
                 } catch {
                     // Fall through to the default date/timestamp render.


### PR DESCRIPTION
### Problem

A timestamp field rendered with a **custom format expression** (e.g. `yyyy-mm-dd hh:mm:ss`) reverted the displayed time to **UTC**, even when the project timezone was non-UTC. A plain timestamp in the same table/tile rendered correctly in the project timezone, so the two diverged.

### Root cause

`formatValueWithExpression` had no timezone awareness. Its date branch fed the raw UTC instant to numfmt with `{ ignoreTimezone: true }` (added in #19759 to stop the *incidental runtime-local* zone from drifting the output). That made expression-formatted timestamps render their UTC wall-clock unconditionally, dropping the project-timezone shift that the default `formatTimestamp` path applies.

### Fix

- Thread the resolved timezone through `formatValueWithExpression`. In the date branch, shift the UTC instant into the project tz (`moment.utc(value).tz(timezone).utc(true).toDate()`) before handing it to numfmt, keeping `ignoreTimezone: true`. This refines #19759 rather than reverting it — we still ignore the incidental runtime-local zone, but now honor the *configured* one.
- Gate the shift at the call sites with the existing `shouldShiftItemTimezone` helper, so calendar DATEs and `skipTimezoneConversion` fields stay put.

### Gating

Inherits `EnableTimezoneSupport` — the `timezone` reaching the formatter is the API's flag-gated `displayTimezone` (null when the flag is off), so flag-off and explicit-UTC output is bit-identical. Chart (cartesian) axis/tooltip formatting is unaffected: it formats via a separate `seriesValueFormatter` that passes no timezone, and its timezone handling lives in `applyTimezoneShiftToEchartsOptions`.

### Tests

Two TDD cases in `formatting.test.ts`: project-tz shift for a custom-format timestamp, and no-shift when the flag is off / timezone is UTC.

**Before**

https://github.com/user-attachments/assets/76fe4a83-ca98-4cd0-8038-b6b9cdcddd56

**After**

https://github.com/user-attachments/assets/9747e7e4-22d5-4588-8ae4-ce2193416ce8

Closes: GLITCH-492
Closes: #24160
Relates: #19759