### PR TITLE
fix: detect Windows when $OSTYPE is cygwin in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,7 +52,7 @@ is_mac() {
 }
 
 is_windows() {
-    [[ $OSTYPE == msys* ]]
+    [[ $OSTYPE == msys* || $OSTYPE == cygwin* ]]
 }
 
 check_os() {


### PR DESCRIPTION
Closes: #24211

### Description

`scripts/install.sh` fails on Windows under Git Bash / MSYS2 / Cygwin because `is_windows()` only matched `$OSTYPE == msys*`. Depending on the build, `$OSTYPE` can be `cygwin` instead. When detection fails, `check_os()` falls through to the Linux branch (`cat /etc/*-release` → OS "Not Found"), and `start_docker()` then runs `sudo systemctl start docker.service` — neither `sudo` nor `systemctl` exists on Windows. The script aborts with a misleading **"The containers didn't seem to start correctly"** even though Docker Desktop is installed and running.

```bash
is_windows() {
    [[ $OSTYPE == msys* || $OSTYPE == cygwin* ]]
}
```

### Testing

Verified end-to-end on Windows 11 (Git Bash, `$OSTYPE=cygwin`, Docker Desktop 29.5.3):

- Before: detection failed → OS "Not Found" → `sudo systemctl` path → misleading failure.
- After: `✅ Detected OS: Windows`, fast install completes, all containers `Up`, `/api/v1/health` returns `200`.