### PR TITLE
feat(ai-writeback): guard follow-ups on merged/closed PRs + card polish

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -62,7 +62,10 @@ import {
     TMP_PROFILES_DIR,
     WAREHOUSE_SKILL_PATH,
 } from './constants';
-import { WritebackGitNotConnectedError } from './errors';
+import {
+    WritebackGitNotConnectedError,
+    WritebackThreadPrClosedError,
+} from './errors';
 import { GithubProvider } from './providers/GithubProvider';
 import { GitlabProvider } from './providers/GitlabProvider';
 import type { GitProvider } from './providers/GitProvider';
@@ -852,6 +855,26 @@ export class AiWritebackService extends BaseService {
         const existingRow = aiThreadUuid
             ? await this.aiWritebackThreadModel.findByAiThreadUuid(aiThreadUuid)
             : null;
+
+        // A thread is bound to its first PR. If that PR has since been merged or
+        // closed (from the chat card or directly on the host), editing it again
+        // would push onto a dead branch and silently orphan the change. Bail
+        // before spinning up the sandbox and tell the user to start a new
+        // thread. (Pasted-link turns are validated separately in adoptPullRequest.)
+        if (existingRow?.pr_url) {
+            const installation = await provider.resolveInstallation(
+                user.organizationUuid,
+                { user, connection: gitConnection },
+            );
+            const editState = await provider.getPullRequestEditState({
+                prUrl: existingRow.pr_url,
+                connection: gitConnection,
+                installation,
+            });
+            if (!editState.editable && editState.reason) {
+                throw new WritebackThreadPrClosedError(editState.reason);
+            }
+        }
 
         // `get()` returns the (de-sensitised) warehouse credentials with the
         // discriminant `type` intact. Null when the project has no warehouse

--- a/packages/backend/src/ee/services/AiWritebackService/errors.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/errors.ts
@@ -1,4 +1,8 @@
-import { ForbiddenError, PullRequestProvider } from '@lightdash/common';
+import {
+    ForbiddenError,
+    ParameterError,
+    PullRequestProvider,
+} from '@lightdash/common';
 
 /**
  * Thrown when a writeback cannot proceed because the project has no usable Git
@@ -20,5 +24,23 @@ export class WritebackGitNotConnectedError extends ForbiddenError {
     ) {
         super(message);
         this.provider = provider;
+    }
+}
+
+/**
+ * Thrown when a resume turn's thread is bound to a pull/merge request that has
+ * since been merged or closed (here or on the host). Editing it again would
+ * push onto a dead branch and silently orphan the change, so the run bails. The
+ * `editDbtProject` tool catches this (via `instanceof`) and tells the user to
+ * start a new thread rather than rendering a generic failure or retrying.
+ */
+export class WritebackThreadPrClosedError extends ParameterError {
+    readonly reason: 'merged' | 'closed';
+
+    constructor(reason: 'merged' | 'closed') {
+        super(
+            `This thread's pull request has already been ${reason}, so it can't be updated. Tell the user that to make further changes they should start a new thread.`,
+        );
+        this.reason = reason;
     }
 }

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GitProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GitProvider.ts
@@ -86,4 +86,15 @@ export interface GitProvider {
     updatePullRequest(args: UpdatePullRequestArgs): Promise<LandedCommit>;
     /** Validate a pasted PR/MR link before editing it on top of its branch. */
     adoptPullRequest(args: AdoptPullRequestArgs): Promise<AdoptedPullRequest>;
+    /**
+     * Whether a thread's stored PR/MR can still be edited. A resume turn reuses
+     * the PR recorded on the thread, which may have been merged or closed (here
+     * or on the host) since — editing it would push onto a dead branch and
+     * orphan the change, so the caller bails first.
+     */
+    getPullRequestEditState(args: {
+        prUrl: string;
+        connection: GitConnection;
+        installation: GitInstallation;
+    }): Promise<{ editable: boolean; reason: 'merged' | 'closed' | null }>;
 }

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.ts
@@ -339,6 +339,29 @@ export class GithubProvider implements GitProvider {
         return landed;
     }
 
+    async getPullRequestEditState(args: {
+        prUrl: string;
+        connection: GitConnection;
+        installation: GitInstallation;
+    }): Promise<{ editable: boolean; reason: 'merged' | 'closed' | null }> {
+        const connection = asGithubConnection(args.connection);
+        const installation = asGithubInstallation(args.installation);
+        const parsed = parsePullRequestUrl(args.prUrl);
+        const pr = await getPullRequest({
+            owner: connection.owner,
+            repo: connection.repo,
+            pullNumber: parsed.pullNumber,
+            ...githubAuth(installation),
+        });
+        if (pr.merged) {
+            return { editable: false, reason: 'merged' };
+        }
+        if (pr.state === 'closed') {
+            return { editable: false, reason: 'closed' };
+        }
+        return { editable: true, reason: null };
+    }
+
     async adoptPullRequest(
         args: AdoptPullRequestArgs,
     ): Promise<AdoptedPullRequest> {

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GitlabProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GitlabProvider.ts
@@ -289,6 +289,34 @@ export class GitlabProvider implements GitProvider {
         return landed;
     }
 
+    async getPullRequestEditState(args: {
+        prUrl: string;
+        connection: GitConnection;
+        installation: GitInstallation;
+    }): Promise<{ editable: boolean; reason: 'merged' | 'closed' | null }> {
+        const connection = asGitlabConnection(args.connection);
+        const installation = asGitlabInstallation(args.installation);
+        assertSameHost(connection, installation);
+        const { mergeRequestIid } = parseMergeRequestUrl(
+            args.prUrl,
+            connection.hostDomain,
+        );
+        const mr = await getMergeRequest({
+            owner: connection.owner,
+            repo: connection.repo,
+            iid: mergeRequestIid,
+            token: installation.token,
+            hostDomain: connection.hostDomain,
+        });
+        if (mr.merged) {
+            return { editable: false, reason: 'merged' };
+        }
+        if (mr.state === 'closed') {
+            return { editable: false, reason: 'closed' };
+        }
+        return { editable: true, reason: null };
+    }
+
     async adoptPullRequest(
         args: AdoptPullRequestArgs,
     ): Promise<AdoptedPullRequest> {

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3654,6 +3654,7 @@ Parameters:
                         "github_not_installed",
                         "gitlab_not_installed",
                         "unsupported_source_control",
+                        "pull_request_not_open",
                         "unknown",
                       ],
                       "type": "string",

--- a/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
+++ b/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
@@ -3,7 +3,10 @@ import {
     PullRequestProvider,
 } from '@lightdash/common';
 import { tool } from 'ai';
-import { WritebackGitNotConnectedError } from '../../AiWritebackService/errors';
+import {
+    WritebackGitNotConnectedError,
+    WritebackThreadPrClosedError,
+} from '../../AiWritebackService/errors';
 import type { EditDbtProjectFn } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
@@ -16,6 +19,7 @@ type WritebackErrorCode =
     | 'github_not_installed'
     | 'gitlab_not_installed'
     | 'unsupported_source_control'
+    | 'pull_request_not_open'
     | 'unknown';
 
 // Map a thrown writeback error to the metadata code the chat card renders.
@@ -31,6 +35,9 @@ const classifyWritebackError = (error: unknown): WritebackErrorCode => {
             return 'gitlab_not_installed';
         }
         return 'unsupported_source_control';
+    }
+    if (error instanceof WritebackThreadPrClosedError) {
+        return 'pull_request_not_open';
     }
     return 'unknown';
 };
