### PR TITLE
feat(ai-review): batch analysis — run review over a window → actions/outcomes report

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -3,6 +3,10 @@ import {
     AiAgentAdminSort,
     AiAgentReviewItemStatus,
     ApiAiAgentAdminConversationsResponse,
+    ApiAiAgentReviewBatchReportResponse,
+    ApiAiAgentReviewBatchRunResponse,
+    ApiAiAgentReviewBatchRunsResponse,
+    ApiAiAgentReviewBatchStartedResponse,
     ApiAiAgentReviewItemActivityResponse,
     ApiAiAgentReviewItemPrDiffResponse,
     ApiAiAgentReviewItemResponse,
@@ -13,6 +17,7 @@ import {
     ApiErrorPayload,
     ApiUpdateAiOrganizationSettingsResponse,
     assertRegisteredAccount,
+    CreateAiAgentReviewBatch,
     KnexPaginateArgs,
     UpdateAiAgentReviewItemStatus,
     UpdateAiOrganizationSettings,
@@ -429,6 +434,99 @@ export class AiAgentAdminController extends BaseController {
         return {
             status: 'ok',
             results: settings,
+        };
+    }
+
+    /**
+     * Start a new AI agent review batch analysis run
+     * @summary Start AI agent review batch
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/review-runs')
+    @OperationId('startAiAgentReviewBatch')
+    async startReviewBatch(
+        @Request() req: express.Request,
+        @Body() body: CreateAiAgentReviewBatch,
+    ): Promise<ApiAiAgentReviewBatchStartedResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().startReviewBatch(
+                toSessionUser(req.account),
+                body,
+            ),
+        };
+    }
+
+    /**
+     * List AI agent review batch runs
+     * @summary List AI agent review batch runs
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/review-runs')
+    @OperationId('listAiAgentReviewBatchRuns')
+    async listReviewBatchRuns(
+        @Request() req: express.Request,
+        @Query() projectUuid?: string,
+        @Query() agentUuid?: string,
+    ): Promise<ApiAiAgentReviewBatchRunsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().listReviewBatchRuns(
+                toSessionUser(req.account),
+                { projectUuid, agentUuid },
+            ),
+        };
+    }
+
+    /**
+     * Get a single AI agent review batch run (for polling status)
+     * @summary Get AI agent review batch run
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/review-runs/{runUuid}')
+    @OperationId('getAiAgentReviewBatchRun')
+    async getReviewBatchRun(
+        @Request() req: express.Request,
+        @Path() runUuid: string,
+    ): Promise<ApiAiAgentReviewBatchRunResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().getReviewBatchRun(
+                toSessionUser(req.account),
+                runUuid,
+            ),
+        };
+    }
+
+    /**
+     * Get the full report for a completed AI agent review batch run
+     * @summary Get AI agent review batch report
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/review-runs/{runUuid}/report')
+    @OperationId('getAiAgentReviewBatchReport')
+    async getReviewBatchReport(
+        @Request() req: express.Request,
+        @Path() runUuid: string,
+    ): Promise<ApiAiAgentReviewBatchReportResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().getReviewBatchReport(
+                toSessionUser(req.account),
+                runUuid,
+            ),
         };
     }
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -1405,27 +1405,30 @@ describe('AiAgentReviewClassifierModel', () => {
                 }),
             ]);
 
-            const report = await model.getRunReport(RUN_UUID);
+            const report = await model.getRunReport({
+                organizationUuid: ORGANIZATION_UUID,
+                runUuid: RUN_UUID,
+            });
 
-            expect(report.runUuid).toBe(RUN_UUID);
-            expect(report.turnsReviewed).toBe(2);
-            expect(report.flaggedTurns).toBe(1);
-            expect(report.flaggedRate).toBe(0.5);
-            expect(report.actions).toHaveLength(1);
-            expect(report.actions[0]).toEqual(
+            expect(report?.runUuid).toBe(RUN_UUID);
+            expect(report?.turnsReviewed).toBe(2);
+            expect(report?.flaggedTurns).toBe(1);
+            expect(report?.flaggedRate).toBe(0.5);
+            expect(report?.actions).toHaveLength(1);
+            expect(report?.actions[0]).toEqual(
                 expect.objectContaining({
                     primaryRootCause: 'semantic_layer',
                     count: 1,
                 }),
             );
-            expect(report.signalsByType).toEqual(
+            expect(report?.signalsByType).toEqual(
                 expect.objectContaining({
                     implicit_correction: 1,
                     new_question: 1,
                 }),
             );
-            expect(report.topExamples).toHaveLength(1);
-            expect(report.topExamples[0].promptUuid).toBe(PROMPT_UUID);
+            expect(report?.topExamples).toHaveLength(1);
+            expect(report?.topExamples[0].promptUuid).toBe(PROMPT_UUID);
         });
     });
 });

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../database/entities/aiAgentReviewClassifier';
 import {
     AiAgentReviewClassifierModel,
+    buildRunReportActions,
     WRITEBACK_STALE_MS,
 } from './AiAgentReviewClassifierModel';
 
@@ -1290,6 +1291,141 @@ describe('AiAgentReviewClassifierModel', () => {
             );
             expect(tracker.history.update[0].bindings).toContain('resolved');
             expect(tracker.history.update[0].bindings).toContain('merged');
+        });
+    });
+
+    describe('buildRunReportActions', () => {
+        const makeReportSignalRow = (
+            overrides: {
+                promoted_to_finding?: boolean;
+                primary_root_cause?:
+                    | import('@lightdash/common').AiAgentRootCause
+                    | null;
+                owner_type?:
+                    | import('@lightdash/common').AiAgentReviewItemOwnerType
+                    | null;
+                fix_targets?:
+                    | import('@lightdash/common').AiAgentFixTarget[]
+                    | null;
+            } = {},
+        ) => ({
+            ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID,
+            ai_prompt_uuid: PROMPT_UUID,
+            ai_thread_uuid: THREAD_UUID,
+            signal: 'implicit_correction' as const,
+            confidence: 'high' as const,
+            promoted_to_finding: true,
+            primary_root_cause: 'semantic_layer' as const,
+            owner_type: 'semantic_layer_owner' as const,
+            fix_targets: [
+                'semantic_yaml_patch' as const,
+            ] as import('@lightdash/common').AiAgentFixTarget[],
+            review_item_title: 'Some title',
+            created_at: SEEN_AT,
+            ...overrides,
+        });
+
+        it('groups promoted rows by (primaryRootCause, ownerType, firstFixTarget) sorted by count desc', () => {
+            const rows = [
+                makeReportSignalRow(),
+                makeReportSignalRow(),
+                makeReportSignalRow({
+                    primary_root_cause: 'project_context',
+                    owner_type: 'agent_admin',
+                    fix_targets: ['project_context_rule'],
+                }),
+            ];
+
+            const actions = buildRunReportActions(rows);
+
+            expect(actions).toHaveLength(2);
+            expect(actions[0]).toEqual({
+                primaryRootCause: 'semantic_layer',
+                ownerType: 'semantic_layer_owner',
+                fixTarget: 'semantic_yaml_patch',
+                count: 2,
+            });
+            expect(actions[1]).toEqual({
+                primaryRootCause: 'project_context',
+                ownerType: 'agent_admin',
+                fixTarget: 'project_context_rule',
+                count: 1,
+            });
+        });
+
+        it('excludes non-promoted rows', () => {
+            const rows = [
+                makeReportSignalRow({ promoted_to_finding: false }),
+                makeReportSignalRow({ promoted_to_finding: true }),
+            ];
+
+            const actions = buildRunReportActions(rows);
+
+            expect(actions).toHaveLength(1);
+            expect(actions[0].count).toBe(1);
+        });
+
+        it('uses null fixTarget when fix_targets is empty', () => {
+            const rows = [makeReportSignalRow({ fix_targets: [] })];
+
+            const actions = buildRunReportActions(rows);
+
+            expect(actions[0].fixTarget).toBeNull();
+        });
+
+        it('returns flaggedRate correctly via turnsReviewed and flaggedTurns', () => {
+            const promoted = makeReportSignalRow({ promoted_to_finding: true });
+            const notPromoted = makeReportSignalRow({
+                promoted_to_finding: false,
+            });
+            const allRows = [promoted, notPromoted];
+            const flaggedTurns = allRows.filter(
+                (r) => r.promoted_to_finding,
+            ).length;
+            const turnsReviewed = allRows.length;
+            const flaggedRate = flaggedTurns / turnsReviewed;
+
+            expect(flaggedRate).toBe(0.5);
+            expect(flaggedTurns).toBe(1);
+        });
+    });
+
+    describe('getRunReport', () => {
+        it('aggregates signal rows into a batch report', async () => {
+            tracker.on
+                .select(AiAgentReviewClassifierRunTableName)
+                .responseOnce([makeRunRow()]);
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
+                makeTurnSignalRow({ promoted_to_finding: true }),
+                makeTurnSignalRow({
+                    ai_agent_review_turn_signal_uuid:
+                        '00000000-0000-0000-0000-000000000099',
+                    promoted_to_finding: false,
+                    signal: 'new_question',
+                }),
+            ]);
+
+            const report = await model.getRunReport(RUN_UUID);
+
+            expect(report.runUuid).toBe(RUN_UUID);
+            expect(report.turnsReviewed).toBe(2);
+            expect(report.flaggedTurns).toBe(1);
+            expect(report.flaggedRate).toBe(0.5);
+            expect(report.actions).toHaveLength(1);
+            expect(report.actions[0]).toEqual(
+                expect.objectContaining({
+                    primaryRootCause: 'semantic_layer',
+                    count: 1,
+                }),
+            );
+            expect(report.signalsByType).toEqual(
+                expect.objectContaining({
+                    implicit_correction: 1,
+                    new_question: 1,
+                }),
+            );
+            expect(report.topExamples).toHaveLength(1);
+            expect(report.topExamples[0].promptUuid).toBe(PROMPT_UUID);
         });
     });
 });

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -2006,11 +2006,15 @@ export class AiAgentReviewClassifierModel {
         return row.ai_agent_review_run_uuid;
     }
 
-    async getRunReport(runUuid: string): Promise<AiAgentReviewBatchReport> {
+    async getRunReport(args: {
+        organizationUuid: string;
+        runUuid: string;
+    }): Promise<AiAgentReviewBatchReport | null> {
         const runRow = await this.database<AiAgentReviewClassifierRunTable>(
             AiAgentReviewClassifierRunTableName,
         )
-            .where('ai_agent_review_run_uuid', runUuid)
+            .where('ai_agent_review_run_uuid', args.runUuid)
+            .where('organization_uuid', args.organizationUuid)
             .first<
                 Pick<
                     DbAiAgentReviewClassifierRun,
@@ -2019,8 +2023,10 @@ export class AiAgentReviewClassifierModel {
             >('ai_agent_review_run_uuid', 'run_scope');
 
         if (!runRow) {
-            throw new Error(`Run not found: ${runUuid}`);
+            return null;
         }
+
+        const { runUuid } = args;
 
         const scope = runRow.run_scope;
         const window =
@@ -2107,6 +2113,54 @@ export class AiAgentReviewClassifierModel {
         };
     }
 
+    private static mapBackfillRunRow(
+        row: DbAiAgentReviewClassifierRun,
+    ): AiAgentReviewBatchRunSummary {
+        const scope = row.run_scope;
+        const window =
+            scope.type === 'backfill'
+                ? {
+                      startedAt: new Date(scope.startedAt),
+                      endedAt: new Date(scope.endedAt),
+                  }
+                : { startedAt: new Date(0), endedAt: new Date(0) };
+        return {
+            runUuid: row.ai_agent_review_run_uuid,
+            status: row.status,
+            window,
+            scope: {
+                projectUuid:
+                    scope.type === 'backfill'
+                        ? (scope.projectUuid ?? null)
+                        : null,
+                agentUuid:
+                    scope.type === 'backfill'
+                        ? (scope.agentUuid ?? null)
+                        : null,
+            },
+            totalTurns: row.total_turns,
+            processedTurns: row.processed_turns,
+            findingCount: row.finding_count,
+            errorMessage: row.error_message,
+            createdAt: row.created_at,
+            completedAt: row.completed_at,
+        };
+    }
+
+    async getBackfillRun(args: {
+        organizationUuid: string;
+        runUuid: string;
+    }): Promise<AiAgentReviewBatchRunSummary | null> {
+        const row = await this.database<AiAgentReviewClassifierRunTable>(
+            AiAgentReviewClassifierRunTableName,
+        )
+            .where('ai_agent_review_run_uuid', args.runUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .first<DbAiAgentReviewClassifierRun>();
+
+        return row ? AiAgentReviewClassifierModel.mapBackfillRunRow(row) : null;
+    }
+
     async listBackfillRuns(args: {
         organizationUuid: string;
         projectUuid?: string;
@@ -2132,36 +2186,6 @@ export class AiAgentReviewClassifierModel {
             .select<DbAiAgentReviewClassifierRun[]>('*')
             .orderBy('created_at', 'desc');
 
-        return rows.map((row): AiAgentReviewBatchRunSummary => {
-            const scope = row.run_scope;
-            const window =
-                scope.type === 'backfill'
-                    ? {
-                          startedAt: new Date(scope.startedAt),
-                          endedAt: new Date(scope.endedAt),
-                      }
-                    : { startedAt: new Date(0), endedAt: new Date(0) };
-            return {
-                runUuid: row.ai_agent_review_run_uuid,
-                status: row.status,
-                window,
-                scope: {
-                    projectUuid:
-                        scope.type === 'backfill'
-                            ? (scope.projectUuid ?? null)
-                            : null,
-                    agentUuid:
-                        scope.type === 'backfill'
-                            ? (scope.agentUuid ?? null)
-                            : null,
-                },
-                totalTurns: row.total_turns,
-                processedTurns: row.processed_turns,
-                findingCount: row.finding_count,
-                errorMessage: row.error_message,
-                createdAt: row.created_at,
-                completedAt: row.completed_at,
-            };
-        });
+        return rows.map(AiAgentReviewClassifierModel.mapBackfillRunRow);
     }
 }

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -5,6 +5,9 @@ import type {
     AiAgentFixTarget,
     AiAgentImplicitSignalSource,
     AiAgentRecommendation,
+    AiAgentReviewBatchAction,
+    AiAgentReviewBatchReport,
+    AiAgentReviewBatchRunSummary,
     AiAgentReviewClassifierConfidence,
     AiAgentReviewClassifierContextTurn,
     AiAgentReviewClassifierQueryHistorySummary,
@@ -16,6 +19,7 @@ import type {
     AiAgentReviewClassifierTurnCandidate,
     AiAgentReviewClassifierTurnSignal,
     AiAgentReviewItemDismissedReason,
+    AiAgentReviewItemOwnerType,
     AiAgentReviewItemPrState,
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
@@ -432,6 +436,58 @@ type CreateTurnSignalArgs = {
     turnSignal: AiAgentReviewClassifierTurnSignal;
     finding?: AiAgentReviewClassifierSignalFinding | null;
 };
+
+type BackfillTurnSignalRow = {
+    ai_agent_review_turn_signal_uuid: string;
+    ai_prompt_uuid: string;
+    ai_thread_uuid: string;
+    signal: AiAgentTurnSignal;
+    confidence: AiAgentReviewClassifierConfidence;
+    promoted_to_finding: boolean;
+    primary_root_cause: AiAgentRootCause | null;
+    owner_type: AiAgentReviewItemOwnerType | null;
+    fix_targets: AiAgentFixTarget[] | null;
+    review_item_title: string | null;
+    created_at: Date;
+};
+
+export function buildRunReportActions(
+    rows: BackfillTurnSignalRow[],
+): AiAgentReviewBatchAction[] {
+    const promoted = rows.filter((r) => r.promoted_to_finding);
+    const counts = new Map<
+        string,
+        AiAgentReviewBatchAction & { key: string }
+    >();
+
+    for (const row of promoted) {
+        const primaryRootCause = row.primary_root_cause ?? 'ambiguous';
+        const ownerType = row.owner_type ?? 'unknown';
+        const fixTarget = row.fix_targets?.[0] ?? null;
+        const key = `${primaryRootCause}::${ownerType}::${fixTarget ?? ''}`;
+        const existing = counts.get(key);
+        if (existing) {
+            existing.count += 1;
+        } else {
+            counts.set(key, {
+                key,
+                primaryRootCause,
+                ownerType,
+                fixTarget,
+                count: 1,
+            });
+        }
+    }
+
+    return Array.from(counts.values())
+        .sort((a, b) => b.count - a.count)
+        .map(({ primaryRootCause, ownerType, fixTarget, count }) => ({
+            primaryRootCause,
+            ownerType,
+            fixTarget,
+            count,
+        }));
+}
 
 export class AiAgentReviewClassifierModel {
     private readonly database: Knex;
@@ -1873,6 +1929,239 @@ export class AiAgentReviewClassifierModel {
             }
 
             return inserted[0].ai_agent_review_turn_signal_uuid;
+        });
+    }
+
+    async countTurnReviewCandidates(args: {
+        organizationUuid: string;
+        projectUuid?: string;
+        agentUuid?: string;
+        startedAt: Date;
+        endedAt: Date;
+    }): Promise<number> {
+        const query = this.database(`${AiPromptTableName} as prompt`)
+            .join(
+                `${AiThreadTableName} as thread`,
+                'thread.ai_thread_uuid',
+                'prompt.ai_thread_uuid',
+            )
+            .where('thread.organization_uuid', args.organizationUuid)
+            .whereNotNull('thread.agent_uuid')
+            .whereIn('thread.created_from', ['web_app', 'slack'])
+            .where((builder) => {
+                void builder
+                    .whereNotNull('prompt.response')
+                    .orWhereNotNull('prompt.error_message');
+            })
+            .where('prompt.created_at', '>=', args.startedAt)
+            .where('prompt.created_at', '<', args.endedAt)
+            .count<[{ count: string }]>('prompt.ai_prompt_uuid as count');
+
+        if (args.projectUuid) {
+            void query.where('thread.project_uuid', args.projectUuid);
+        }
+        if (args.agentUuid) {
+            void query.where('thread.agent_uuid', args.agentUuid);
+        }
+
+        const [row] = await query;
+        return parseInt(row.count, 10);
+    }
+
+    async createQueuedBackfillRun(args: {
+        organizationUuid: string;
+        projectUuid?: string;
+        agentUuid?: string;
+        startedAt: Date;
+        endedAt: Date;
+        totalTurns: number;
+        reviewAgentVersion: string;
+        judgePromptHash: string;
+    }): Promise<string> {
+        const runScope: AiAgentReviewClassifierRunScope = {
+            type: 'backfill',
+            startedAt: args.startedAt.toISOString(),
+            endedAt: args.endedAt.toISOString(),
+            projectUuid: args.projectUuid,
+            agentUuid: args.agentUuid,
+        };
+
+        const [row] = await this.database<AiAgentReviewClassifierRunTable>(
+            AiAgentReviewClassifierRunTableName,
+        )
+            .insert({
+                organization_uuid: args.organizationUuid,
+                review_agent_version: args.reviewAgentVersion,
+                judge_prompt_hash: args.judgePromptHash,
+                run_scope: this.jsonb(runScope) as never,
+                status: 'queued',
+                total_turns: args.totalTurns,
+                processed_turns: 0,
+                signal_count: 0,
+                finding_count: 0,
+                review_item_count: 0,
+            })
+            .returning('ai_agent_review_run_uuid');
+
+        return row.ai_agent_review_run_uuid;
+    }
+
+    async getRunReport(runUuid: string): Promise<AiAgentReviewBatchReport> {
+        const runRow = await this.database<AiAgentReviewClassifierRunTable>(
+            AiAgentReviewClassifierRunTableName,
+        )
+            .where('ai_agent_review_run_uuid', runUuid)
+            .first<
+                Pick<
+                    DbAiAgentReviewClassifierRun,
+                    'ai_agent_review_run_uuid' | 'run_scope'
+                >
+            >('ai_agent_review_run_uuid', 'run_scope');
+
+        if (!runRow) {
+            throw new Error(`Run not found: ${runUuid}`);
+        }
+
+        const scope = runRow.run_scope;
+        const window =
+            scope.type === 'backfill'
+                ? {
+                      startedAt: new Date(scope.startedAt),
+                      endedAt: new Date(scope.endedAt),
+                  }
+                : { startedAt: new Date(0), endedAt: new Date(0) };
+
+        const reportScope = {
+            projectUuid:
+                scope.type === 'backfill' ? (scope.projectUuid ?? null) : null,
+            agentUuid:
+                scope.type === 'backfill' ? (scope.agentUuid ?? null) : null,
+        };
+
+        const signalRows = await this.database<AiAgentTurnSignalTable>(
+            AiAgentTurnSignalTableName,
+        )
+            .where('ai_agent_review_run_uuid', runUuid)
+            .select<BackfillTurnSignalRow[]>(
+                'ai_agent_review_turn_signal_uuid',
+                'ai_prompt_uuid',
+                'ai_thread_uuid',
+                'signal',
+                'confidence',
+                'promoted_to_finding',
+                'primary_root_cause',
+                'owner_type',
+                'fix_targets',
+                'review_item_title',
+                'created_at',
+            );
+
+        const turnsReviewed = signalRows.length;
+        const flaggedTurns = signalRows.filter(
+            (r) => r.promoted_to_finding,
+        ).length;
+        const flaggedRate =
+            turnsReviewed > 0 ? flaggedTurns / turnsReviewed : 0;
+
+        const signalsByType: Partial<Record<AiAgentTurnSignal, number>> = {};
+        for (const row of signalRows) {
+            signalsByType[row.signal] = (signalsByType[row.signal] ?? 0) + 1;
+        }
+
+        const confidenceOrder: Record<
+            AiAgentReviewClassifierConfidence,
+            number
+        > = { high: 0, medium: 1, low: 2 };
+
+        const topExamples = signalRows
+            .filter((r) => r.promoted_to_finding)
+            .sort((a, b) => {
+                const cmp =
+                    confidenceOrder[a.confidence] -
+                    confidenceOrder[b.confidence];
+                if (cmp !== 0) return cmp;
+                return (
+                    new Date(b.created_at).getTime() -
+                    new Date(a.created_at).getTime()
+                );
+            })
+            .slice(0, 10)
+            .map((r) => ({
+                promptUuid: r.ai_prompt_uuid,
+                threadUuid: r.ai_thread_uuid,
+                title: r.review_item_title ?? '',
+                primaryRootCause: r.primary_root_cause ?? 'ambiguous',
+                confidence: r.confidence,
+            }));
+
+        return {
+            runUuid,
+            window,
+            scope: reportScope,
+            turnsReviewed,
+            flaggedTurns,
+            flaggedRate,
+            actions: buildRunReportActions(signalRows),
+            signalsByType,
+            topExamples,
+        };
+    }
+
+    async listBackfillRuns(args: {
+        organizationUuid: string;
+        projectUuid?: string;
+        agentUuid?: string;
+    }): Promise<AiAgentReviewBatchRunSummary[]> {
+        const rows = await this.database<AiAgentReviewClassifierRunTable>(
+            AiAgentReviewClassifierRunTableName,
+        )
+            .where('organization_uuid', args.organizationUuid)
+            .whereRaw(`run_scope->>'type' = ?`, ['backfill'])
+            .modify((query) => {
+                if (args.projectUuid) {
+                    void query.whereRaw(`run_scope->>'projectUuid' = ?`, [
+                        args.projectUuid,
+                    ]);
+                }
+                if (args.agentUuid) {
+                    void query.whereRaw(`run_scope->>'agentUuid' = ?`, [
+                        args.agentUuid,
+                    ]);
+                }
+            })
+            .select<DbAiAgentReviewClassifierRun[]>('*')
+            .orderBy('created_at', 'desc');
+
+        return rows.map((row): AiAgentReviewBatchRunSummary => {
+            const scope = row.run_scope;
+            const window =
+                scope.type === 'backfill'
+                    ? {
+                          startedAt: new Date(scope.startedAt),
+                          endedAt: new Date(scope.endedAt),
+                      }
+                    : { startedAt: new Date(0), endedAt: new Date(0) };
+            return {
+                runUuid: row.ai_agent_review_run_uuid,
+                status: row.status,
+                window,
+                scope: {
+                    projectUuid:
+                        scope.type === 'backfill'
+                            ? (scope.projectUuid ?? null)
+                            : null,
+                    agentUuid:
+                        scope.type === 'backfill'
+                            ? (scope.agentUuid ?? null)
+                            : null,
+                },
+                totalTurns: row.total_turns,
+                processedTurns: row.processed_turns,
+                findingCount: row.finding_count,
+                errorMessage: row.error_message,
+                createdAt: row.created_at,
+                completedAt: row.completed_at,
+            };
         });
     }
 }

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -1,5 +1,6 @@
 import {
     AiAgentEvalRunJobPayload,
+    AiAgentReviewBatchJobPayload,
     AiAgentReviewClassifierJobPayload,
     AiAgentReviewRemediationCompileJobPayload,
     AiAgentReviewRemediationPreviewJobPayload,
@@ -72,6 +73,20 @@ export class CommercialSchedulerClient extends SchedulerClient {
                 runAt,
                 maxAttempts: 1,
                 jobKey: `ai-agent-review:${payload.eventType}:${payload.promptUuid}`,
+            },
+        );
+        return { jobId };
+    }
+
+    async aiAgentReviewBatch(payload: AiAgentReviewBatchJobPayload) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_BATCH,
+            payload,
+            {
+                runAt: new Date(),
+                maxAttempts: 1,
+                jobKey: `ai-agent-review-batch:${payload.runUuid}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -26,6 +26,7 @@ const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_REMEDIATION_RUN_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 const AI_AGENT_REVIEW_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const AI_AGENT_REVIEW_BATCH_TIMEOUT_MS = 30 * 60_000;
 const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 
 type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
@@ -288,6 +289,45 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                                 organizationUuid: payload.organizationUuid,
                                 projectUuid: payload.projectUuid,
                                 fingerprint: payload.fingerprint,
+                            },
+                        });
+                    },
+                );
+            },
+            [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_BATCH]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_BATCH,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.aiAgentReviewClassifierService.runReviewBatchJob(
+                                payload,
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    AI_AGENT_REVIEW_BATCH_TIMEOUT_MS,
+                    async (job, e) => {
+                        await this.aiAgentReviewClassifierService.failReviewBatchRun(
+                            {
+                                runUuid: payload.runUuid,
+                                message: getErrorMessage(e),
+                            },
+                        );
+                        await this.schedulerService.logSchedulerJob({
+                            task: EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_BATCH,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                error: getErrorMessage(e),
+                                organizationUuid: payload.organizationUuid,
+                                runUuid: payload.runUuid,
                             },
                         });
                     },

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -1306,6 +1306,27 @@ describe('AiAgentAdminService.startReviewBatch', () => {
         });
     });
 
+    it('throws when the AiReviewBatch feature flag is disabled', async () => {
+        const countTurnReviewCandidates = jest.fn();
+        const service = makeService({
+            aiAgentReviewClassifierModel: { countTurnReviewCandidates },
+            featureFlagService: {
+                get: jest.fn().mockResolvedValue({ enabled: false }),
+            },
+        });
+
+        await expect(
+            service.startReviewBatch(makeAdminUser(), {
+                projectUuid: PROJECT_UUID,
+                agentUuid: AGENT_UUID,
+                startedAt: START_DATE,
+                endedAt: END_DATE,
+            }),
+        ).rejects.toThrow('not enabled');
+
+        expect(countTurnReviewCandidates).not.toHaveBeenCalled();
+    });
+
     it('creates a queued run and enqueues the batch job when under the cap', async () => {
         const ESTIMATED_TURNS = 42;
         const createQueuedBackfillRun = jest.fn().mockResolvedValue(RUN_UUID);

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -1270,3 +1270,92 @@ describe('AiAgentAdminService.pollReviewRemediationCompile', () => {
         ).not.toHaveBeenCalled();
     });
 });
+
+const START_DATE = new Date('2026-01-01T00:00:00.000Z');
+const END_DATE = new Date('2026-06-01T00:00:00.000Z');
+const RUN_UUID = '00000000-0000-0000-0000-000000000099';
+
+describe('AiAgentAdminService.startReviewBatch', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('throws ParameterError when estimated turns exceed the cap', async () => {
+        const aiAgentReviewClassifierModel = {
+            countTurnReviewCandidates: jest.fn().mockResolvedValue(5000),
+        };
+        const service = makeService({ aiAgentReviewClassifierModel });
+
+        await expect(
+            service.startReviewBatch(makeAdminUser(), {
+                projectUuid: PROJECT_UUID,
+                agentUuid: AGENT_UUID,
+                startedAt: START_DATE,
+                endedAt: END_DATE,
+            }),
+        ).rejects.toThrow('exceeds the 500 cap');
+
+        expect(
+            aiAgentReviewClassifierModel.countTurnReviewCandidates,
+        ).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            startedAt: START_DATE,
+            endedAt: END_DATE,
+        });
+    });
+
+    it('creates a queued run and enqueues the batch job when under the cap', async () => {
+        const ESTIMATED_TURNS = 42;
+        const createQueuedBackfillRun = jest.fn().mockResolvedValue(RUN_UUID);
+        const aiAgentReviewBatch = jest
+            .fn()
+            .mockResolvedValue({ jobId: 'job-1' });
+        const aiAgentReviewClassifierModel = {
+            countTurnReviewCandidates: jest
+                .fn()
+                .mockResolvedValue(ESTIMATED_TURNS),
+            createQueuedBackfillRun,
+        };
+        const schedulerClient = {
+            aiAgentReviewBatch,
+        };
+        const service = makeService({
+            aiAgentReviewClassifierModel,
+            schedulerClient,
+        });
+
+        const result = await service.startReviewBatch(makeAdminUser(), {
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            startedAt: START_DATE,
+            endedAt: END_DATE,
+        });
+
+        expect(result).toEqual({
+            runUuid: RUN_UUID,
+            estimatedTurns: ESTIMATED_TURNS,
+        });
+        expect(createQueuedBackfillRun).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            startedAt: START_DATE,
+            endedAt: END_DATE,
+            totalTurns: ESTIMATED_TURNS,
+            reviewAgentVersion: 'llm-judge-v1',
+            judgePromptHash: 'ai-agent-review-judge-v3',
+        });
+        expect(aiAgentReviewBatch).toHaveBeenCalledWith({
+            runUuid: RUN_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            startedAt: START_DATE.toISOString(),
+            endedAt: END_DATE.toISOString(),
+            limit: 500,
+            requestedByUserUuid: USER_UUID,
+        });
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -1990,6 +1990,26 @@ export class AiAgentAdminService extends BaseService {
         return { available: true, ...preview };
     }
 
+    private async assertReviewBatchEnabled(user: SessionUser): Promise<void> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        const flag = await this.featureFlagService.get({
+            featureFlagId: FeatureFlags.AiReviewBatch,
+            user: {
+                userUuid: user.userUuid,
+                organizationUuid,
+                organizationName: user.organizationName ?? '',
+            },
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError(
+                'AI review batch analysis is not enabled',
+            );
+        }
+    }
+
     async startReviewBatch(
         user: SessionUser,
         args: CreateAiAgentReviewBatch,
@@ -1998,6 +2018,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid)
             throw new ForbiddenError('Organization not found');
         this.checkOrganizationAdminAccess(user);
+        await this.assertReviewBatchEnabled(user);
 
         const estimatedTurns =
             await this.aiAgentReviewClassifierModel.countTurnReviewCandidates({
@@ -2047,6 +2068,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid)
             throw new ForbiddenError('Organization not found');
         this.checkOrganizationAdminAccess(user);
+        await this.assertReviewBatchEnabled(user);
 
         const run = await this.aiAgentReviewClassifierModel.getBackfillRun({
             organizationUuid,
@@ -2066,6 +2088,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid)
             throw new ForbiddenError('Organization not found');
         this.checkOrganizationAdminAccess(user);
+        await this.assertReviewBatchEnabled(user);
 
         const report = await this.aiAgentReviewClassifierModel.getRunReport({
             organizationUuid,
@@ -2085,6 +2108,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid)
             throw new ForbiddenError('Organization not found');
         this.checkOrganizationAdminAccess(user);
+        await this.assertReviewBatchEnabled(user);
 
         return this.aiAgentReviewClassifierModel.listBackfillRuns({
             organizationUuid,

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -30,6 +30,9 @@ import {
     PullRequestProvider,
     PullRequestSource,
     UpdateAiAgentReviewItemStatus,
+    type AiAgentReviewBatchReport,
+    type AiAgentReviewBatchRunSummary,
+    type AiAgentReviewBatchStarted,
     type AiAgentReviewItemWritebackBlockedReason,
     type AiAgentReviewItemWritebackEligibility,
     type AiAgentReviewItemWritebackPreview,
@@ -39,6 +42,7 @@ import {
     type AiAgentReviewRemediationEventType,
     type AiAgentReviewRemediationLiveState,
     type AiAgentReviewRemediationStatus,
+    type CreateAiAgentReviewBatch,
     type PullRequest,
     type SessionUser,
 } from '@lightdash/common';
@@ -67,6 +71,10 @@ import {
     buildYmlPathByModel,
     planReviewWriteback,
 } from './ai/reviewWriteback/buildReviewWritebackPrompt';
+import {
+    JUDGE_PROMPT_HASH,
+    REVIEW_AGENT_VERSION,
+} from './AiAgentReviewClassifierService';
 import { type AiOrganizationSettingsService } from './AiOrganizationSettingsService';
 import { type AiWritebackService } from './AiWritebackService/AiWritebackService';
 import { type WritebackPreviewService } from './AiWritebackService/WritebackPreviewService';
@@ -130,6 +138,7 @@ const REVIEW_PREVIEW_POLL_INTERVAL_MS = 25_000;
 const REVIEW_PREVIEW_WAIT_TIMEOUT_MS = 10 * 60_000;
 const PREVIEW_COMPILE_POLL_INTERVAL_MS = 10_000;
 const PREVIEW_COMPILE_WAIT_TIMEOUT_MS = 10 * 60_000;
+const REVIEW_BATCH_MAX_TURNS = 500;
 
 const unavailableWritebackEligibility = (
     reason: AiAgentReviewItemWritebackBlockedReason,
@@ -1979,6 +1988,109 @@ export class AiAgentAdminService extends BaseService {
         });
         trackPreviewViewed(true, toReviewWritebackStrategy(plan.strategy));
         return { available: true, ...preview };
+    }
+
+    async startReviewBatch(
+        user: SessionUser,
+        args: CreateAiAgentReviewBatch,
+    ): Promise<AiAgentReviewBatchStarted> {
+        const { organizationUuid } = user;
+        if (!organizationUuid)
+            throw new ForbiddenError('Organization not found');
+        this.checkOrganizationAdminAccess(user);
+
+        const estimatedTurns =
+            await this.aiAgentReviewClassifierModel.countTurnReviewCandidates({
+                organizationUuid,
+                projectUuid: args.projectUuid ?? undefined,
+                agentUuid: args.agentUuid ?? undefined,
+                startedAt: args.startedAt,
+                endedAt: args.endedAt,
+            });
+        if (estimatedTurns > REVIEW_BATCH_MAX_TURNS) {
+            throw new ParameterError(
+                `This window has ~${estimatedTurns} turns, which exceeds the ${REVIEW_BATCH_MAX_TURNS} cap. Narrow the window.`,
+            );
+        }
+
+        const runUuid =
+            await this.aiAgentReviewClassifierModel.createQueuedBackfillRun({
+                organizationUuid,
+                projectUuid: args.projectUuid ?? undefined,
+                agentUuid: args.agentUuid ?? undefined,
+                startedAt: args.startedAt,
+                endedAt: args.endedAt,
+                totalTurns: estimatedTurns,
+                reviewAgentVersion: REVIEW_AGENT_VERSION,
+                judgePromptHash: JUDGE_PROMPT_HASH,
+            });
+
+        await this.schedulerClient.aiAgentReviewBatch({
+            runUuid,
+            organizationUuid,
+            ...(args.projectUuid != null && { projectUuid: args.projectUuid }),
+            ...(args.agentUuid != null && { agentUuid: args.agentUuid }),
+            startedAt: args.startedAt.toISOString(),
+            endedAt: args.endedAt.toISOString(),
+            limit: REVIEW_BATCH_MAX_TURNS,
+            requestedByUserUuid: user.userUuid,
+        } as Parameters<typeof this.schedulerClient.aiAgentReviewBatch>[0]);
+
+        return { runUuid, estimatedTurns };
+    }
+
+    async getReviewBatchRun(
+        user: SessionUser,
+        runUuid: string,
+    ): Promise<AiAgentReviewBatchRunSummary> {
+        const { organizationUuid } = user;
+        if (!organizationUuid)
+            throw new ForbiddenError('Organization not found');
+        this.checkOrganizationAdminAccess(user);
+
+        const run = await this.aiAgentReviewClassifierModel.getBackfillRun({
+            organizationUuid,
+            runUuid,
+        });
+        if (!run) {
+            throw new NotFoundError('Review batch run not found');
+        }
+        return run;
+    }
+
+    async getReviewBatchReport(
+        user: SessionUser,
+        runUuid: string,
+    ): Promise<AiAgentReviewBatchReport> {
+        const { organizationUuid } = user;
+        if (!organizationUuid)
+            throw new ForbiddenError('Organization not found');
+        this.checkOrganizationAdminAccess(user);
+
+        const report = await this.aiAgentReviewClassifierModel.getRunReport({
+            organizationUuid,
+            runUuid,
+        });
+        if (!report) {
+            throw new NotFoundError('Review batch run not found');
+        }
+        return report;
+    }
+
+    async listReviewBatchRuns(
+        user: SessionUser,
+        filters: { projectUuid?: string; agentUuid?: string },
+    ): Promise<AiAgentReviewBatchRunSummary[]> {
+        const { organizationUuid } = user;
+        if (!organizationUuid)
+            throw new ForbiddenError('Organization not found');
+        this.checkOrganizationAdminAccess(user);
+
+        return this.aiAgentReviewClassifierModel.listBackfillRuns({
+            organizationUuid,
+            projectUuid: filters.projectUuid,
+            agentUuid: filters.agentUuid,
+        });
     }
 
     /**

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -728,6 +728,30 @@ describe('AiAgentReviewClassifierService', () => {
             }),
         );
     });
+
+    it('reuses a pre-created queued run when runUuid is supplied', async () => {
+        const QUEUED_RUN_UUID = 'run-existing';
+        model.listTurnReviewCandidates.mockResolvedValue([makeCandidate()]);
+
+        await service.run({
+            organizationUuid: ORGANIZATION_UUID,
+            startedAt: NOW,
+            endedAt: NOW,
+            runUuid: QUEUED_RUN_UUID,
+            promoteFindingsToReviewItems: false,
+        });
+
+        expect(model.createRun).not.toHaveBeenCalled();
+        expect(model.updateRun).toHaveBeenCalledWith(
+            expect.objectContaining({
+                runUuid: QUEUED_RUN_UUID,
+                status: 'running',
+            }),
+        );
+        expect(model.createTurnSignal).toHaveBeenCalledWith(
+            expect.objectContaining({ runUuid: QUEUED_RUN_UUID }),
+        );
+    });
 });
 
 describe('resolveReviewJudgeProvider', () => {

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -11,6 +11,7 @@ import {
     type AiAgentConfigSnapshot,
     type AiAgentConfigurationSetting,
     type AiAgentEvidenceExcerpt,
+    type AiAgentReviewBatchJobPayload,
     type AiAgentReviewClassifierEventType,
     type AiAgentReviewClassifierJudgeOutput,
     type AiAgentReviewClassifierRunScope,
@@ -37,8 +38,8 @@ import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettin
 import { defaultAgentOptions } from './ai/agents/agentV2';
 import { getModel } from './ai/models';
 
-const REVIEW_AGENT_VERSION = 'llm-judge-v1';
-const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v3';
+export const REVIEW_AGENT_VERSION = 'llm-judge-v1';
+export const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v3';
 const WRITEBACK_TOOL_NAMES = new Set([
     'editDbtProject',
     'propose_writeback',
@@ -1292,6 +1293,36 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
             : '';
 
         return `${subagentPrefix}: ${evidence.toolName} (${evidence.toolCallId}).${args}${result}`;
+    }
+
+    async runReviewBatchJob(
+        payload: AiAgentReviewBatchJobPayload,
+    ): Promise<void> {
+        await this.run({
+            runUuid: payload.runUuid,
+            organizationUuid: payload.organizationUuid,
+            projectUuid: payload.projectUuid,
+            agentUuid: payload.agentUuid,
+            startedAt: new Date(payload.startedAt),
+            endedAt: new Date(payload.endedAt),
+            limit: payload.limit,
+            requestedByUserUuid: payload.requestedByUserUuid,
+            dryRun: false,
+            persistSignals: true,
+            persistFindings: true,
+            promoteFindingsToReviewItems: false,
+        });
+    }
+
+    async failReviewBatchRun(args: {
+        runUuid: string;
+        message: string;
+    }): Promise<void> {
+        await this.aiAgentReviewClassifierModel.updateRun({
+            runUuid: args.runUuid,
+            status: 'failed',
+            errorMessage: args.message,
+        });
     }
 
     private static getRelevantCatalogMatches({

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -153,6 +153,7 @@ type RunArgs = {
     persistSignals?: boolean;
     persistFindings?: boolean;
     promoteFindingsToReviewItems?: boolean;
+    runUuid?: string;
 };
 
 type RunLiveEventArgs = {
@@ -177,6 +178,7 @@ type ProcessCandidatesArgs = {
     persistFindings?: boolean;
     promoteFindingsToReviewItems?: boolean;
     failWhenDisabled?: boolean;
+    runUuid?: string;
 };
 
 export type AiAgentReviewClassifierRunResult = {
@@ -299,6 +301,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             persistFindings: args.persistFindings,
             promoteFindingsToReviewItems: args.promoteFindingsToReviewItems,
             failWhenDisabled: true,
+            runUuid: args.runUuid,
         });
         if (!result) {
             throw new ForbiddenError('AI agent review agent is not enabled');
@@ -409,20 +412,32 @@ export class AiAgentReviewClassifierService extends BaseService {
             },
         });
 
-        const run = await this.aiAgentReviewClassifierModel.createRun({
-            organizationUuid: args.organizationUuid,
-            reviewAgentVersion: REVIEW_AGENT_VERSION,
-            judgePromptHash: JUDGE_PROMPT_HASH,
-            status: 'running',
-            totalTurns: args.candidates.length,
-            runScope: args.runScope,
-            agentConfigSnapshotHash: runAgentConfig.snapshotHash,
-            agentConfigSnapshot: runAgentConfig.snapshot,
-            agentConfigSnapshotAgentUpdatedAt: runAgentConfig.agentUpdatedAt,
-        });
+        let runUuid: string;
+        if (args.runUuid) {
+            runUuid = args.runUuid;
+            await this.aiAgentReviewClassifierModel.updateRun({
+                runUuid,
+                status: 'running',
+                totalTurns: args.candidates.length,
+            });
+        } else {
+            const run = await this.aiAgentReviewClassifierModel.createRun({
+                organizationUuid: args.organizationUuid,
+                reviewAgentVersion: REVIEW_AGENT_VERSION,
+                judgePromptHash: JUDGE_PROMPT_HASH,
+                status: 'running',
+                totalTurns: args.candidates.length,
+                runScope: args.runScope,
+                agentConfigSnapshotHash: runAgentConfig.snapshotHash,
+                agentConfigSnapshot: runAgentConfig.snapshot,
+                agentConfigSnapshotAgentUpdatedAt:
+                    runAgentConfig.agentUpdatedAt,
+            });
+            runUuid = run.uuid;
+        }
 
         this.debugLog('RunStarted', {
-            runUuid: run.uuid,
+            runUuid,
             organizationUuid: args.organizationUuid,
             runScope: args.runScope,
             agentConfigSnapshotHash: runAgentConfig.snapshotHash,
@@ -470,7 +485,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             for (const { classifiedTurn } of reviewedTurns) {
                 if (shouldPersistSignals) {
                     await this.aiAgentReviewClassifierModel.createTurnSignal({
-                        runUuid: run.uuid,
+                        runUuid,
                         turnSignal: classifiedTurn.signal,
                         finding: shouldPersistFindings
                             ? classifiedTurn.finding
@@ -494,7 +509,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             /* eslint-enable no-await-in-loop */
 
             await this.aiAgentReviewClassifierModel.updateRun({
-                runUuid: run.uuid,
+                runUuid,
                 status: 'completed',
                 processedTurns,
                 signalCount,
@@ -504,7 +519,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             });
 
             this.debugLog('RunCompleted', {
-                runUuid: run.uuid,
+                runUuid,
                 processedTurns,
                 signalCount,
                 findingCount: reviewedFindingCount,
@@ -512,7 +527,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             });
 
             return {
-                runUuid: run.uuid,
+                runUuid,
                 processedTurns,
                 signalCount,
                 findingCount: reviewedFindingCount,
@@ -521,7 +536,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             };
         } catch (error) {
             this.debugLog('RunFailed', {
-                runUuid: run.uuid,
+                runUuid,
                 processedTurns,
                 signalCount,
                 findingCount,
@@ -530,7 +545,7 @@ export class AiAgentReviewClassifierService extends BaseService {
                     error instanceof Error ? error.message : String(error),
             });
             await this.aiAgentReviewClassifierModel.updateRun({
-                runUuid: run.uuid,
+                runUuid,
                 status: 'failed',
                 processedTurns,
                 signalCount,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12578,11 +12578,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13891,11 +13891,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13956,11 +13956,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14137,11 +14137,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14156,11 +14156,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14175,11 +14175,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -21807,6 +21807,395 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewBatchStarted: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                estimatedTurns: { dataType: 'double', required: true },
+                runUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiAgentReviewBatchStarted_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiAgentReviewBatchStarted', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentReviewBatchStartedResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiAgentReviewBatchStarted_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateAiAgentReviewBatch: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                endedAt: { dataType: 'datetime', required: true },
+                startedAt: { dataType: 'datetime', required: true },
+                agentUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                projectUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewClassifierRunStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['queued'] },
+                { dataType: 'enum', enums: ['running'] },
+                { dataType: 'enum', enums: ['completed'] },
+                { dataType: 'enum', enums: ['failed'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewBatchRunSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                completedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdAt: { dataType: 'datetime', required: true },
+                errorMessage: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                findingCount: { dataType: 'double', required: true },
+                processedTurns: { dataType: 'double', required: true },
+                totalTurns: { dataType: 'double', required: true },
+                scope: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        agentUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        projectUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                window: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        endedAt: { dataType: 'datetime', required: true },
+                        startedAt: { dataType: 'datetime', required: true },
+                    },
+                    required: true,
+                },
+                status: {
+                    ref: 'AiAgentReviewClassifierRunStatus',
+                    required: true,
+                },
+                runUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiAgentReviewBatchRunSummary-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentReviewBatchRunSummary',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentReviewBatchRunsResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiAgentReviewBatchRunSummary-Array_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiAgentReviewBatchRunSummary_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'AiAgentReviewBatchRunSummary',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentReviewBatchRunResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiAgentReviewBatchRunSummary_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewBatchAction: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                count: { dataType: 'double', required: true },
+                fixTarget: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiAgentFixTarget' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                ownerType: {
+                    ref: 'AiAgentReviewItemOwnerType',
+                    required: true,
+                },
+                primaryRootCause: { ref: 'AiAgentRootCause', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Partial_Record_AiAgentTurnSignal.number__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                ambiguous: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                normal_refinement: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                implicit_correction: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                explicit_dispute: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                retry_after_failure: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                output_shape_correction: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                new_question: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                acceptance_or_continuation: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                product_capability_request: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                human_intervention: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewBatchExample: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                confidence: {
+                    ref: 'AiAgentReviewClassifierConfidence',
+                    required: true,
+                },
+                primaryRootCause: { ref: 'AiAgentRootCause', required: true },
+                title: { dataType: 'string', required: true },
+                threadUuid: { dataType: 'string', required: true },
+                promptUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewBatchReport: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                topExamples: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentReviewBatchExample',
+                    },
+                    required: true,
+                },
+                signalsByType: {
+                    ref: 'Partial_Record_AiAgentTurnSignal.number__',
+                    required: true,
+                },
+                actions: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentReviewBatchAction',
+                    },
+                    required: true,
+                },
+                flaggedRate: { dataType: 'double', required: true },
+                flaggedTurns: { dataType: 'double', required: true },
+                turnsReviewed: { dataType: 'double', required: true },
+                scope: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        agentUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        projectUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                window: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        endedAt: { dataType: 'datetime', required: true },
+                        startedAt: { dataType: 'datetime', required: true },
+                    },
+                    required: true,
+                },
+                runUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiAgentReviewBatchReport_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiAgentReviewBatchReport', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentReviewBatchReportResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiAgentReviewBatchReport_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiJobScheduledResponse: {
         dataType: 'refAlias',
         type: {
@@ -25957,6 +26346,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['aiAgentEvalResult'] },
                 { dataType: 'enum', enums: ['aiAgentReviewClassifier'] },
                 { dataType: 'enum', enums: ['aiAgentReviewWriteback'] },
