### PR TITLE
feat: create embed dashboard

### DIFF
--- a/packages/backend/src/auth/account/account.test.ts
+++ b/packages/backend/src/auth/account/account.test.ts
@@ -1,6 +1,7 @@
 import { AbilityBuilder } from '@casl/ability';
 import {
     CreateEmbedJwt,
+    ForbiddenError,
     MemberAbility,
     OrganizationMemberRole,
     OssEmbed,
@@ -8,7 +9,7 @@ import {
     UserAccessControls,
 } from '@lightdash/common';
 // Import the functions we want to test
-import { fromJwt, fromSession } from './account';
+import { fromJwt, fromSession, getAccountWriteContext } from './account';
 
 describe('account', () => {
     describe('fromJwt', () => {
@@ -288,6 +289,90 @@ describe('account', () => {
 
             expect(result.user.email).toBeUndefined();
             expect(result.isAuthenticated()).toBe(true);
+        });
+    });
+
+    describe('getAccountWriteContext', () => {
+        const mockSessionUser: SessionUser = {
+            userUuid: 'session-user-uuid',
+            userId: 123,
+            role: OrganizationMemberRole.DEVELOPER,
+            email: 'session@example.com',
+            firstName: 'Session',
+            lastName: 'User',
+            organizationUuid: 'session-org-uuid',
+            organizationName: 'Session Organization',
+            organizationCreatedAt: new Date('2024-01-01'),
+            isActive: true,
+            isTrackingAnonymized: false,
+            isMarketingOptedIn: false,
+            timezone: null,
+            isSetupComplete: true,
+            createdAt: new Date('2024-01-01'),
+            updatedAt: new Date('2024-01-01'),
+            ability: {
+                can: jest.fn(),
+                cannot: jest.fn(),
+            } as unknown as MemberAbility,
+            abilityRules: [{}] as AbilityBuilder<MemberAbility>['rules'],
+        };
+
+        const buildJwtAccount = ({
+            writeActions,
+            embedWriteUser,
+        }: {
+            writeActions?: CreateEmbedJwt['writeActions'];
+            embedWriteUser?: SessionUser;
+        }) =>
+            ({
+                isJwtUser: () => true,
+                authentication: {
+                    type: 'jwt',
+                    data: {
+                        writeActions,
+                    },
+                },
+                embedWriteUser,
+            }) as Parameters<typeof getAccountWriteContext>[0];
+
+        it('returns the session user for registered accounts', () => {
+            const account = fromSession(mockSessionUser, 'session-cookie');
+            const context = getAccountWriteContext(account);
+
+            expect(context.embedWriteActions).toBeUndefined();
+            expect(context.user).toEqual(
+                expect.objectContaining({
+                    type: 'registered',
+                    userUuid: account.user.userUuid,
+                    organizationUuid: account.organization.organizationUuid,
+                    email: account.user.email,
+                }),
+            );
+        });
+
+        it('rejects JWT accounts without write actions', () => {
+            expect(() =>
+                getAccountWriteContext(buildJwtAccount({})),
+            ).toThrowError(ForbiddenError);
+        });
+
+        it('returns the embed write actor and space for write-action JWTs', () => {
+            expect(
+                getAccountWriteContext(
+                    buildJwtAccount({
+                        writeActions: {
+                            spaceUuid: 'write-space-uuid',
+                            userUuid: mockSessionUser.userUuid,
+                        },
+                        embedWriteUser: mockSessionUser,
+                    }),
+                ),
+            ).toEqual({
+                user: mockSessionUser,
+                embedWriteActions: {
+                    spaceUuid: 'write-space-uuid',
+                },
+            });
         });
     });
 });

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -922,7 +922,6 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
         @Request() req: express.Request,
         @Query() duplicateFrom?: string,
     ): Promise<ApiCreateDashboardResponse> {
-        assertRegisteredAccount(req.account);
         const dashboardService = this.services.getDashboardService();
         this.setStatus(201);
 
@@ -935,8 +934,8 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                 );
             }
 
-            results = await dashboardService.duplicate(
-                toSessionUser(req.account),
+            results = await dashboardService.duplicateFromAccount(
+                req.account!,
                 projectUuid,
                 duplicateFrom.toString(),
                 body,
@@ -948,8 +947,8 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                 );
             }
 
-            results = await dashboardService.create(
-                toSessionUser(req.account),
+            results = await dashboardService.createFromAccount(
+                req.account!,
                 projectUuid,
                 body,
             );

--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -258,13 +258,12 @@ export class SqlRunnerController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSqlChart> {
-        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
-                .getSqlChart(toSessionUser(req.account), projectUuid, uuid),
+                .getSqlChartFromAccount(req.account!, projectUuid, uuid),
         };
     }
 
@@ -284,14 +283,13 @@ export class SqlRunnerController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSqlChart> {
-        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
-                .getSqlChart(
-                    toSessionUser(req.account),
+                .getSqlChartFromAccount(
+                    req.account!,
                     projectUuid,
                     undefined,
                     slug,

--- a/packages/backend/src/controllers/v2/ContentController.ts
+++ b/packages/backend/src/controllers/v2/ContentController.ts
@@ -29,7 +29,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { toSessionUser } from '../../auth/account';
+import { getAccountWriteContext, toSessionUser } from '../../auth/account';
 import { ContentArgs } from '../../models/ContentModel/ContentModelTypes';
 import { allowApiKeyAuthentication, isAuthenticated } from '../authentication';
 import { BaseController } from '../baseController';
@@ -58,15 +58,19 @@ export class ContentController extends BaseController {
         @Query() sortBy?: ContentArgs['sortBy'],
         @Query() sortDirection?: ContentArgs['sortDirection'],
     ): Promise<ApiContentResponse> {
-        assertRegisteredAccount(req.account);
+        const { user, embedWriteActions } = getAccountWriteContext(
+            req.account!,
+        );
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services.getContentService().find(
-                toSessionUser(req.account),
+                user,
                 {
                     projectUuids,
-                    spaceUuids,
+                    spaceUuids: embedWriteActions
+                        ? [embedWriteActions.spaceUuid]
+                        : spaceUuids,
                     contentTypes,
                     search,
                 },

--- a/packages/backend/src/controllers/v2/ProjectDashboardController.ts
+++ b/packages/backend/src/controllers/v2/ProjectDashboardController.ts
@@ -81,13 +81,12 @@ export class ProjectDashboardControllerV2 extends BaseController {
         @Body() body: UpdateDashboard,
         @Request() req: express.Request,
     ): Promise<ApiDashboardResponse> {
-        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getDashboardService()
-                .update(toSessionUser(req.account), dashboardUuidOrSlug, body, {
+                .updateFromAccount(req.account!, dashboardUuidOrSlug, body, {
                     projectUuid,
                 }),
         };

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -321,11 +321,6 @@ export class QueryController extends BaseController {
 
         const context = body.context ?? getContextFromHeader(req);
 
-        if (req.account!.isJwtUser()) {
-            // we need more granular CASTL abilities before enabling this
-            throw new ForbiddenError('Feature not available for JWT users');
-        }
-
         const results = await this.services
             .getAsyncQueryService()
             .executeAsyncDashboardChartQuery({

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -664,23 +664,66 @@ export class EmbedService extends BaseService {
             ({ savedChartUuid }) => savedChartUuid,
         );
 
-        if (checkPermissions) {
-            await Promise.all(
-                savedQueryUuids.map((chartUuid) =>
-                    this._permissionsGetChartAndResults(
-                        { dashboardUuids, allowAllDashboards },
-                        projectUuid,
-                        chartUuid,
-                        dashboardUuid,
-                    ),
-                ),
-            );
-        }
-
         const savedCharts =
             await this.savedChartModel.getInfoForAvailableFilters(
                 savedQueryUuids,
             );
+
+        if (checkPermissions) {
+            const writeSpaceUuid =
+                account.embedWriteUser &&
+                account.authentication.data.writeActions?.spaceUuid;
+            const chartsByUuid = new Map(
+                savedCharts.map((chart) => [chart.uuid, chart]),
+            );
+            await Promise.all(
+                savedQueryUuids.map(async (chartUuid) => {
+                    const chart = chartsByUuid.get(chartUuid);
+                    const { embedWriteUser } = account;
+                    if (
+                        chart &&
+                        embedWriteUser &&
+                        chart.spaceUuid === writeSpaceUuid
+                    ) {
+                        const spaceAccessContext =
+                            await this.spacePermissionService.getSpaceAccessContext(
+                                embedWriteUser.userUuid,
+                                chart.spaceUuid,
+                            );
+                        const auditedAbility =
+                            this.createAuditedAbility(embedWriteUser);
+
+                        if (
+                            auditedAbility.cannot(
+                                'view',
+                                subject('SavedChart', {
+                                    organizationUuid: chart.organizationUuid,
+                                    projectUuid: chart.projectUuid,
+                                    inheritsFromOrgOrProject:
+                                        spaceAccessContext.inheritsFromOrgOrProject,
+                                    access: spaceAccessContext.access,
+                                    metadata: {
+                                        savedChartUuid: chart.uuid,
+                                        savedChartName: chart.name,
+                                    },
+                                }),
+                            )
+                        ) {
+                            throw new ForbiddenError();
+                        }
+
+                        return;
+                    }
+
+                    await this._permissionsGetChartAndResults(
+                        { dashboardUuids, allowAllDashboards },
+                        projectUuid,
+                        chartUuid,
+                        dashboardUuid,
+                    );
+                }),
+            );
+        }
 
         const exploreCacheKeys: Record<string, boolean> = {};
         const exploreCache: Record<string, Explore | ExploreError> = {};

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12784,7 +12784,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12792,11 +12792,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12811,7 +12807,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12819,7 +12815,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -13124,13 +13124,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -13157,13 +13157,13 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: [
-                                                                'not_found',
-                                                            ],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: [
+                                                                'not_found',
+                                                            ],
                                                         },
                                                     ],
                                                     required: true,
@@ -13215,130 +13215,6 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                            },
-                                                                    },
-                                                                    required: true,
-                                                                },
                                                                 explore: {
                                                                     dataType:
                                                                         'nestedObjectLiteral',
@@ -13373,6 +13249,130 @@ const models: TsoaRoute.Models = {
                                                                         },
                                                                     required: true,
                                                                 },
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
                                                                 status: {
                                                                     dataType:
                                                                         'enum',
@@ -13401,17 +13401,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -13536,14 +13536,6 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13551,6 +13543,14 @@ const models: TsoaRoute.Models = {
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                uuid: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -13782,11 +13782,6 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
-                                                    required: true,
-                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13796,6 +13791,11 @@ const models: TsoaRoute.Models = {
                                                             enums: [null],
                                                         },
                                                     ],
+                                                    required: true,
+                                                },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -13868,10 +13868,6 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13881,6 +13877,10 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                             },
                                         },
                                         {
@@ -13930,14 +13930,14 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13977,6 +13977,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -14066,13 +14085,6 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
-                                                                                ],
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
                                                                                     'metric',
                                                                                 ],
                                                                             },
@@ -14080,20 +14092,8 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    null,
+                                                                                    'dimension',
                                                                                 ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
                                                                             },
                                                                             {
                                                                                 dataType:
@@ -29062,7 +29062,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29072,7 +29072,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29082,7 +29082,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29095,7 +29095,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -29750,7 +29750,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29760,7 +29760,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29770,7 +29770,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29783,7 +29783,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14207,16 +14207,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -14364,19 +14364,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14386,8 +14386,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "not_found",
-                                                            "success"
+                                                            "success",
+                                                            "not_found"
                                                         ]
                                                     }
                                                 },
@@ -14417,66 +14417,6 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "false",
-                                                                                        "not_applicable",
-                                                                                        "true"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "description",
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
-                                                                                "fieldFilterType",
-                                                                                "fieldValueType",
-                                                                                "fieldType",
-                                                                                "table",
-                                                                                "label",
-                                                                                "name",
-                                                                                "fieldId"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "joinedTables": {
@@ -14503,6 +14443,66 @@
                                                                         ],
                                                                         "type": "object"
                                                                     },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "metric",
+                                                                                        "dimension"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldValueType",
+                                                                                "fieldFilterType",
+                                                                                "description",
+                                                                                "fieldType",
+                                                                                "table",
+                                                                                "fieldId",
+                                                                                "label",
+                                                                                "name"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -14513,8 +14513,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "fields",
                                                                     "explore",
+                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14527,10 +14527,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -14538,8 +14538,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "reason",
                                                                                 "exploreLabel",
+                                                                                "reason",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -14622,12 +14622,6 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "uuid": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
@@ -14635,16 +14629,22 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "uuid": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "uuid",
-                                                    "name",
                                                     "slug",
-                                                    "status"
+                                                    "status",
+                                                    "uuid",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14703,17 +14703,17 @@
                                                         ],
                                                         "nullable": true
                                                     },
+                                                    "prUrl": {
+                                                        "type": "string",
+                                                        "nullable": true
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "prUrl": {
-                                                        "type": "string",
-                                                        "nullable": true
                                                     }
                                                 },
-                                                "required": ["status", "prUrl"],
+                                                "required": ["prUrl", "status"],
                                                 "type": "object"
                                             },
                                             {
@@ -14744,9 +14744,6 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
@@ -14754,13 +14751,16 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "name",
                                                     "slug",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14770,8 +14770,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "rejected",
                                                             "success",
+                                                            "rejected",
                                                             "timeout"
                                                         ]
                                                     }
@@ -14783,6 +14783,10 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -14822,21 +14826,17 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "dimension",
                                                                     "metric",
+                                                                    "dimension",
                                                                     null
                                                                 ],
-                                                                "nullable": true
-                                                            },
-                                                            "searchQuery": {
-                                                                "type": "string",
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
+                                                            "searchQuery",
                                                             "fields",
-                                                            "type",
-                                                            "searchQuery"
+                                                            "type"
                                                         ],
                                                         "type": "object"
                                                     },
