### PR TITLE
feat(embedding): sticky filter bar and tabs on embedded dashboards

### DIFF
--- a/packages/backend/src/ee/analytics/index.ts
+++ b/packages/backend/src/ee/analytics/index.ts
@@ -15,6 +15,7 @@ export type EmbedDashboardViewed = BaseTrack & {
         canExportImages?: boolean;
         canExportPagePdf: boolean;
         canDateZoom?: boolean;
+        stickyHeader?: boolean;
     };
 };
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -549,6 +549,7 @@ export class EmbedService extends BaseService {
             canExplore,
             canViewUnderlyingData,
             canViewDataApps,
+            stickyHeader,
         } = decodedToken.content;
         // Embed paletteUuid query param overrides everything; otherwise fall back
         // through chart → dashboard → space → project → org via the resolver.
@@ -595,6 +596,7 @@ export class EmbedService extends BaseService {
                 canExportImages,
                 canExportPagePdf: canExportPagePdf ?? true,
                 canDateZoom,
+                stickyHeader,
                 ...(account.access.filtering
                     ? {
                           dashboardFiltersInteractivity: {
@@ -621,6 +623,7 @@ export class EmbedService extends BaseService {
             canExplore,
             canViewUnderlyingData,
             canViewDataApps,
+            stickyHeader,
             selectedPalette,
         };
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1834,6 +1834,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                stickyHeader: { dataType: 'boolean' },
                 canViewDataApps: { dataType: 'boolean' },
                 canViewUnderlyingData: { dataType: 'boolean' },
                 canExplore: { dataType: 'boolean' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1841,6 +1841,9 @@
             },
             "CommonEmbedJwtContent": {
                 "properties": {
+                    "stickyHeader": {
+                        "type": "boolean"
+                    },
                     "canViewDataApps": {
                         "type": "boolean"
                     },

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -80,6 +80,8 @@ export const InteractivityOptionsSchema = z.object({
     // existing canExplore opt-in: an explicit decision to widen the embed's
     // surface beyond pre-built chart queries.
     canViewDataApps: z.boolean().optional(),
+    // Pins tabs and the filter bar to the top while scrolling. Off by default.
+    stickyHeader: z.boolean().optional(),
 });
 
 export type InteractivityOptions = z.infer<typeof InteractivityOptionsSchema>;
@@ -192,6 +194,7 @@ export type CommonEmbedJwtContent = {
     canExplore?: boolean;
     canViewUnderlyingData?: boolean;
     canViewDataApps?: boolean;
+    stickyHeader?: boolean;
 };
 
 type CommonChartEmbedJwtContent = {

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -355,11 +355,6 @@ const EmbedDashboard: FC<{
                 }
             }
         >
-            <EmbedDashboardHeader
-                dashboard={dashboard}
-                projectUuid={projectUuid}
-            />
-
             <LockedDashboardModal
                 opened={hasRequiredDashboardFiltersToSet && !!hasChartTiles}
             />
@@ -368,23 +363,30 @@ const EmbedDashboard: FC<{
                 <Tabs
                     value={activeTab?.uuid}
                     onChange={handleTabChange}
-                    mt="md"
                     classNames={{
                         list: tabStyles.list,
                         tab: tabStyles.tab,
                     }}
                 >
-                    <Tabs.List px="lg">
-                        {visibleTabs.map((tab) => (
-                            <Tabs.Tab
-                                key={tab.uuid}
-                                value={tab.uuid}
-                                maw={`${100 / (visibleTabs.length || 1)}vw`}
-                            >
-                                {tab.name}
-                            </Tabs.Tab>
-                        ))}
-                    </Tabs.List>
+                    <EmbedDashboardHeader
+                        dashboard={dashboard}
+                        projectUuid={projectUuid}
+                        tabs={
+                            <Tabs.List px="lg">
+                                {visibleTabs.map((tab) => (
+                                    <Tabs.Tab
+                                        key={tab.uuid}
+                                        value={tab.uuid}
+                                        maw={`${
+                                            100 / (visibleTabs.length || 1)
+                                        }vw`}
+                                    >
+                                        {tab.name}
+                                    </Tabs.Tab>
+                                ))}
+                            </Tabs.List>
+                        }
+                    />
                     <EmbedDashboardGrid
                         filteredTiles={filteredTiles}
                         layouts={layouts}
@@ -402,18 +404,26 @@ const EmbedDashboard: FC<{
                     />
                 </Tabs>
             ) : (
-                <EmbedDashboardGrid
-                    filteredTiles={filteredTiles}
-                    layouts={layouts}
-                    dashboard={dashboard}
-                    projectUuid={projectUuid}
-                    paletteColors={dashboard.selectedPalette?.colors}
-                    paletteDarkColors={dashboard.selectedPalette?.darkColors}
-                    hasRequiredDashboardFiltersToSet={
-                        hasRequiredDashboardFiltersToSet
-                    }
-                    gridProps={gridProps}
-                />
+                <>
+                    <EmbedDashboardHeader
+                        dashboard={dashboard}
+                        projectUuid={projectUuid}
+                    />
+                    <EmbedDashboardGrid
+                        filteredTiles={filteredTiles}
+                        layouts={layouts}
+                        dashboard={dashboard}
+                        projectUuid={projectUuid}
+                        paletteColors={dashboard.selectedPalette?.colors}
+                        paletteDarkColors={
+                            dashboard.selectedPalette?.darkColors
+                        }
+                        hasRequiredDashboardFiltersToSet={
+                            hasRequiredDashboardFiltersToSet
+                        }
+                        gridProps={gridProps}
+                    />
+                </>
             )}
         </div>
     );

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportPdf.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportPdf.tsx
@@ -1,5 +1,5 @@
 import { type Dashboard, type InteractivityOptions } from '@lightdash/common';
-import { ActionIcon, getDefaultZIndex, Tooltip } from '@mantine/core';
+import { ActionIcon, Tooltip } from '@mantine-8/core';
 import { IconPrinter } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -9,15 +9,10 @@ import '../styles/print.css';
 
 type Props = {
     dashboard: Dashboard & InteractivityOptions;
-    inHeader: boolean;
     projectUuid: string;
 };
 
-const EmbedDashboardExportPdf: FC<Props> = ({
-    projectUuid,
-    dashboard,
-    inHeader,
-}) => {
+const EmbedDashboardExportPdf: FC<Props> = ({ projectUuid, dashboard }) => {
     const { track } = useTracking();
 
     if (!dashboard.canExportPagePdf) {
@@ -83,16 +78,6 @@ const EmbedDashboardExportPdf: FC<Props> = ({
                 }}
                 size="lg"
                 radius="md"
-                sx={{
-                    ...(inHeader
-                        ? {}
-                        : {
-                              position: 'absolute',
-                              top: 20,
-                              right: 72, // Make sure the button does not overlap the chart options
-                          }),
-                    zIndex: getDefaultZIndex('modal') - 1,
-                }}
             >
                 <MantineIcon icon={IconPrinter} />
             </ActionIcon>

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
@@ -1,0 +1,131 @@
+import {
+    isParameterInteractivityEnabled,
+    type Dashboard,
+    type InteractivityOptions,
+} from '@lightdash/common';
+import { Box, Button, Divider, Group, Tooltip } from '@mantine-8/core';
+import { IconChevronUp } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { DashboardFiltersBarSummary } from '../../../../../features/dashboardFilters/DashboardFiltersBarSummary';
+import { DateZoom } from '../../../../../features/dateZoom';
+import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
+import EmbedDashboardFilters from './EmbedDashboardFilters';
+import EmbedDashboardParameters from './EmbedDashboardParameters';
+
+type Props = {
+    dashboard: Dashboard & InteractivityOptions;
+    shouldShowFilters: boolean;
+};
+
+const EmbedDashboardFilterBar: FC<Props> = ({
+    dashboard,
+    shouldShowFilters,
+}) => {
+    const [isCollapsed, setIsCollapsed] = useState(false);
+
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const dashboardTemporaryFilters = useDashboardContext(
+        (c) => c.dashboardTemporaryFilters,
+    );
+    const dateZoomGranularity = useDashboardContext(
+        (c) => c.dateZoomGranularity,
+    );
+    const parameterDefinitions = useDashboardContext(
+        (c) => c.parameterDefinitions,
+    );
+    const parameterReferences = useDashboardContext(
+        (c) => c.dashboardParameterReferences,
+    );
+
+    const parametersEnabled = isParameterInteractivityEnabled(
+        dashboard.parameterInteractivity,
+    );
+
+    const totalFiltersCount = shouldShowFilters
+        ? dashboardFilters.dimensions.length +
+          dashboardTemporaryFilters.dimensions.length
+        : 0;
+    const totalParametersCount = useMemo(
+        () =>
+            parametersEnabled
+                ? Object.keys(parameterDefinitions).filter((key) =>
+                      parameterReferences.has(key),
+                  ).length
+                : 0,
+        [parametersEnabled, parameterDefinitions, parameterReferences],
+    );
+
+    // Collapsing only hides filters and parameters — date zoom stays visible
+    const isCollapsible = totalFiltersCount > 0 || totalParametersCount > 0;
+
+    // Interactivity may be enabled with nothing to show (hidden filters, or
+    // none defined) — render nothing rather than an empty padded row
+    if (!dashboard.canDateZoom && !isCollapsible) {
+        return null;
+    }
+
+    if (isCollapsible && isCollapsed) {
+        return (
+            <DashboardFiltersBarSummary
+                filtersCount={totalFiltersCount}
+                parametersCount={totalParametersCount}
+                dateZoomLabel={
+                    dashboard.canDateZoom
+                        ? dateZoomGranularity || 'Default'
+                        : null
+                }
+                onExpand={() => setIsCollapsed(false)}
+            />
+        );
+    }
+
+    return (
+        <Group
+            justify="space-between"
+            align="flex-start"
+            wrap="nowrap"
+            gap="sm"
+            px="lg"
+            py="xs"
+        >
+            <Group
+                align="flex-start"
+                wrap="wrap"
+                gap="sm"
+                style={{ flex: 1, minWidth: 0 }}
+            >
+                {shouldShowFilters && <EmbedDashboardFilters />}
+                {parametersEnabled && <EmbedDashboardParameters />}
+            </Group>
+
+            <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
+                {dashboard.canDateZoom && (
+                    <Box>
+                        <DateZoom isEditMode={false} />
+                    </Box>
+                )}
+                {isCollapsible && (
+                    <>
+                        <Divider orientation="vertical" />
+                        <Tooltip label="Hide filters" withinPortal>
+                            <Button
+                                size="xs"
+                                variant="subtle"
+                                color="gray"
+                                rightSection={
+                                    <MantineIcon icon={IconChevronUp} />
+                                }
+                                onClick={() => setIsCollapsed(true)}
+                            >
+                                Hide
+                            </Button>
+                        </Tooltip>
+                    </>
+                )}
+            </Group>
+        </Group>
+    );
+};
+
+export default EmbedDashboardFilterBar;

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.module.css
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.module.css
@@ -1,0 +1,79 @@
+/* Header grid: row 1 = tabs (or filter bar) + reserved actions column for the
+   print button, optional row 2 = filter bar when tabs are present */
+.headerBar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    background-color: var(--mantine-color-ldGray-0);
+
+    &[data-sticky='true'] {
+        position: sticky;
+        top: 0;
+        z-index: var(--dashboard-tabs-zindex);
+        isolation: isolate;
+        container-type: scroll-state;
+    }
+}
+
+.primary {
+    min-width: 0;
+}
+
+/* Stretched so its background covers the full row height */
+.actions {
+    display: flex;
+    align-items: center;
+    padding-right: var(--mantine-spacing-lg);
+    padding-left: var(--mantine-spacing-sm);
+}
+
+.secondary {
+    grid-column: 1 / -1;
+}
+
+/* Same background as the tab list (tabs.module.css .list), extended across
+   the actions slot, with a shared hairline under the whole row */
+.headerBar[data-has-tabs='true'] > .primary,
+.headerBar[data-has-tabs='true'] > .actions {
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+
+    @mixin dark {
+        background-color: var(--mantine-color-background-0);
+    }
+    @mixin light {
+        background-color: var(--mantine-color-white);
+    }
+}
+
+/* Without a tabs row, align the actions with the filter bar's first line */
+.headerBar[data-has-tabs='false'] > .actions {
+    align-items: flex-start;
+    padding-block: var(--mantine-spacing-xs);
+}
+
+/* Keep tiles from sitting right against the tabs hairline when the filter
+   bar is absent or rendered empty */
+.headerBar[data-has-tabs='true']:not(:has(> .secondary > *)) {
+    margin-bottom: var(--mantine-spacing-xs);
+}
+
+.stuckBorder {
+    position: absolute;
+    inset: auto 0 0 0;
+    height: 1px;
+    background-color: transparent;
+    pointer-events: none;
+}
+
+/* CSS-only stuck detection. Browsers without scroll-state queries
+   (Firefox/Safari) keep the sticky bar but never show the border. */
+@container scroll-state(stuck: top) {
+    .stuckBorder {
+        background-color: var(--mantine-color-ldGray-3);
+    }
+}
+
+@media print {
+    .actions {
+        display: none;
+    }
+}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
@@ -4,63 +4,65 @@ import {
     type Dashboard,
     type InteractivityOptions,
 } from '@lightdash/common';
-import { Group } from '@mantine-8/core';
-import { type FC } from 'react';
-import { DateZoom } from '../../../../../features/dateZoom';
+import { Box } from '@mantine-8/core';
+import { type FC, type ReactNode } from 'react';
 import EmbedDashboardExportPdf from './EmbedDashboardExportPdf';
-import EmbedDashboardFilters from './EmbedDashboardFilters';
-import EmbedDashboardParameters from './EmbedDashboardParameters';
+import EmbedDashboardFilterBar from './EmbedDashboardFilterBar';
+import styles from './EmbedDashboardHeader.module.css';
 
 type Props = {
     dashboard: Dashboard & InteractivityOptions;
     projectUuid: string;
+    /** Tab switcher, pinned on top of the filters when the dashboard has tabs */
+    tabs?: ReactNode;
 };
 
-const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid }) => {
-    const hasHeader =
+const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid, tabs }) => {
+    const hasFilterBar =
         dashboard.canDateZoom ||
         isParameterInteractivityEnabled(dashboard.parameterInteractivity) ||
         isFilterInteractivityEnabled(dashboard.dashboardFiltersInteractivity);
 
-    // If no header, and exportPagePdf is enabled, show the Export button on the top right corner
-    if (!hasHeader && dashboard.canExportPagePdf) {
-        return (
-            <EmbedDashboardExportPdf
-                dashboard={dashboard}
-                projectUuid={projectUuid}
-                inHeader={false}
-            />
-        );
+    if (!hasFilterBar && !tabs && !dashboard.canExportPagePdf) {
+        return null;
     }
 
-    const shouldShowFilters =
+    const shouldShowFilters = Boolean(
         dashboard.dashboardFiltersInteractivity &&
         isFilterInteractivityEnabled(dashboard.dashboardFiltersInteractivity) &&
-        !dashboard.dashboardFiltersInteractivity.hidden;
-    return (
-        <Group
-            justify="flex-start"
-            align="center"
-            wrap="wrap"
-            pos="relative"
-            m="sm"
-            mb="0"
-            gap="sm"
-        >
-            {isParameterInteractivityEnabled(
-                dashboard.parameterInteractivity,
-            ) && <EmbedDashboardParameters />}
-            {dashboard.canDateZoom && <DateZoom isEditMode={false} />}
+        !dashboard.dashboardFiltersInteractivity.hidden,
+    );
 
+    const isSticky = Boolean(dashboard.stickyHeader);
+
+    const filterBar = hasFilterBar ? (
+        <EmbedDashboardFilterBar
+            dashboard={dashboard}
+            shouldShowFilters={shouldShowFilters}
+        />
+    ) : null;
+
+    return (
+        <Box
+            className={styles.headerBar}
+            data-sticky={isSticky}
+            data-has-tabs={Boolean(tabs)}
+        >
+            <Box className={styles.primary}>{tabs ?? filterBar}</Box>
             {dashboard.canExportPagePdf && (
-                <EmbedDashboardExportPdf
-                    dashboard={dashboard}
-                    projectUuid={projectUuid}
-                    inHeader={true}
-                />
+                <Box className={styles.actions}>
+                    <EmbedDashboardExportPdf
+                        dashboard={dashboard}
+                        projectUuid={projectUuid}
+                    />
+                </Box>
             )}
-            {shouldShowFilters && <EmbedDashboardFilters />}
-        </Group>
+            {tabs && filterBar && (
+                <Box className={styles.secondary}>{filterBar}</Box>
+            )}
+            {/* The scroll-state query can't style the container's own pseudo-elements, so the stuck border needs a real descendant */}
+            {isSticky && <Box className={styles.stuckBorder} />}
+        </Box>
     );
 };
 

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/styles/print.css
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/styles/print.css
@@ -7,4 +7,9 @@
         height: auto !important;
         overflow: visible !important;
     }
+    /* Tooltips portal to body and print if open when window.print() runs
+       (e.g. hovering the print button itself) */
+    .mantine-8-Tooltip-tooltip {
+        display: none !important;
+    }
 }

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -318,6 +318,7 @@ const data = {
         canExportImages: {{canExportImages}},
         canExportPagePdf: {{canExportPagePdf}},
         canDateZoom: {{canDateZoom}},
+        stickyHeader: {{stickyHeader}},
         canExplore: {{canExplore}},
         canViewUnderlyingData: {{canViewUnderlyingData}},
         canViewDataApps: {{canViewDataApps}},
@@ -357,6 +358,7 @@ data = {
         "canExportImages": {{canExportImages}},
         "canExportPagePdf": {{canExportPagePdf}},
         "canDateZoom": {{canDateZoom}},
+        "stickyHeader": {{stickyHeader}},
         "canExplore": {{canExplore}},
         "canViewUnderlyingData": {{canViewUnderlyingData}},
         "canViewDataApps": {{canViewDataApps}},
@@ -406,6 +408,7 @@ func main() {
             CanExportImages bool \`json:"canExportImages"\`
             CanExportPagePdf bool \`json:"canExportPagePdf"\`
             CanDateZoom bool \`json:"canDateZoom"\`
+            StickyHeader bool \`json:"stickyHeader"\`
             CanExplore bool \`json:"canExplore"\`
             CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
             CanViewDataApps bool \`json:"canViewDataApps"\`
@@ -441,6 +444,7 @@ func main() {
             CanExportImages bool \`json:"canExportImages"\`
             CanExportPagePdf bool \`json:"canExportPagePdf"\`
             CanDateZoom bool \`json:"canDateZoom"\`
+            StickyHeader bool \`json:"stickyHeader"\`
             CanExplore bool \`json:"canExplore"\`
             CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
             CanViewDataApps bool \`json:"canViewDataApps"\`
@@ -466,6 +470,7 @@ func main() {
             CanExportImages: {{canExportImages}},
             CanExportPagePdf: {{canExportPagePdf}},
             CanDateZoom: {{canDateZoom}},
+            StickyHeader: {{stickyHeader}},
             CanExplore: {{canExplore}},
             CanViewUnderlyingData: {{canViewUnderlyingData}},
             CanViewDataApps: {{canViewDataApps}},
@@ -654,6 +659,7 @@ const data = {
         canExportImages: {{canExportImages}},
         canExportPagePdf: {{canExportPagePdf}},
         canDateZoom: {{canDateZoom}},
+        stickyHeader: {{stickyHeader}},
         canExplore: {{canExplore}},
         canViewUnderlyingData: {{canViewUnderlyingData}},
         canViewDataApps: {{canViewDataApps}},
@@ -692,6 +698,7 @@ data = {
         "canExportImages": {{canExportImages}},
         "canExportPagePdf": {{canExportPagePdf}},
         "canDateZoom": {{canDateZoom}},
+        "stickyHeader": {{stickyHeader}},
         "canExplore": {{canExplore}},
         "canViewUnderlyingData": {{canViewUnderlyingData}},
         "canViewDataApps": {{canViewDataApps}},
@@ -739,6 +746,7 @@ func main() {
             CanExportImages bool \`json:"canExportImages"\`
             CanExportPagePdf bool \`json:"canExportPagePdf"\`
             CanDateZoom bool \`json:"canDateZoom"\`
+            StickyHeader bool \`json:"stickyHeader"\`
             CanExplore bool \`json:"canExplore"\`
             CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
             CanViewDataApps bool \`json:"canViewDataApps"\`
@@ -773,6 +781,7 @@ func main() {
             CanExportImages bool \`json:"canExportImages"\`
             CanExportPagePdf bool \`json:"canExportPagePdf"\`
             CanDateZoom bool \`json:"canDateZoom"\`
+            StickyHeader bool \`json:"stickyHeader"\`
             CanExplore bool \`json:"canExplore"\`
             CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
             CanViewDataApps bool \`json:"canViewDataApps"\`
@@ -798,6 +807,7 @@ func main() {
             CanExportImages: {{canExportImages}},
             CanExportPagePdf: {{canExportPagePdf}},
             CanDateZoom: {{canDateZoom}},
+            StickyHeader: {{stickyHeader}},
             CanExplore: {{canExplore}},
             CanViewUnderlyingData: {{canViewUnderlyingData}},
             CanViewDataApps: {{canViewDataApps}},
@@ -944,6 +954,10 @@ const getBackendCodeSnippet = (
                 .replace(
                     '{{canExportPagePdf}}',
                     languageBoolean(language, data.content.canExportPagePdf),
+                )
+                .replace(
+                    '{{stickyHeader}}',
+                    languageBoolean(language, data.content.stickyHeader),
                 )
                 .replace(
                     '{{canDateZoom}}',

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -88,6 +88,7 @@ type FormValues = {
     canExplore?: boolean;
     canViewUnderlyingData?: boolean;
     canViewDataApps?: boolean;
+    stickyHeader?: boolean;
 } & IntrinsicUserAttributes;
 
 const EmbedPreviewDashboardForm: FC<{
@@ -135,6 +136,7 @@ const EmbedPreviewDashboardForm: FC<{
             canExplore: false,
             canViewUnderlyingData: false,
             canViewDataApps: false,
+            stickyHeader: false,
         },
         validate: {
             dashboardUuid: (value: undefined | string) => {
@@ -177,6 +179,7 @@ const EmbedPreviewDashboardForm: FC<{
                     canExplore: values.canExplore,
                     canViewUnderlyingData: values.canViewUnderlyingData,
                     canViewDataApps: values.canViewDataApps,
+                    stickyHeader: values.stickyHeader,
                 },
                 writeActions,
                 userAttributes: values.userAttributes.reduce(
@@ -464,6 +467,18 @@ const EmbedPreviewDashboardForm: FC<{
                                         }
                                     />
                                 )}
+                            </Stack>
+
+                            <Stack gap="xs">
+                                <Text size="sm" fw={500}>
+                                    Appearance:
+                                </Text>
+                                <Switch
+                                    {...form.getInputProps('stickyHeader', {
+                                        type: 'checkbox',
+                                    })}
+                                    label="Sticky header (keep tabs & filters visible when scrolling)"
+                                />
                             </Stack>
                         </Stack>
                     </Stack>


### PR DESCRIPTION
### Description:

Adds an opt-in sticky header for embedded dashboards, plus a reworked embed header layout.

**New `stickyHeader` embed option** (JWT content flag, default off — existing embeds keep the current scroll-away behavior):
- When enabled, dashboard tabs and the filter bar pin to the top of the embed scroll container while tiles scroll underneath.
- Plumbed through the embed JWT schema, `EmbedService`, the embed preview form (new "Appearance" toggle), the generated backend code snippets (TS/Python/Go), and the `embed_dashboard.viewed` analytics event.

**Header rework** (applies to all embeds):
- The header is now a stateless CSS grid: tabs (or filter bar) + a reserved actions column for the print button, with an optional full-width filter bar row below the tabs.
- Stickiness and the "stuck" bottom border are pure CSS: `data-sticky` attribute + `position: sticky`, with stuck detection via scroll-state container queries (`container-type: scroll-state`) — no IntersectionObserver or React state. Browsers without scroll-state support (Firefox/Safari) keep the sticky bar and just never show the border.
- The print button no longer floats over chart content; it has a dedicated slot in the header in every layout, is hidden from printed output via `@media print` (along with any open tooltip), and `EmbedDashboardExportPdf` is migrated from Mantine v6 to v8.
- The filter bar collapses to a summary ("N filters · Date Zoom"), only shows the Hide button when there are actually filters/parameters to hide, and renders nothing when interactivity is enabled but there's no visible content (no more empty padded row under the tabs).

Closes: #24140


#### Preview

<img width="972" height="464" alt="CleanShot 2026-06-12 at 12 33 16" src="https://github.com/user-attachments/assets/f39a30af-5e50-4370-86e1-c9dc64017f89" />

<img width="800" height="599" alt="CleanShot 2026-06-12 at 12 37 58" src="https://github.com/user-attachments/assets/5be5f356-2f6a-4180-b08e-5a1a405fc44c" />

