### PR TITLE
feat(ai-review): add Validate link to the review verification panel

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
@@ -15,6 +15,7 @@ import {
     IconCircleCheckFilled,
     IconFileDiff,
     IconGitPullRequest,
+    IconListCheck,
     IconMessages,
     IconRefresh,
 } from '@tabler/icons-react';
@@ -66,6 +67,9 @@ export const ReviewVerificationPanel: FC<Props> = ({
     const linkedPrUrl = remediation?.linkedPrUrl ?? null;
     const prNumber = linkedPrUrl ? getPrNumber(linkedPrUrl) : null;
     const isResolved = reviewItem.status === 'resolved';
+    const validatorUrl = remediation?.previewProjectUuid
+        ? `/generalSettings/projectManagement/${remediation.previewProjectUuid}/validator`
+        : null;
     const sourceThreadUrl =
         remediation &&
         `/projects/${remediation.sourceProjectUuid}/ai-agents/${remediation.sourceAgentUuid}/threads/${remediation.sourceThreadUuid}`;
@@ -156,6 +160,27 @@ export const ReviewVerificationPanel: FC<Props> = ({
                                         ? `Pull request #${prNumber}`
                                         : 'Pull request'
                                 }
+                                trailing={
+                                    <MantineIcon
+                                        icon={IconArrowUpRight}
+                                        size="sm"
+                                        color="dimmed"
+                                    />
+                                }
+                            />
+                        </Anchor>
+                    )}
+
+                    {validatorUrl && (
+                        <Anchor
+                            className={styles.row}
+                            component={Link}
+                            to={validatorUrl}
+                            underline="never"
+                        >
+                            <Row
+                                icon={IconListCheck}
+                                label="Validate"
                                 trailing={
                                     <MantineIcon
                                         icon={IconArrowUpRight}


### PR DESCRIPTION
Adds a **Validate** row to the review verification panel, between the pull-request link and "Where it was flagged". It links to the preview project's validator so a reviewer can see what the generated change breaks before marking the review done.

Builds on the verification panel introduced in #24193 (merged) — shown only when the review's remediation has a `previewProjectUuid`, the same gating as the PR link.

## How it looks

```
Pull request #123            ↗
Validate                     ↗   ← new
Where it was flagged         ↗
Retry question
──────────────────────────────
Mark done
```

Links via react-router `Link` to `/generalSettings/projectManagement/{previewProjectUuid}/validator`, styled with the panel's existing `Row` pattern (`IconListCheck` + trailing arrow).

## Test plan

- [x] `pnpm -F frontend typecheck` and lint (oxlint) clean on `ReviewVerificationPanel.tsx`
- [ ] Open a review whose remediation has a preview project → Validate row appears after the PR row and opens that project's validator
- [ ] Open a review with no preview project → Validate row is hidden
