### PR TITLE
feat(ai-review): surface agent writeback PRs to the judge + block double-PR remediation

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -38,6 +38,7 @@ import {
     AiSlackPromptTableName,
     AiSlackThreadTableName,
     AiThreadTableName,
+    AiWritebackThreadTableName,
 } from '../database/entities/ai';
 import {
     AiAgentReviewClassifierRunTableName,
@@ -1184,6 +1185,53 @@ export class AiAgentReviewClassifierModel {
             }
         });
         return remediations;
+    }
+
+    /**
+     * Writeback PRs the agent itself opened in a given set of threads (via the
+     * editDbtProject / runAiWriteback tools). Used to warn the judge and to block
+     * remediation from opening a second PR on a thread that already has one.
+     */
+    async getThreadWritebackPullRequests(
+        threadUuids: string[],
+    ): Promise<Map<string, { prUrl: string | null; createdAt: Date }[]>> {
+        if (threadUuids.length === 0) {
+            return new Map();
+        }
+
+        const rows = await this.database(
+            `${AiWritebackThreadTableName} as writeback`,
+        )
+            .leftJoin(
+                `${PullRequestsTableName} as pull_request`,
+                'pull_request.pull_request_uuid',
+                'writeback.pull_request_uuid',
+            )
+            .whereIn('writeback.ai_thread_uuid', threadUuids)
+            .whereNotNull('writeback.pull_request_uuid')
+            .select<
+                {
+                    ai_thread_uuid: string;
+                    pr_url: string | null;
+                    created_at: Date;
+                }[]
+            >(
+                'writeback.ai_thread_uuid',
+                { pr_url: 'pull_request.pr_url' },
+                { created_at: 'writeback.created_at' },
+            )
+            .orderBy('writeback.created_at', 'desc');
+
+        const byThread = new Map<
+            string,
+            { prUrl: string | null; createdAt: Date }[]
+        >();
+        rows.forEach((row) => {
+            const existing = byThread.get(row.ai_thread_uuid) ?? [];
+            existing.push({ prUrl: row.pr_url, createdAt: row.created_at });
+            byThread.set(row.ai_thread_uuid, existing);
+        });
+        return byThread;
     }
 
     async getReviewRemediation(args: {

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -221,6 +221,7 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
                     hasGitAppInstallation: true,
                 },
                 hasSemanticWritebackConfig: true,
+                sourceThreadHasWritebackPr: false,
             }),
         ).toEqual({
             eligible: true,
@@ -241,6 +242,7 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
                     hasGitAppInstallation: true,
                 },
                 hasSemanticWritebackConfig: true,
+                sourceThreadHasWritebackPr: false,
             }),
         ).toEqual({
             eligible: true,
@@ -284,6 +286,7 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
                     hasGitAppInstallation: true,
                 },
                 hasSemanticWritebackConfig: false,
+                sourceThreadHasWritebackPr: false,
             }),
         ).toEqual({
             eligible: false,
@@ -304,6 +307,7 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
                     hasGitAppInstallation: true,
                 },
                 hasSemanticWritebackConfig: false,
+                sourceThreadHasWritebackPr: false,
             }),
         ).toEqual({
             eligible: false,
@@ -348,12 +352,34 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
                     hasGitAppInstallation: true,
                 },
                 hasSemanticWritebackConfig: true,
+                sourceThreadHasWritebackPr: false,
             }),
         ).toEqual({
             eligible: false,
             provider: null,
             strategy: null,
             reason: 'writeback_in_progress',
+        });
+    });
+
+    it('blocks writeback when the source thread already opened a PR', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem(),
+                reviewsEnabled: true,
+                projectContextEnabled: false,
+                projectAccess: {
+                    provider: PullRequestProvider.GITHUB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: true,
+                sourceThreadHasWritebackPr: true,
+            }),
+        ).toEqual({
+            eligible: false,
+            provider: null,
+            strategy: null,
+            reason: 'source_thread_writeback_exists',
         });
     });
 });

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -175,6 +175,7 @@ export const getAiAgentReviewItemWritebackEligibility = (args: {
     projectContextEnabled: boolean;
     projectAccess: ProjectWritebackAccess | null;
     hasSemanticWritebackConfig: boolean;
+    sourceThreadHasWritebackPr: boolean;
 }): AiAgentReviewItemWritebackEligibility => {
     const {
         item,
@@ -182,6 +183,7 @@ export const getAiAgentReviewItemWritebackEligibility = (args: {
         projectContextEnabled,
         projectAccess,
         hasSemanticWritebackConfig,
+        sourceThreadHasWritebackPr,
     } = args;
 
     if (!reviewsEnabled) {
@@ -204,6 +206,13 @@ export const getAiAgentReviewItemWritebackEligibility = (args: {
         item.prWritebackStatus === 'running'
     ) {
         return unavailableWritebackEligibility('writeback_in_progress');
+    }
+    // The agent already opened a writeback PR in the thread this finding came
+    // from — remediating would open a second PR for the same issue.
+    if (sourceThreadHasWritebackPr && !item.linkedPrUrl) {
+        return unavailableWritebackEligibility(
+            'source_thread_writeback_exists',
+        );
     }
 
     const strategyResult = getWritebackStrategy(item, projectContextEnabled);
@@ -397,6 +406,13 @@ export class AiAgentAdminService extends BaseService {
                 .filter((uuid): uuid is string => uuid !== null),
         );
 
+        const writebackPrByThread =
+            await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
+                items
+                    .map((item) => item.latestFinding?.threadUuid)
+                    .filter((uuid): uuid is string => !!uuid),
+            );
+
         const reconciled = items.map((item) => {
             const override = overrides.get(item.fingerprint);
             const reconciledItem = { ...item, ...(override ?? {}) };
@@ -412,6 +428,11 @@ export class AiAgentAdminService extends BaseService {
                         : null,
                     hasSemanticWritebackConfig:
                         this.hasSemanticWritebackConfig(),
+                    sourceThreadHasWritebackPr:
+                        !!reconciledItem.latestFinding?.threadUuid &&
+                        (writebackPrByThread.get(
+                            reconciledItem.latestFinding.threadUuid,
+                        )?.length ?? 0) > 0,
                 });
 
             return {
@@ -583,6 +604,10 @@ export class AiAgentAdminService extends BaseService {
             case 'pull_request_open':
                 throw new ParameterError(
                     'A pull request is already open for this review item',
+                );
+            case 'source_thread_writeback_exists':
+                throw new ParameterError(
+                    'The agent already opened a pull request in the source thread for this finding',
                 );
             case 'writeback_in_progress':
                 throw new ParameterError(
@@ -867,6 +892,12 @@ export class AiAgentAdminService extends BaseService {
             organizationUuid,
             reviewItem.projectUuid ? [reviewItem.projectUuid] : [],
         );
+        const writebackPrByThread =
+            await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
+                [finding.threadUuid],
+            );
+        const sourceThreadHasWritebackPr =
+            (writebackPrByThread.get(finding.threadUuid)?.length ?? 0) > 0;
         const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
             item: reviewItem,
             reviewsEnabled,
@@ -875,6 +906,7 @@ export class AiAgentAdminService extends BaseService {
                 ? (projectAccessByUuid.get(reviewItem.projectUuid) ?? null)
                 : null,
             hasSemanticWritebackConfig: this.hasSemanticWritebackConfig(),
+            sourceThreadHasWritebackPr,
         });
         if (!writebackEligibility.eligible) {
             AiAgentAdminService.throwWritebackBlocked(writebackEligibility);
@@ -1609,6 +1641,13 @@ export class AiAgentAdminService extends BaseService {
             organizationUuid,
             reviewItem.projectUuid ? [reviewItem.projectUuid] : [],
         );
+        const sourceThreadHasWritebackPr = reviewItem.latestFinding
+            ? ((
+                  await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
+                      [reviewItem.latestFinding.threadUuid],
+                  )
+              ).get(reviewItem.latestFinding.threadUuid)?.length ?? 0) > 0
+            : false;
         const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
             item: reviewItem,
             reviewsEnabled,
@@ -1617,6 +1656,7 @@ export class AiAgentAdminService extends BaseService {
                 ? (projectAccessByUuid.get(reviewItem.projectUuid) ?? null)
                 : null,
             hasSemanticWritebackConfig: this.hasSemanticWritebackConfig(),
+            sourceThreadHasWritebackPr,
         });
 
         return {

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -286,6 +286,7 @@ describe('AiAgentReviewClassifierService', () => {
         createRun: jest.fn(),
         updateRun: jest.fn(),
         createTurnSignal: jest.fn(),
+        getThreadWritebackPullRequests: jest.fn().mockResolvedValue(new Map()),
     } as unknown as jest.Mocked<AiAgentReviewClassifierModel>;
     const aiAgentModel = {
         getAgent: jest.fn(),
@@ -322,6 +323,7 @@ describe('AiAgentReviewClassifierService', () => {
         model.createRun.mockResolvedValue(makeRun());
         model.updateRun.mockResolvedValue(makeRun({ status: 'completed' }));
         model.createTurnSignal.mockResolvedValue(SIGNAL_UUID);
+        model.getThreadWritebackPullRequests.mockResolvedValue(new Map());
         aiAgentModel.getAgent.mockResolvedValue({
             uuid: AGENT_UUID,
             organizationUuid: ORGANIZATION_UUID,

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -126,6 +126,9 @@ type AiAgentReviewJudgeEvidencePacket = {
         summary: string;
     })[];
     suggestedEvidenceExcerpts: AiAgentEvidenceExcerpt[];
+    // PRs the agent already opened in this thread via writeback tools. Non-empty
+    // means a real PR exists — the judge should only promote if it failed/was wrong.
+    threadWritebackPullRequests: { prUrl: string | null; createdAt: Date }[];
 };
 
 type AiAgentReviewAgentConfigEvidence =
@@ -773,6 +776,12 @@ export class AiAgentReviewClassifierService extends BaseService {
         agentConfig: AiAgentReviewAgentConfigEvidence;
     }> {
         const semanticContext = await this.buildSemanticContext(candidate);
+        const threadWritebackPullRequests =
+            (
+                await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
+                    [candidate.subject.threadUuid],
+                )
+            ).get(candidate.subject.threadUuid) ?? [];
 
         return {
             agentConfig,
@@ -781,6 +790,7 @@ export class AiAgentReviewClassifierService extends BaseService {
                     candidate,
                     agentConfig,
                     semanticContext,
+                    threadWritebackPullRequests,
                 }),
         };
     }
@@ -993,7 +1003,7 @@ Decision rules — apply in order:
 
 1. First, populate implicitSignalSources by inspecting the evidence packet. Do not skip this step.
 
-2. If the evidence shows the assistant successfully called a writeback tool (for example editDbtProject or runAiWriteback) and opened or updated a pull request, do not promote this as a semantic_layer or project_context finding. The remediation is already in progress; use promotedToFinding=false, signal=acceptance_or_continuation, primaryRootCause=not_a_failure, and promotionReason=writeback_tool_already_started. Only consider writeback turns promotable when the tool failed, opened no pull request despite a clear requested change, or the user later says the PR is wrong.
+2. If the evidence shows the assistant successfully called a writeback tool (for example editDbtProject or runAiWriteback) and opened or updated a pull request, do not promote this as a semantic_layer or project_context finding. The remediation is already in progress; use promotedToFinding=false, signal=acceptance_or_continuation, primaryRootCause=not_a_failure, and promotionReason=writeback_tool_already_started. The evidence packet field threadWritebackPullRequests lists PRs the agent has already opened in this thread — when it is non-empty a real pull request exists, so do not infer from prose that the assistant fabricated it. Only consider writeback turns promotable when the tool failed, opened no pull request despite a clear requested change, or the user later says the PR is wrong.
 
 3. Treat implicitSignalSources as strong evidence of unresolved user intent, not as decoration. Promote when the implicit signal points to likely assistant failure:
    - Always promote assistant_no_answer, next_user_dispute, tool_error, product_capability_request, and human_intervention.
@@ -1023,6 +1033,7 @@ When promoting, pick primaryRootCause by mapping the dominant signal:
 7. If you would promote but cannot pick one primaryRootCause confidently, set primaryRootCause=ambiguous with confidence=low or medium and still promote.
 
 When promotedToFinding=true, provide concise evidence excerpts copied or summarized from the packet and a practical recommendation.
+Never set promotedToFinding=true together with primaryRootCause=not_a_failure — they are mutually exclusive; a promoted finding always has an actionable root cause.
 Use one primaryRootCause. Secondary causes are optional.
 For targetRefs, return compact refs:
 - type: one of the allowed target types.
@@ -1176,10 +1187,12 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
         candidate,
         agentConfig,
         semanticContext,
+        threadWritebackPullRequests,
     }: {
         candidate: AiAgentReviewClassifierTurnCandidate;
         agentConfig: AiAgentReviewJudgeEvidencePacket['agentConfig'];
         semanticContext: AiAgentReviewJudgeEvidencePacket['semanticContext'];
+        threadWritebackPullRequests: AiAgentReviewJudgeEvidencePacket['threadWritebackPullRequests'];
     }): AiAgentReviewJudgeEvidencePacket {
         return {
             subject: candidate.subject,
@@ -1217,6 +1230,7 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
             ),
             suggestedEvidenceExcerpts:
                 AiAgentReviewClassifierService.buildEvidenceExcerpts(candidate),
+            threadWritebackPullRequests,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12474,11 +12474,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12536,11 +12536,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12577,11 +12577,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13890,11 +13890,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13955,11 +13955,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14136,11 +14136,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14155,11 +14155,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14174,11 +14174,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -20193,6 +20193,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['git_app_not_installed'] },
                 { dataType: 'enum', enums: ['missing_writeback_config'] },
                 { dataType: 'enum', enums: ['pull_request_open'] },
+                { dataType: 'enum', enums: ['source_thread_writeback_exists'] },
                 { dataType: 'enum', enums: ['terminal_state'] },
                 { dataType: 'enum', enums: ['writeback_in_progress'] },
             ],
@@ -28550,7 +28551,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28560,7 +28561,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28570,7 +28571,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28583,7 +28584,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -29238,7 +29239,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29248,7 +29249,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29258,7 +29259,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29271,7 +29272,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14041,8 +14041,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14100,8 +14100,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14125,19 +14125,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -20656,6 +20643,7 @@
                     "git_app_not_installed",
                     "missing_writeback_config",
                     "pull_request_open",
+                    "source_thread_writeback_exists",
                     "terminal_state",
                     "writeback_in_progress"
                 ]
@@ -29369,22 +29357,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -29944,22 +29932,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -1,11 +1,31 @@
 import {
     aiAgentJudgeProjectContextEntrySchema,
+    aiAgentReviewClassifierJudgeOutputSchema,
     getAiAgentConfigSnapshotHash,
     getAiAgentReviewItemFingerprint,
     getAiAgentReviewItemFingerprintScope,
     type AiAgentConfigSnapshot,
     type AiAgentReviewItemFingerprintInput,
 } from './aiAgentReviewClassifierTypes';
+
+const baseJudgeOutput = {
+    signal: 'implicit_correction' as const,
+    implicitSignalSources: ['next_user_correction' as const],
+    confidence: 'high' as const,
+    promotedToFinding: true,
+    promotionReason: 'Found a semantic-layer correction.',
+    primaryRootCause: 'semantic_layer' as const,
+    secondaryRootCauses: [],
+    subcategories: [],
+    fixTargets: [],
+    targetRefs: [],
+    agentConfigurationSettings: [],
+    ownerType: 'semantic_layer_owner' as const,
+    evidenceExcerpts: [],
+    recommendation: null,
+    reviewItem: { title: 'Fix metric', description: 'why' },
+    projectContextEntry: null,
+};
 
 const baseInput: AiAgentReviewItemFingerprintInput = {
     organizationUuid: 'org-1',
@@ -134,6 +154,34 @@ describe('aiAgentJudgeProjectContextEntrySchema', () => {
             objects: [],
         });
         expect(result.success).toBe(false);
+    });
+});
+
+describe('aiAgentReviewClassifierJudgeOutputSchema', () => {
+    it('accepts a promoted finding with an actionable root cause', () => {
+        expect(
+            aiAgentReviewClassifierJudgeOutputSchema.safeParse(baseJudgeOutput)
+                .success,
+        ).toBe(true);
+    });
+
+    it('rejects a promoted finding with primaryRootCause not_a_failure', () => {
+        const result = aiAgentReviewClassifierJudgeOutputSchema.safeParse({
+            ...baseJudgeOutput,
+            promotedToFinding: true,
+            primaryRootCause: 'not_a_failure',
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('accepts not_a_failure when not promoted', () => {
+        expect(
+            aiAgentReviewClassifierJudgeOutputSchema.safeParse({
+                ...baseJudgeOutput,
+                promotedToFinding: false,
+                primaryRootCause: 'not_a_failure',
+            }).success,
+        ).toBe(true);
     });
 });
 

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -334,6 +334,7 @@ export type AiAgentReviewItemWritebackBlockedReason =
     | 'git_app_not_installed'
     | 'missing_writeback_config'
     | 'pull_request_open'
+    | 'source_thread_writeback_exists'
     | 'terminal_state'
     | 'writeback_in_progress';
 
@@ -452,46 +453,36 @@ export type AiAgentJudgeProjectContextEntry = {
     objects: string[];
 };
 
-export const aiAgentReviewClassifierJudgeOutputSchema = z.object({
-    signal: z.enum([
-        'normal_refinement',
-        'implicit_correction',
-        'explicit_dispute',
-        'retry_after_failure',
-        'output_shape_correction',
-        'new_question',
-        'acceptance_or_continuation',
-        'product_capability_request',
-        'human_intervention',
-        'ambiguous',
-    ]),
-    implicitSignalSources: z.array(
-        z.enum([
-            'next_user_correction',
-            'next_user_dispute',
-            'next_user_retry',
+export const aiAgentReviewClassifierJudgeOutputSchema = z
+    .object({
+        signal: z.enum([
+            'normal_refinement',
+            'implicit_correction',
+            'explicit_dispute',
+            'retry_after_failure',
             'output_shape_correction',
-            'tool_error',
-            'assistant_no_answer',
+            'new_question',
+            'acceptance_or_continuation',
             'product_capability_request',
             'human_intervention',
+            'ambiguous',
         ]),
-    ),
-    confidence: z.enum(['low', 'medium', 'high']),
-    promotedToFinding: z.boolean(),
-    promotionReason: z.string().nullable(),
-    primaryRootCause: z.enum([
-        'semantic_layer',
-        'project_context',
-        'agent_configuration',
-        'product_capability',
-        'runtime_reliability',
-        'feedback_quality',
-        'not_a_failure',
-        'ambiguous',
-    ]),
-    secondaryRootCauses: z.array(
-        z.enum([
+        implicitSignalSources: z.array(
+            z.enum([
+                'next_user_correction',
+                'next_user_dispute',
+                'next_user_retry',
+                'output_shape_correction',
+                'tool_error',
+                'assistant_no_answer',
+                'product_capability_request',
+                'human_intervention',
+            ]),
+        ),
+        confidence: z.enum(['low', 'medium', 'high']),
+        promotedToFinding: z.boolean(),
+        promotionReason: z.string().nullable(),
+        primaryRootCause: z.enum([
             'semantic_layer',
             'project_context',
             'agent_configuration',
@@ -501,72 +492,96 @@ export const aiAgentReviewClassifierJudgeOutputSchema = z.object({
             'not_a_failure',
             'ambiguous',
         ]),
-    ),
-    subcategories: z.array(z.string()),
-    fixTargets: z.array(
-        z.enum([
-            'semantic_yaml_patch',
-            'project_context_rule',
-            'agent_configuration_change',
-            'dbt_modeling_ticket',
-            'semantic_layer_ticket',
-            'product_capability_ticket',
-            'runtime_reliability_ticket',
-            'feedback_needed',
-            'no_action',
-        ]),
-    ),
-    targetRefs: z.array(aiAgentJudgeTargetRefSchema),
-    agentConfigurationSettings: z.array(aiAgentConfigurationSettingSchema),
-    ownerType: z.enum([
-        'semantic_layer_owner',
-        'agent_admin',
-        'product',
-        'support',
-        'unknown',
-    ]),
-    evidenceExcerpts: z.array(
-        z.object({
-            source: z.enum([
-                'user_prompt',
-                'assistant_answer',
-                'next_user_prompt',
-                'conversation_context',
-                'tool_call',
-                'tool_result',
-                'agent_config',
+        secondaryRootCauses: z.array(
+            z.enum([
+                'semantic_layer',
+                'project_context',
+                'agent_configuration',
+                'product_capability',
+                'runtime_reliability',
+                'feedback_quality',
+                'not_a_failure',
+                'ambiguous',
             ]),
-            text: z.string(),
-            redacted: z.boolean(),
-        }),
-    ),
-    recommendation: z
-        .object({
-            actionType: z.enum([
-                'update_semantic_yaml',
-                'update_agent_instructions',
-                'add_knowledge_document',
-                'enable_data_access',
-                'enable_sql_mode',
-                'enable_self_improvement',
-                'configure_mcp_server',
-                'adjust_explore_tags',
-                'update_access',
-                'route_to_product_work',
-                'request_more_evidence',
+        ),
+        subcategories: z.array(z.string()),
+        fixTargets: z.array(
+            z.enum([
+                'semantic_yaml_patch',
+                'project_context_rule',
+                'agent_configuration_change',
+                'dbt_modeling_ticket',
+                'semantic_layer_ticket',
+                'product_capability_ticket',
+                'runtime_reliability_ticket',
+                'feedback_needed',
                 'no_action',
             ]),
+        ),
+        targetRefs: z.array(aiAgentJudgeTargetRefSchema),
+        agentConfigurationSettings: z.array(aiAgentConfigurationSettingSchema),
+        ownerType: z.enum([
+            'semantic_layer_owner',
+            'agent_admin',
+            'product',
+            'support',
+            'unknown',
+        ]),
+        evidenceExcerpts: z.array(
+            z.object({
+                source: z.enum([
+                    'user_prompt',
+                    'assistant_answer',
+                    'next_user_prompt',
+                    'conversation_context',
+                    'tool_call',
+                    'tool_result',
+                    'agent_config',
+                ]),
+                text: z.string(),
+                redacted: z.boolean(),
+            }),
+        ),
+        recommendation: z
+            .object({
+                actionType: z.enum([
+                    'update_semantic_yaml',
+                    'update_agent_instructions',
+                    'add_knowledge_document',
+                    'enable_data_access',
+                    'enable_sql_mode',
+                    'enable_self_improvement',
+                    'configure_mcp_server',
+                    'adjust_explore_tags',
+                    'update_access',
+                    'route_to_product_work',
+                    'request_more_evidence',
+                    'no_action',
+                ]),
+                title: z.string(),
+                rationale: z.string(),
+                targetRefs: z.array(aiAgentJudgeTargetRefSchema),
+            })
+            .nullable(),
+        reviewItem: z.object({
             title: z.string(),
-            rationale: z.string(),
-            targetRefs: z.array(aiAgentJudgeTargetRefSchema),
-        })
-        .nullable(),
-    reviewItem: z.object({
-        title: z.string(),
-        description: z.string(),
-    }),
-    projectContextEntry: aiAgentJudgeProjectContextEntrySchema.nullable(),
-});
+            description: z.string(),
+        }),
+        projectContextEntry: aiAgentJudgeProjectContextEntrySchema.nullable(),
+    })
+    .superRefine((output, ctx) => {
+        if (
+            output.promotedToFinding &&
+            output.primaryRootCause === 'not_a_failure'
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message:
+                    'promotedToFinding must be false when primaryRootCause is not_a_failure',
+                path: ['promotedToFinding'],
+            });
+        }
+    });
 
 export type AiAgentReviewClassifierJudgeOutput = z.infer<
     typeof aiAgentReviewClassifierJudgeOutputSchema

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -41,6 +41,8 @@ export const writebackBlockedReasonLabels: Record<
     git_app_not_installed: 'Git app is not installed',
     missing_writeback_config: 'Writeback runtime is not configured',
     pull_request_open: 'A pull request is already open',
+    source_thread_writeback_exists:
+        'The agent already opened a pull request in the source thread',
     terminal_state: 'Finding is already closed',
     writeback_in_progress: 'Writeback is already in progress',
 };
@@ -111,6 +113,7 @@ const getTargetLabel = (targetRefs: AiAgentTargetRef[]): string | null => {
 
 const isTriageReviewItem = (reviewItem: AiAgentReviewItemSummary): boolean =>
     reviewItem.primaryRootCause === 'ambiguous' ||
+    reviewItem.ownerType === 'unknown' ||
     reviewItem.latestFinding?.fixTargets.includes('feedback_needed') === true;
 
 export const getIssueTitle = (reviewItem: AiAgentReviewItemSummary): string => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -113,7 +113,6 @@ const getTargetLabel = (targetRefs: AiAgentTargetRef[]): string | null => {
 
 const isTriageReviewItem = (reviewItem: AiAgentReviewItemSummary): boolean =>
     reviewItem.primaryRootCause === 'ambiguous' ||
-    reviewItem.ownerType === 'unknown' ||
     reviewItem.latestFinding?.fixTargets.includes('feedback_needed') === true;
 
 export const getIssueTitle = (reviewItem: AiAgentReviewItemSummary): string => {


### PR DESCRIPTION
Two judge/remediation-quality fixes found by auditing the review classifier against production data.

**1. Agent writeback PRs are now first-class evidence (was: judge guessed)**
The judge's "did the agent already open a PR?" check was turn-scoped, so when a PR was opened in an earlier turn of a thread it couldn't see it and inferred from prose ("claimed to have opened a PR… unverifiable"). Now the evidence packet carries `threadWritebackPullRequests` (real PRs the agent opened in the thread, from `ai_writeback_thread` ⨝ `pull_requests`), and the prompt tells the judge to trust it.

**2. Remediation can't open a second PR on a thread that already has one**
`getAiAgentReviewItemWritebackEligibility` only checked the review item's *own* PR, never the source thread's agent-opened writeback PR — so remediating a finding from such a thread would open a duplicate. Adds blocked reason `source_thread_writeback_exists`. Keyed on a real `ai_writeback_thread` row (only present for genuine PRs), so fabricated-PR cases are unaffected.

**3. Judge-output invariant**
zod `superRefine` rejects `promotedToFinding=true` with `primaryRootCause=not_a_failure` (logically contradictory; was happening in prod).

**Regression note:** the new guard is conservative — it blocks remediation whenever the source thread has any recorded writeback PR, even if that PR was later closed (PR state isn't persisted). Manual remediation is the only affected path; admins still see the existing PR and can handle it manually.

**Verified:** backend/common/frontend typecheck, all affected suites (incl. new guard + superRefine tests + the admin frontend tests).

_No Linear ticket._