### PR TITLE
fix: support upstream self preview permissions

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1059,6 +1059,7 @@ export class ProjectModel {
                     | 'project_uuid'
                     | 'project_type'
                     | 'copied_from_project_uuid'
+                    | 'created_by_user_uuid'
                 > &
                     Pick<DbOrganization, 'organization_uuid'>
             >([
@@ -1067,6 +1068,7 @@ export class ProjectModel {
                 `${OrganizationTableName}.organization_uuid`,
                 `${ProjectTableName}.copied_from_project_uuid`,
                 `${ProjectTableName}.project_type`,
+                `${ProjectTableName}.created_by_user_uuid`,
             ])
             .where('projects.project_uuid', projectUuid)
             .first();
@@ -1081,6 +1083,7 @@ export class ProjectModel {
             name: project.name,
             type: project.project_type,
             upstreamProjectUuid: project.copied_from_project_uuid || undefined,
+            createdByUserUuid: project.created_by_user_uuid,
         };
     }
 

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1235,6 +1235,7 @@ export class CoderService extends BaseService {
                 subject('ContentAsCode', {
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    upstreamProjectUuid: project.upstreamProjectUuid,
                     type: project.type,
                     createdByUserUuid: project.createdByUserUuid,
                     metadata: { slug },
@@ -1471,6 +1472,7 @@ export class CoderService extends BaseService {
                 subject('ContentAsCode', {
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    upstreamProjectUuid: project.upstreamProjectUuid,
                     type: project.type,
                     createdByUserUuid: project.createdByUserUuid,
                     metadata: { slug },
@@ -1768,6 +1770,7 @@ export class CoderService extends BaseService {
                 subject('ContentAsCode', {
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    upstreamProjectUuid: project.upstreamProjectUuid,
                     type: project.type,
                     createdByUserUuid: project.createdByUserUuid,
                     metadata: { slug },

--- a/packages/backend/src/services/DeployService.test.ts
+++ b/packages/backend/src/services/DeployService.test.ts
@@ -1,0 +1,87 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
+import {
+    ProjectType,
+    type Account,
+    type MemberAbility,
+} from '@lightdash/common';
+import { DeployService } from './DeployService';
+
+const buildAccount = (ability: MemberAbility): Account =>
+    ({
+        authentication: {
+            type: 'service-account',
+            source: 'token',
+            serviceAccountUuid: 'service-account-uuid',
+            serviceAccountDescription: 'Deploy service account',
+        },
+        organization: {
+            organizationUuid: 'org-uuid',
+            name: 'Org',
+            createdAt: new Date(),
+        },
+        user: {
+            id: 'service-account-user-uuid',
+            userUuid: 'service-account-user-uuid',
+            userId: 1,
+            email: undefined,
+            firstName: 'Service',
+            lastName: 'Account',
+            role: 'member',
+            type: 'registered',
+            isActive: true,
+            ability,
+            abilityRules: ability.rules,
+            isTrackingAnonymized: false,
+            isMarketingOptedIn: false,
+            isSetupComplete: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            timezone: null,
+        },
+        isAnonymousUser: () => false,
+        isAuthenticated: () => true,
+        isJwtUser: () => false,
+        isOauthUser: () => false,
+        isPatUser: () => false,
+        isRegisteredUser: () => true,
+        isServiceAccount: () => true,
+        isSessionUser: () => false,
+    }) as Account;
+
+describe('DeployService', () => {
+    it('allows starting a deploy session for an own preview from a granted upstream project', async () => {
+        const builder = new AbilityBuilder<MemberAbility>(Ability);
+        builder.can('manage', 'DeployProject', {
+            upstreamProjectUuid: 'upstream-project-uuid',
+            createdByUserUuid: 'service-account-user-uuid',
+            type: ProjectType.PREVIEW,
+        });
+
+        const service = new DeployService({
+            deploySessionModel: {
+                createSession: jest
+                    .fn()
+                    .mockResolvedValue('deploy-session-uuid'),
+            },
+            projectModel: {
+                getWithSensitiveFields: jest.fn().mockResolvedValue({
+                    projectUuid: 'preview-project-uuid',
+                    organizationUuid: 'org-uuid',
+                    upstreamProjectUuid: 'upstream-project-uuid',
+                    name: 'Preview',
+                    type: ProjectType.PREVIEW,
+                    createdByUserUuid: 'service-account-user-uuid',
+                }),
+            },
+            projectService: {},
+            schedulerClient: {},
+        } as never);
+
+        await expect(
+            service.startDeploySession(
+                buildAccount(builder.build()),
+                'preview-project-uuid',
+            ),
+        ).resolves.toEqual({ deploySessionUuid: 'deploy-session-uuid' });
+    });
+});

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -79,6 +79,7 @@ export class DeployService extends BaseService {
                 subject('DeployProject', {
                     projectUuid,
                     organizationUuid: project.organizationUuid,
+                    upstreamProjectUuid: project.upstreamProjectUuid,
                     type: project.type,
                     createdByUserUuid: project.createdByUserUuid,
                     metadata: {

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -352,6 +352,7 @@ export const projectSummary: ProjectSummary = {
     projectUuid: 'projectUuid',
     name: 'name',
     type: ProjectType.DEFAULT,
+    createdByUserUuid: sessionAccount.user.id,
 };
 export const defaultProject: OrganizationProject = {
     projectUuid: 'projectUuid',

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2706,6 +2706,7 @@ export class ProjectService extends BaseService {
                 subject('DeployProject', {
                     projectUuid,
                     organizationUuid: project.organizationUuid,
+                    upstreamProjectUuid: project.upstreamProjectUuid,
                     type: project.type,
                     createdByUserUuid: project.createdByUserUuid,
                     metadata: {
@@ -2857,7 +2858,10 @@ export class ProjectService extends BaseService {
                 'update',
                 subject('Project', {
                     organizationUuid: savedProject.organizationUuid,
-                    projectUuid,
+                    projectUuid: savedProject.projectUuid,
+                    upstreamProjectUuid: savedProject.upstreamProjectUuid,
+                    type: savedProject.type,
+                    createdByUserUuid: savedProject.createdByUserUuid,
                 }),
             )
         ) {
@@ -2971,7 +2975,10 @@ export class ProjectService extends BaseService {
                 'update',
                 subject('Project', {
                     organizationUuid: savedProject.organizationUuid,
-                    projectUuid,
+                    projectUuid: savedProject.projectUuid,
+                    upstreamProjectUuid: savedProject.upstreamProjectUuid,
+                    type: savedProject.type,
+                    createdByUserUuid: savedProject.createdByUserUuid,
                 }),
             )
         ) {
@@ -3404,6 +3411,7 @@ export class ProjectService extends BaseService {
                     type: project.type,
                     organizationUuid: project.organizationUuid,
                     projectUuid: project.projectUuid,
+                    upstreamProjectUuid: project.upstreamProjectUuid,
                     createdByUserUuid: project.createdByUserUuid,
                     metadata: {
                         createdByUserUuid: project.createdByUserUuid,

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -2291,12 +2291,20 @@ describe('scopeAbilityBuilder', () => {
             expect(ability.can('manage', contentAsCodeSubject)).toBe(true);
         });
 
-        it('manage:ContentAsCode@self allows upload only to own preview projects (PROD-8004)', () => {
+        it('manage:ContentAsCode@self allows upload only to own previews from the granted project', () => {
             const ability = buildAbility(['manage:ContentAsCode@self']);
 
-            const ownPreview = subject('ContentAsCode', {
+            const ownPreviewFromDirectProject = subject('ContentAsCode', {
                 organizationUuid: 'org-123',
                 projectUuid: 'project-123',
+                upstreamProjectUuid: 'upstream-project',
+                type: ProjectType.PREVIEW,
+                createdByUserUuid: 'user-456',
+            });
+            const ownPreviewFromUpstreamProject = subject('ContentAsCode', {
+                organizationUuid: 'org-123',
+                projectUuid: 'preview-123',
+                upstreamProjectUuid: 'project-123',
                 type: ProjectType.PREVIEW,
                 createdByUserUuid: 'user-456',
             });
@@ -2308,19 +2316,36 @@ describe('scopeAbilityBuilder', () => {
             });
             const othersPreview = subject('ContentAsCode', {
                 organizationUuid: 'org-123',
-                projectUuid: 'project-123',
+                projectUuid: 'preview-123',
+                upstreamProjectUuid: 'project-123',
                 type: ProjectType.PREVIEW,
                 createdByUserUuid: 'another-user',
             });
+            const ownPreviewFromAnotherProject = subject('ContentAsCode', {
+                organizationUuid: 'org-123',
+                projectUuid: 'preview-456',
+                upstreamProjectUuid: 'another-project',
+                type: ProjectType.PREVIEW,
+                createdByUserUuid: 'user-456',
+            });
 
             // Can upload to a preview project they created
-            expect(ability.can('manage', ownPreview)).toBe(true);
+            expect(ability.can('manage', ownPreviewFromDirectProject)).toBe(
+                true,
+            );
+            expect(ability.can('manage', ownPreviewFromUpstreamProject)).toBe(
+                true,
+            );
 
             // Cannot upload to production, even their own
             expect(ability.can('manage', ownProduction)).toBe(false);
 
             // Cannot upload to a preview created by someone else
             expect(ability.can('manage', othersPreview)).toBe(false);
+
+            expect(ability.can('manage', ownPreviewFromAnotherProject)).toBe(
+                false,
+            );
 
             // Does not grant blanket manage when the subject lacks self context
             expect(ability.can('manage', contentAsCodeSubject)).toBe(false);
@@ -2350,13 +2375,22 @@ describe('scopeAbilityBuilder', () => {
             projectCreatedByUserUuid: 'user1',
         };
 
-        const buildWith = (
-            context: typeof baseContext & {
-                projectType?: ProjectType;
-                projectCreatedByUserUuid?: string | null;
-            },
-            scopes: string[],
-        ): MemberAbility => {
+        type BaseTestScopeContext = Omit<typeof baseContext, 'projectUuid'>;
+        type TestScopeContext =
+            | (BaseTestScopeContext & {
+                  projectUuid: string;
+                  organizationUuid?: undefined;
+                  projectType?: ProjectType;
+                  projectCreatedByUserUuid?: string | null;
+              })
+            | (BaseTestScopeContext & {
+                  organizationUuid: string;
+                  projectUuid?: undefined;
+                  projectType?: undefined;
+                  projectCreatedByUserUuid?: undefined;
+              });
+
+        const buildWith = (context: TestScopeContext, scopes: string[]) => {
             const builder = new AbilityBuilder<MemberAbility>(Ability);
             buildAbilityFromScopes({ ...context, scopes }, builder);
             return builder.build();
@@ -2570,6 +2604,93 @@ describe('scopeAbilityBuilder', () => {
                     subject('Explore', {
                         organizationUuid: 'org-123',
                         projectUuid: 'other-project',
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('project-management @self scopes match own previews from the granted upstream project', () => {
+            const ability = buildWith(baseContext, [
+                'manage:DeployProject@self',
+                'update:Project@self',
+                'delete:Project@self',
+            ]);
+            const ownPreviewFromProject = () => ({
+                organizationUuid: 'org-123',
+                projectUuid: 'preview-123',
+                upstreamProjectUuid: 'project-123',
+                type: ProjectType.PREVIEW,
+                createdByUserUuid: 'user1',
+            });
+            const ownPreviewFromAnotherProject = {
+                ...ownPreviewFromProject(),
+                projectUuid: 'preview-456',
+                upstreamProjectUuid: 'another-project',
+            };
+
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DeployProject', ownPreviewFromProject()),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'update',
+                    subject('Project', ownPreviewFromProject()),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'delete',
+                    subject('Project', ownPreviewFromProject()),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DeployProject', ownPreviewFromAnotherProject),
+                ),
+            ).toBe(false);
+        });
+
+        it('org-level @self scopes match only previews created by the user', () => {
+            const ability = buildWith(
+                { ...baseContextWithOrg, userUuid: 'user1' },
+                ['manage:DeployProject@self'],
+            );
+            const builderWithoutUser = new AbilityBuilder<MemberAbility>(
+                Ability,
+            );
+            buildAbilityFromScopes(
+                {
+                    ...baseContextWithOrg,
+                    userUuid: undefined,
+                    scopes: ['manage:DeployProject@self'],
+                } as never,
+                builderWithoutUser,
+            );
+            const abilityWithoutUser = builderWithoutUser.build();
+
+            const ownPreviewInOrg = subject('DeployProject', {
+                organizationUuid: 'org-123',
+                projectUuid: 'preview-123',
+                type: ProjectType.PREVIEW,
+                createdByUserUuid: 'user1',
+            });
+
+            expect(ability.can('manage', ownPreviewInOrg)).toBe(true);
+            expect(abilityWithoutUser.can('manage', ownPreviewInOrg)).toBe(
+                false,
+            );
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DeployProject', {
+                        organizationUuid: 'org-123',
+                        projectUuid: 'preview-456',
+                        type: ProjectType.PREVIEW,
+                        createdByUserUuid: 'another-user',
                     }),
                 ),
             ).toBe(false);

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -51,6 +51,36 @@ const isSelfPreview = (context: ScopeContext) =>
         context.projectCreatedByUserUuid === context.userUuid,
     );
 
+const ownPreviewProjectConditions = (context: ScopeContext) => {
+    if (context.organizationUuid) {
+        return [
+            {
+                // Org assignments can reach any preview created by this principal.
+                organizationUuid: context.organizationUuid,
+                createdByUserUuid: context.userUuid || false,
+                type: ProjectType.PREVIEW,
+            },
+        ];
+    }
+
+    if (!context.projectUuid || !context.userUuid) return null;
+
+    return [
+        {
+            // Direct preview assignment: the grant is on the preview itself.
+            projectUuid: context.projectUuid,
+            createdByUserUuid: context.userUuid,
+            type: ProjectType.PREVIEW,
+        },
+        {
+            // Upstream assignment: the grant is on the source project.
+            upstreamProjectUuid: context.projectUuid,
+            createdByUserUuid: context.userUuid,
+            type: ProjectType.PREVIEW,
+        },
+    ];
+};
+
 /**
  * Project-wide grant inside the user's own preview. For subjects with no space
  * access to gate on (Explore). Returns null (no rule) outside the own preview.
@@ -339,13 +369,7 @@ const scopes: Scope[] = [
         description: 'Update projects created by the user',
         isEnterprise: false,
         group: ScopeGroup.PROJECT_MANAGEMENT,
-        getConditions: (context) => [
-            {
-                projectUuid: context.projectUuid,
-                createdByUserUuid: context.userUuid || false,
-                type: ProjectType.PREVIEW,
-            },
-        ],
+        getConditions: ownPreviewProjectConditions,
     },
     {
         name: 'delete:Project',
@@ -359,13 +383,7 @@ const scopes: Scope[] = [
         description: 'Delete projects created by the user',
         isEnterprise: false,
         group: ScopeGroup.PROJECT_MANAGEMENT,
-        getConditions: (context) => [
-            {
-                projectUuid: context.projectUuid,
-                createdByUserUuid: context.userUuid || false,
-                type: ProjectType.PREVIEW,
-            },
-        ],
+        getConditions: ownPreviewProjectConditions,
     },
     {
         name: 'manage:Project',
@@ -393,13 +411,7 @@ const scopes: Scope[] = [
         description: 'Deploy to preview projects created by the user',
         isEnterprise: false,
         group: ScopeGroup.PROJECT_MANAGEMENT,
-        getConditions: (context) => [
-            {
-                projectUuid: context.projectUuid,
-                createdByUserUuid: context.userUuid || false,
-                type: ProjectType.PREVIEW,
-            },
-        ],
+        getConditions: ownPreviewProjectConditions,
     },
     {
         name: 'manage:Validation',
@@ -576,13 +588,7 @@ const scopes: Scope[] = [
             'Upload content as code to preview projects created by the user',
         isEnterprise: true,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
-        getConditions: (context) => [
-            {
-                projectUuid: context.projectUuid,
-                createdByUserUuid: context.userUuid || false,
-                type: ProjectType.PREVIEW,
-            },
-        ],
+        getConditions: ownPreviewProjectConditions,
     },
     {
         name: 'manage:PersonalAccessToken',

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -908,7 +908,12 @@ export type Project = {
 
 export type ProjectSummary = Pick<
     Project,
-    'name' | 'projectUuid' | 'organizationUuid' | 'type' | 'upstreamProjectUuid'
+    | 'name'
+    | 'projectUuid'
+    | 'organizationUuid'
+    | 'type'
+    | 'upstreamProjectUuid'
+    | 'createdByUserUuid'
 >;
 
 export type ApiProjectResponse = {


### PR DESCRIPTION
### Description

Fixes `@self` preview permissions so project-scoped grants on an upstream/source project can apply to previews created from that project by the same principal.

This lets a user or service account with `manage:DeployProject@self`, `manage:ContentAsCode@self`, `update:Project@self`, or `delete:Project@self` on a source project act on their own previews from that source project, without granting access to production projects, other users' previews, or previews from another source project.

### Testing

- `pnpm -F backend test -- DeployService.test.ts`
- `pnpm -F common test -- scopeAbilityBuilder.test.ts`
- `pnpm -F common test -- roleToScopeParity.test.ts`
- `pnpm -F common test -- projectMemberAbility.test.ts`
- `pnpm -F common typecheck:fast`
- `git diff --check`

`pnpm -F backend typecheck:fast` currently fails on existing common/backend type drift unrelated to this change.

Closes: PROD-8281
Closes: #24224