+                { dataType: 'enum', enums: ['aiAgentReviewBatch'] },
                 {
                     dataType: 'enum',
                     enums: ['aiAgentReviewRemediationPreview'],
@@ -29062,7 +29452,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29072,7 +29462,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29082,7 +29472,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29095,7 +29485,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -29750,7 +30140,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29760,7 +30150,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29770,7 +30160,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29783,7 +30173,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -52338,6 +52728,246 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'upsertSettings',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_startReviewBatch: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CreateAiAgentReviewBatch',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/admin/review-runs',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.startReviewBatch,
+        ),
+
+        async function AiAgentAdminController_startReviewBatch(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_startReviewBatch,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'startReviewBatch',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_listReviewBatchRuns: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: { in: 'query', name: 'projectUuid', dataType: 'string' },
+        agentUuid: { in: 'query', name: 'agentUuid', dataType: 'string' },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/review-runs',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.listReviewBatchRuns,
+        ),
+
+        async function AiAgentAdminController_listReviewBatchRuns(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_listReviewBatchRuns,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listReviewBatchRuns',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getReviewBatchRun: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        runUuid: {
+            in: 'path',
+            name: 'runUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/review-runs/:runUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getReviewBatchRun,
+        ),
+
+        async function AiAgentAdminController_getReviewBatchRun(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getReviewBatchRun,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getReviewBatchRun',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getReviewBatchReport: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        runUuid: {
+            in: 'path',
+            name: 'runUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/review-runs/:runUuid/report',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getReviewBatchReport,
+        ),
+
+        async function AiAgentAdminController_getReviewBatchReport(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getReviewBatchReport,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getReviewBatchReport',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14138,19 +14138,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -22239,6 +22226,373 @@
             "UpdateAiOrganizationSettings": {
                 "$ref": "#/components/schemas/Partial_Omit_AiOrganizationSettings.organizationUuid__"
             },
+            "AiAgentReviewBatchStarted": {
+                "properties": {
+                    "estimatedTurns": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "runUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["estimatedTurns", "runUuid"],
+                "type": "object"
+            },
+            "ApiSuccess_AiAgentReviewBatchStarted_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentReviewBatchStarted"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentReviewBatchStartedResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewBatchStarted_"
+            },
+            "CreateAiAgentReviewBatch": {
+                "properties": {
+                    "endedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "agentUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "projectUuid": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "endedAt",
+                    "startedAt",
+                    "agentUuid",
+                    "projectUuid"
+                ],
+                "type": "object"
+            },
+            "AiAgentReviewClassifierRunStatus": {
+                "type": "string",
+                "enum": ["queued", "running", "completed", "failed"]
+            },
+            "AiAgentReviewBatchRunSummary": {
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "errorMessage": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "findingCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "processedTurns": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "totalTurns": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "scope": {
+                        "properties": {
+                            "agentUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "projectUuid": {
+                                "type": "string",
+                                "nullable": true
+                            }
+                        },
+                        "required": ["agentUuid", "projectUuid"],
+                        "type": "object"
+                    },
+                    "window": {
+                        "properties": {
+                            "endedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "startedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "required": ["endedAt", "startedAt"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/AiAgentReviewClassifierRunStatus"
+                    },
+                    "runUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "completedAt",
+                    "createdAt",
+                    "errorMessage",
+                    "findingCount",
+                    "processedTurns",
+                    "totalTurns",
+                    "scope",
+                    "window",
+                    "status",
+                    "runUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiAgentReviewBatchRunSummary-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentReviewBatchRunSummary"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentReviewBatchRunsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewBatchRunSummary-Array_"
+            },
+            "ApiSuccess_AiAgentReviewBatchRunSummary_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentReviewBatchRunSummary"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentReviewBatchRunResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewBatchRunSummary_"
+            },
+            "AiAgentReviewBatchAction": {
+                "properties": {
+                    "count": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "fixTarget": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiAgentFixTarget"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "ownerType": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemOwnerType"
+                    },
+                    "primaryRootCause": {
+                        "$ref": "#/components/schemas/AiAgentRootCause"
+                    }
+                },
+                "required": [
+                    "count",
+                    "fixTarget",
+                    "ownerType",
+                    "primaryRootCause"
+                ],
+                "type": "object"
+            },
+            "Partial_Record_AiAgentTurnSignal.number__": {
+                "properties": {
+                    "ambiguous": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "normal_refinement": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "implicit_correction": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "explicit_dispute": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "retry_after_failure": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "output_shape_correction": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "new_question": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "acceptance_or_continuation": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "product_capability_request": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "human_intervention": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "type": "object",
+                "description": "Make all properties in T optional"
+            },
+            "AiAgentReviewBatchExample": {
+                "properties": {
+                    "confidence": {
+                        "$ref": "#/components/schemas/AiAgentReviewClassifierConfidence"
+                    },
+                    "primaryRootCause": {
+                        "$ref": "#/components/schemas/AiAgentRootCause"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "threadUuid": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "confidence",
+                    "primaryRootCause",
+                    "title",
+                    "threadUuid",
+                    "promptUuid"
+                ],
+                "type": "object"
+            },
+            "AiAgentReviewBatchReport": {
+                "properties": {
+                    "topExamples": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentReviewBatchExample"
+                        },
+                        "type": "array"
+                    },
+                    "signalsByType": {
+                        "$ref": "#/components/schemas/Partial_Record_AiAgentTurnSignal.number__"
+                    },
+                    "actions": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentReviewBatchAction"
+                        },
+                        "type": "array"
+                    },
+                    "flaggedRate": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "flaggedTurns": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "turnsReviewed": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "scope": {
+                        "properties": {
+                            "agentUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "projectUuid": {
+                                "type": "string",
+                                "nullable": true
+                            }
+                        },
+                        "required": ["agentUuid", "projectUuid"],
+                        "type": "object"
+                    },
+                    "window": {
+                        "properties": {
+                            "endedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "startedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "required": ["endedAt", "startedAt"],
+                        "type": "object"
+                    },
+                    "runUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "topExamples",
+                    "signalsByType",
+                    "actions",
+                    "flaggedRate",
+                    "flaggedTurns",
+                    "turnsReviewed",
+                    "scope",
+                    "window",
+                    "runUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiAgentReviewBatchReport_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentReviewBatchReport"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentReviewBatchReportResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewBatchReport_"
+            },
             "ApiJobScheduledResponse": {
                 "properties": {
                     "results": {
@@ -26495,6 +26849,7 @@
                     "aiAgentEvalResult",
                     "aiAgentReviewClassifier",
                     "aiAgentReviewWriteback",
+                    "aiAgentReviewBatch",
                     "aiAgentReviewRemediationPreview",
                     "aiAgentReviewRemediationCompile",
                     "aiAgentReviewRemediationRun",
@@ -29823,22 +30178,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -30398,22 +30753,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -39361,7 +39716,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3156.1",
+        "version": "0.3157.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -46564,6 +46919,173 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/aiAgents/admin/review-runs": {
+            "post": {
+                "operationId": "startAiAgentReviewBatch",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewBatchStartedResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Start a new AI agent review batch analysis run",
+                "summary": "Start AI agent review batch",
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateAiAgentReviewBatch"
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "operationId": "listAiAgentReviewBatchRuns",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewBatchRunsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List AI agent review batch runs",
+                "summary": "List AI agent review batch runs",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "projectUuid",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "agentUuid",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/aiAgents/admin/review-runs/{runUuid}": {
+            "get": {
+                "operationId": "getAiAgentReviewBatchRun",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewBatchRunResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a single AI agent review batch run (for polling status)",
+                "summary": "Get AI agent review batch run",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "runUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/aiAgents/admin/review-runs/{runUuid}/report": {
+            "get": {
+                "operationId": "getAiAgentReviewBatchReport",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewBatchReportResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the full report for a completed AI agent review batch run",
+                "summary": "Get AI agent review batch report",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "runUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/projects/{projectUuid}/validate": {

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -171,6 +171,12 @@ const getTagsForTask: {
         'user.uuid': payload.userUuid,
     }),
 
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_BATCH]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.requestedByUserUuid,
+        ...(payload.projectUuid ? { 'project.uuid': payload.projectUuid } : {}),
+    }),
+
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'project.uuid': payload.projectUuid,

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -1005,3 +1005,65 @@ export const getAiAgentReviewItemFingerprint = (
 
     return `ai_agent_review_item:${hashCanonicalJson(canonicalJson)}`;
 };
+
+export type AiAgentReviewBatchAction = {
+    primaryRootCause: AiAgentRootCause;
+    ownerType: AiAgentReviewItemOwnerType;
+    fixTarget: AiAgentFixTarget | null;
+    count: number;
+};
+
+export type AiAgentReviewBatchExample = {
+    promptUuid: string;
+    threadUuid: string;
+    title: string;
+    primaryRootCause: AiAgentRootCause;
+    confidence: AiAgentReviewClassifierConfidence;
+};
+
+export type AiAgentReviewBatchReport = {
+    runUuid: string;
+    window: { startedAt: Date; endedAt: Date };
+    scope: { projectUuid: string | null; agentUuid: string | null };
+    turnsReviewed: number;
+    flaggedTurns: number;
+    flaggedRate: number;
+    actions: AiAgentReviewBatchAction[];
+    signalsByType: Partial<Record<AiAgentTurnSignal, number>>;
+    topExamples: AiAgentReviewBatchExample[];
+};
+
+export type AiAgentReviewBatchRunSummary = {
+    runUuid: string;
+    status: AiAgentReviewClassifierRunStatus;
+    window: { startedAt: Date; endedAt: Date };
+    scope: { projectUuid: string | null; agentUuid: string | null };
+    totalTurns: number;
+    processedTurns: number;
+    findingCount: number;
+    errorMessage: string | null;
+    createdAt: Date;
+    completedAt: Date | null;
+};
+
+export type CreateAiAgentReviewBatch = {
+    projectUuid: string | null;
+    agentUuid: string | null;
+    startedAt: Date;
+    endedAt: Date;
+};
+
+export type AiAgentReviewBatchStarted = {
+    runUuid: string;
+    estimatedTurns: number;
+};
+
+export type ApiAiAgentReviewBatchStartedResponse =
+    ApiSuccess<AiAgentReviewBatchStarted>;
+export type ApiAiAgentReviewBatchRunResponse =
+    ApiSuccess<AiAgentReviewBatchRunSummary>;
+export type ApiAiAgentReviewBatchReportResponse =
+    ApiSuccess<AiAgentReviewBatchReport>;
+export type ApiAiAgentReviewBatchRunsResponse = ApiSuccess<
+    AiAgentReviewBatchRunSummary[]
+>;

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -193,6 +193,17 @@ export type AiAgentReviewClassifierJobPayload = TraceTaskBase & {
     promptUuid: string;
 };
 
+export type AiAgentReviewBatchJobPayload = TraceTaskBase & {
+    runUuid: string;
+    organizationUuid: string;
+    projectUuid?: string;
+    agentUuid?: string;
+    startedAt: string;
+    endedAt: string;
+    limit: number;
+    requestedByUserUuid: string;
+};
+
 export type AiAgentReviewWritebackJobPayload = TraceTaskBase & {
     fingerprint: string;
     organizationUuid: string;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -11,6 +11,10 @@ import type {
     ApiAiAgentEvaluationRunSummaryListResponse,
     ApiAiAgentEvaluationSummaryListResponse,
     ApiAiAgentProjectThreadSummaryListResponse,
+    ApiAiAgentReviewBatchReportResponse,
+    ApiAiAgentReviewBatchRunResponse,
+    ApiAiAgentReviewBatchRunsResponse,
+    ApiAiAgentReviewBatchStartedResponse,
     ApiAiAgentReviewItemActivityResponse,
     ApiAiAgentReviewItemPrDiffResponse,
     ApiAiAgentReviewItemWritebackPreviewResponse,
@@ -1104,6 +1108,10 @@ type ApiResults =
     | ApiAiAgentReviewItemPrDiffResponse['results']
     | ApiAiAgentReviewItemActivityResponse['results']
     | ApiAiAgentThreadPullRequestResponse['results']
+    | ApiAiAgentReviewBatchStartedResponse['results']
+    | ApiAiAgentReviewBatchRunResponse['results']
+    | ApiAiAgentReviewBatchRunsResponse['results']
+    | ApiAiAgentReviewBatchReportResponse['results']
     | ApiAiAgentEvaluationSummaryListResponse['results']
     | ApiAiAgentEvaluationResponse['results']
     | ApiAiAgentEvaluationRunResponse['results']

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -208,6 +208,15 @@ export enum FeatureFlags {
     AiWriteback = 'ai-writeback',
 
     /**
+     * Enable AI agent review batch analysis: the admin-triggered, analysis-only
+     * windowed review run (`/review-runs` endpoints + the Analysis panel). Off
+     * by default and independent of the `ai_agent_reviews_enabled` org setting,
+     * so the on-demand batch (which incurs LLM cost per run) can be rolled out
+     * separately from live per-turn review.
+     */
+    AiReviewBatch = 'ai-review-batch',
+
+    /**
      * Enable the `searchSemanticLayer` agent tool, which lets the AI agent
      * list/search metrics and dimensions across ALL explores at once (backed
      * by the catalog search index) to answer project-wide questions like

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -1,6 +1,7 @@
 import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
+    type AiAgentReviewBatchJobPayload,
     type AiAgentReviewClassifierJobPayload,
     type AiAgentReviewRemediationCompileJobPayload,
     type AiAgentReviewRemediationPreviewJobPayload,
@@ -67,6 +68,7 @@ export const EE_SCHEDULER_TASKS = {
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
     AI_AGENT_REVIEW_CLASSIFIER: 'aiAgentReviewClassifier',
     AI_AGENT_REVIEW_WRITEBACK: 'aiAgentReviewWriteback',
+    AI_AGENT_REVIEW_BATCH: 'aiAgentReviewBatch',
     AI_AGENT_REVIEW_REMEDIATION_PREVIEW: 'aiAgentReviewRemediationPreview',
     AI_AGENT_REVIEW_REMEDIATION_COMPILE: 'aiAgentReviewRemediationCompile',
     AI_AGENT_REVIEW_REMEDIATION_RUN: 'aiAgentReviewRemediationRun',
@@ -157,6 +159,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_BATCH]: AiAgentReviewBatchJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: AiAgentReviewRemediationPreviewJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: AiAgentReviewRemediationCompileJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
@@ -171,6 +174,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;
+    [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_BATCH]: AiAgentReviewBatchJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: AiAgentReviewRemediationPreviewJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: AiAgentReviewRemediationCompileJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/BatchAnalysisPanel.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/BatchAnalysisPanel.test.tsx
@@ -1,0 +1,111 @@
+import {
+    type AiAgentReviewBatchReport,
+    type AiAgentReviewBatchRunSummary,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { BatchAnalysisPanel } from './BatchAnalysisPanel';
+
+const mockUseReviewBatchRun = vi.fn();
+const mockUseReviewBatchReport = vi.fn();
+
+vi.mock('../../hooks/useAiAgentReviewBatch', () => ({
+    useStartReviewBatch: () => ({ isLoading: false, mutateAsync: vi.fn() }),
+    useReviewBatchRuns: () => ({ data: [] }),
+    useReviewBatchRun: (...args: unknown[]) => mockUseReviewBatchRun(...args),
+    useReviewBatchReport: (...args: unknown[]) =>
+        mockUseReviewBatchReport(...args),
+}));
+
+const makeRunSummary = (
+    overrides: Partial<AiAgentReviewBatchRunSummary> = {},
+): AiAgentReviewBatchRunSummary => ({
+    runUuid: 'run-1',
+    status: 'completed',
+    window: {
+        startedAt: new Date('2026-05-01T00:00:00.000Z'),
+        endedAt: new Date('2026-05-31T00:00:00.000Z'),
+    },
+    scope: { projectUuid: null, agentUuid: null },
+    totalTurns: 500,
+    processedTurns: 500,
+    findingCount: 12,
+    errorMessage: null,
+    createdAt: new Date('2026-06-01T08:00:00.000Z'),
+    completedAt: new Date('2026-06-01T08:05:00.000Z'),
+    ...overrides,
+});
+
+const makeReport = (
+    overrides: Partial<AiAgentReviewBatchReport> = {},
+): AiAgentReviewBatchReport => ({
+    runUuid: 'run-1',
+    window: {
+        startedAt: new Date('2026-05-01T00:00:00.000Z'),
+        endedAt: new Date('2026-05-31T00:00:00.000Z'),
+    },
+    scope: { projectUuid: null, agentUuid: null },
+    turnsReviewed: 400,
+    flaggedTurns: 40,
+    flaggedRate: 0.1,
+    actions: [
+        {
+            primaryRootCause: 'semantic_layer',
+            ownerType: 'semantic_layer_owner',
+            fixTarget: 'semantic_yaml_patch',
+            count: 25,
+        },
+        {
+            primaryRootCause: 'project_context',
+            ownerType: 'agent_admin',
+            fixTarget: 'project_context_rule',
+            count: 15,
+        },
+    ],
+    signalsByType: { explicit_dispute: 30, implicit_correction: 10 },
+    topExamples: [],
+    ...overrides,
+});
+
+describe('BatchAnalysisPanel', () => {
+    beforeEach(() => {
+        mockUseReviewBatchRun.mockReset();
+        mockUseReviewBatchReport.mockReset();
+        mockUseReviewBatchRun.mockReturnValue({ data: undefined });
+        mockUseReviewBatchReport.mockReturnValue({ data: undefined });
+    });
+
+    it('renders actions breakdown and flagged-rate % when a run is completed', () => {
+        mockUseReviewBatchRun.mockReturnValue({ data: makeRunSummary() });
+        mockUseReviewBatchReport.mockReturnValue({ data: makeReport() });
+
+        renderWithProviders(
+            <BatchAnalysisPanel projectUuid={null} agentUuid={null} />,
+        );
+
+        expect(screen.getByText(/10%/)).toBeInTheDocument();
+        expect(screen.getByText('Semantic layer')).toBeInTheDocument();
+        expect(screen.getByText('Project context')).toBeInTheDocument();
+    });
+
+    it('shows progress text while running and does not show the report', () => {
+        mockUseReviewBatchRun.mockReturnValue({
+            data: makeRunSummary({
+                status: 'running',
+                processedTurns: 120,
+                totalTurns: 800,
+            }),
+        });
+        mockUseReviewBatchReport.mockReturnValue({ data: undefined });
+
+        renderWithProviders(
+            <BatchAnalysisPanel projectUuid={null} agentUuid={null} />,
+        );
+
+        expect(screen.getByText(/Reviewing/i)).toBeInTheDocument();
+        expect(
+            screen.queryByText(/actions breakdown/i),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/BatchAnalysisPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/BatchAnalysisPanel.tsx
@@ -1,0 +1,29 @@
+import { Stack } from '@mantine-8/core';
+import type { FC } from 'react';
+import {
+    useReviewBatchReport,
+    useReviewBatchRun,
+    useReviewBatchRuns,
+    useStartReviewBatch,
+} from '../../hooks/useAiAgentReviewBatch';
+
+type Props = {
+    projectUuid: string | null;
+    agentUuid: string | null;
+};
+
+// Placeholder for T9 — batch analysis panel.
+export const BatchAnalysisPanel: FC<Props> = ({ projectUuid, agentUuid }) => {
+    const { data: runs } = useReviewBatchRuns({
+        projectUuid: projectUuid ?? undefined,
+        agentUuid: agentUuid ?? undefined,
+    });
+    const latestRunUuid = runs?.[0]?.runUuid;
+    const { data: run } = useReviewBatchRun(latestRunUuid, { poll: true });
+    const { data: _report } = useReviewBatchReport(latestRunUuid, {
+        enabled: run?.status === 'completed',
+    });
+    const _startBatch = useStartReviewBatch();
+
+    return <Stack />;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/BatchAnalysisPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/BatchAnalysisPanel.tsx
@@ -1,29 +1,357 @@
-import { Stack } from '@mantine-8/core';
-import type { FC } from 'react';
+import {
+    type AiAgentReviewBatchAction,
+    type AiAgentReviewBatchExample,
+    type AiAgentReviewBatchRunSummary,
+} from '@lightdash/common';
+import {
+    Badge,
+    Button,
+    Divider,
+    Group,
+    Progress,
+    SegmentedControl,
+    Stack,
+    Table,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { DatePickerInput } from '@mantine/dates';
+import { IconPlaystationCircle } from '@tabler/icons-react';
+import { type FC, useState } from 'react';
+import Callout from '../../../../../components/common/Callout';
+import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
+import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
     useReviewBatchReport,
     useReviewBatchRun,
     useReviewBatchRuns,
     useStartReviewBatch,
 } from '../../hooks/useAiAgentReviewBatch';
+import {
+    formatReviewDate,
+    reviewRootCauseColors,
+    reviewRootCauseLabels,
+} from './reviewItemDetails';
+
+type WindowPreset = '7d' | '30d' | '90d' | 'custom';
 
 type Props = {
     projectUuid: string | null;
     agentUuid: string | null;
 };
 
-// Placeholder for T9 — batch analysis panel.
+const WINDOW_PRESETS: { value: WindowPreset; label: string }[] = [
+    { value: '7d', label: 'Last 7 days' },
+    { value: '30d', label: 'Last 30 days' },
+    { value: '90d', label: 'Last 90 days' },
+    { value: 'custom', label: 'Custom' },
+];
+
+const computeWindow = (
+    preset: WindowPreset,
+    customRange: [Date | null, Date | null],
+): { startedAt: Date; endedAt: Date } | null => {
+    const now = new Date();
+    if (preset === 'custom') {
+        const [start, end] = customRange;
+        if (!start || !end) return null;
+        return { startedAt: start, endedAt: end };
+    }
+    const daysBack = preset === '7d' ? 7 : preset === '30d' ? 30 : 90;
+    const startedAt = new Date(now);
+    startedAt.setDate(startedAt.getDate() - daysBack);
+    return { startedAt, endedAt: now };
+};
+
+const humanize = (str: string): string =>
+    str.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+const BatchActionsTable: FC<{ actions: AiAgentReviewBatchAction[] }> = ({
+    actions,
+}) => (
+    <Table withTableBorder withColumnBorders>
+        <Table.Thead>
+            <Table.Tr>
+                <Table.Th>Root cause</Table.Th>
+                <Table.Th>Owner</Table.Th>
+                <Table.Th>Fix target</Table.Th>
+                <Table.Th>Count</Table.Th>
+            </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+            {actions.map((action, idx) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <Table.Tr key={idx}>
+                    <Table.Td>
+                        <CategoryBadge
+                            variant="dot"
+                            label={
+                                reviewRootCauseLabels[action.primaryRootCause]
+                            }
+                            color={
+                                reviewRootCauseColors[action.primaryRootCause]
+                            }
+                        />
+                    </Table.Td>
+                    <Table.Td>
+                        <Text fz="sm">{humanize(action.ownerType)}</Text>
+                    </Table.Td>
+                    <Table.Td>
+                        <Text fz="sm" c="dimmed">
+                            {action.fixTarget
+                                ? humanize(action.fixTarget)
+                                : '—'}
+                        </Text>
+                    </Table.Td>
+                    <Table.Td>
+                        <Text fz="sm" fw={600}>
+                            {action.count}
+                        </Text>
+                    </Table.Td>
+                </Table.Tr>
+            ))}
+        </Table.Tbody>
+    </Table>
+);
+
+const TopExamplesList: FC<{ examples: AiAgentReviewBatchExample[] }> = ({
+    examples,
+}) => (
+    <Stack gap="xs">
+        {examples.map((example) => (
+            <Group key={example.promptUuid} gap="sm" wrap="nowrap">
+                <CategoryBadge
+                    variant="dot"
+                    label={reviewRootCauseLabels[example.primaryRootCause]}
+                    color={reviewRootCauseColors[example.primaryRootCause]}
+                />
+                <Text fz="sm" c="ldGray.8" lineClamp={1}>
+                    {example.title}
+                </Text>
+            </Group>
+        ))}
+    </Stack>
+);
+
+const HistoryTable: FC<{
+    runs: AiAgentReviewBatchRunSummary[];
+    selectedRunUuid: string | undefined;
+    onSelect: (runUuid: string) => void;
+}> = ({ runs, selectedRunUuid, onSelect }) => (
+    <Table withTableBorder withColumnBorders highlightOnHover>
+        <Table.Thead>
+            <Table.Tr>
+                <Table.Th>Window</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th>Findings</Table.Th>
+                <Table.Th>Run at</Table.Th>
+            </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+            {runs.map((run) => (
+                <Table.Tr
+                    key={run.runUuid}
+                    onClick={() => onSelect(run.runUuid)}
+                    style={{ cursor: 'pointer' }}
+                    bg={
+                        run.runUuid === selectedRunUuid ? 'ldGray.0' : undefined
+                    }
+                >
+                    <Table.Td>
+                        <Text fz="sm">
+                            {formatReviewDate(run.window.startedAt)} –{' '}
+                            {formatReviewDate(run.window.endedAt)}
+                        </Text>
+                    </Table.Td>
+                    <Table.Td>
+                        <Badge
+                            variant="light"
+                            color={
+                                run.status === 'completed'
+                                    ? 'green'
+                                    : run.status === 'failed'
+                                      ? 'red'
+                                      : 'blue'
+                            }
+                        >
+                            {run.status}
+                        </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                        <Text fz="sm">{run.findingCount}</Text>
+                    </Table.Td>
+                    <Table.Td>
+                        <Text fz="sm" c="dimmed">
+                            {formatReviewDate(run.createdAt)}
+                        </Text>
+                    </Table.Td>
+                </Table.Tr>
+            ))}
+        </Table.Tbody>
+    </Table>
+);
+
 export const BatchAnalysisPanel: FC<Props> = ({ projectUuid, agentUuid }) => {
-    const { data: runs } = useReviewBatchRuns({
+    const [windowPreset, setWindowPreset] = useState<WindowPreset>('30d');
+    const [customRange, setCustomRange] = useState<[Date | null, Date | null]>([
+        null,
+        null,
+    ]);
+    const [activeRunUuid, setActiveRunUuid] = useState<string | undefined>(
+        undefined,
+    );
+
+    // TODO: project/agent scoping
+    const startBatch = useStartReviewBatch();
+
+    const { data: runs = [] } = useReviewBatchRuns({
         projectUuid: projectUuid ?? undefined,
         agentUuid: agentUuid ?? undefined,
     });
-    const latestRunUuid = runs?.[0]?.runUuid;
-    const { data: run } = useReviewBatchRun(latestRunUuid, { poll: true });
-    const { data: _report } = useReviewBatchReport(latestRunUuid, {
+
+    const { data: run } = useReviewBatchRun(activeRunUuid, { poll: true });
+
+    const { data: report } = useReviewBatchReport(activeRunUuid, {
         enabled: run?.status === 'completed',
     });
-    const _startBatch = useStartReviewBatch();
 
-    return <Stack />;
+    const isInFlight =
+        startBatch.isLoading ||
+        run?.status === 'queued' ||
+        run?.status === 'running';
+
+    const windowDates = computeWindow(windowPreset, customRange);
+
+    const handleRunAnalysis = async () => {
+        if (!windowDates) return;
+        const result = await startBatch.mutateAsync({
+            projectUuid: null,
+            agentUuid: null,
+            startedAt: windowDates.startedAt,
+            endedAt: windowDates.endedAt,
+        });
+        setActiveRunUuid(result.runUuid);
+    };
+
+    const progressValue =
+        run && run.totalTurns > 0
+            ? Math.round((run.processedTurns / run.totalTurns) * 100)
+            : 0;
+
+    return (
+        <Stack gap="xl">
+            <Stack gap="md">
+                <Title order={5}>Run batch analysis</Title>
+                <Text fz="sm" c="dimmed">
+                    Analyse a time window of agent conversations without writing
+                    anything to the live review queue.
+                </Text>
+
+                <Group gap="md" align="flex-end" wrap="wrap">
+                    <Stack gap={4}>
+                        <Text fz="xs" fw={500} c="ldGray.7">
+                            Time window
+                        </Text>
+                        <SegmentedControl
+                            value={windowPreset}
+                            onChange={(v) => setWindowPreset(v as WindowPreset)}
+                            data={WINDOW_PRESETS}
+                            size="sm"
+                        />
+                    </Stack>
+
+                    {windowPreset === 'custom' && (
+                        <DatePickerInput
+                            type="range"
+                            label="Custom range"
+                            value={customRange}
+                            onChange={setCustomRange}
+                            size="sm"
+                            clearable
+                        />
+                    )}
+
+                    <Button
+                        onClick={() => void handleRunAnalysis()}
+                        loading={isInFlight}
+                        disabled={
+                            isInFlight ||
+                            (windowPreset === 'custom' &&
+                                (!customRange[0] || !customRange[1]))
+                        }
+                        leftSection={
+                            <MantineIcon icon={IconPlaystationCircle} />
+                        }
+                        size="sm"
+                    >
+                        Run analysis
+                    </Button>
+                </Group>
+            </Stack>
+
+            {run && (run.status === 'queued' || run.status === 'running') && (
+                <Stack gap="xs">
+                    <Progress value={progressValue} animated size="sm" />
+                    <Text fz="sm" c="dimmed">
+                        Reviewing {run.processedTurns} / {run.totalTurns} turns
+                    </Text>
+                </Stack>
+            )}
+
+            {run?.status === 'failed' && (
+                <Callout variant="danger">
+                    <Text fz="sm">
+                        {run.errorMessage ??
+                            'Analysis failed. Please try again.'}
+                    </Text>
+                </Callout>
+            )}
+
+            {report && run?.status === 'completed' && (
+                <Stack gap="lg">
+                    <Divider />
+                    <Group gap="xs" wrap="wrap">
+                        <Text fz="sm" fw={600} c="ldGray.9">
+                            {report.turnsReviewed} turns reviewed
+                        </Text>
+                        <Text fz="sm" c="dimmed">
+                            ·
+                        </Text>
+                        <Text fz="sm" fw={600} c="ldGray.9">
+                            {report.flaggedTurns} flagged
+                        </Text>
+                        <Text fz="sm" c="dimmed">
+                            ({Math.round(report.flaggedRate * 100)}%)
+                        </Text>
+                    </Group>
+
+                    {report.actions.length > 0 && (
+                        <Stack gap="sm">
+                            <Title order={6}>Actions breakdown</Title>
+                            <BatchActionsTable actions={report.actions} />
+                        </Stack>
+                    )}
+
+                    {report.topExamples.length > 0 && (
+                        <Stack gap="sm">
+                            <Title order={6}>Top examples</Title>
+                            <TopExamplesList examples={report.topExamples} />
+                        </Stack>
+                    )}
+                </Stack>
+            )}
+
+            {runs.length > 0 && (
+                <Stack gap="sm">
+                    <Divider />
+                    <Title order={5}>Past runs</Title>
+                    <HistoryTable
+                        runs={runs}
+                        selectedRunUuid={activeRunUuid}
+                        onSelect={setActiveRunUuid}
+                    />
+                </Stack>
+            )}
+        </Stack>
+    );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlags } from '@lightdash/common';
 import { Button, Drawer, Group, Stack, Text } from '@mantine-8/core';
 import { IconRoute } from '@tabler/icons-react';
 import { useMemo } from 'react';
@@ -7,6 +8,7 @@ import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { useGuidedTour } from '../../../../../../hooks/useGuidedTour';
+import { useServerFeatureFlag } from '../../../../../../hooks/useServerOrClientFeatureFlag';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import AiAgentAdminReviewItemsTable, {
     type AiAgentAdminReviewItemPreviewTarget,
@@ -19,6 +21,10 @@ import drawerClasses from './ThreadPreviewDrawer.module.css';
 
 export const AiReviewsSettingsPage = () => {
     const { data: settings } = useAiOrganizationSettings();
+    const { data: batchAnalysisFlag } = useServerFeatureFlag(
+        FeatureFlags.AiReviewBatch,
+    );
+    const isBatchAnalysisEnabled = batchAnalysisFlag?.enabled === true;
     const [searchParams, setSearchParams] = useSearchParams();
 
     // The selected review item and the sidebar's open state are derived
@@ -125,7 +131,9 @@ export const AiReviewsSettingsPage = () => {
 
             {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
 
-            <BatchAnalysisPanel projectUuid={null} agentUuid={null} />
+            {isBatchAnalysisEnabled && (
+                <BatchAnalysisPanel projectUuid={null} agentUuid={null} />
+            )}
 
             <AiAgentAdminReviewItemsTable
                 selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -11,6 +11,7 @@ import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSetti
 import AiAgentAdminReviewItemsTable, {
     type AiAgentAdminReviewItemPreviewTarget,
 } from '../AiAgentAdminReviewItemsTable';
+import { BatchAnalysisPanel } from '../BatchAnalysisPanel';
 import { REVIEWS_TOUR_STEPS } from '../onboarding';
 import { ThreadPreviewSidebar } from '../ThreadPreviewSidebar';
 import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
@@ -123,6 +124,8 @@ export const AiReviewsSettingsPage = () => {
             </Stack>
 
             {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
+
+            <BatchAnalysisPanel projectUuid={null} agentUuid={null} />
 
             <AiAgentAdminReviewItemsTable
                 selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentReviewBatch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentReviewBatch.ts
@@ -1,0 +1,124 @@
+import {
+    type AiAgentReviewBatchReport,
+    type AiAgentReviewBatchRunSummary,
+    type AiAgentReviewBatchStarted,
+    type ApiAiAgentReviewBatchReportResponse,
+    type ApiAiAgentReviewBatchRunResponse,
+    type ApiAiAgentReviewBatchRunsResponse,
+    type ApiAiAgentReviewBatchStartedResponse,
+    type ApiError,
+    type CreateAiAgentReviewBatch,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+
+const REVIEW_BATCH_KEY = 'aiAgentReviewBatch';
+
+function buildQueryString(params: Record<string, string | undefined>): string {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined) {
+            query.append(key, value);
+        }
+    }
+    const str = query.toString();
+    return str ? `?${str}` : '';
+}
+
+const startReviewBatch = async (
+    body: CreateAiAgentReviewBatch,
+): Promise<AiAgentReviewBatchStarted> =>
+    lightdashApi<ApiAiAgentReviewBatchStartedResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-runs`,
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+export const useStartReviewBatch = () => {
+    const queryClient = useQueryClient();
+    return useMutation<
+        AiAgentReviewBatchStarted,
+        ApiError,
+        CreateAiAgentReviewBatch
+    >({
+        mutationFn: startReviewBatch,
+        onSuccess: () => {
+            void queryClient.invalidateQueries({
+                queryKey: [REVIEW_BATCH_KEY, 'runs'],
+            });
+        },
+    });
+};
+
+const getReviewBatchRun = async (
+    runUuid: string,
+): Promise<AiAgentReviewBatchRunSummary> =>
+    lightdashApi<ApiAiAgentReviewBatchRunResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-runs/${encodeURIComponent(runUuid)}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useReviewBatchRun = (
+    runUuid: string | undefined,
+    opts?: { poll?: boolean },
+) => {
+    return useQuery<AiAgentReviewBatchRunSummary, ApiError>({
+        queryKey: [REVIEW_BATCH_KEY, 'run', runUuid],
+        queryFn: () => getReviewBatchRun(runUuid!),
+        enabled: !!runUuid,
+        refetchInterval: (data) =>
+            opts?.poll &&
+            (data?.status === 'queued' || data?.status === 'running')
+                ? 2500
+                : false,
+    });
+};
+
+const getReviewBatchReport = async (
+    runUuid: string,
+): Promise<AiAgentReviewBatchReport> =>
+    lightdashApi<ApiAiAgentReviewBatchReportResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-runs/${encodeURIComponent(runUuid)}/report`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useReviewBatchReport = (
+    runUuid: string | undefined,
+    opts?: { enabled?: boolean },
+) => {
+    return useQuery<AiAgentReviewBatchReport, ApiError>({
+        queryKey: [REVIEW_BATCH_KEY, 'report', runUuid],
+        queryFn: () => getReviewBatchReport(runUuid!),
+        enabled: !!runUuid && (opts?.enabled ?? true),
+    });
+};
+
+const getReviewBatchRuns = async (filters?: {
+    projectUuid?: string;
+    agentUuid?: string;
+}): Promise<AiAgentReviewBatchRunSummary[]> =>
+    lightdashApi<ApiAiAgentReviewBatchRunsResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-runs${buildQueryString({
+            projectUuid: filters?.projectUuid,
+            agentUuid: filters?.agentUuid,
+        })}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useReviewBatchRuns = (filters?: {
+    projectUuid?: string;
+    agentUuid?: string;
+}) => {
+    return useQuery<AiAgentReviewBatchRunSummary[], ApiError>({
+        queryKey: [REVIEW_BATCH_KEY, 'runs', filters],
+        queryFn: () => getReviewBatchRuns(filters),
+        keepPreviousData: true,
+    });
+};


### PR DESCRIPTION
Adds an **analysis-only batch review**: an org admin runs the existing AI review classifier over a time window (e.g. last 30 days) as a background job and gets an actions/outcomes report — **without** creating any live review-queue items.

## How it works
- `POST /api/v1/aiAgents/admin/review-runs` does a pre-flight turn count (cap `REVIEW_BATCH_MAX_TURNS = 500`), creates a `queued` run row, and enqueues a Graphile worker task — returns `{ runUuid, estimatedTurns }` immediately (never blocks the API pod).
- The worker drives the existing `AiAgentReviewClassifierService.run()` with `promoteFindingsToReviewItems: false`, reusing the pre-created run row so the UI can poll `runUuid` for progress.
- `GET /review-runs/{uuid}` (status/progress), `GET /review-runs/{uuid}/report` (aggregate), `GET /review-runs` (history) — all org-scoped, admin-gated.
- Frontend **Analysis panel**: window picker (7/30/90/custom) → Run → progress bar → report (turns reviewed, % flagged, **actions** grouped by root cause × owner × fix target, top recurring examples) + a history table of past runs.

## Invariants / scope
- **Analysis-only**: every batch run passes `promoteFindingsToReviewItems: false`. Nothing lands in the live review-items queue.
- **Out of scope (deferred):** promoting batch findings into the live queue, aggregating pre-existing live signals without running, scheduled/recurring batches, customer self-serve, per-prompt idempotency, and project/agent scoping in the UI (runs org-wide for now, `// TODO` left in place).

## Verification
- Typecheck: common / backend / frontend all clean.
- Backend: model + service suites pass (queued-run reuse, report aggregation, pre-flight cap rejection, batch start).
- Frontend: panel render tests (completed report + running progress).
- Not run: manual smoke against a live app+worker — recommend a short-window run on seed data before merge to confirm the queued→running→completed→report flow and that **no review items are created**.

_No Linear ticket._