### PR TITLE
feat(explorer): chart timezone control in run-query settings

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -1,32 +1,25 @@
 import { subject } from '@casl/ability';
-import { FeatureFlags, getTimezoneLabel, isTimeZone } from '@lightdash/common';
 import { Badge, Box, Button, Group, Tooltip } from '@mantine-8/core';
 import { IconAlertCircle, IconArrowLeft } from '@tabler/icons-react';
 import { memo, useEffect, useMemo, type FC } from 'react';
 import useEmbed from '../../../ee/providers/Embed/useEmbed';
 import {
-    explorerActions,
     selectIsValidQuery,
     selectQueryLimit,
     selectSavedChart,
-    selectTimezone,
     selectUnsavedChartVersion,
-    useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
-import { useProject } from '../../../hooks/useProject';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../../providers/Ability';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
 import ShareShortLinkButton from '../../common/ShareShortLinkButton';
-import TimeZonePicker from '../../common/TimeZonePicker';
 import { RefreshButton } from '../../RefreshButton';
 import RefreshDbtButton from '../../RefreshDbtButton';
 import SaveChartButton from '../SaveChartButton';
@@ -40,7 +33,6 @@ const ExplorerHeader: FC = memo(() => {
 
     // Get state from Redux and new hook
     const limit = useExplorerSelector(selectQueryLimit);
-    const selectedTimezone = useExplorerSelector(selectTimezone);
     const isValidQuery = useExplorerSelector(selectIsValidQuery);
     const { query, queryResults } = useExplorerQuery();
 
@@ -51,19 +43,9 @@ const ExplorerHeader: FC = memo(() => {
     );
     const queryWarnings = query.data?.warnings;
 
-    const dispatch = useExplorerDispatch();
-
     const savedChart = useExplorerSelector(selectSavedChart);
 
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
-
-    const handleSetTimeZone = (timezone: string | null) => {
-        if (timezone === null) {
-            dispatch(explorerActions.setTimeZone(undefined));
-        } else if (isTimeZone(timezone)) {
-            dispatch(explorerActions.setTimeZone(timezone));
-        }
-    };
 
     const { getHasDashboardChanges } = useDashboardStorage();
 
@@ -120,21 +102,6 @@ const ExplorerHeader: FC = memo(() => {
         };
     }, [getHasDashboardChanges]);
 
-    const { data: enableUserTimezonesFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableUserTimezones,
-    );
-    const userTimeZonesEnabled = enableUserTimezonesFlag?.enabled ?? false;
-
-    const { data: project } = useProject(projectUuid);
-    const timezonePlaceholder = useMemo(() => {
-        const tz = project?.queryTimezone;
-        if (tz) {
-            const label = getTimezoneLabel(tz);
-            return label ? `Project: ${label}` : `Project: ${tz}`;
-        }
-        return 'Select timezone';
-    }, [project?.queryTimezone]);
-
     const userCanManageCompileProject = ability.can('manage', 'CompileProject');
 
     return (
@@ -183,15 +150,6 @@ const ExplorerHeader: FC = memo(() => {
                     queryWarnings.length > 0 && (
                         <QueryWarnings queryWarnings={queryWarnings} />
                     )}
-
-                {userTimeZonesEnabled && (
-                    <TimeZonePicker
-                        onChange={handleSetTimeZone}
-                        value={selectedTimezone ?? null}
-                        placeholder={timezonePlaceholder}
-                        clearable
-                    />
-                )}
 
                 <RefreshButton size="xs" />
 

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -5,6 +5,7 @@ import {
     getTotalFilterRules,
     getVisibleFields,
     isFilterableField,
+    isTimeZone,
     overrideFilterGroupWithFilterRules,
     reduceRequiredDimensionFiltersToFilterRules,
     resetRequiredFilterRules,
@@ -322,7 +323,11 @@ const FiltersCard: FC = memo(() => {
                     }}
                     baseTable={data?.baseTable}
                     parameterValues={parameterValues}
-                    metricQueryTimezone={metricQuery.timezone ?? undefined}
+                    metricQueryTimezone={
+                        metricQuery.timezone && isTimeZone(metricQuery.timezone)
+                            ? metricQuery.timezone
+                            : undefined
+                    }
                 >
                     <FiltersForm
                         isEditMode={isEditMode}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -5,6 +5,7 @@ import {
     getFieldsFromMetricQuery,
     getHiddenTableFields,
     getPivotConfig,
+    isTimeZone,
     NotFoundError,
     FeatureFlags,
     type ApiErrorDetail,
@@ -394,7 +395,12 @@ const VisualizationCard: FC<Props> = memo((props) => {
                                         query.data?.resolvedTimezone
                                     }
                                     metricQueryTimezone={
-                                        query.data?.metricQuery?.timezone
+                                        query.data?.metricQuery?.timezone &&
+                                        isTimeZone(
+                                            query.data.metricQuery.timezone,
+                                        )
+                                            ? query.data.metricQuery.timezone
+                                            : undefined
                                     }
                                 />
                                 {isEditMode ? (

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlags, type TimezoneSetting } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -16,11 +17,13 @@ import {
     selectIsValidQuery,
     selectPreAggVisible,
     selectQueryLimit,
+    selectTimezone,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../features/explorer/store';
 import useHealth from '../hooks/health/useHealth';
 import { useExplorerQuery } from '../hooks/useExplorerQuery';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useTracking from '../providers/Tracking/useTracking';
 import { EventName } from '../types/Events';
 import MantineIcon from './common/MantineIcon';
@@ -39,6 +42,18 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     const isValidQuery = useExplorerSelector(selectIsValidQuery);
     const dispatch = useExplorerDispatch();
     const preAggVisible = useExplorerSelector(selectPreAggVisible);
+    const timezone = useExplorerSelector(selectTimezone);
+
+    const { data: timezoneSupportFlag } = useServerFeatureFlag(
+        FeatureFlags.EnableTimezoneSupport,
+    );
+
+    const setTimeZone = useCallback(
+        (newTimezone: TimezoneSetting) => {
+            dispatch(explorerActions.setTimeZone(newTimezone));
+        },
+        [dispatch],
+    );
 
     // Get query state and actions from hooks
     const { isLoading, fetchResults, cancelQuery } = useExplorerQuery();
@@ -136,6 +151,11 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
                         onLimitChange={setRowLimit}
                         showAutoFetchSetting
                         showPreAggregateSetting={preAggVisible}
+                        showTimezoneSetting={
+                            timezoneSupportFlag?.enabled ?? false
+                        }
+                        timezone={timezone ?? undefined}
+                        onTimezoneChange={setTimeZone}
                         targetProps={{
                             style: {
                                 borderTopLeftRadius: 0,

--- a/packages/frontend/src/components/RunQuerySettings/LimitInput.tsx
+++ b/packages/frontend/src/components/RunQuerySettings/LimitInput.tsx
@@ -29,7 +29,7 @@ const LimitInput = ({
             max={maxLimit}
             step={100}
             size={size}
-            label="Row limit:"
+            label="Row limit"
             clampBehavior="strict"
             {...numberInputProps}
         />

--- a/packages/frontend/src/components/RunQuerySettings/index.tsx
+++ b/packages/frontend/src/components/RunQuerySettings/index.tsx
@@ -1,3 +1,4 @@
+import { type TimezoneSetting } from '@lightdash/common';
 import {
     Button,
     Divider,
@@ -9,6 +10,7 @@ import {
 import { useClickOutside, useDisclosure } from '@mantine-8/hooks';
 import { IconChevronDown } from '@tabler/icons-react';
 import { memo, useCallback, useEffect, useRef, useState, type FC } from 'react';
+import ChartTimezoneSelect from '../common/ChartTimezoneSelect';
 import MantineIcon from '../common/MantineIcon';
 import AutoFetchResultsSwitch from './AutoFetchResultsSwitch';
 import LimitInput from './LimitInput';
@@ -22,6 +24,9 @@ export type Props = {
     onLimitChange: (value: number) => void;
     showAutoFetchSetting?: boolean;
     showPreAggregateSetting?: boolean;
+    showTimezoneSetting?: boolean;
+    timezone?: string;
+    onTimezoneChange?: (value: TimezoneSetting) => void;
     targetProps?: ButtonProps;
 };
 
@@ -34,6 +39,9 @@ const RunQuerySettings: FC<Props> = memo(
         onLimitChange,
         showAutoFetchSetting = false,
         showPreAggregateSetting = false,
+        showTimezoneSetting = false,
+        timezone,
+        onTimezoneChange,
         targetProps,
     }) => {
         const [opened, { open, close }] = useDisclosure(false);
@@ -66,6 +74,9 @@ const RunQuerySettings: FC<Props> = memo(
             }
         };
 
+        const hasToggleSettings =
+            showAutoFetchSetting || showPreAggregateSetting;
+
         return (
             <Popover
                 withinPortal
@@ -92,22 +103,23 @@ const RunQuerySettings: FC<Props> = memo(
                 <Popover.Dropdown>
                     <Stack
                         ref={ref}
+                        gap="sm"
+                        w={232}
                         onMouseDown={() => {
                             mouseDownInsideRef.current = true;
                         }}
                     >
-                        {showPreAggregateSetting && (
-                            <PreAggregateCacheSwitch size={size} />
+                        {hasToggleSettings && (
+                            <Stack gap="xs">
+                                {showPreAggregateSetting && (
+                                    <PreAggregateCacheSwitch size={size} />
+                                )}
+                                {showAutoFetchSetting && (
+                                    <AutoFetchResultsSwitch size={size} />
+                                )}
+                            </Stack>
                         )}
-                        {showPreAggregateSetting && showAutoFetchSetting && (
-                            <Divider />
-                        )}
-                        {showAutoFetchSetting && (
-                            <AutoFetchResultsSwitch size={size} />
-                        )}
-                        {(showAutoFetchSetting || showPreAggregateSetting) && (
-                            <Divider />
-                        )}
+                        {hasToggleSettings && <Divider />}
                         <LimitInput
                             maxLimit={maxLimit}
                             limit={tempLimit}
@@ -123,6 +135,14 @@ const RunQuerySettings: FC<Props> = memo(
                                 },
                             }}
                         />
+                        {showTimezoneSetting && onTimezoneChange && (
+                            <ChartTimezoneSelect
+                                label="Timezone"
+                                value={timezone}
+                                onChange={onTimezoneChange}
+                                w="100%"
+                            />
+                        )}
                     </Stack>
                 </Popover.Dropdown>
             </Popover>

--- a/packages/frontend/src/components/common/ChartTimezoneSelect/ChartTimezoneSelect.module.css
+++ b/packages/frontend/src/components/common/ChartTimezoneSelect/ChartTimezoneSelect.module.css
@@ -1,0 +1,5 @@
+.option {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/packages/frontend/src/components/common/ChartTimezoneSelect/getChartTimezoneSelectData.ts
+++ b/packages/frontend/src/components/common/ChartTimezoneSelect/getChartTimezoneSelectData.ts
@@ -1,0 +1,43 @@
+import {
+    PROJECT_TIMEZONE_SETTING,
+    TimeZone,
+    USER_TIMEZONE_SETTING,
+} from '@lightdash/common';
+
+export type ChartTimezoneSelectGroup = {
+    group: string;
+    items: { value: string; label: string }[];
+};
+
+// Grouped options for the chart timezone dropdown. Labels here are the compact
+// form shown in the closed control; the open list adds the UTC offset and the
+// resolved project zone via the Select's renderOption. The per-viewer option is
+// only offered when user timezones are enabled.
+export const getChartTimezoneSelectData = (
+    localTimezone: string | undefined,
+    includeUserTimezone: boolean,
+): ChartTimezoneSelectGroup[] => {
+    const specificZones = Object.keys(TimeZone)
+        .filter((key) => isNaN(Number(key)))
+        .map((key) => {
+            const name = key.replaceAll('_', ' ');
+            const label = key === localTimezone ? `${name} - Local` : name;
+            return { value: key, label };
+        });
+
+    return [
+        {
+            group: 'Default',
+            items: [
+                { value: PROJECT_TIMEZONE_SETTING, label: 'Project timezone' },
+                ...(includeUserTimezone
+                    ? [{ value: USER_TIMEZONE_SETTING, label: 'User timezone' }]
+                    : []),
+            ],
+        },
+        {
+            group: 'Specific timezone',
+            items: specificZones,
+        },
+    ];
+};

--- a/packages/frontend/src/components/common/ChartTimezoneSelect/index.tsx
+++ b/packages/frontend/src/components/common/ChartTimezoneSelect/index.tsx
@@ -1,0 +1,122 @@
+import {
+    FeatureFlags,
+    getTimezoneLabel,
+    isTimeZone,
+    PROJECT_TIMEZONE_SETTING,
+    toTimezoneSetting,
+    USER_TIMEZONE_SETTING,
+    type TimezoneSetting,
+} from '@lightdash/common';
+import {
+    CheckIcon,
+    Group,
+    Select,
+    Text,
+    Tooltip,
+    type SelectProps,
+} from '@mantine-8/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+import dayjs from 'dayjs';
+import { useMemo, type FC } from 'react';
+import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import MantineIcon from '../MantineIcon';
+import classes from './ChartTimezoneSelect.module.css';
+import { getChartTimezoneSelectData } from './getChartTimezoneSelectData';
+
+interface Props extends Omit<
+    SelectProps,
+    'data' | 'value' | 'onChange' | 'defaultValue'
+> {
+    value: string | undefined;
+    onChange: (value: TimezoneSetting) => void;
+}
+
+const USER_TIMEZONE_TOOLTIP =
+    "Each viewer sees data in their own timezone. Falls back to the project timezone if they haven't set one.";
+
+const ChartTimezoneSelect: FC<Props> = ({ value, onChange, ...rest }) => {
+    const projectUuid = useProjectUuid();
+    const { data: project } = useProject(projectUuid);
+    const projectTimezone = project?.queryTimezone ?? undefined;
+
+    const { data: userTimezonesFlag } = useServerFeatureFlag(
+        FeatureFlags.EnableUserTimezones,
+    );
+
+    const normalizedValue = toTimezoneSetting(value);
+    // Only offer the per-viewer option when user timezones are enabled, but keep
+    // it available if a chart is already pinned to it so the value still renders.
+    const includeUserTimezone =
+        (userTimezonesFlag?.enabled ?? false) ||
+        normalizedValue === USER_TIMEZONE_SETTING;
+
+    const localTimezone = dayjs.tz.guess();
+    const data = useMemo(
+        () => getChartTimezoneSelectData(localTimezone, includeUserTimezone),
+        [localTimezone, includeUserTimezone],
+    );
+
+    // The closed control shows the compact label; specific zones gain their UTC
+    // offset only here, in the open list.
+    const getPrimaryLabel = (option: { value: string; label: string }) => {
+        if (isTimeZone(option.value)) {
+            const offset = getTimezoneLabel(option.value) ?? option.label;
+            return option.value === localTimezone
+                ? `${offset} - Local`
+                : offset;
+        }
+        return option.label;
+    };
+
+    return (
+        <Select
+            size="xs"
+            searchable
+            allowDeselect={false}
+            data={data}
+            value={normalizedValue}
+            onChange={(newValue) =>
+                onChange(toTimezoneSetting(newValue ?? undefined))
+            }
+            comboboxProps={{ width: 300, position: 'bottom-start' }}
+            classNames={{ option: classes.option }}
+            renderOption={({ option, checked }) => (
+                <Group gap={6} wrap="nowrap" w="100%">
+                    <CheckIcon
+                        size={11}
+                        style={{
+                            flexShrink: 0,
+                            visibility: checked ? undefined : 'hidden',
+                        }}
+                    />
+                    <span>{getPrimaryLabel(option)}</span>
+                    {option.value === PROJECT_TIMEZONE_SETTING &&
+                    projectTimezone ? (
+                        <Text span size="xs" c="dimmed">
+                            {projectTimezone.replaceAll('_', ' ')}
+                        </Text>
+                    ) : null}
+                    {option.value === USER_TIMEZONE_SETTING ? (
+                        <Tooltip
+                            multiline
+                            w={260}
+                            withinPortal
+                            label={USER_TIMEZONE_TOOLTIP}
+                        >
+                            <MantineIcon
+                                icon={IconInfoCircle}
+                                color="ldGray.6"
+                                size={14}
+                            />
+                        </Tooltip>
+                    ) : null}
+                </Group>
+            )}
+            {...rest}
+        />
+    );
+};
+
+export default ChartTimezoneSelect;

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -24,7 +24,7 @@ import {
     type SavedChart,
     type SortField,
     type TableCalculation,
-    type TimeZone,
+    type TimezoneSetting,
 } from '@lightdash/common';
 import {
     createNextState,
@@ -244,7 +244,10 @@ const explorerSlice = createSlice({
             state.unsavedChartVersion.metricQuery.limit = action.payload;
         },
 
-        setTimeZone: (state, action: PayloadAction<TimeZone | undefined>) => {
+        setTimeZone: (
+            state,
+            action: PayloadAction<TimezoneSetting | undefined>,
+        ) => {
             state.unsavedChartVersion.metricQuery.timezone = action.payload;
         },
 


### PR DESCRIPTION
Closes: GLITCH-456

### Description:

Adds a chart-level timezone control (`ChartTimezoneSelect`) that writes `metricQuery.timezone` as the project default, each viewer's timezone, or a specific IANA zone, gated behind `EnableTimezoneSupport` and surfaced in the Run query settings popover next to the row limit. The closed control shows compact labels while the open list adds the UTC offset and the resolved project zone, and the per-viewer option is gated behind `EnableUserTimezones` with an explainer tooltip. Widens the `setTimeZone` Redux action to accept `TimezoneSetting` and strips the keyword values from the filter-date and resolved-timezone-badge paths so those only consume real IANA zones.

<img width="3634" height="2566" alt="CleanShot 2026-06-11 at 17 36 13@2x" src="https://github.com/user-attachments/assets/fc2b8d2c-6fab-40ee-8eb0-07f1e32b87dc" />

<img width="3632" height="2556" alt="CleanShot 2026-06-11 at 17 35 39@2x" src="https://github.com/user-attachments/assets/238f1754-6241-472a-ba4f-bdc6f9df325a" />
