### PR TITLE
fix(backend): add ?skipMigrationCheck opt-out to /api/v1/health

### DIFF
--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -390,9 +390,10 @@ apiV1Router.get('/livez', async (req, res, next) => {
 });
 
 apiV1Router.get('/health', async (req, res, next) => {
+    const skipMigrationCheck = req.query.skipMigrationCheck === 'true';
     req.services
         .getHealthService()
-        .getHealthState(req.user)
+        .getHealthState(req.user, { skipMigrationCheck })
         .then((state) =>
             res.json({
                 status: 'ok',

--- a/packages/backend/src/services/HealthService/HealthService.test.ts
+++ b/packages/backend/src/services/HealthService/HealthService.test.ts
@@ -108,6 +108,33 @@ describe('health', () => {
         });
     });
 
+    describe('skipMigrationCheck', () => {
+        it('checks migration status by default', async () => {
+            await healthService.getHealthState(undefined);
+            expect(migrationModel.getMigrationStatus).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not check migration status when skipMigrationCheck is true', async () => {
+            const result = await healthService.getHealthState(undefined, {
+                skipMigrationCheck: true,
+            });
+            expect(result).toEqual(BaseResponse);
+            expect(migrationModel.getMigrationStatus).not.toHaveBeenCalled();
+        });
+
+        it('throws when the DB is unmigrated and the check runs', async () => {
+            (
+                migrationModel.getMigrationStatus as jest.Mock
+            ).mockImplementationOnce(() => ({
+                status: -1,
+                currentVersion: 'example',
+            }));
+            await expect(
+                healthService.getHealthState(undefined),
+            ).rejects.toThrow('Database has not been migrated yet');
+        });
+    });
+
     describe('getPylonVerificationHash', () => {
         const testEmail = 'test@example.com';
         // Valid hex string (32 bytes = 64 hex chars)

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -48,7 +48,12 @@ export class HealthService extends BaseService {
         return this.lightdashConfig.license.licenseKey !== undefined;
     }
 
-    async getHealthState(user: SessionUser | undefined): Promise<HealthState> {
+    async getHealthState(
+        user: SessionUser | undefined,
+        options: { skipMigrationCheck: boolean } = {
+            skipMigrationCheck: false,
+        },
+    ): Promise<HealthState> {
         const isAuthenticated: boolean = !!user?.userUuid;
 
         // Resolve the query/CSV limits for the requesting org (override ?? the
@@ -68,21 +73,24 @@ export class HealthService extends BaseService {
                   csvCellsLimit: this.lightdashConfig.query.csvCellsLimit,
               };
 
-        const migrationStartTime = performance.now();
-        const { status: migrationStatus, currentVersion } =
-            await this.migrationModel.getMigrationStatus();
-        const migrationExecutionTime = performance.now() - migrationStartTime;
+        let migrationExecutionTime = 0;
+        if (!options.skipMigrationCheck) {
+            const migrationStartTime = performance.now();
+            const { status: migrationStatus, currentVersion } =
+                await this.migrationModel.getMigrationStatus();
+            migrationExecutionTime = performance.now() - migrationStartTime;
 
-        if (migrationStatus < 0) {
-            throw new UnexpectedDatabaseError(
-                'Database has not been migrated yet',
-                { currentVersion },
-            );
-        } else if (migrationStatus > 0) {
-            console.warn(
-                `There are more DB migrations than defined in the code (you are running old code against a newer DB). Current version: ${currentVersion}`,
-            );
-        } // else migrationStatus === 0 (all migrations are up to date)
+            if (migrationStatus < 0) {
+                throw new UnexpectedDatabaseError(
+                    'Database has not been migrated yet',
+                    { currentVersion },
+                );
+            } else if (migrationStatus > 0) {
+                console.warn(
+                    `There are more DB migrations than defined in the code (you are running old code against a newer DB). Current version: ${currentVersion}`,
+                );
+            } // else migrationStatus === 0 (all migrations are up to date)
+        }
 
         const hasOrgsStartTime = performance.now();
         const requiresOrgRegistration =

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -141,7 +141,7 @@ type CreateProjectOptions = {
 const isSnowflakeSsoEnabled = async (): Promise<boolean> => {
     const response = await lightdashApi<HealthState>({
         method: 'GET',
-        url: `/api/v1/health`,
+        url: `/api/v1/health?skipMigrationCheck=true`,
         body: undefined,
     });
 

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -222,7 +222,7 @@ export const checkLightdashVersion = async (): Promise<void> => {
     try {
         const health = await lightdashApi<ApiHealthResults>({
             method: 'GET',
-            url: `/api/v1/health`,
+            url: `/api/v1/health?skipMigrationCheck=true`,
             body: undefined,
         });
 

--- a/packages/frontend/src/hooks/health/useHealth.tsx
+++ b/packages/frontend/src/hooks/health/useHealth.tsx
@@ -9,7 +9,7 @@ import useQueryError from '../useQueryError';
 
 const getHealthState = async () =>
     lightdashApi<ApiHealthResults>({
-        url: `/health`,
+        url: `/health?skipMigrationCheck=true`,
         method: 'GET',
         body: undefined,
     });


### PR DESCRIPTION
Closes: PROD-8271
Closes: #24204

### Description:

`GET /api/v1/health` called `MigrationModel.getMigrationStatus()` on every request, running `knex.migrate.status()` + `currentVersion()` — roughly 4–6 `information_schema`/`knex_migrations` queries per call, which becomes significant DB load for deployments with many replicas and frequent orchestration probes pointed at `/health`. This adds an opt-out `?skipMigration=true` query param that skips the migration guard (default behaviour unchanged), and wires the first-party callers that don't need it (frontend health hook and CLI version/SSO checks) to pass it. The migration result is only an internal guard and is never returned in the response, so skipping it does not change the `HealthState` payload.