@@ -102,6 +109,18 @@ export const getEditDbtProject = ({ editDbtProject }: Dependencies) =>
                     },
                 };
             } catch (error) {
+                // A merged/closed thread PR is a terminal, expected state — not
+                // a failure to retry. Surface its guidance verbatim (no "try
+                // again" suffix, no Sentry noise) so the agent relays it.
+                if (error instanceof WritebackThreadPrClosedError) {
+                    return {
+                        result: error.message,
+                        metadata: {
+                            status: 'error' as const,
+                            errorCode: 'pull_request_not_open' as const,
+                        },
+                    };
+                }
                 return {
                     result: toolErrorHandler(
                         error,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
@@ -83,6 +83,7 @@ export const toolEditDbtProjectOutputSchema = z.object({
                     'github_not_installed',
                     'gitlab_not_installed',
                     'unsupported_source_control',
+                    'pull_request_not_open',
                     'unknown',
                 ])
                 .nullish(),

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.module.css
@@ -1,0 +1,20 @@
+.card {
+    container-type: inline-size;
+}
+
+.actions {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+}
+
+/* In the narrow minimized chat bubble, "View" + the Close/Merge group overflow
+   side by side, so stack them and let each fill the column width. */
+@container (max-width: 400px) {
+    .actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.tsx
@@ -4,6 +4,7 @@ import {
     type ToolEditDbtProjectOutput,
 } from '@lightdash/common';
 import {
+    Box,
     Button,
     Group,
     Menu,
@@ -32,6 +33,7 @@ import MantineModal from '../../../../../../components/common/MantineModal';
 import { useClosePullRequest } from '../../../hooks/useClosePullRequest';
 import { useMergePullRequest } from '../../../hooks/useMergePullRequest';
 import { usePullRequestCiChecks } from '../../../hooks/usePullRequestCiChecks';
+import styles from './AiEditDbtProjectToolCall.module.css';
 import { isMergeable } from './pullRequestActions';
 import { PullRequestCiChecks } from './PullRequestCiChecks';
 import { WritebackDiffModal } from './WritebackDiffModal';
@@ -394,6 +396,38 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
                 </Paper>
             );
         }
+        // The thread's pull request was already merged or closed, so further
+        // edits can't be added here. Not a failure — guide the user to a new
+        // thread rather than show a red error.
+        if (metadata.errorCode === 'pull_request_not_open') {
+            return (
+                <Paper withBorder p="sm" radius="md">
+                    <Group gap="xs" align="flex-start" wrap="nowrap">
+                        <ThemeIcon
+                            variant="light"
+                            color="ldGray"
+                            radius="md"
+                            size="md"
+                        >
+                            <MantineIcon
+                                icon={IconGitPullRequestClosed}
+                                size={16}
+                            />
+                        </ThemeIcon>
+                        <Stack gap={2}>
+                            <Text size="sm" fw={500}>
+                                This thread's pull request is closed
+                            </Text>
+                            <Text size="xs" c="ldGray.6">
+                                Its pull request has already been merged or
+                                closed, so further changes can't be added here.
+                                Start a new thread to request more changes.
+                            </Text>
+                        </Stack>
+                    </Group>
+                </Paper>
+            );
+        }
         return (
             <Paper withBorder p="sm" radius="md" bg="red.0">
                 <Group gap="xs" align="center" wrap="nowrap">
@@ -455,7 +489,7 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
     const title = 'Edited semantic layer';
 
     return (
-        <Paper withBorder p="sm" radius="md">
+        <Paper withBorder p="sm" radius="md" className={styles.card}>
             <Stack gap="xs">
                 <Group
                     gap="sm"
@@ -522,12 +556,13 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
                             )}
                         </Stack>
                     </Group>
-                    <Group gap="xs" wrap="nowrap">
+                    <Box className={styles.actions}>
                         {/* View (preview / PR / diff) stands alone; the Close and
                             Merge terminal actions are joined in their own group.
                             Preview URL is generated server-side during the run
                             and carried in the tool metadata — a setup PR never
-                            previews itself. */}
+                            previews itself. Stacks vertically in the narrow
+                            minimized chat bubble (see the module's container query). */}
                         <PullRequestViewMenu
                             projectUuid={projectUuid}
                             prUrl={metadata.prUrl}
@@ -545,7 +580,7 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
                             commitSha={metadata.commitSha ?? null}
                             ciChecks={ciChecks ?? null}
                         />
-                    </Group>
+                    </Box>
                 </Group>
                 <PullRequestCiChecks
                     prUrl={metadata.prUrl}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/PullRequestCiChecks.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/PullRequestCiChecks.tsx
@@ -24,6 +24,7 @@ import {
     IconCircleX,
     IconClock,
     IconGitMerge,
+    IconGitPullRequestClosed,
     IconPlayerSkipForward,
     type Icon as TablerIcon,
 } from '@tabler/icons-react';
@@ -186,15 +187,22 @@ export const PullRequestCiChecks: FC<{
         return null;
     }
 
-    // Once merged the policy verdict is no longer meaningful — show a terminal
-    // "Merged" roll-up instead of the (now stale) merge-readiness state.
-    const { color, icon, title } = ciChecks.merged
-        ? {
-              color: 'green' as DefaultMantineColor,
-              icon: IconGitMerge,
-              title: 'Merged',
-          }
-        : READINESS[ciChecks.mergeState];
+    // Once a PR is merged or closed the policy verdict is no longer meaningful —
+    // show the terminal state instead of the (now stale) merge-readiness verdict.
+    const terminal: {
+        color: DefaultMantineColor;
+        icon: TablerIcon;
+        title: string;
+    } | null = ciChecks.merged
+        ? { color: 'green', icon: IconGitMerge, title: 'Merged' }
+        : ciChecks.state === 'closed'
+          ? {
+                color: 'ldGray.6',
+                icon: IconGitPullRequestClosed,
+                title: 'Closed',
+            }
+          : null;
+    const { color, icon, title } = terminal ?? READINESS[ciChecks.mergeState];
 
     return (
         <Stack gap={4}>


### PR DESCRIPTION
## What

Follow-up to #24206 (PR-card merge/close actions), from manually testing the matrix end-to-end. Three fixes:

1. **Guard follow-ups against a terminal PR.** A chat thread is bound to its first pull request. If that PR is merged or closed (from the card, or directly on the host) and the user asks for another change in the same thread, the writeback would silently push a new commit onto the dead branch and report success — orphaning the change. Now the run **bails up front** and tells the user to **start a new thread**.
2. **Closed roll-up verdict.** The CI roll-up row showed the stale "Mergeable" for a closed-not-merged PR; it now shows a terminal **"Closed"** (the merged case already showed "Merged").
3. **Minimized-bubble layout.** "View" and the Close/Merge group overflowed side-by-side in the narrow chat bubble; they now stack vertically (restored container query).

## How

- New `GitProvider.getPullRequestEditState` (implemented for GitHub + GitLab) reports whether a stored PR/MR is still editable. `prepareTurn` checks it for resume turns and throws `WritebackThreadPrClosedError` **before spinning up the sandbox** (fail-fast, ~1.5s, no wasted agent run).
- The tool maps it to a new `pull_request_not_open` error code (no "try again" suffix, no Sentry noise); the chat card renders a calm "this thread's pull request is closed — start a new thread" state instead of a red failure.
- Pasted-link turns were already guarded in `adoptPullRequest`; this closes the same gap on the resume path.

## Testing

Verified end-to-end against the running app:
- Follow-up on a **closed** PR thread → blocked in **1.6s**, no sandbox, **no commit pushed**, agent relays "start a new thread", card shows the calm closed state.
- Closed PR roll-up now reads "Closed · 1 failing check".
- Minimized bubble: actions container computes `flex-direction: column` (buttons stack).
- `agentToolContracts` snapshot updated for the new error code; backend/frontend typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)