@@ -29823,22 +29823,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -30398,22 +30398,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -39361,7 +39361,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3156.1",
+        "version": "0.3158.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1,5 +1,6 @@
 import { Ability } from '@casl/ability';
 import {
+    Account,
     AnyType,
     CreateWarehouseCredentials,
     DimensionType,
@@ -299,7 +300,14 @@ const getMockedAsyncQueryService = (
         preAggregateStrategy: new NoOpPreAggregateStrategy(),
         projectCompileLogModel: {} as ProjectCompileLogModel,
         adminNotificationService: {} as AdminNotificationService,
-        spacePermissionService: {} as SpacePermissionService,
+        spacePermissionService: {
+            getSpaceAccessContext: jest.fn(async () => ({
+                organizationUuid: projectSummary.organizationUuid,
+                projectUuid,
+                inheritsFromOrgOrProject: true,
+                access: [],
+            })),
+        } as unknown as SpacePermissionService,
         organizationSettingsModel: {
             get: jest.fn(async () => ({
                 queryLimit: null,
@@ -312,7 +320,137 @@ const getMockedAsyncQueryService = (
 const getJsonlStream = (rows: Record<string, unknown>[]) =>
     Readable.from(rows.map((row) => `${JSON.stringify(row)}\n`).join(''));
 
+type JwtDashboardQueryContextTestService = {
+    getJwtDashboardQueryContext: (
+        account: Account,
+        projectUuid: string,
+        requestDashboardUuid: string | undefined,
+    ) => Promise<{ dashboardUuid: string | undefined }>;
+};
+
 describe('AsyncQueryService', () => {
+    describe('getJwtDashboardQueryContext', () => {
+        const buildDashboardEmbedAccount = () =>
+            ({
+                ...buildAccount({
+                    accountType: 'jwt',
+                    userType: 'anonymous',
+                }),
+                access: {
+                    content: {
+                        type: 'dashboard',
+                        dashboardUuid: 'embedded-dashboard-uuid',
+                    },
+                },
+                authentication: {
+                    type: 'jwt',
+                    data: {},
+                },
+            }) as unknown as Account;
+
+        const buildEmbedWriteAccount = () =>
+            ({
+                ...buildAccount({
+                    accountType: 'jwt',
+                    userType: 'anonymous',
+                }),
+                access: {
+                    content: {
+                        type: 'dashboard',
+                        dashboardUuid: 'embedded-dashboard-uuid',
+                    },
+                },
+                authentication: {
+                    type: 'jwt',
+                    data: {
+                        writeActions: {
+                            spaceUuid: 'write-space-uuid',
+                        },
+                    },
+                },
+                embedWriteUser: {
+                    ...sessionAccount.user,
+                    ability: new Ability<PossibleAbilities>([
+                        {
+                            subject: 'Dashboard',
+                            action: 'view',
+                            conditions: {
+                                projectUuid,
+                                inheritsFromOrgOrProject: true,
+                            },
+                        },
+                    ]),
+                },
+            }) as unknown as Account;
+
+        test('uses the embedded dashboard for non-write JWTs', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                dashboardModel: {
+                    getByIdOrSlug: jest.fn(),
+                } as unknown as DashboardModel,
+            });
+
+            const result = await (
+                service as unknown as JwtDashboardQueryContextTestService
+            ).getJwtDashboardQueryContext(
+                buildDashboardEmbedAccount(),
+                projectUuid,
+                'request-dashboard-uuid',
+            );
+
+            expect(result.dashboardUuid).toBe('embedded-dashboard-uuid');
+            expect(service.dashboardModel.getByIdOrSlug).not.toHaveBeenCalled();
+        });
+
+        test('uses request dashboard when it belongs to the embed write space', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                dashboardModel: {
+                    getByIdOrSlug: jest.fn(async () => ({
+                        uuid: 'request-dashboard-uuid',
+                        name: 'Request dashboard',
+                        organizationUuid: projectSummary.organizationUuid,
+                        projectUuid,
+                        spaceUuid: 'write-space-uuid',
+                    })),
+                } as unknown as DashboardModel,
+            });
+
+            const result = await (
+                service as unknown as JwtDashboardQueryContextTestService
+            ).getJwtDashboardQueryContext(
+                buildEmbedWriteAccount(),
+                projectUuid,
+                'request-dashboard-uuid',
+            );
+
+            expect(result.dashboardUuid).toBe('request-dashboard-uuid');
+        });
+
+        test('falls back to embedded dashboard when request dashboard is outside the embed write space', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                dashboardModel: {
+                    getByIdOrSlug: jest.fn(async () => ({
+                        uuid: 'request-dashboard-uuid',
+                        name: 'Request dashboard',
+                        organizationUuid: projectSummary.organizationUuid,
+                        projectUuid,
+                        spaceUuid: 'other-space-uuid',
+                    })),
+                } as unknown as DashboardModel,
+            });
+
+            const result = await (
+                service as unknown as JwtDashboardQueryContextTestService
+            ).getJwtDashboardQueryContext(
+                buildEmbedWriteAccount(),
+                projectUuid,
+                'request-dashboard-uuid',
+            );
+
+            expect(result.dashboardUuid).toBe('embedded-dashboard-uuid');
+        });
+    });
+
     describe('executeAsyncQuery', () => {
         const serviceWithCache = getMockedAsyncQueryService({
             ...lightdashConfigMock,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     Account,
     addDashboardFiltersToMetricQuery,
+    AnonymousAccount,
     ApiExecuteAsyncDashboardChartQueryResults,
     ApiExecuteAsyncDashboardSqlChartQueryResults,
     ApiExecuteAsyncSqlQueryResults,
@@ -111,6 +112,7 @@ import {
     type ReadyQueryResultsPage,
     type ResultColumns,
     type RunQueryTags,
+    type SessionUser,
     type SpaceSummaryBase,
     type WarehouseExecuteAsyncQuery,
     type WarehouseResults,
@@ -462,6 +464,79 @@ export class AsyncQueryService extends ProjectService {
             )
         ) {
             throw new ForbiddenError("You don't have access to this chart");
+        }
+    }
+
+    private async assertSavedChartViewAccessForUser(
+        user: SessionUser,
+        savedChart: {
+            organizationUuid: string;
+            projectUuid: string;
+            spaceUuid: string;
+            savedChartUuid?: string;
+            savedSqlUuid?: string;
+        },
+    ) {
+        const ctx = await this.spacePermissionService.getSpaceAccessContext(
+            user.userUuid,
+            savedChart.spaceUuid,
+        );
+
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('SavedChart', {
+                    organizationUuid: savedChart.organizationUuid,
+                    projectUuid: savedChart.projectUuid,
+                    inheritsFromOrgOrProject: ctx.inheritsFromOrgOrProject,
+                    access: ctx.access,
+                    metadata: {
+                        spaceUuid: savedChart.spaceUuid,
+                        savedChartUuid: savedChart.savedChartUuid,
+                        savedSqlUuid: savedChart.savedSqlUuid,
+                    },
+                }),
+            )
+        ) {
+            throw new ForbiddenError("You don't have access to this chart");
+        }
+    }
+
+    private async assertDashboardViewAccessForUser(
+        user: SessionUser,
+        dashboard: {
+            uuid: string;
+            name: string;
+            organizationUuid: string;
+            projectUuid: string;
+            spaceUuid: string;
+        },
+    ) {
+        const ctx = await this.spacePermissionService.getSpaceAccessContext(
+            user.userUuid,
+            dashboard.spaceUuid,
+        );
+
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Dashboard', {
+                    organizationUuid: dashboard.organizationUuid,
+                    projectUuid: dashboard.projectUuid,
+                    inheritsFromOrgOrProject: ctx.inheritsFromOrgOrProject,
+                    access: ctx.access,
+                    metadata: {
+                        dashboardUuid: dashboard.uuid,
+                        dashboardName: dashboard.name,
+                    },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                "You don't have access to the space this dashboard belongs to",
+            );
         }
     }
 
@@ -4747,13 +4822,45 @@ export class AsyncQueryService extends ProjectService {
         savedChartUuid: string,
         space: SpaceSummaryBase,
     ) {
-        const auditedAbility = this.createAuditedAbility(account);
         if (isJwtUser(account)) {
+            const embedWriteActions = account.authentication.data.writeActions;
+            if (
+                account.embedWriteUser &&
+                embedWriteActions?.spaceUuid === space.uuid
+            ) {
+                const auditedAbility = this.createAuditedAbility(
+                    account.embedWriteUser,
+                );
+                await this.assertSavedChartViewAccessForUser(
+                    account.embedWriteUser,
+                    {
+                        organizationUuid: space.organizationUuid,
+                        projectUuid,
+                        spaceUuid: space.uuid,
+                        savedChartUuid,
+                    },
+                );
+                if (
+                    auditedAbility.cannot(
+                        'view',
+                        subject('Project', {
+                            organizationUuid: space.organizationUuid,
+                            projectUuid,
+                            metadata: { savedChartUuid },
+                        }),
+                    )
+                ) {
+                    throw new ForbiddenError();
+                }
+                return;
+            }
+
             await this.permissionsService.checkEmbedPermissions(
                 account,
                 savedChartUuid,
             );
         } else {
+            const auditedAbility = this.createAuditedAbility(account);
             const ctx = await this.spacePermissionService.getSpaceAccessContext(
                 account.user.id,
                 space.uuid,
@@ -4775,6 +4882,7 @@ export class AsyncQueryService extends ProjectService {
             }
         }
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'view',
@@ -4787,6 +4895,50 @@ export class AsyncQueryService extends ProjectService {
         ) {
             throw new ForbiddenError();
         }
+    }
+
+    private async getJwtDashboardQueryContext(
+        account: AnonymousAccount,
+        projectUuid: string,
+        requestDashboardUuid: string | undefined,
+    ): Promise<{
+        dashboardUuid: string | undefined;
+    }> {
+        const { embedWriteUser } = account;
+        const embedWriteActions = account.authentication.data.writeActions;
+        const writeSpaceUuid = embedWriteUser
+            ? embedWriteActions?.spaceUuid
+            : undefined;
+
+        if (writeSpaceUuid && requestDashboardUuid) {
+            try {
+                const dashboard = await this.dashboardModel.getByIdOrSlug(
+                    requestDashboardUuid,
+                    { projectUuid },
+                );
+
+                if (embedWriteUser && dashboard.spaceUuid === writeSpaceUuid) {
+                    await this.assertDashboardViewAccessForUser(
+                        embedWriteUser,
+                        dashboard,
+                    );
+                    return {
+                        dashboardUuid: dashboard.uuid,
+                    };
+                }
+            } catch (error) {
+                if (!(error instanceof NotFoundError)) {
+                    throw error;
+                }
+            }
+        }
+
+        return {
+            dashboardUuid:
+                account.access.content.type === 'dashboard'
+                    ? account.access.content.dashboardUuid
+                    : undefined,
+        };
     }
 
     async executeAsyncDashboardChartQuery({
@@ -4828,6 +4980,24 @@ export class AsyncQueryService extends ProjectService {
                 organizationUuid,
             ),
         ]);
+
+        let effectiveDashboardUuid: string | undefined = dashboardUuid;
+
+        if (isJwtUser(account)) {
+            const jwtDashboardContext = await this.getJwtDashboardQueryContext(
+                account,
+                projectUuid,
+                dashboardUuid,
+            );
+            effectiveDashboardUuid = jwtDashboardContext.dashboardUuid;
+        }
+
+        if (!effectiveDashboardUuid) {
+            throw new ForbiddenError(
+                'JWT does not grant access to a dashboard',
+            );
+        }
+        const resolvedDashboardUuid = effectiveDashboardUuid;
 
         await this.checkDashboardChartQueryPermissions(
             account,
@@ -4915,7 +5085,7 @@ export class AsyncQueryService extends ProjectService {
             tileUuid,
             chartUuid,
             context,
-            dashboardUuid,
+            dashboardUuid: resolvedDashboardUuid,
             dashboardFilters,
             dashboardSorts,
             dateZoom,
@@ -4928,7 +5098,7 @@ export class AsyncQueryService extends ProjectService {
             organization_uuid: organizationUuid,
             project_uuid: projectUuid,
             chart_uuid: chartUuid,
-            dashboard_uuid: dashboardUuid,
+            dashboard_uuid: resolvedDashboardUuid,
             explore_name: explore.name,
             query_context: context,
         };
@@ -4954,7 +5124,7 @@ export class AsyncQueryService extends ProjectService {
                     organizationWarehouseCredentialsUuid,
             }),
             this.dashboardModel.getDashboardParametersByIdOrSlug(
-                dashboardUuid,
+                resolvedDashboardUuid,
                 projectUuid,
             ),
             this.projectParametersModel.find(projectUuid),
@@ -5047,7 +5217,7 @@ export class AsyncQueryService extends ProjectService {
                         ? routingDecision.route
                         : undefined,
                 chartId: savedChart.uuid,
-                dashboardId: dashboardUuid,
+                dashboardId: resolvedDashboardUuid,
             });
         }
 
@@ -5056,7 +5226,7 @@ export class AsyncQueryService extends ProjectService {
             exploreName: explore.name,
             routingDecision,
             chartUuid: savedChart.uuid,
-            dashboardUuid,
+            dashboardUuid: resolvedDashboardUuid,
             queryContext: context,
         });
 
@@ -5928,31 +6098,54 @@ export class AsyncQueryService extends ProjectService {
             limit,
         } = args;
 
-        // For JWT users, the dashboard scope is bound to the token, not the
-        // request body. Trusting `args.dashboardUuid` would let a JWT user
-        // merge another dashboard's parameter values into their query.
-        const dashboardUuid = isJwtUser(account)
-            ? account.access.content.dashboardUuid
-            : requestDashboardUuid;
+        let dashboardUuid: string | undefined = requestDashboardUuid;
+
+        // For JWT users without write actions, the dashboard scope is bound to
+        // the token. Write-action embeds may use a dashboard from their write
+        // space so newly added draft tiles can preview with dashboard context.
+        if (isJwtUser(account)) {
+            const jwtDashboardContext = await this.getJwtDashboardQueryContext(
+                account,
+                projectUuid,
+                requestDashboardUuid,
+            );
+            dashboardUuid = jwtDashboardContext.dashboardUuid;
+        }
 
         if (!dashboardUuid) {
             throw new ForbiddenError(
                 'JWT does not grant access to a dashboard',
             );
         }
+        const resolvedDashboardUuid = dashboardUuid;
 
         if (isJwtUser(account)) {
-            await this.permissionsService.checkEmbedSqlChartPermissions(
-                account,
-                savedChart.savedSqlUuid,
-            );
+            const { embedWriteUser } = account;
+            const embedWriteActions = account.authentication.data.writeActions;
+            const canUseWriteDashboard =
+                embedWriteUser &&
+                embedWriteActions?.spaceUuid === savedChart.space.uuid;
+
+            if (canUseWriteDashboard) {
+                await this.assertSavedChartViewAccessForUser(embedWriteUser, {
+                    organizationUuid: savedChart.organization.organizationUuid,
+                    projectUuid: savedChart.project.projectUuid,
+                    spaceUuid: savedChart.space.uuid,
+                    savedSqlUuid: savedChart.savedSqlUuid,
+                });
+            } else {
+                await this.permissionsService.checkEmbedSqlChartPermissions(
+                    account,
+                    savedChart.savedSqlUuid,
+                );
+            }
         } else {
             await this.assertSavedChartAccess(account, 'view', savedChart);
         }
 
         const dashboardParameters = convertDashboardParametersToValuesMap(
             await this.dashboardModel.getDashboardParametersByIdOrSlug(
-                dashboardUuid,
+                resolvedDashboardUuid,
                 projectUuid,
             ),
         );

--- a/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
@@ -16,6 +16,7 @@ import { OrganizationModel } from '../../models/OrganizationModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
+import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SearchModel } from '../../models/SearchModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -100,6 +101,7 @@ describe('DashboardService - Content Verification', () => {
         savedChartModel: {
             getInfoForAvailableFilters: jest.fn(async () => []),
         } as unknown as SavedChartModel,
+        savedSqlModel: {} as unknown as SavedSqlModel,
         savedChartService: {} as unknown as SavedChartService,
         projectModel: {
             getCachedExploreNames: jest.fn(async () => []),

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -10,9 +10,11 @@ import {
     PossibleAbilities,
     ProjectMemberRole,
     SessionUser,
+    type Account,
     type Dashboard,
     type DashboardChartTile,
     type DashboardFilterRule,
+    type UpdateDashboard,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { SlackClient } from '../../clients/Slack/SlackClient';
@@ -25,6 +27,7 @@ import { OrganizationModel } from '../../models/OrganizationModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
+import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SearchModel } from '../../models/SearchModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -80,6 +83,13 @@ const savedChartModel = {
         projectUuid: 'project_uuid',
     })),
     getInfoForAvailableFilters: jest.fn(async () => []),
