### PR TITLE
feat(explorer): explain timezone source in chart badge tooltip

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -5,7 +5,6 @@ import {
     getFieldsFromMetricQuery,
     getHiddenTableFields,
     getPivotConfig,
-    isTimeZone,
     NotFoundError,
     FeatureFlags,
     type ApiErrorDetail,
@@ -394,13 +393,8 @@ const VisualizationCard: FC<Props> = memo((props) => {
                                     resolvedTimezone={
                                         query.data?.resolvedTimezone
                                     }
-                                    metricQueryTimezone={
-                                        query.data?.metricQuery?.timezone &&
-                                        isTimeZone(
-                                            query.data.metricQuery.timezone,
-                                        )
-                                            ? query.data.metricQuery.timezone
-                                            : undefined
+                                    timezoneSetting={
+                                        query.data?.metricQuery?.timezone
                                     }
                                 />
                                 {isEditMode ? (

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
@@ -1,4 +1,10 @@
-import { FeatureFlags, getTimezoneLabel } from '@lightdash/common';
+import {
+    FeatureFlags,
+    getTimezoneLabel,
+    isTimeZone,
+    PROJECT_TIMEZONE_SETTING,
+    USER_TIMEZONE_SETTING,
+} from '@lightdash/common';
 import { Badge, Tooltip } from '@mantine-8/core';
 import { IconClock } from '@tabler/icons-react';
 import { type FC } from 'react';
@@ -7,28 +13,50 @@ import MantineIcon from '../../common/MantineIcon';
 
 type Props = {
     resolvedTimezone: string | null | undefined;
-    // Backwards-compat fallback: before `EnableTimezoneSupport`, the only
-    // timezone signal was the user override on the query. Remove this prop
-    // once that flag graduates and `resolvedTimezone` is always populated.
-    metricQueryTimezone: string | null | undefined;
+    // The saved chart's single `timezone` setting, used to explain where the
+    // resolved zone came from (project default / per-viewer / override).
+    timezoneSetting: string | null | undefined;
+};
+
+const getSourceLabel = (
+    timezoneSetting: string | null | undefined,
+    resolvedTimezone: string,
+): string => {
+    if (timezoneSetting === USER_TIMEZONE_SETTING) {
+        return `This chart follows each viewer's own time zone. You're seeing it in ${resolvedTimezone}.`;
+    }
+    if (
+        timezoneSetting &&
+        timezoneSetting !== PROJECT_TIMEZONE_SETTING &&
+        isTimeZone(timezoneSetting)
+    ) {
+        return `This chart is pinned to ${resolvedTimezone} and won't follow the project time zone.`;
+    }
+    return `This chart resolves in the project time zone (${resolvedTimezone}).`;
 };
 
 const VisualizationTimezone: FC<Props> = ({
     resolvedTimezone,
-    metricQueryTimezone,
+    timezoneSetting,
 }) => {
     const { data: enableUserTimezonesFlag } = useServerFeatureFlag(
         FeatureFlags.EnableUserTimezones,
     );
     const userTimeZonesEnabled = enableUserTimezonesFlag?.enabled ?? false;
+    // Backwards-compat fallback: before `EnableTimezoneSupport`, the only
+    // timezone signal is an explicit override zone on the query.
+    const overrideFallback =
+        timezoneSetting && isTimeZone(timezoneSetting) ? timezoneSetting : null;
     const timezone =
-        resolvedTimezone ?? (userTimeZonesEnabled ? metricQueryTimezone : null);
+        resolvedTimezone ?? (userTimeZonesEnabled ? overrideFallback : null);
     if (!timezone) return null;
 
     return (
         <Tooltip
-            label={`Chart and results shown in ${timezone} time zone`}
+            label={getSourceLabel(timezoneSetting, timezone)}
             position="bottom"
+            multiline
+            w={260}
         >
             <Badge
                 leftSection={<MantineIcon icon={IconClock} size="sm" />}


### PR DESCRIPTION
Closes: GLITCH-455

### Description:

The chart card already shows the resolved timezone as a badge, but a viewer had no signal as to *where* that zone came from. This classifies the chart's single `timezone` setting and explains it in the badge tooltip: project default ("resolves in the project time zone"), per-viewer (`user_timezone` → "follows each viewer's own time zone"), or a pinned override IANA zone ("pinned to X and won't follow the project time zone"). The badge's display and backwards-compat fallback are unchanged.


<img width="2136" height="1882" alt="CleanShot 2026-06-12 at 11 58 56@2x" src="https://github.com/user-attachments/assets/0fd7e288-3c0c-4e40-8151-23306a6c1350" />

<img width="2124" height="1864" alt="CleanShot 2026-06-12 at 11 59 38@2x" src="https://github.com/user-attachments/assets/f58c7e9e-826b-46ba-882b-b2cb1af255d7" />

<img width="2124" height="1862" alt="CleanShot 2026-06-12 at 11 59 55@2x" src="https://github.com/user-attachments/assets/9598c6da-80f8-4c6f-a90a-611908e4a55a" />