+};
+const savedSqlModel = {
+    getByUuid: jest.fn(async () => ({
+        space: {
+            uuid: publicSpace.uuid,
+        },
+    })),
 };
 
 const projectModel = {
@@ -165,6 +175,7 @@ describe('DashboardService', () => {
         searchModel: searchModel as unknown as SearchModel,
         schedulerService: {} as SchedulerService,
         savedChartModel: savedChartModel as unknown as SavedChartModel,
+        savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
         savedChartService: {} as SavedChartService, // Mock for test
         projectModel: projectModel as unknown as ProjectModel,
         slackClient: {} as SlackClient,
@@ -194,6 +205,63 @@ describe('DashboardService', () => {
             { projectUuid: undefined },
         );
     });
+
+    test('throws when an embed write token saves a SQL chart from outside the write space', async () => {
+        const embedWriteAccount = {
+            isJwtUser: () => true,
+            embedWriteUser: user,
+            authentication: {
+                type: 'jwt',
+                data: {
+                    writeActions: {
+                        spaceUuid: publicSpace.uuid,
+                    },
+                },
+            },
+        } as unknown as Account;
+        const updateDashboardWithSqlTile: UpdateDashboard = {
+            tiles: [
+                {
+                    uuid: 'sql-tile-uuid',
+                    type: DashboardTileTypes.SQL_CHART,
+                    x: 0,
+                    y: 0,
+                    h: 10,
+                    w: 10,
+                    tabUuid: undefined,
+                    properties: {
+                        savedSqlUuid: 'saved-sql-uuid',
+                        title: 'SQL chart',
+                        chartName: 'SQL chart',
+                    },
+                },
+            ],
+            filters: {
+                dimensions: [],
+                metrics: [],
+                tableCalculations: [],
+            },
+            tabs: [],
+        };
+
+        savedSqlModel.getByUuid.mockResolvedValueOnce({
+            space: {
+                uuid: privateSpace.uuid,
+            },
+        });
+
+        await expect(
+            service.updateFromAccount(
+                embedWriteAccount,
+                dashboard.uuid,
+                updateDashboardWithSqlTile,
+                { projectUuid: dashboard.projectUuid },
+            ),
+        ).rejects.toThrowError(ForbiddenError);
+
+        expect(dashboardModel.update).not.toHaveBeenCalled();
+    });
+
     test('should get dashboard charts after dashboard access check', async () => {
         const result = await service.getDashboardCharts(
             user,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -38,10 +38,12 @@ import {
     TogglePinnedItemInfo,
     UpdateDashboard,
     UpdateMultipleDashboards,
+    type Account,
     type ChartFieldUpdates,
     type ChartVersionDifference,
     type ChartVersionSummary,
     type ContentVerificationInfo,
+    type CreateDashboardSqlChartTile,
     type DashboardBasicDetailsWithTileTypes,
     type DashboardHistory,
     type DashboardTileTarget,
@@ -59,7 +61,7 @@ import {
     LightdashAnalytics,
     SchedulerDashboardUpsertEvent,
 } from '../../analytics/LightdashAnalytics';
-import { toSessionUser } from '../../auth/account';
+import { getAccountWriteContext, toSessionUser } from '../../auth/account';
 import { SlackClient } from '../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import { getSchedulerTargetType } from '../../database/entities/scheduler';
@@ -73,6 +75,7 @@ import { OrganizationModel } from '../../models/OrganizationModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
+import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SearchModel } from '../../models/SearchModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -99,6 +102,7 @@ type DashboardServiceArguments = {
     searchModel: SearchModel;
     schedulerService: SchedulerService;
     savedChartModel: SavedChartModel;
+    savedSqlModel: SavedSqlModel;
     savedChartService: SavedChartService;
     schedulerClient: SchedulerClient;
     slackClient: SlackClient;
@@ -133,6 +137,8 @@ export class DashboardService
 
     savedChartModel: SavedChartModel;
 
+    savedSqlModel: SavedSqlModel;
+
     savedChartService: SavedChartService;
 
     catalogModel: CatalogModel;
@@ -160,6 +166,7 @@ export class DashboardService
         searchModel,
         schedulerService,
         savedChartModel,
+        savedSqlModel,
         savedChartService,
         schedulerClient,
         slackClient,
@@ -180,6 +187,7 @@ export class DashboardService
         this.searchModel = searchModel;
         this.schedulerService = schedulerService;
         this.savedChartModel = savedChartModel;
+        this.savedSqlModel = savedSqlModel;
         this.savedChartService = savedChartService;
         this.projectModel = projectModel;
         this.catalogModel = catalogModel;
@@ -745,6 +753,203 @@ export class DashboardService
         );
     }
 
+    private async assertWriteSpaceBelongsToProject(
+        projectUuid: string,
+        spaceUuid: string,
+    ) {
+        const space = await this.spaceModel.get(spaceUuid);
+
+        if (space.projectUuid !== projectUuid) {
+            throw new ForbiddenError(
+                'Embed token does not allow writing to this project space',
+            );
+        }
+
+        return space;
+    }
+
+    private async assertDashboardTilesBelongToWriteSpace(
+        user: SessionUser,
+        tiles: CreateDashboard['tiles'],
+        writeSpaceUuid: string,
+        projectUuid: string,
+    ) {
+        const savedChartUuids = [
+            ...new Set(
+                tiles
+                    .filter(
+                        (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
+                    )
+                    .map((tile) => tile.properties.savedChartUuid)
+                    .filter((uuid): uuid is string => !!uuid),
+            ),
+        ];
+
+        await Promise.all(
+            savedChartUuids.map(async (savedChartUuid) => {
+                const savedChart = await this.savedChartModel.get(
+                    savedChartUuid,
+                    undefined,
+                    { projectUuid },
+                );
+
+                if (savedChart.spaceUuid !== writeSpaceUuid) {
+                    throw new ForbiddenError(
+                        'Embed token does not allow saving charts from outside the write space',
+                    );
+                }
+
+                const spaceAccessContext =
+                    await this.spacePermissionService.getSpaceAccessContext(
+                        user.userUuid,
+                        savedChart.spaceUuid,
+                    );
+                const auditedAbility = this.createAuditedAbility(user);
+                if (
+                    auditedAbility.cannot(
+                        'view',
+                        subject('SavedChart', {
+                            ...savedChart,
+                            inheritsFromOrgOrProject:
+                                spaceAccessContext.inheritsFromOrgOrProject,
+                            access: spaceAccessContext.access,
+                            metadata: {
+                                savedChartUuid: savedChart.uuid,
+                                savedChartName: savedChart.name,
+                            },
+                        }),
+                    )
+                ) {
+                    throw new ForbiddenError(
+                        'Embed token does not allow viewing this chart',
+                    );
+                }
+            }),
+        );
+
+        const savedSqlUuids = [
+            ...new Set(
+                tiles
+                    .filter(
+                        (tile) => tile.type === DashboardTileTypes.SQL_CHART,
+                    )
+                    .map(
+                        (tile) =>
+                            (tile as CreateDashboardSqlChartTile).properties
+                                .savedSqlUuid,
+                    )
+                    .filter((uuid): uuid is string => !!uuid),
+            ),
+        ];
+
+        await Promise.all(
+            savedSqlUuids.map(async (savedSqlUuid) => {
+                const savedSqlChart = await this.savedSqlModel.getByUuid(
+                    savedSqlUuid,
+                    { projectUuid },
+                );
+
+                if (savedSqlChart.space.uuid !== writeSpaceUuid) {
+                    throw new ForbiddenError(
+                        'Embed token does not allow saving SQL charts from outside the write space',
+                    );
+                }
+
+                const spaceAccessContext =
+                    await this.spacePermissionService.getSpaceAccessContext(
+                        user.userUuid,
+                        savedSqlChart.space.uuid,
+                    );
+                const auditedAbility = this.createAuditedAbility(user);
+                if (
+                    auditedAbility.cannot(
+                        'view',
+                        subject('SavedChart', {
+                            ...spaceAccessContext,
+                            metadata: {
+                                savedSqlUuid: savedSqlChart.savedSqlUuid,
+                            },
+                        }),
+                    )
+                ) {
+                    throw new ForbiddenError(
+                        'Embed token does not allow viewing this SQL chart',
+                    );
+                }
+            }),
+        );
+    }
+
+    private async getCreateDashboardContext(
+        account: Account,
+        projectUuid: string,
+        dashboard: CreateDashboard,
+    ): Promise<{ user: SessionUser; dashboard: CreateDashboard }> {
+        const { user, embedWriteActions } = getAccountWriteContext(account);
+
+        if (!embedWriteActions) {
+            return { user, dashboard };
+        }
+
+        await this.assertWriteSpaceBelongsToProject(
+            projectUuid,
+            embedWriteActions.spaceUuid,
+        );
+        await this.assertDashboardTilesBelongToWriteSpace(
+            user,
+            dashboard.tiles,
+            embedWriteActions.spaceUuid,
+            projectUuid,
+        );
+
+        return {
+            user,
+            dashboard: {
+                ...dashboard,
+                spaceUuid: embedWriteActions.spaceUuid,
+            },
+        };
+    }
+
+    private async getDashboardWriteContext(
+        account: Account,
+        projectUuid: string | undefined,
+    ): Promise<{
+        user: SessionUser;
+        embedWriteActions?: { spaceUuid: string };
+    }> {
+        const context = getAccountWriteContext(account);
+
+        if (context.embedWriteActions) {
+            if (!projectUuid) {
+                throw new ForbiddenError(
+                    'Project UUID is required for embedded write actions',
+                );
+            }
+
+            await this.assertWriteSpaceBelongsToProject(
+                projectUuid,
+                context.embedWriteActions.spaceUuid,
+            );
+        }
+
+        return context;
+    }
+
+    async createFromAccount(
+        account: Account,
+        projectUuid: string,
+        dashboard: CreateDashboard,
+    ): Promise<Dashboard> {
+        const { user, dashboard: dashboardToCreate } =
+            await this.getCreateDashboardContext(
+                account,
+                projectUuid,
+                dashboard,
+            );
+        return this.create(user, projectUuid, dashboardToCreate);
+    }
+
     async create(
         user: SessionUser,
         projectUuid: string,
@@ -757,6 +962,9 @@ export class DashboardService
                 projectUuid,
             ));
         const space = await this.spaceModel.get(resolvedSpaceUuid);
+        if (space.projectUuid !== projectUuid) {
+            throw new ForbiddenError('Space does not belong to this project');
+        }
 
         const { inheritsFromOrgOrProject, access } =
             await this.spacePermissionService.getSpaceAccessContext(
@@ -811,14 +1019,41 @@ export class DashboardService
         };
     }
 
+    async duplicateFromAccount(
+        account: Account,
+        projectUuid: string,
+        dashboardUuid: string,
+        data: DuplicateDashboardParams,
+    ): Promise<Dashboard> {
+        const { user, embedWriteActions } = await this.getDashboardWriteContext(
+            account,
+            projectUuid,
+        );
+        return this.duplicate(user, projectUuid, dashboardUuid, data, {
+            targetSpaceUuid: embedWriteActions?.spaceUuid,
+            sourceSpaceUuid: embedWriteActions?.spaceUuid,
+        });
+    }
+
     async duplicate(
         user: SessionUser,
         projectUuid: string,
         dashboardUuid: string,
         data: DuplicateDashboardParams,
+        options?: { targetSpaceUuid?: string; sourceSpaceUuid?: string },
     ): Promise<Dashboard> {
-        const dashboardDao =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboardDao = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
+        if (
+            options?.sourceSpaceUuid &&
+            dashboardDao.spaceUuid !== options.sourceSpaceUuid
+        ) {
+            throw new ForbiddenError(
+                'Embed token does not allow duplicating dashboards from outside the write space',
+            );
+        }
         const { inheritsFromOrgOrProject, access } =
             await this.spacePermissionService.getSpaceAccessContext(
                 user.userUuid,
@@ -829,16 +1064,52 @@ export class DashboardService
             inheritsFromOrgOrProject,
             access,
         };
+        const targetSpaceUuid = options?.targetSpaceUuid ?? dashboard.spaceUuid;
+        const targetSpaceAccess =
+            await this.spacePermissionService.getSpaceAccessContext(
+                user.userUuid,
+                targetSpaceUuid,
+            );
+        if (targetSpaceAccess.projectUuid !== projectUuid) {
+            throw new ForbiddenError(
+                'Target space does not belong to this project',
+            );
+        }
 
         const auditedAbility = this.createAuditedAbility(user);
+        if (
+            options?.sourceSpaceUuid &&
+            auditedAbility.cannot(
+                'view',
+                subject('Dashboard', {
+                    organizationUuid: dashboard.organizationUuid,
+                    projectUuid,
+                    inheritsFromOrgOrProject,
+                    access,
+                    metadata: {
+                        dashboardUuid: dashboard.uuid,
+                        dashboardName: dashboard.name,
+                    },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Embed token does not allow viewing this dashboard',
+            );
+        }
+
         if (
             auditedAbility.cannot(
                 'create',
                 subject('Dashboard', {
-                    ...dashboard,
+                    organizationUuid: dashboard.organizationUuid,
+                    projectUuid,
+                    inheritsFromOrgOrProject:
+                        targetSpaceAccess.inheritsFromOrgOrProject,
+                    access: targetSpaceAccess.access,
                     metadata: {
-                        dashboardUuid: dashboard.uuid,
-                        dashboardName: dashboard.name,
+                        spaceUuid: targetSpaceUuid,
+                        dashboardName: data.dashboardName,
                     },
                 }),
             )
@@ -873,7 +1144,7 @@ export class DashboardService
         };
 
         const newDashboard = await this.dashboardModel.create(
-            dashboard.spaceUuid,
+            targetSpaceUuid,
             duplicatedDashboard,
             user,
             projectUuid,
@@ -978,9 +1249,60 @@ export class DashboardService
 
         return {
             ...updatedNewDashboard,
-            inheritsFromOrgOrProject,
-            access,
+            inheritsFromOrgOrProject:
+                targetSpaceAccess.inheritsFromOrgOrProject,
+            access: targetSpaceAccess.access,
         };
+    }
+
+    async updateFromAccount(
+        account: Account,
+        dashboardUuidOrSlug: string,
+        dashboard: UpdateDashboard,
+        options?: { projectUuid?: string },
+    ): Promise<Dashboard> {
+        const { user, embedWriteActions } = await this.getDashboardWriteContext(
+            account,
+            options?.projectUuid,
+        );
+        const existingDashboardDao = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuidOrSlug,
+            {
+                projectUuid: options?.projectUuid,
+            },
+        );
+
+        if (
+            embedWriteActions &&
+            existingDashboardDao.spaceUuid !== embedWriteActions.spaceUuid
+        ) {
+            throw new ForbiddenError(
+                'Embed token does not allow writing to this dashboard space',
+            );
+        }
+
+        if (embedWriteActions) {
+            if (
+                isDashboardUnversionedFields(dashboard) &&
+                dashboard.spaceUuid &&
+                dashboard.spaceUuid !== embedWriteActions.spaceUuid
+            ) {
+                throw new ForbiddenError(
+                    'Embed token does not allow moving dashboards outside the write space',
+                );
+            }
+
+            if (isDashboardVersionedFields(dashboard)) {
+                await this.assertDashboardTilesBelongToWriteSpace(
+                    user,
+                    dashboard.tiles,
+                    embedWriteActions.spaceUuid,
+                    options?.projectUuid ?? existingDashboardDao.projectUuid,
+                );
+            }
+        }
+
+        return this.update(user, dashboardUuidOrSlug, dashboard, options);
     }
 
     async update(

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -1135,23 +1135,39 @@ export class SavedChartService
     ): Promise<{ access: SpaceAccess[]; inheritsFromOrgOrProject: boolean }> {
         let access;
         let inheritsFromOrgOrProject: boolean;
+        let permissionActor: Account | SessionUser = account;
         if (isJwtUser(account)) {
-            await this.permissionsService.checkEmbedPermissions(
-                account,
-                savedChart.uuid,
-            );
-            // We pass this access everytime, but we only define the ability
-            // rule for this chart only if the JWT is type: 'chart'.
-            // Dashboards won't have `access` defined in their abilityRules,
-            // so this CASL check will pass for them.
-            // TODO: Get all chartUuids for a given dashboard in the middleware.
-            //       https://linear.app/lightdash/issue/CENG-110/front-load-available-charts-for-dashboard-requests
-            access = [{ chartUuid: savedChart.uuid }];
-            const spaceCtx =
-                await this.spacePermissionService.getAllSpaceAccessContext(
-                    space.uuid,
+            const { embedWriteUser } = account;
+            const writeSpaceUuid =
+                account.authentication.data.writeActions?.spaceUuid;
+            if (embedWriteUser && writeSpaceUuid === space.uuid) {
+                permissionActor = embedWriteUser;
+                const spaceCtx =
+                    await this.spacePermissionService.getSpaceAccessContext(
+                        embedWriteUser.userUuid,
+                        space.uuid,
+                    );
+
+                access = spaceCtx.access;
+                inheritsFromOrgOrProject = spaceCtx.inheritsFromOrgOrProject;
+            } else {
+                await this.permissionsService.checkEmbedPermissions(
+                    account,
+                    savedChart.uuid,
                 );
-            inheritsFromOrgOrProject = spaceCtx.inheritsFromOrgOrProject;
+                // We pass this access everytime, but we only define the ability
+                // rule for this chart only if the JWT is type: 'chart'.
+                // Dashboards won't have `access` defined in their abilityRules,
+                // so this CASL check will pass for them.
+                // TODO: Get all chartUuids for a given dashboard in the middleware.
+                //       https://linear.app/lightdash/issue/CENG-110/front-load-available-charts-for-dashboard-requests
+                access = [{ chartUuid: savedChart.uuid }];
+                const spaceCtx =
+                    await this.spacePermissionService.getAllSpaceAccessContext(
+                        space.uuid,
+                    );
+                inheritsFromOrgOrProject = spaceCtx.inheritsFromOrgOrProject;
+            }
         } else {
             const ctx = await this.spacePermissionService.getSpaceAccessContext(
                 account.user.userUuid,
@@ -1161,7 +1177,7 @@ export class SavedChartService
             inheritsFromOrgOrProject = ctx.inheritsFromOrgOrProject;
         }
 
-        const auditedAbility = this.createAuditedAbility(account);
+        const auditedAbility = this.createAuditedAbility(permissionActor);
         if (
             auditedAbility.cannot(
                 'view',

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -23,6 +23,7 @@ import {
     SqlRunnerPivotQueryBody,
     UpdateSqlChart,
     VIZ_DEFAULT_AGGREGATION,
+    type Account,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { uniq } from 'lodash';
@@ -30,6 +31,7 @@ import {
     CreateSqlChartVersionEvent,
     LightdashAnalytics,
 } from '../../analytics/LightdashAnalytics';
+import { getAccountWriteContext } from '../../auth/account';
 import { LightdashConfig } from '../../config/parseConfig';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -261,6 +263,72 @@ export class SavedSqlService
             space: {
                 ...savedChart.space,
                 userAccess: spaceCtx.access[0],
+            },
+            resolvedColorPalette,
+        };
+    }
+
+    async getSqlChartFromAccount(
+        account: Account,
+        projectUuid: string,
+        savedSqlUuid: string | undefined,
+        slug?: string,
+    ): Promise<SqlChart> {
+        const { user, embedWriteActions } = getAccountWriteContext(account);
+
+        let savedChart;
+        if (savedSqlUuid) {
+            savedChart = await this.savedSqlModel.getByUuid(savedSqlUuid, {
+                projectUuid,
+            });
+        } else if (slug) {
+            savedChart = await this.savedSqlModel.getBySlug(projectUuid, slug);
+        } else {
+            throw new Error('Either savedSqlUuid or slug must be provided');
+        }
+
+        if (
+            embedWriteActions &&
+            savedChart.space.uuid !== embedWriteActions.spaceUuid
+        ) {
+            throw new ForbiddenError(
+                'SQL chart does not belong to embedded write space',
+            );
+        }
+
+        const spaceCtx = await this.hasAccess(
+            'view',
+            {
+                user,
+                projectUuid,
+            },
+            {
+                savedSqlUuid: savedChart.savedSqlUuid,
+            },
+        );
+
+        this.analytics.track({
+            event: 'sql_chart.view',
+            userId: user.userUuid,
+            properties: {
+                chartId: savedChart.savedSqlUuid,
+                projectId: savedChart.project.projectUuid,
+                organizationId: savedChart.organization.organizationUuid,
+            },
+        });
+
+        const resolvedColorPalette =
+            await this.savedSqlModel.resolveColorPalette({
+                projectUuid: savedChart.project.projectUuid,
+                dashboardUuid: savedChart.dashboard?.uuid,
+                spaceUuid: savedChart.space.uuid,
+            });
+
+        return {
+            ...savedChart,
+            space: {
+                ...savedChart.space,
+                userAccess: embedWriteActions ? undefined : spaceCtx.access[0],
             },
             resolvedColorPalette,
         };

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -395,6 +395,7 @@ export class ServiceRepository
                     searchModel: this.models.getSearchModel(),
                     schedulerService: this.getSchedulerService(),
                     savedChartModel: this.models.getSavedChartModel(),
+                    savedSqlModel: this.models.getSavedSqlModel(),
                     savedChartService: this.getSavedChartService(),
                     projectModel: this.models.getProjectModel(),
                     schedulerClient: this.clients.getSchedulerClient(),

--- a/packages/common/src/visualizations/TableDataModel.test.ts
+++ b/packages/common/src/visualizations/TableDataModel.test.ts
@@ -1,0 +1,69 @@
+import { TableDataModel } from './TableDataModel';
+import { type IResultsRunner } from './types/IResultsRunner';
+
+const resultsRunner: IResultsRunner = {
+    getColumnNames: () => ['payment_method', 'total_amount'],
+    getRows: () => [
+        {
+            payment_method: 'credit_card',
+            total_amount: 100,
+        },
+    ],
+    getPivotedVisualizationData: async () => ({
+        queryUuid: undefined,
+        columns: [],
+        fileUrl: '',
+        indexColumn: undefined,
+        results: [],
+        valuesColumns: [],
+        columnCount: undefined,
+    }),
+    getPivotQueryDimensions: () => [],
+    getPivotQueryMetrics: () => [],
+    getPivotQueryCustomMetrics: () => [],
+};
+
+describe('TableDataModel', () => {
+    it('shows result columns when column config is undefined', () => {
+        const model = new TableDataModel({ resultsRunner });
+
+        expect(model.getVisibleColumns()).toEqual([
+            'payment_method',
+            'total_amount',
+        ]);
+    });
+
+    it('shows result columns when saved column config is empty', () => {
+        const model = new TableDataModel({
+            resultsRunner,
+            columnsConfig: {},
+        });
+
+        expect(model.getVisibleColumns()).toEqual([
+            'payment_method',
+            'total_amount',
+        ]);
+    });
+
+    it('respects explicit hidden columns', () => {
+        const model = new TableDataModel({
+            resultsRunner,
+            columnsConfig: {
+                payment_method: {
+                    reference: 'payment_method',
+                    label: 'Payment method',
+                    visible: true,
+                    frozen: false,
+                },
+                total_amount: {
+                    reference: 'total_amount',
+                    label: 'Total amount',
+                    visible: false,
+                    frozen: false,
+                },
+            },
+        });
+
+        expect(model.getVisibleColumns()).toEqual(['payment_method']);
+    });
+});

--- a/packages/common/src/visualizations/TableDataModel.ts
+++ b/packages/common/src/visualizations/TableDataModel.ts
@@ -21,7 +21,9 @@ export class TableDataModel {
     }) {
         this.resultsRunner = args.resultsRunner;
         this.columnsConfig =
-            args.columnsConfig ?? this.getResultOptions().defaultColumnConfig;
+            args.columnsConfig && Object.keys(args.columnsConfig).length > 0
+                ? args.columnsConfig
+                : this.getResultOptions().defaultColumnConfig;
     }
 
     private getColumns() {

--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -1,19 +1,30 @@
 import '@mantine-8/core/styles.css';
 import {
     FilterOperator,
+    getErrorMessage,
+    type EmbedDashboard as EmbedDashboardType,
     type LanguageMap,
     type SavedChart,
 } from '@lightdash/common';
 import { ModalsProvider } from '@mantine/modals';
-import { useEffect, useState, type FC, type PropsWithChildren } from 'react';
+import {
+    useEffect,
+    useRef,
+    useState,
+    type FC,
+    type PropsWithChildren,
+} from 'react';
 import { MemoryRouter } from 'react-router';
 import { type SdkFilter } from '../src/ee/features/embed/EmbedDashboard/types';
 import EmbedChart from '../src/ee/pages/EmbedChart';
 import EmbedDashboard from '../src/ee/pages/EmbedDashboard';
 import EmbedExplore from '../src/ee/pages/EmbedExplore';
 import EmbedProvider from '../src/ee/providers/Embed/EmbedProvider';
+import useEmbed from '../src/ee/providers/Embed/useEmbed';
+import SuboptimalState from '../src/components/common/SuboptimalState/SuboptimalState';
 import ErrorBoundary from '../src/features/errorBoundary/ErrorBoundary';
 import ChartColorMappingContextProvider from '../src/hooks/useChartColorConfig/ChartColorMappingContextProvider';
+import { useCreateMutation } from '../src/hooks/dashboard/useDashboard';
 import AbilityProvider from '../src/providers/Ability/AbilityProvider';
 import ActiveJobProvider from '../src/providers/ActiveJob/ActiveJobProvider';
 import AppProvider from '../src/providers/App/AppProvider';
@@ -43,6 +54,12 @@ type BaseProps = {
 
 type DashboardProps = BaseProps & {
     paletteUuid?: string;
+    isEditMode?: boolean;
+    onEditModeChange?: (isEditMode: boolean) => void;
+};
+
+type DashboardBuilderProps = DashboardProps & {
+    onDashboardReady?: (dashboard: EmbedDashboardType) => void;
 };
 
 const decodeJWT = (token: string) => {
@@ -80,6 +97,70 @@ const persistInstanceUrl = (instanceUrl: string) => {
         );
     }
 };
+
+const useEmbedTokenContext = (
+    instanceUrl: string,
+    tokenOrTokenPromise: BaseProps['token'],
+) => {
+    const [tokenContext, setTokenContext] = useState<{
+        token: string;
+        projectUuid: string;
+    } | null>(null);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        persistInstanceUrl(instanceUrl);
+
+        const resolveToken = async () =>
+            typeof tokenOrTokenPromise === 'string'
+                ? tokenOrTokenPromise
+                : tokenOrTokenPromise;
+
+        resolveToken()
+            .then((tokenToDecode) => {
+                const { payload } = decodeJWT(tokenToDecode);
+
+                if (
+                    payload &&
+                    'content' in payload &&
+                    'projectUuid' in payload.content
+                ) {
+                    if (isMounted) {
+                        setTokenContext({
+                            token: tokenToDecode,
+                            projectUuid: payload.content.projectUuid,
+                        });
+                    }
+                } else {
+                    throw new Error('Error decoding token');
+                }
+            })
+            .catch((error) => {
+                console.error(error);
+                throw new Error('Error retrieving token');
+            });
+
+        return () => {
+            isMounted = false;
+        };
+    }, [instanceUrl, tokenOrTokenPromise]);
+
+    return tokenContext;
+};
+
+const getDashboardContainerStyles = (
+    styles: DashboardProps['styles'],
+    theme: DashboardProps['theme'],
+) => ({
+    width: '100%',
+    height: '100%',
+    position: 'relative' as const,
+    overflow: 'auto',
+    backgroundColor:
+        styles?.backgroundColor ??
+        (theme ? 'var(--mantine-color-body)' : undefined),
+});
 
 const SdkProviders: FC<
     PropsWithChildren<{
@@ -145,68 +226,170 @@ const Dashboard: FC<DashboardProps> = ({
     contentOverrides,
     onExplore,
     paletteUuid,
+    isEditMode,
+    onEditModeChange,
 }) => {
-    const [token, setToken] = useState<string | null>(null);
-    const [projectUuid, setProjectUuid] = useState<string | null>(null);
+    const tokenContext = useEmbedTokenContext(instanceUrl, tokenOrTokenPromise);
 
-    const handleDecodeToken = (tokenToDecode: string) => {
-        const { payload } = decodeJWT(tokenToDecode);
-
-        if (
-            payload &&
-            'content' in payload &&
-            'projectUuid' in payload.content
-        ) {
-            setToken(tokenToDecode);
-            setProjectUuid(payload.content.projectUuid);
-        } else {
-            throw new Error('Error decoding token');
-        }
-    };
-
-    useEffect(() => {
-        persistInstanceUrl(instanceUrl);
-
-        if (typeof tokenOrTokenPromise === 'string') {
-            handleDecodeToken(tokenOrTokenPromise);
-        } else {
-            tokenOrTokenPromise
-                .then((tokenToDecode) => {
-                    handleDecodeToken(tokenToDecode);
-                })
-                .catch((error) => {
-                    console.error(error);
-                    throw new Error('Error retrieving token');
-                });
-        }
-    }, [instanceUrl, tokenOrTokenPromise]);
-
-    if (!token || !projectUuid) {
+    if (!tokenContext) {
         return null;
     }
 
     return (
         <SdkProviders styles={styles} theme={theme}>
             <EmbedProvider
-                embedToken={token}
-                projectUuid={projectUuid}
+                embedToken={tokenContext.token}
+                projectUuid={tokenContext.projectUuid}
                 filters={filters}
                 paletteUuid={paletteUuid}
                 contentOverrides={contentOverrides}
                 onExplore={onExplore}
             >
                 <EmbedDashboard
-                    containerStyles={{
-                        width: '100%',
-                        height: '100%',
-                        position: 'relative',
-                        overflow: 'auto',
-                        backgroundColor:
-                            styles?.backgroundColor ??
-                            (theme
-                                ? 'var(--mantine-color-body)'
-                                : undefined),
-                    }}
+                    containerStyles={getDashboardContainerStyles(styles, theme)}
+                    isEditMode={isEditMode}
+                    onEditModeChange={onEditModeChange}
+                />
+            </EmbedProvider>
+        </SdkProviders>
+    );
+};
+
+const dashboardBuilderCreatePromises = new Map<
+    string,
+    Promise<EmbedDashboardType>
+>();
+
+const DashboardBuilderContent: FC<{
+    containerStyles?: React.CSSProperties;
+    isEditMode?: boolean;
+    onEditModeChange?: (isEditMode: boolean) => void;
+    onDashboardReady?: (dashboard: EmbedDashboardType) => void;
+}> = ({ containerStyles, isEditMode, onEditModeChange, onDashboardReady }) => {
+    const { content, embedToken, projectUuid, writeActions } = useEmbed();
+    const [dashboard, setDashboard] = useState<EmbedDashboardType>();
+    const [createDashboardError, setCreateDashboardError] = useState<
+        string | null
+    >(null);
+    const hasCreatedDashboard = useRef(false);
+    const { mutateAsync: createDashboard } = useCreateMutation(
+        projectUuid,
+        false,
+        { showToastOnSuccess: false },
+    );
+
+    useEffect(() => {
+        if (
+            hasCreatedDashboard.current ||
+            dashboard ||
+            !embedToken ||
+            !projectUuid ||
+            !writeActions?.spaceUuid
+        )
+            return;
+
+        hasCreatedDashboard.current = true;
+        setCreateDashboardError(null);
+
+        const createKey = `${projectUuid}:${writeActions.spaceUuid}:${
+            content?.type === 'dashboard' && 'dashboardUuid' in content
+                ? content.dashboardUuid
+                : ''
+        }`;
+        const createPromise =
+            dashboardBuilderCreatePromises.get(createKey) ??
+            createDashboard({
+                name: 'Untitled dashboard',
+                description: '',
+                spaceUuid: writeActions.spaceUuid,
+                tiles: [],
+                tabs: [],
+            }).then((createdDashboard) => createdDashboard as EmbedDashboardType);
+
+        dashboardBuilderCreatePromises.set(createKey, createPromise);
+
+        createPromise
+            .then((createdDashboard) => setDashboard(createdDashboard))
+            .catch((error) => {
+                console.error(error);
+                setCreateDashboardError(getErrorMessage(error));
+                hasCreatedDashboard.current = false;
+            })
+            .finally(() => {
+                dashboardBuilderCreatePromises.delete(createKey);
+            });
+    }, [
+        createDashboard,
+        content,
+        dashboard,
+        embedToken,
+        projectUuid,
+        writeActions?.spaceUuid,
+    ]);
+
+    useEffect(() => {
+        if (dashboard) {
+            onDashboardReady?.(dashboard);
+        }
+    }, [dashboard, onDashboardReady]);
+
+    if (createDashboardError) {
+        return (
+            <SuboptimalState
+                title="Unable to create dashboard"
+                description={createDashboardError}
+            />
+        );
+    }
+
+    if (!dashboard) {
+        return null;
+    }
+
+    return (
+        <EmbedDashboard
+            initialDashboard={dashboard}
+            containerStyles={containerStyles}
+            isEditMode={isEditMode}
+            onEditModeChange={onEditModeChange}
+        />
+    );
+};
+
+const DashboardBuilder: FC<DashboardBuilderProps> = ({
+    token: tokenOrTokenPromise,
+    instanceUrl,
+    styles,
+    theme,
+    filters,
+    contentOverrides,
+    onExplore,
+    paletteUuid,
+    isEditMode,
+    onEditModeChange,
+    onDashboardReady,
+}) => {
+    const tokenContext = useEmbedTokenContext(instanceUrl, tokenOrTokenPromise);
+
+    if (!tokenContext) {
+        return null;
+    }
+
+    return (
+        <SdkProviders styles={styles} theme={theme}>
+            <EmbedProvider
+                embedToken={tokenContext.token}
+                projectUuid={tokenContext.projectUuid}
+                filters={filters}
+                paletteUuid={paletteUuid}
+                contentOverrides={contentOverrides}
+                onExplore={onExplore}
+            >
+                <DashboardBuilderContent
+                    containerStyles={getDashboardContainerStyles(styles, theme)}
+                    isEditMode={isEditMode}
+                    onEditModeChange={onEditModeChange}
+                    onDashboardReady={onDashboardReady}
                 />
             </EmbedProvider>
         </SdkProviders>
@@ -365,9 +548,15 @@ const Chart: FC<Omit<BaseProps, 'filters' | 'onExplore'> & { id: string }> = ({
     );
 };
 
-const Lightdash = { Dashboard, Explore, Chart, FilterOperator };
+const Lightdash = {
+    Dashboard,
+    DashboardBuilder,
+    Explore,
+    Chart,
+    FilterOperator,
+};
 
 // ts-unused-exports:disable-next-line
-export { Chart, Dashboard, Explore, FilterOperator };
+export { Chart, Dashboard, DashboardBuilder, Explore, FilterOperator };
 // ts-unused-exports:disable-next-line
 export default Lightdash;

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -75,12 +75,15 @@ const finalizeHeaders = (
 };
 
 function finalizeUrl(url: string, embed: InMemoryEmbed | undefined): string {
-    if (embed?.projectUuid && !url.includes('projectUuid')) {
-        const separator = url.includes('?') ? '&' : '?';
-        url += `${separator}projectUuid=${encodeURIComponent(
-            embed.projectUuid,
-        )}`;
+    if (embed?.projectUuid) {
+        const parsedUrl = new URL(url, window.location.origin);
+
+        if (!parsedUrl.searchParams.has('projectUuid')) {
+            parsedUrl.searchParams.set('projectUuid', embed.projectUuid);
+            return parsedUrl.toString();
+        }
     }
+
     return url;
 }
 

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -40,6 +40,9 @@ type Props = {
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
     activeTabUuid?: string;
     dashboardTabs?: Dashboard['tabs'];
+    allowedTileTypes?: DashboardTileTypes[];
+    spaceUuid?: string;
+    maxSelectedValues?: number;
 } & Pick<ButtonProps, 'disabled' | 'radius'>;
 
 const AddTileButton: FC<Props> = ({
@@ -49,6 +52,9 @@ const AddTileButton: FC<Props> = ({
     activeTabUuid,
     dashboardTabs,
     radius,
+    allowedTileTypes,
+    spaceUuid,
+    maxSelectedValues,
 }) => {
     const [addTileType, setAddTileType] = useState<DashboardTileTypes>();
     const [isAddChartTilesModalOpen, setIsAddChartTilesModalOpen] =
@@ -64,6 +70,19 @@ const AddTileButton: FC<Props> = ({
     const { health } = useApp();
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const dataAppsEnabled = dataAppsFlag.data?.enabled === true;
+    const isTileTypeAllowed = useCallback(
+        (tileType: DashboardTileTypes) =>
+            !allowedTileTypes || allowedTileTypes.includes(tileType),
+        [allowedTileTypes],
+    );
+    const showSavedCharts = isTileTypeAllowed(DashboardTileTypes.SAVED_CHART);
+    const showNewChart = !allowedTileTypes;
+    const showDataApps =
+        dataAppsEnabled && isTileTypeAllowed(DashboardTileTypes.DATA_APP);
+    const showMarkdown = isTileTypeAllowed(DashboardTileTypes.MARKDOWN);
+    const showLoom = isTileTypeAllowed(DashboardTileTypes.LOOM);
+    const showTabs = !allowedTileTypes;
+    const showHeading = isTileTypeAllowed(DashboardTileTypes.HEADING);
 
     // Calculate current tiles in the active tab
     const currentTabTilesCount = useMemo(() => {
@@ -126,43 +145,51 @@ const AddTileButton: FC<Props> = ({
                     </Menu.Target>
                     <Menu.Dropdown>
                         <Menu.Label>Tiles</Menu.Label>
-                        <Menu.Item
-                            onClick={() => setIsAddChartTilesModalOpen(true)}
-                            leftSection={<MantineIcon icon={IconChartBar} />}
-                        >
-                            Saved chart
-                        </Menu.Item>
+                        {showSavedCharts && (
+                            <Menu.Item
+                                onClick={() =>
+                                    setIsAddChartTilesModalOpen(true)
+                                }
+                                leftSection={
+                                    <MantineIcon icon={IconChartBar} />
+                                }
+                            >
+                                Saved chart
+                            </Menu.Item>
+                        )}
 
-                        <Menu.Item
-                            onClick={() => {
-                                storeDashboard(
-                                    dashboardTiles,
-                                    dashboardFilters,
-                                    haveTilesChanged,
-                                    haveFiltersChanged,
-                                    dashboard?.uuid,
-                                    dashboard?.name,
-                                    activeTabUuid,
-                                    dashboardTabs,
-                                );
-                                void navigate(
-                                    `/projects/${projectUuid}/tables`,
-                                );
-                            }}
-                            leftSection={<MantineIcon icon={IconPlus} />}
-                        >
-                            <Group gap="xxs">
-                                <Text fz="sm">New chart</Text>
-                                <Tooltip label="Charts generated from here are exclusive to this dashboard">
-                                    <MantineIcon
-                                        icon={IconInfoCircle}
-                                        color="ldGray.6"
-                                    />
-                                </Tooltip>
-                            </Group>
-                        </Menu.Item>
+                        {showNewChart && (
+                            <Menu.Item
+                                onClick={() => {
+                                    storeDashboard(
+                                        dashboardTiles,
+                                        dashboardFilters,
+                                        haveTilesChanged,
+                                        haveFiltersChanged,
+                                        dashboard?.uuid,
+                                        dashboard?.name,
+                                        activeTabUuid,
+                                        dashboardTabs,
+                                    );
+                                    void navigate(
+                                        `/projects/${projectUuid}/tables`,
+                                    );
+                                }}
+                                leftSection={<MantineIcon icon={IconPlus} />}
+                            >
+                                <Group gap="xxs">
+                                    <Text fz="sm">New chart</Text>
+                                    <Tooltip label="Charts generated from here are exclusive to this dashboard">
+                                        <MantineIcon
+                                            icon={IconInfoCircle}
+                                            color="ldGray.6"
+                                        />
+                                    </Tooltip>
+                                </Group>
+                            </Menu.Item>
+                        )}
 
-                        {dataAppsEnabled && (
+                        {showDataApps && (
                             <Menu.Item
                                 onClick={() =>
                                     setAddTileType(DashboardTileTypes.DATA_APP)
@@ -175,42 +202,56 @@ const AddTileButton: FC<Props> = ({
                             </Menu.Item>
                         )}
 
-                        <Menu.Item
-                            onClick={() =>
-                                setAddTileType(DashboardTileTypes.MARKDOWN)
-                            }
-                            leftSection={<MantineIcon icon={IconMarkdown} />}
-                        >
-                            Markdown
-                        </Menu.Item>
+                        {showMarkdown && (
+                            <Menu.Item
+                                onClick={() =>
+                                    setAddTileType(DashboardTileTypes.MARKDOWN)
+                                }
+                                leftSection={
+                                    <MantineIcon icon={IconMarkdown} />
+                                }
+                            >
+                                Markdown
+                            </Menu.Item>
+                        )}
 
-                        <Menu.Item
-                            onClick={() =>
-                                setAddTileType(DashboardTileTypes.LOOM)
-                            }
-                            leftSection={<MantineIcon icon={IconVideo} />}
-                        >
-                            Loom video
-                        </Menu.Item>
+                        {showLoom && (
+                            <Menu.Item
+                                onClick={() =>
+                                    setAddTileType(DashboardTileTypes.LOOM)
+                                }
+                                leftSection={<MantineIcon icon={IconVideo} />}
+                            >
+                                Loom video
+                            </Menu.Item>
+                        )}
 
-                        <Menu.Divider />
+                        {(showTabs || showHeading) && <Menu.Divider />}
 
-                        <Menu.Label>Elements</Menu.Label>
-                        <Menu.Item
-                            onClick={() => setAddingTab(true)}
-                            leftSection={<MantineIcon icon={IconNewSection} />}
-                        >
-                            Tab
-                        </Menu.Item>
+                        {(showTabs || showHeading) && (
+                            <Menu.Label>Elements</Menu.Label>
+                        )}
+                        {showTabs && (
+                            <Menu.Item
+                                onClick={() => setAddingTab(true)}
+                                leftSection={
+                                    <MantineIcon icon={IconNewSection} />
+                                }
+                            >
+                                Tab
+                            </Menu.Item>
+                        )}
 
-                        <Menu.Item
-                            onClick={() =>
-                                setAddTileType(DashboardTileTypes.HEADING)
-                            }
-                            leftSection={<MantineIcon icon={IconHeading} />}
-                        >
-                            Heading
-                        </Menu.Item>
+                        {showHeading && (
+                            <Menu.Item
+                                onClick={() =>
+                                    setAddTileType(DashboardTileTypes.HEADING)
+                                }
+                                leftSection={<MantineIcon icon={IconHeading} />}
+                            >
+                                Heading
+                            </Menu.Item>
+                        )}
                     </Menu.Dropdown>
                 </Menu>
             ) : canAddTab ? (
@@ -248,6 +289,8 @@ const AddTileButton: FC<Props> = ({
                 <AddChartTilesModal
                     onClose={() => setIsAddChartTilesModalOpen(false)}
                     onAddTiles={onAddTiles}
+                    spaceUuid={spaceUuid}
+                    maxSelectedValues={maxSelectedValues}
                 />
             )}
 

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -22,6 +22,7 @@ import {
     type ApiChartAndResults,
     type ApiError,
     type Dashboard,
+    type QueryExecutionContext,
     type DashboardFilterRule,
     type EChartsSeries,
     type Field,
@@ -2117,6 +2118,7 @@ type DashboardChartTileProps = Omit<
     dashboardChartReadyQuery?: DashboardChartReadyQuery;
     resultsData?: InfiniteQueryResults;
     onExplore?: (options: { chart: SavedChart }) => void;
+    queryContextOverride?: QueryExecutionContext;
 };
 
 // Abstraction needed for enterprise version
@@ -2321,6 +2323,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
     const readyQuery = useDashboardChartReadyQuery(
         props.tile.uuid,
         props.tile.properties?.savedChartUuid,
+        props.queryContextOverride,
     );
 
     // Use fresh chart data from useSavedQuery to keep dashboard tiles aligned

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -46,6 +46,8 @@ interface Props extends Pick<
      * tile membership) instead of the registered chart endpoints.
      */
     isEmbed?: boolean;
+    projectUuidOverride?: string;
+    dashboardUuidOverride?: string;
 }
 
 /**
@@ -74,12 +76,21 @@ const DashboardOptions = memo(
     ),
 );
 
-const SqlChartTile: FC<Props> = ({ tile, isEditMode, isEmbed, ...rest }) => {
+const SqlChartTile: FC<Props> = ({
+    tile,
+    isEditMode,
+    isEmbed,
+    projectUuidOverride,
+    dashboardUuidOverride,
+    ...rest
+}) => {
     const { user } = useApp();
     const { projectUuid, dashboardUuid } = useParams<{
         projectUuid: string;
         dashboardUuid: string;
     }>();
+    const effectiveProjectUuid = projectUuidOverride ?? projectUuid;
+    const effectiveDashboardUuid = dashboardUuidOverride ?? dashboardUuid;
     const context = useSearchParams('context') || undefined;
     const savedSqlUuid = tile.properties.savedSqlUuid || undefined;
     const [isDataExportModalOpen, setIsDataExportModalOpen] = useState(false);
@@ -87,7 +98,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, isEmbed, ...rest }) => {
         'manage',
         subject('SqlRunner', {
             organizationUuid: user.data?.organizationUuid,
-            projectUuid,
+            projectUuid: effectiveProjectUuid,
         }),
     );
     const updateSqlChartTilesMetadata = useDashboardTileStatusContext(
@@ -123,7 +134,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, isEmbed, ...rest }) => {
     } = useSavedSqlChartResults(
         isEmbed
             ? {
-                  projectUuid,
+                  projectUuid: effectiveProjectUuid,
                   savedSqlUuid,
                   context,
                   tileUuid: tile.uuid,
@@ -133,10 +144,10 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, isEmbed, ...rest }) => {
                   isEmbed: true,
               }
             : {
-                  projectUuid,
+                  projectUuid: effectiveProjectUuid,
                   savedSqlUuid,
                   context,
-                  dashboardUuid: dashboardUuid!,
+                  dashboardUuid: effectiveDashboardUuid!,
                   tileUuid: tile.uuid,
                   dashboardFilters,
                   dashboardSorts: [],
@@ -243,14 +254,14 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, isEmbed, ...rest }) => {
                 hasError={!!chartResultsError}
                 chartKind={chartData.config.type}
                 {...rest}
-                titleHref={`/projects/${projectUuid}/sql-runner/${chartData.slug}`}
+                titleHref={`/projects/${effectiveProjectUuid}/sql-runner/${chartData.slug}`}
                 extraMenuItems={
-                    projectUuid &&
+                    effectiveProjectUuid &&
                     canManageSqlRunner &&
                     chartData.slug && (
                         <DashboardOptions
                             isEditMode={isEditMode}
-                            projectUuid={projectUuid}
+                            projectUuid={effectiveProjectUuid}
                             slug={chartData.slug}
                         />
                     )
@@ -275,20 +286,20 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, isEmbed, ...rest }) => {
         <TileBase
             isEditMode={isEditMode}
             chartName={tile.properties.chartName ?? ''}
-            titleHref={`/projects/${projectUuid}/sql-runner/${chartData.slug}`}
+            titleHref={`/projects/${effectiveProjectUuid}/sql-runner/${chartData.slug}`}
             tile={tile}
             title={tile.properties.title || tile.properties.chartName || ''}
             chartKind={chartData.config.type}
             fullWidth={chartData.config.type === ChartKind.TABLE}
             {...rest}
             extraMenuItems={
-                projectUuid &&
+                effectiveProjectUuid &&
                 (canManageSqlRunner || userCanExportData) && (
                     <>
                         {canManageSqlRunner && (
                             <DashboardOptions
                                 isEditMode={isEditMode}
-                                projectUuid={projectUuid}
+                                projectUuid={effectiveProjectUuid}
                                 slug={chartData.slug}
                             />
                         )}
@@ -333,7 +344,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, isEmbed, ...rest }) => {
             <ExportDataModal
                 isOpen={isDataExportModalOpen}
                 onClose={closeDataExportModal}
-                projectUuid={projectUuid!}
+                projectUuid={effectiveProjectUuid!}
                 totalResults={
                     chartResultsData.chartUnderlyingData?.rows.length ?? 0
                 }

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -41,6 +41,8 @@ type Props = {
         tileUuidMapping?: Record<string, string>,
     ) => void;
     onClose: () => void;
+    spaceUuid?: string;
+    maxSelectedValues?: number;
 };
 
 interface ItemProps extends React.ComponentPropsWithoutRef<'div'> {
@@ -96,8 +98,17 @@ const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
     ),
 );
 
-const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+const AddChartTilesModal: FC<Props> = ({
+    onAddTiles,
+    onClose,
+    spaceUuid,
+    maxSelectedValues,
+}) => {
+    const { projectUuid: projectUuidFromParams } = useParams<{
+        projectUuid: string;
+    }>();
+    const projectUuidFromContext = useDashboardContext((c) => c.projectUuid);
+    const projectUuid = projectUuidFromParams ?? projectUuidFromContext;
     const [searchQuery, setSearchQuery] = useState<string>('');
     const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 300);
     const {
@@ -109,6 +120,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
     } = useChartSummariesV2(
         {
             projectUuid,
+            spaceUuid,
             page: 1,
             pageSize: 25,
             search: debouncedSearchQuery,
@@ -127,8 +139,8 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
         );
     }, [chartPages?.pages]);
 
-    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const dashboard = useDashboardContext((c) => c.dashboard);
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
 
     const form = useForm({
         initialValues: {
@@ -198,7 +210,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
     );
 
     const allSavedCharts = useMemo(() => {
-        const reorderedCharts = savedQueries?.sort((chartA, chartB) => {
+        const reorderedCharts = [...savedQueries].sort((chartA, chartB) => {
             if (
                 chartA.space.uuid === chartB.space.uuid &&
                 !!chartA.lastUpdatedAt &&
@@ -214,7 +226,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
             }
         });
 
-        return (reorderedCharts || []).map((chart) => {
+        return reorderedCharts.map((chart) => {
             const { uuid, name, space, chartKind } = chart;
             const isAlreadyAdded = dashboardTiles?.find((tile) => {
                 return (
@@ -285,7 +297,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
         onClose();
     });
 
-    if (!savedQueries || !dashboardTiles || isInitialLoading) return null;
+    if (!dashboardTiles || isInitialLoading) return null;
 
     return (
         <MantineModal
@@ -297,8 +309,8 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
             modalRootProps={{ closeOnClickOutside: false }}
             actions={
                 <Button
-                    type="submit"
-                    form="add-saved-charts-to-dashboard"
+                    type="button"
+                    onClick={() => handleSubmit()}
                     disabled={
                         isInitialLoading ||
                         form.values.savedChartsUuids.length === 0
@@ -352,6 +364,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                     searchValue={searchQuery}
                     onSearchChange={setSearchQuery}
                     maxDropdownHeight={300}
+                    maxSelectedValues={maxSelectedValues}
                     rightSection={
                         isFetching && <Loader size="xs" color="gray" />
                     }

--- a/packages/frontend/src/components/DataViz/hooks/useTableDataModel.ts
+++ b/packages/frontend/src/components/DataViz/hooks/useTableDataModel.ts
@@ -34,22 +34,23 @@ export const useTableDataModel = ({
         });
     }, [resultsRunner, config]);
 
+    const columnsConfig = useMemo(() => tableModel.getConfig(), [tableModel]);
     const columns = useMemo(() => tableModel.getVisibleColumns(), [tableModel]);
     const rows = useMemo(() => tableModel.getRows(), [tableModel]);
 
     // Calculate stats for columns with bar display style
     const columnStats = useMemo(() => {
-        if (!config?.columns) return {};
+        if (!columnsConfig) return {};
 
         // Find columns that need bar chart display
         const barColumns = columns.filter(
-            (col) => config?.columns?.[col]?.displayStyle === 'bar',
+            (col) => columnsConfig[col]?.displayStyle === 'bar',
         );
 
         if (barColumns.length === 0) return {};
 
         return calculateColumnStats(rows, barColumns);
-    }, [rows, columns, config?.columns]);
+    }, [rows, columns, columnsConfig]);
 
     const [setResizeRef, containerRect] = useResizeObserver<HTMLDivElement>();
     const scrollElementRef = useRef<HTMLDivElement | null>(null);
@@ -71,10 +72,10 @@ export const useTableDataModel = ({
             // we found the fix here -> https://github.com/TanStack/table/issues/1671
             // do not remove the line below
             accessorFn: TableDataModel.getColumnsAccessorFn(column),
-            header: config?.columns[column].label || column,
+            header: columnsConfig?.[column]?.label || column,
             cell: enableJsonViewer ? getJsonValueCell : getValueCell,
         }));
-    }, [columns, config?.columns, enableJsonViewer]);
+    }, [columns, columnsConfig, enableJsonViewer]);
 
     const table = useReactTable({
         data: rows,
@@ -82,7 +83,7 @@ export const useTableDataModel = ({
         getCoreRowModel: getCoreRowModel(),
         meta: {
             columnStats,
-            columnsConfig: config?.columns ?? undefined,
+            columnsConfig: columnsConfig ?? undefined,
         },
     });
 

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -1,24 +1,35 @@
 import {
-    assertUnreachable,
     DashboardTileTypes,
+    QueryExecutionContext,
+    assertUnreachable,
     type DashboardTile,
+    type EmbedDashboard as EmbedDashboardType,
 } from '@lightdash/common';
-import { Group, Tabs } from '@mantine-8/core';
-import { IconUnlink } from '@tabler/icons-react';
-import { useEffect, useMemo, type FC } from 'react';
+import { Button, Group, Tabs, TextInput } from '@mantine-8/core';
+import { IconCheck, IconPencil, IconUnlink, IconX } from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import { useLocation, useNavigate } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
 import { LockedDashboardModal } from '../../../../../components/common/modal/LockedDashboardModal';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
+import AddTileButton from '../../../../../components/DashboardTiles/AddTileButton';
+import DashboardChartTile from '../../../../../components/DashboardTiles/DashboardChartTile';
 import LoomTile from '../../../../../components/DashboardTiles/DashboardLoomTile';
 import SqlChartTile from '../../../../../components/DashboardTiles/DashboardSqlChartTile';
 import {
+    convertLayoutToBaseCoordinates,
+    GRID_CONTAINER_PADDING,
     getReactGridLayoutConfig,
     getResponsiveGridLayoutProps,
     type ResponsiveGridLayoutProps,
 } from '../../../../../features/dashboardTabs/gridUtils';
 // eslint-disable-next-line css-modules/no-unused-class
 import tabStyles from '../../../../../features/dashboardTabs/tabs.module.css';
+import {
+    appendNewTilesToBottom,
+    useUpdateDashboard,
+} from '../../../../../hooks/dashboard/useDashboard';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
 import useEmbed from '../../../../providers/Embed/useEmbed';
 import { useEmbedDashboard } from '../hooks';
@@ -31,6 +42,12 @@ import '../../../../../styles/react-grid.css';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
+const EMBED_EDIT_TILE_TYPES = [
+    DashboardTileTypes.SAVED_CHART,
+    DashboardTileTypes.MARKDOWN,
+    DashboardTileTypes.HEADING,
+];
+
 const EmbedDashboardGrid: FC<{
     filteredTiles: DashboardTile[];
     layouts: { lg: Layout[]; md: Layout[]; sm: Layout[] };
@@ -41,6 +58,12 @@ const EmbedDashboardGrid: FC<{
     hasRequiredDashboardFiltersToSet: boolean;
     isTabEmpty?: boolean;
     gridProps: ResponsiveGridLayoutProps;
+    isEditMode: boolean;
+    onLayoutChange: (layout: Layout[]) => void;
+    onBreakpointChange: (cols: number) => void;
+    onDeleteTile: (tile: DashboardTile) => void;
+    onEditTile: (tile: DashboardTile) => void;
+    useDashboardEditorTileQueries: boolean;
 }> = ({
     filteredTiles,
     layouts,
@@ -51,6 +74,12 @@ const EmbedDashboardGrid: FC<{
     hasRequiredDashboardFiltersToSet,
     isTabEmpty,
     gridProps,
+    isEditMode,
+    onLayoutChange,
+    onBreakpointChange,
+    onDeleteTile,
+    onEditTile,
+    useDashboardEditorTileQueries,
 }) => (
     <Group grow pt="sm" px="xs">
         {isTabEmpty ? (
@@ -66,110 +95,230 @@ const EmbedDashboardGrid: FC<{
                 />
             </div>
         ) : (
-            <ResponsiveGridLayout
-                {...gridProps}
-                layouts={layouts}
-                className={`react-grid-layout-dashboard ${
-                    hasRequiredDashboardFiltersToSet ? 'locked' : ''
-                }`}
-            >
-                {filteredTiles.map((tile, index) => (
-                    <div key={tile.uuid}>
-                        {tile.type === DashboardTileTypes.SAVED_CHART ? (
-                            <EmbedDashboardChartTile
-                                projectUuid={projectUuid}
-                                dashboardSlug={dashboard.slug}
-                                paletteColors={paletteColors}
-                                paletteDarkColors={paletteDarkColors}
-                                key={tile.uuid}
-                                minimal
-                                tile={tile}
-                                isEditMode={false}
-                                onDelete={() => {}}
-                                onEdit={() => {}}
-                                canExportCsv={dashboard.canExportCsv}
-                                canExportImages={dashboard.canExportImages}
-                                canViewExplore={dashboard.canExplore}
-                                locked={hasRequiredDashboardFiltersToSet}
-                                tileIndex={index}
-                            />
-                        ) : tile.type === DashboardTileTypes.MARKDOWN ? (
-                            <EmbedMarkdownTile
-                                key={tile.uuid}
-                                tile={tile}
-                                isEditMode={false}
-                                onDelete={() => {}}
-                                onEdit={() => {}}
-                                tileIndex={index}
-                                dashboardSlug={dashboard.slug}
-                            />
-                        ) : tile.type === DashboardTileTypes.LOOM ? (
-                            <LoomTile
-                                key={tile.uuid}
-                                tile={tile}
-                                isEditMode={false}
-                                onDelete={() => {}}
-                                onEdit={() => {}}
-                            />
-                        ) : tile.type === DashboardTileTypes.SQL_CHART ? (
-                            <SqlChartTile
-                                key={tile.uuid}
-                                tile={tile}
-                                isEditMode={false}
-                                onDelete={() => {}}
-                                onEdit={() => {}}
-                                isEmbed
-                            />
-                        ) : tile.type === DashboardTileTypes.HEADING ? (
-                            <EmbedHeadingTile
-                                key={tile.uuid}
-                                tile={tile}
-                                isEditMode={false}
-                                onDelete={() => {}}
-                                onEdit={() => {}}
-                                tileIndex={index}
-                                dashboardSlug={dashboard.slug}
-                            />
-                        ) : tile.type === DashboardTileTypes.DATA_APP ? (
-                            <EmbedDataAppTile
-                                key={tile.uuid}
-                                tile={tile}
-                                projectUuid={projectUuid}
-                            />
-                        ) : (
-                            assertUnreachable(
-                                tile,
-                                `Dashboard tile type is not recognised`,
-                            )
-                        )}
-                    </div>
-                ))}
-            </ResponsiveGridLayout>
+            <div className={tabStyles.tabGridContainer}>
+                <ResponsiveGridLayout
+                    {...gridProps}
+                    layouts={layouts}
+                    containerPadding={GRID_CONTAINER_PADDING}
+                    onDragStop={onLayoutChange}
+                    onResizeStop={onLayoutChange}
+                    onBreakpointChange={(_, cols) => onBreakpointChange(cols)}
+                    className={`react-grid-layout-dashboard ${
+                        hasRequiredDashboardFiltersToSet ? 'locked' : ''
+                    }`}
+                >
+                    {filteredTiles.map((tile, index) => (
+                        <div key={tile.uuid} data-tile-uuid={tile.uuid}>
+                            {tile.type === DashboardTileTypes.SAVED_CHART ? (
+                                useDashboardEditorTileQueries ? (
+                                    <DashboardChartTile
+                                        key={tile.uuid}
+                                        minimal
+                                        tile={tile}
+                                        isEditMode={isEditMode}
+                                        onDelete={() => onDeleteTile(tile)}
+                                        onEdit={onEditTile}
+                                        canExportCsv={dashboard.canExportCsv}
+                                        canExportImages={
+                                            dashboard.canExportImages
+                                        }
+                                        canViewExplore={dashboard.canExplore}
+                                        queryContextOverride={
+                                            QueryExecutionContext.DASHBOARD
+                                        }
+                                        colorPaletteOverride={paletteColors}
+                                        darkColorPaletteOverride={
+                                            paletteDarkColors
+                                        }
+                                    />
+                                ) : (
+                                    <EmbedDashboardChartTile
+                                        projectUuid={projectUuid}
+                                        dashboardSlug={dashboard.slug}
+                                        paletteColors={paletteColors}
+                                        paletteDarkColors={paletteDarkColors}
+                                        key={tile.uuid}
+                                        minimal
+                                        tile={tile}
+                                        isEditMode={isEditMode}
+                                        onDelete={() => onDeleteTile(tile)}
+                                        onEdit={onEditTile}
+                                        canExportCsv={dashboard.canExportCsv}
+                                        canExportImages={
+                                            dashboard.canExportImages
+                                        }
+                                        canViewExplore={dashboard.canExplore}
+                                        locked={
+                                            hasRequiredDashboardFiltersToSet
+                                        }
+                                        tileIndex={index}
+                                    />
+                                )
+                            ) : tile.type === DashboardTileTypes.MARKDOWN ? (
+                                <EmbedMarkdownTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={isEditMode}
+                                    onDelete={() => onDeleteTile(tile)}
+                                    onEdit={onEditTile}
+                                    tileIndex={index}
+                                    dashboardSlug={dashboard.slug}
+                                />
+                            ) : tile.type === DashboardTileTypes.LOOM ? (
+                                <LoomTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={isEditMode}
+                                    onDelete={() => onDeleteTile(tile)}
+                                    onEdit={onEditTile}
+                                />
+                            ) : tile.type === DashboardTileTypes.SQL_CHART ? (
+                                <SqlChartTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={isEditMode}
+                                    onDelete={() => onDeleteTile(tile)}
+                                    onEdit={onEditTile}
+                                    isEmbed={!useDashboardEditorTileQueries}
+                                    projectUuidOverride={projectUuid}
+                                    dashboardUuidOverride={dashboard.uuid}
+                                />
+                            ) : tile.type === DashboardTileTypes.HEADING ? (
+                                <EmbedHeadingTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={isEditMode}
+                                    onDelete={() => onDeleteTile(tile)}
+                                    onEdit={onEditTile}
+                                    tileIndex={index}
+                                    dashboardSlug={dashboard.slug}
+                                />
+                            ) : tile.type === DashboardTileTypes.DATA_APP ? (
+                                <EmbedDataAppTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    projectUuid={projectUuid}
+                                />
+                            ) : (
+                                assertUnreachable(
+                                    tile,
+                                    `Dashboard tile type is not recognised`,
+                                )
+                            )}
+                        </div>
+                    ))}
+                </ResponsiveGridLayout>
+            </div>
         )}
     </Group>
 );
 
 const EmbedDashboard: FC<{
     containerStyles?: React.CSSProperties;
-}> = ({ containerStyles }) => {
+    initialDashboard?: EmbedDashboardType;
+    isEditMode?: boolean;
+    onEditModeChange?: (isEditMode: boolean) => void;
+}> = ({
+    containerStyles,
+    initialDashboard,
+    isEditMode: controlledIsEditMode,
+    onEditModeChange,
+}) => {
     const projectUuid = useDashboardContext((c) => c.projectUuid);
     const activeTab = useDashboardContext((c) => c.activeTab);
     const setActiveTab = useDashboardContext((c) => c.setActiveTab);
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
+    const setHaveTilesChanged = useDashboardContext(
+        (c) => c.setHaveTilesChanged,
+    );
+    const haveTilesChanged = useDashboardContext((c) => c.haveTilesChanged);
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const dashboardTemporaryFilters = useDashboardContext(
+        (c) => c.dashboardTemporaryFilters,
+    );
+    const haveFiltersChanged = useDashboardContext((c) => c.haveFiltersChanged);
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
+    const setHaveTabsChanged = useDashboardContext((c) => c.setHaveTabsChanged);
+    const haveTabsChanged = useDashboardContext((c) => c.haveTabsChanged);
 
-    const { embedToken, mode, paletteUuid } = useEmbed();
+    const { embedToken, mode, paletteUuid, writeActions } = useEmbed();
     const navigate = useNavigate();
     const { pathname, search } = useLocation();
+    const [localDashboard, setLocalDashboard] = useState<
+        EmbedDashboardType | undefined
+    >(initialDashboard);
+    const [uncontrolledIsEditMode, setUncontrolledIsEditMode] = useState(false);
+    const isEditModeControlled = controlledIsEditMode !== undefined;
+    const isEditMode = controlledIsEditMode ?? uncontrolledIsEditMode;
+    const setIsEditMode = useCallback(
+        (nextIsEditMode: boolean) => {
+            if (!isEditModeControlled) {
+                setUncontrolledIsEditMode(nextIsEditMode);
+            }
+            onEditModeChange?.(nextIsEditMode);
+        },
+        [isEditModeControlled, onEditModeChange],
+    );
+    const [draftDashboardName, setDraftDashboardName] = useState(
+        initialDashboard?.name ?? '',
+    );
+    const [currentCols, setCurrentCols] = useState(
+        getResponsiveGridLayoutProps().cols.lg,
+    );
 
     if (!embedToken) {
         throw new Error('Embed token is required');
     }
 
-    const { data: dashboard, error: dashboardError } = useEmbedDashboard(
+    const { data: fetchedDashboard, error: dashboardError } = useEmbedDashboard(
         projectUuid,
         paletteUuid,
+        !initialDashboard,
+    );
+
+    useEffect(() => {
+        if (initialDashboard) {
+            setLocalDashboard(initialDashboard);
+        }
+    }, [initialDashboard]);
+
+    useEffect(() => {
+        if (fetchedDashboard) {
+            setLocalDashboard(fetchedDashboard);
+        }
+    }, [fetchedDashboard]);
+
+    const dashboard = localDashboard;
+
+    const handleDashboardUpdateSuccess = useCallback(
+        (updatedDashboard: EmbedDashboardType) => {
+            setLocalDashboard((currentDashboard) => ({
+                ...currentDashboard,
+                ...updatedDashboard,
+            }));
+            setDashboardTiles(updatedDashboard.tiles);
+            setDashboardTabs(updatedDashboard.tabs);
+            setDraftDashboardName(updatedDashboard.name);
+            setHaveTilesChanged(false);
+            setHaveTabsChanged(false);
+            setIsEditMode(false);
+        },
+        [
+            setDashboardTabs,
+            setDashboardTiles,
+            setHaveTabsChanged,
+            setHaveTilesChanged,
+            setIsEditMode,
+        ],
+    );
+
+    const { mutate: updateDashboard, isLoading: isSaving } = useUpdateDashboard(
+        dashboard?.uuid,
+        projectUuid,
+        false,
+        handleDashboardUpdateSuccess,
     );
 
     useEffect(() => {
@@ -177,6 +326,12 @@ const EmbedDashboard: FC<{
             setDashboardTiles(dashboard.tiles);
         }
     }, [dashboard, setDashboardTiles]);
+
+    useEffect(() => {
+        if (!dashboard || isEditMode) return;
+
+        setDraftDashboardName(dashboard.name);
+    }, [dashboard, isEditMode]);
 
     const setEmbedDashboard = useDashboardContext((c) => c.setEmbedDashboard);
     useEffect(() => {
@@ -190,13 +345,17 @@ const EmbedDashboard: FC<{
 
     const hasRequiredDashboardFiltersToSet =
         requiredDashboardFilters.length > 0;
+    const currentDashboardTiles = useMemo(
+        () => dashboardTiles ?? dashboard?.tiles ?? [],
+        [dashboard?.tiles, dashboardTiles],
+    );
     const hasChartTiles =
         useMemo(
             () =>
-                dashboard?.tiles.some(
+                currentDashboardTiles.some(
                     (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
                 ),
-            [dashboard],
+            [currentDashboardTiles],
         ) || false;
 
     // Ensure dashboard tabs are set in context
@@ -215,14 +374,10 @@ const EmbedDashboard: FC<{
 
     // Filter tiles by active tab
     const filteredTiles = useMemo(() => {
-        if (!dashboard?.tiles) {
-            return [];
-        }
-
         const hiddenTabUuids = new Set(
             dashboardTabs.filter((t) => t.hidden).map((t) => t.uuid),
         );
-        const tilesOnVisibleTabs = dashboard.tiles.filter(
+        const tilesOnVisibleTabs = currentDashboardTiles.filter(
             (tile) => !tile.tabUuid || !hiddenTabUuids.has(tile.tabUuid),
         );
 
@@ -249,7 +404,7 @@ const EmbedDashboard: FC<{
         }
 
         return [];
-    }, [dashboard?.tiles, dashboardTabs, visibleTabs, activeTab]);
+    }, [currentDashboardTiles, dashboardTabs, visibleTabs, activeTab]);
 
     // Check if tabs should be enabled (more than one visible tab)
     const tabsEnabled = visibleTabs.length > 1;
@@ -258,17 +413,167 @@ const EmbedDashboard: FC<{
     const layouts = useMemo(
         () => ({
             lg: filteredTiles.map<Layout>((tile) =>
-                getReactGridLayoutConfig(tile, false, gridProps.cols.lg),
+                getReactGridLayoutConfig(tile, isEditMode, gridProps.cols.lg),
             ),
             md: filteredTiles.map<Layout>((tile) =>
-                getReactGridLayoutConfig(tile, false, gridProps.cols.md),
+                getReactGridLayoutConfig(tile, isEditMode, gridProps.cols.md),
             ),
             sm: filteredTiles.map<Layout>((tile) =>
-                getReactGridLayoutConfig(tile, false, gridProps.cols.sm),
+                getReactGridLayoutConfig(tile, isEditMode, gridProps.cols.sm),
             ),
         }),
-        [filteredTiles, gridProps.cols],
+        [filteredTiles, gridProps.cols, isEditMode],
     );
+
+    const canWriteDashboard =
+        !!writeActions && dashboard?.spaceUuid === writeActions.spaceUuid;
+    const hasDashboardNameChanged =
+        !!dashboard && draftDashboardName.trim() !== dashboard.name;
+    const hasDashboardChanged =
+        hasDashboardNameChanged ||
+        haveTilesChanged ||
+        haveFiltersChanged ||
+        haveTabsChanged;
+
+    const handleLayoutChange = useCallback(
+        (layout: Layout[]) => {
+            const unscaledLayout = convertLayoutToBaseCoordinates(
+                layout,
+                currentCols,
+            );
+
+            const nextTiles = currentDashboardTiles.map((tile) => {
+                const layoutTile = unscaledLayout.find(
+                    ({ i }) => i === tile.uuid,
+                );
+                if (!layoutTile) {
+                    return tile;
+                }
+                return {
+                    ...tile,
+                    x: layoutTile.x,
+                    y: layoutTile.y,
+                    h: layoutTile.h,
+                    w: layoutTile.w,
+                };
+            });
+            setDashboardTiles(nextTiles);
+            setHaveTilesChanged(true);
+        },
+        [
+            currentCols,
+            currentDashboardTiles,
+            setDashboardTiles,
+            setHaveTilesChanged,
+        ],
+    );
+
+    const handleAddTiles = useCallback(
+        (tiles: DashboardTile[]) => {
+            const tilesToAdd =
+                tabsEnabled && activeTab
+                    ? tiles.map((tile) => ({
+                          ...tile,
+                          tabUuid: activeTab.uuid,
+                      }))
+                    : tiles;
+            const nextTiles = appendNewTilesToBottom(
+                currentDashboardTiles,
+                tilesToAdd,
+            );
+            setDashboardTiles(nextTiles);
+            setHaveTilesChanged(true);
+        },
+        [
+            activeTab,
+            currentDashboardTiles,
+            tabsEnabled,
+            setDashboardTiles,
+            setHaveTilesChanged,
+        ],
+    );
+
+    const handleDeleteTile = useCallback(
+        (tile: DashboardTile) => {
+            const nextTiles = currentDashboardTiles.filter(
+                (dashboardTile) => dashboardTile.uuid !== tile.uuid,
+            );
+            setDashboardTiles(nextTiles);
+            setHaveTilesChanged(true);
+        },
+        [currentDashboardTiles, setDashboardTiles, setHaveTilesChanged],
+    );
+
+    const handleEditTile = useCallback(
+        (updatedTile: DashboardTile) => {
+            const nextTiles = currentDashboardTiles.map((tile) =>
+                tile.uuid === updatedTile.uuid ? updatedTile : tile,
+            );
+            setDashboardTiles(nextTiles);
+            setHaveTilesChanged(true);
+        },
+        [currentDashboardTiles, setDashboardTiles, setHaveTilesChanged],
+    );
+
+    const resetDashboardDraft = useCallback(() => {
+        if (!dashboard) return;
+        setDashboardTiles(dashboard.tiles);
+        setDashboardTabs(dashboard.tabs);
+        setDraftDashboardName(dashboard.name);
+        setHaveTilesChanged(false);
+        setHaveTabsChanged(false);
+    }, [
+        dashboard,
+        setDashboardTabs,
+        setDashboardTiles,
+        setHaveTabsChanged,
+        setHaveTilesChanged,
+    ]);
+
+    useEffect(() => {
+        if (!isEditMode) {
+            resetDashboardDraft();
+        }
+    }, [isEditMode, resetDashboardDraft]);
+
+    const handleCancel = useCallback(() => {
+        resetDashboardDraft();
+        setIsEditMode(false);
+    }, [resetDashboardDraft, setIsEditMode]);
+
+    const handleSaveDashboard = useCallback(() => {
+        if (!dashboard) return;
+
+        updateDashboard({
+            tiles: currentDashboardTiles,
+            filters: {
+                dimensions: [
+                    ...dashboardFilters.dimensions,
+                    ...dashboardTemporaryFilters.dimensions,
+                ],
+                metrics: [
+                    ...dashboardFilters.metrics,
+                    ...dashboardTemporaryFilters.metrics,
+                ],
+                tableCalculations: [
+                    ...dashboardFilters.tableCalculations,
+                    ...dashboardTemporaryFilters.tableCalculations,
+                ],
+            },
+            name: draftDashboardName.trim() || dashboard.name,
+            tabs: dashboardTabs,
+            config: dashboard.config,
+            parameters: dashboard.parameters,
+        });
+    }, [
+        dashboard,
+        dashboardFilters,
+        dashboardTabs,
+        dashboardTemporaryFilters,
+        draftDashboardName,
+        currentDashboardTiles,
+        updateDashboard,
+    ]);
 
     if (!projectUuid) {
         return (
@@ -297,17 +602,6 @@ const EmbedDashboard: FC<{
         return (
             <div style={{ marginTop: '20px' }}>
                 <SuboptimalState title="Loading..." loading />
-            </div>
-        );
-    }
-
-    if (dashboard.tiles.length === 0) {
-        return (
-            <div style={{ marginTop: '20px' }}>
-                <SuboptimalState
-                    title="Empty dashboard"
-                    description="This dashboard has no tiles"
-                />
             </div>
         );
     }
@@ -344,6 +638,89 @@ const EmbedDashboard: FC<{
         }
     };
 
+    const renderEditControls = () => {
+        if (!canWriteDashboard) return null;
+
+        if (!isEditMode) {
+            if (isEditModeControlled) return null;
+
+            return (
+                <Button
+                    size="xs"
+                    variant="default"
+                    leftSection={<MantineIcon icon={IconPencil} />}
+                    onClick={() => setIsEditMode(true)}
+                >
+                    Edit
+                </Button>
+            );
+        }
+
+        return (
+            <Group gap="xs">
+                <AddTileButton
+                    onAddTiles={handleAddTiles}
+                    setAddingTab={() => undefined}
+                    activeTabUuid={activeTab?.uuid}
+                    dashboardTabs={dashboardTabs}
+                    allowedTileTypes={EMBED_EDIT_TILE_TYPES}
+                    spaceUuid={writeActions?.spaceUuid}
+                    maxSelectedValues={1}
+                    disabled={isSaving}
+                />
+                <Button
+                    size="xs"
+                    variant="default"
+                    leftSection={<MantineIcon icon={IconX} />}
+                    onClick={handleCancel}
+                    disabled={isSaving}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    size="xs"
+                    leftSection={<MantineIcon icon={IconCheck} />}
+                    onClick={handleSaveDashboard}
+                    loading={isSaving}
+                    disabled={!hasDashboardChanged}
+                >
+                    Save
+                </Button>
+            </Group>
+        );
+    };
+
+    const renderDashboardEditToolbar = () => {
+        const editControls = renderEditControls();
+
+        if (!editControls && !(canWriteDashboard && isEditMode)) return null;
+
+        return (
+            <Group
+                justify={
+                    canWriteDashboard && isEditMode
+                        ? 'space-between'
+                        : 'flex-end'
+                }
+                px="lg"
+                pt="sm"
+            >
+                {canWriteDashboard && isEditMode ? (
+                    <TextInput
+                        aria-label="Dashboard title"
+                        value={draftDashboardName}
+                        onChange={(event) =>
+                            setDraftDashboardName(event.currentTarget.value)
+                        }
+                        size="xs"
+                        w={320}
+                    />
+                ) : null}
+                {editControls}
+            </Group>
+        );
+    };
+
     return (
         <div
             // Used by EmbedDashboardExportPdf to temporarily set height:auto for multipage PDF printing
@@ -359,7 +736,21 @@ const EmbedDashboard: FC<{
                 opened={hasRequiredDashboardFiltersToSet && !!hasChartTiles}
             />
 
-            {tabsEnabled ? (
+            {currentDashboardTiles.length === 0 ? (
+                <>
+                    <EmbedDashboardHeader
+                        dashboard={dashboard}
+                        projectUuid={projectUuid}
+                    />
+                    {renderDashboardEditToolbar()}
+                    <div style={{ marginTop: '20px' }}>
+                        <SuboptimalState
+                            title="Empty dashboard"
+                            description="This dashboard has no tiles"
+                        />
+                    </div>
+                </>
+            ) : tabsEnabled ? (
                 <Tabs
                     value={activeTab?.uuid}
                     onChange={handleTabChange}
@@ -387,6 +778,7 @@ const EmbedDashboard: FC<{
                             </Tabs.List>
                         }
                     />
+                    {renderDashboardEditToolbar()}
                     <EmbedDashboardGrid
                         filteredTiles={filteredTiles}
                         layouts={layouts}
@@ -401,6 +793,12 @@ const EmbedDashboard: FC<{
                         }
                         isTabEmpty={isTabEmpty}
                         gridProps={gridProps}
+                        isEditMode={isEditMode}
+                        onLayoutChange={handleLayoutChange}
+                        onBreakpointChange={setCurrentCols}
+                        onDeleteTile={handleDeleteTile}
+                        onEditTile={handleEditTile}
+                        useDashboardEditorTileQueries={canWriteDashboard}
                     />
                 </Tabs>
             ) : (
@@ -409,6 +807,7 @@ const EmbedDashboard: FC<{
                         dashboard={dashboard}
                         projectUuid={projectUuid}
                     />
+                    {renderDashboardEditToolbar()}
                     <EmbedDashboardGrid
                         filteredTiles={filteredTiles}
                         layouts={layouts}
@@ -422,6 +821,12 @@ const EmbedDashboard: FC<{
                             hasRequiredDashboardFiltersToSet
                         }
                         gridProps={gridProps}
+                        isEditMode={isEditMode}
+                        onLayoutChange={handleLayoutChange}
+                        onBreakpointChange={setCurrentCols}
+                        onDeleteTile={handleDeleteTile}
+                        onEditTile={handleEditTile}
+                        useDashboardEditorTileQueries={canWriteDashboard}
                     />
                 </>
             )}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
@@ -5,11 +5,12 @@ import { postEmbedDashboard } from './api';
 export const useEmbedDashboard = (
     projectUuid: string | undefined,
     paletteUuid?: string,
+    enabled: boolean = true,
 ) => {
     return useQuery<EmbedDashboard, ApiError>({
         queryKey: ['embed-dashboard', projectUuid, paletteUuid],
         queryFn: () => postEmbedDashboard(projectUuid!, { paletteUuid }),
-        enabled: !!projectUuid,
+        enabled: !!projectUuid && enabled,
         retry: false,
     });
 };

--- a/packages/frontend/src/ee/pages/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/pages/EmbedDashboard.tsx
@@ -1,3 +1,4 @@
+import { type EmbedDashboard as EmbedDashboardType } from '@lightdash/common';
 import { IconUnlink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useParams } from 'react-router';
@@ -8,7 +9,10 @@ import useEmbed from '../providers/Embed/useEmbed';
 
 const EmbedDashboardPage: FC<{
     containerStyles?: React.CSSProperties;
-}> = ({ containerStyles }) => {
+    initialDashboard?: EmbedDashboardType;
+    isEditMode?: boolean;
+    onEditModeChange?: (isEditMode: boolean) => void;
+}> = ({ containerStyles, initialDashboard, isEditMode, onEditModeChange }) => {
     const { projectUuid: projectUuidFromParams } = useParams<{
         projectUuid?: string;
     }>();
@@ -30,7 +34,12 @@ const EmbedDashboardPage: FC<{
 
     return (
         <DashboardProvider embedToken={embedToken} projectUuid={projectUuid}>
-            <EmbedDashboard containerStyles={containerStyles} />
+            <EmbedDashboard
+                containerStyles={containerStyles}
+                initialDashboard={initialDashboard}
+                isEditMode={isEditMode}
+                onEditModeChange={onEditModeChange}
+            />
         </DashboardProvider>
     );
 };

--- a/packages/frontend/src/hooks/useChartSummariesV2.ts
+++ b/packages/frontend/src/hooks/useChartSummariesV2.ts
@@ -11,6 +11,7 @@ import { lightdashApi } from '../api';
 
 type UseChartSummariesV2Args = {
     projectUuid: string | undefined;
+    spaceUuid?: string;
     pageSize: number;
     page: number;
     search?: string;
@@ -18,13 +19,26 @@ type UseChartSummariesV2Args = {
 
 const getChartSummariesInProjectV2 = async ({
     projectUuid,
+    spaceUuid,
     page,
     pageSize,
     search,
 }: UseChartSummariesV2Args) => {
+    const searchParams = new URLSearchParams({
+        projectUuids: projectUuid ?? '',
+        contentTypes: ContentType.CHART,
+        pageSize: pageSize.toString(),
+        page: page.toString(),
+        search: search ?? '',
+    });
+
+    if (spaceUuid) {
+        searchParams.set('spaceUuids', spaceUuid);
+    }
+
     return lightdashApi<ApiChartContentResponse['results']>({
         version: 'v2',
-        url: `/content?projectUuids=${projectUuid}&contentTypes=${ContentType.CHART}&pageSize=${pageSize}&page=${page}&search=${search}`,
+        url: `/content?${searchParams.toString()}`,
         method: 'GET',
         body: undefined,
     });

--- a/packages/frontend/src/utils/request.ts
+++ b/packages/frontend/src/utils/request.ts
@@ -6,6 +6,17 @@ import {
 import { EMBED_KEY, type InMemoryEmbed } from '../ee/providers/Embed/types';
 import { getFromInMemoryStorage } from './inMemoryStorage';
 
+const LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY =
+    '__lightdash_sdk_instance_url';
+
+const resolveRequestUrl = (url: string) => {
+    const sdkInstanceUrl = sessionStorage.getItem(
+        LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY,
+    );
+
+    return new URL(url, sdkInstanceUrl ?? window.location.origin).toString();
+};
+
 // To be reused across all hooks that need to fetch SQL query results
 export const getResultsFromStream = async <T>(url: string | undefined) => {
     try {
@@ -22,7 +33,7 @@ export const getResultsFromStream = async <T>(url: string | undefined) => {
         if (embed?.token) {
             headers[JWT_HEADER_NAME] = embed.token;
         }
-        const response = await fetch(url, {
+        const response = await fetch(resolveRequestUrl(url), {
             method: 'GET',
             headers,
         });

--- a/packages/sdk-test-app/generate-embed-token.ts
+++ b/packages/sdk-test-app/generate-embed-token.ts
@@ -78,12 +78,25 @@ async function main() {
             .select(
                 'dashboards.dashboard_uuid',
                 'dashboards.name',
+                'spaces.space_uuid',
                 'projects.project_uuid',
             )
             .join('spaces', 'dashboards.space_id', 'spaces.space_id')
             .join('projects', 'spaces.project_id', 'projects.project_id')
             .whereNull('dashboards.deleted_at')
-            .where('dashboards.name', 'Jaffle dashboard')
+            .modify((queryBuilder) => {
+                if (process.env.DASHBOARD_UUID) {
+                    void queryBuilder.where(
+                        'dashboards.dashboard_uuid',
+                        process.env.DASHBOARD_UUID,
+                    );
+                } else {
+                    void queryBuilder.where(
+                        'dashboards.name',
+                        process.env.DASHBOARD_NAME || 'Jaffle dashboard',
+                    );
+                }
+            })
             .first();
         if (!dashboard) {
             console.error('No dashboards found in database');
@@ -91,6 +104,7 @@ async function main() {
         }
         const projectUuid = dashboard.project_uuid;
         const dashboardUuid = dashboard.dashboard_uuid;
+        const spaceUuid = dashboard.space_uuid;
 
         const existing = await db('embedding')
             .where({ project_uuid: projectUuid })
@@ -114,6 +128,13 @@ async function main() {
             });
         }
 
+        const user = await db('users').select('user_uuid').first();
+
+        if (!user) {
+            console.error('No users found in database');
+            process.exit(1);
+        }
+
         const payload = {
             content: {
                 type: 'dashboard',
@@ -128,6 +149,10 @@ async function main() {
                 isPreview: false,
                 canDateZoom: false,
                 canExportPagePdf: false,
+            },
+            writeActions: {
+                userUuid: user.user_uuid,
+                spaceUuid,
             },
             user: {
                 email: 'demo@lightdash.com',

--- a/packages/sdk-test-app/src/examples/DashboardBuilderExamplePage.tsx
+++ b/packages/sdk-test-app/src/examples/DashboardBuilderExamplePage.tsx
@@ -1,0 +1,90 @@
+import Lightdash from '@lightdash/sdk';
+import { useEffect, useState } from 'react';
+import { ExampleLayout } from '../components/ExampleLayout';
+import type { EmbedConfigState } from '../hooks/useEmbedConfig';
+import { getRepoSourceUrl } from '../lib/repo';
+import { emptyStateBoxStyle, emptyStateStyle } from '../styles';
+import {
+    dashboardContainerStyle,
+    sectionDescStyle,
+    sectionTitleStyle,
+} from './PaletteUuidExamplePage.styles';
+
+type DashboardBuilderExamplePageProps = {
+    embedConfig: EmbedConfigState;
+};
+
+const sourceUrl = getRepoSourceUrl(
+    'packages/sdk-test-app/src/examples/DashboardBuilderExamplePage.tsx',
+);
+
+export function DashboardBuilderExamplePage({
+    embedConfig,
+}: DashboardBuilderExamplePageProps) {
+    const [isEditMode, setIsEditMode] = useState(false);
+    const [isDashboardReady, setIsDashboardReady] = useState(false);
+
+    useEffect(() => {
+        setIsEditMode(false);
+        setIsDashboardReady(false);
+    }, [embedConfig.remountKey]);
+
+    return (
+        <ExampleLayout
+            embedConfig={embedConfig}
+            sourceUrl={sourceUrl}
+            title="Dashboard builder demo"
+            description={
+                <>
+                    This example creates a new embedded dashboard in the
+                    configured <code>writeActions.spaceUuid</code>, then lets
+                    the embedded user add saved charts from that same space and
+                    save layout changes.
+                </>
+            }
+        >
+            {embedConfig.instanceUrl && embedConfig.token ? (
+                <section>
+                    <h3 style={sectionTitleStyle}>New dashboard</h3>
+                    <p style={sectionDescStyle}>
+                        The SDK creates an empty dashboard on mount. Toggle edit
+                        mode, add a saved chart, move or resize tiles, then
+                        save.
+                    </p>
+                    {isDashboardReady && !isEditMode && (
+                        <button
+                            type="button"
+                            onClick={() => setIsEditMode(true)}
+                            style={{
+                                marginBottom: 12,
+                                padding: '8px 12px',
+                                borderRadius: 6,
+                                border: '1px solid #ced4da',
+                                background: '#fff',
+                                cursor: 'pointer',
+                            }}
+                        >
+                            Edit dashboard
+                        </button>
+                    )}
+                    <div style={dashboardContainerStyle}>
+                        <Lightdash.DashboardBuilder
+                            key={embedConfig.remountKey}
+                            instanceUrl={embedConfig.instanceUrl}
+                            token={embedConfig.token}
+                            isEditMode={isEditMode}
+                            onEditModeChange={setIsEditMode}
+                            onDashboardReady={() => setIsDashboardReady(true)}
+                        />
+                    </div>
+                </section>
+            ) : (
+                <div style={emptyStateStyle}>
+                    <div style={emptyStateBoxStyle}>
+                        Click <strong>Config</strong> to add your embed URL
+                    </div>
+                </div>
+            )}
+        </ExampleLayout>
+    );
+}

--- a/packages/sdk-test-app/src/examples/examples.tsx
+++ b/packages/sdk-test-app/src/examples/examples.tsx
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 import type { EmbedConfigState } from '../hooks/useEmbedConfig';
+import { DashboardBuilderExamplePage } from './DashboardBuilderExamplePage';
 import { FiltersExamplePage } from './FiltersExamplePage';
 import { I18nExamplePage } from './I18nExamplePage';
 import { PaletteUuidExamplePage } from './PaletteUuidExamplePage';
@@ -15,6 +16,16 @@ export type ExampleDefinition = {
 };
 
 export const examples: ExampleDefinition[] = [
+    {
+        slug: 'dashboard-builder',
+        path: '/examples/dashboard-builder',
+        title: 'Dashboard builder demo',
+        description:
+            'Create a new embedded dashboard, add saved charts from the configured write space, and save layout changes.',
+        sourcePath:
+            'packages/sdk-test-app/src/examples/DashboardBuilderExamplePage.tsx',
+        component: DashboardBuilderExamplePage,
+    },
     {
         slug: 'i18n',
         path: '/examples/i18n',


### PR DESCRIPTION
## Summary

Adds embedded dashboard creation/editing through the SDK by reusing existing dashboard, content, SQL chart, and async query endpoints instead of introducing embed-specific API routes.

### What changed

- Exposes a new SDK dashboard builder flow that creates an empty dashboard in the JWT `writeActions.spaceUuid` and lets the host app control edit mode.
- Allows embedded users with write actions to rename dashboards, add saved charts from the allowed space, move/resize tiles, save changes, and then view the dashboard through the normal embedded dashboard renderer.
- Reuses existing dashboard tile components for saved charts, SQL charts, markdown, headings, and dashboard layout behavior where possible.
- Filters add-tile content to the JWT write space so users cannot choose charts outside the allowed space.
- Keeps dashboards created/edited from embed equivalent to normal dashboards: they can be viewed/edited from Lightdash and vice versa.

### JWT write access and security

- Existing endpoints now accept JWT accounts only where the SDK needs dashboard builder behavior.
- JWTs without `writeActions` fail closed for write-capable paths.
- JWT write actions execute as the resolved write actor and are constrained to `writeActions.spaceUuid`.
- Dashboard create/update/duplicate validates target spaces and tile chart ownership server-side, including SQL chart tiles.
- Async dashboard queries preserve existing non-write JWT behavior: a dashboard JWT can still render charts already on its embedded dashboard, while write-action previews may use dashboards from the allowed write space.

### Testing

- `pnpm generate-api`
- `pnpm -F common test -- TableDataModel.test.ts`
- `pnpm -F backend test -- account.test.ts DashboardService.test.ts AsyncQueryService.test.ts`
- `pnpm -F backend test -- AsyncQueryService.test.ts DashboardService.test.ts`
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- `pnpm -F backend lint`
- `pnpm -F frontend lint`
- `pnpm sdk-build:fast`

Closes: PROD-569

<!-- test-all -->