### PR TITLE
feat(common): cast day-or-coarser DATE_TRUNCs to DATE in getSqlForTruncatedDate

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -5164,6 +5164,7 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
                         hidden: false,
                         timeInterval: TimeFrames.DAY,
                         timeIntervalBaseDimensionName: 'occurred_at',
+                        timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
                     },
                 },
                 metrics: {
@@ -5210,6 +5211,39 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
         expect(query).toContain(
             `CAST(DATE_TRUNC('DAY', ("events".occurred_at)::timestamptz AT TIME ZONE 'America/New_York') AS DATE)`,
         );
+    });
+
+    test('TIMESTAMP base + flag on: day-grain EQUALS filter uses a bare date literal, not timestamptz (Postgres)', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(),
+            compiledMetricQuery: {
+                ...dayQuery,
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: { fieldId: 'events_occurred_at_day' },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-01-15'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            useTimezoneAwareDateTrunc: true,
+        });
+        // WHERE LHS is the DATE-cast expression…
+        expect(query).toContain(
+            `CAST(DATE_TRUNC('DAY', ("events".occurred_at)::timestamptz AT TIME ZONE 'America/New_York') AS DATE)`,
+        );
+        // …and the literal must be a bare date, not wrapped as a timestamptz
+        // (LHS is a DATE now — a timestamptz literal would re-introduce a tz drift).
+        expect(query).not.toContain(`'2024-01-15'::timestamp`);
     });
 });
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -5119,6 +5119,100 @@ describe('Nested aggregate metrics', () => {
 
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', () => {
+    const buildDayExplore = (
+        baseType: DimensionType = DimensionType.TIMESTAMP,
+        adapter: SupportedDbtAdapter = SupportedDbtAdapter.POSTGRES,
+    ): Explore => ({
+        targetDatabase: adapter,
+        name: 'events',
+        label: 'events',
+        baseTable: 'events',
+        tags: [],
+        joinedTables: [],
+        tables: {
+            events: {
+                name: 'events',
+                label: 'events',
+                database: 'db',
+                schema: 's',
+                sqlTable: '"events"',
+                primaryKey: ['id'],
+                dimensions: {
+                    occurred_at: {
+                        type: baseType,
+                        name: 'occurred_at',
+                        label: 'occurred_at',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: '${TABLE}.occurred_at',
+                        compiledSql: '"events".occurred_at',
+                        tablesReferences: ['events'],
+                        hidden: false,
+                    },
+                    occurred_at_day: {
+                        type: DimensionType.DATE,
+                        name: 'occurred_at_day',
+                        label: 'occurred_at_day',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: `DATE_TRUNC('DAY', \${TABLE}.occurred_at)`,
+                        compiledSql: `DATE_TRUNC('DAY', "events".occurred_at)`,
+                        tablesReferences: ['events'],
+                        hidden: false,
+                        timeInterval: TimeFrames.DAY,
+                        timeIntervalBaseDimensionName: 'occurred_at',
+                    },
+                },
+                metrics: {
+                    event_count: {
+                        type: MetricType.COUNT,
+                        fieldType: FieldType.METRIC,
+                        table: 'events',
+                        tableLabel: 'events',
+                        name: 'event_count',
+                        label: 'event_count',
+                        sql: '${TABLE}.id',
+                        compiledSql: 'COUNT("events".id)',
+                        tablesReferences: ['events'],
+                        hidden: false,
+                    },
+                },
+                lineageGraph: {},
+            },
+        },
+    });
+
+    const dayQuery: CompiledMetricQuery = {
+        exploreName: 'events',
+        dimensions: ['events_occurred_at_day'],
+        metrics: ['events_event_count'],
+        filters: {},
+        sorts: [],
+        limit: 100,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+    test('TIMESTAMP base + flag on + non-UTC TZ casts day-grain SELECT to DATE (Postgres)', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(),
+            compiledMetricQuery: dayQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            useTimezoneAwareDateTrunc: true,
+        });
+        expect(query).toContain(
+            `CAST(DATE_TRUNC('DAY', ("events".occurred_at)::timestamptz AT TIME ZONE 'America/New_York') AS DATE)`,
+        );
+    });
+});
+
 describe('Timezone-aware EXTRACT-based time dimensions', () => {
     const buildExtractExplore = (
         baseType: DimensionType,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -679,6 +679,9 @@ export class MetricQueryBuilder {
                 startOfWeek,
                 timezone,
                 this.columnTimezone,
+                // GLITCH-452: reached only when useTimezoneAwareDateTrunc is on,
+                // so day-or-coarser grains emit a real DATE (matches metadata).
+                true,
             );
         }
 

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -2610,7 +2610,9 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
         values: ['2024-01-15'],
     };
 
-    test('DATE-over-TIMESTAMP filter wraps literal in project TZ when parameter is true', () => {
+    // GLITCH-452: day-or-coarser dims now compile to a real DATE, so the filter
+    // LHS is a DATE and the literal stays bare — the old timestamptz wrap is gone.
+    test('DATE-over-TIMESTAMP filter emits a bare literal (GLITCH-452)', () => {
         const sql = renderFilterRuleSql(
             equalsFilter,
             DimensionType.DATE,
@@ -2625,8 +2627,8 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             true,
             DimensionType.TIMESTAMP,
         );
-        expect(sql).toContain("AT TIME ZONE 'Asia/Tokyo'");
-        expect(sql).toContain("'2024-01-15'::timestamp");
+        expect(sql).not.toContain('AT TIME ZONE');
+        expect(sql).not.toContain('::timestamp');
     });
 
     test('DATE filter leaves literal bare when parameter is omitted', () => {
@@ -2662,7 +2664,7 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
         expect(sql).not.toContain('::timestamp');
     });
 
-    test('BigQuery DATE-over-TIMESTAMP filter emits TIMESTAMP(literal, tz)', () => {
+    test('BigQuery DATE-over-TIMESTAMP filter emits a bare literal (GLITCH-452)', () => {
         const sql = renderFilterRuleSql(
             equalsFilter,
             DimensionType.DATE,
@@ -2677,8 +2679,8 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             true,
             DimensionType.TIMESTAMP,
         );
-        expect(sql).toContain("TIMESTAMP('2024-01-15', 'Asia/Tokyo')");
-        expect(sql).not.toContain('::timestamp');
+        expect(sql).not.toContain('TIMESTAMP(');
+        expect(sql).toContain("'2024-01-15'");
     });
 
     test('BigQuery DATE filter over a DATE base emits a bare literal (no TIMESTAMP wrap)', () => {
@@ -2700,7 +2702,7 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
         expect(sql).toContain("'2024-01-15'");
     });
 
-    test('ClickHouse DATE-over-TIMESTAMP filter anchors literal with toDateTime(literal, tz)', () => {
+    test('ClickHouse DATE-over-TIMESTAMP filter emits a bare literal (GLITCH-452)', () => {
         const sql = renderFilterRuleSql(
             equalsFilter,
             DimensionType.DATE,
@@ -2715,8 +2717,8 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             true,
             DimensionType.TIMESTAMP,
         );
-        expect(sql).toContain("toDateTime('2024-01-15', 'Asia/Tokyo')");
-        expect(sql).not.toContain('::timestamp');
+        expect(sql).not.toContain('toDateTime(');
+        expect(sql).toContain("'2024-01-15'");
     });
 
     test('ClickHouse DATE filter over a DATE base emits a bare literal (no toDateTime wrap)', () => {
@@ -2780,7 +2782,9 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 baseTimeIntervalDimensionType,
             );
 
-        test('inThePast completed day wraps boundaries in project TZ', () => {
+        // GLITCH-452: boundaries are still computed in the project TZ, but the
+        // LHS is now a DATE so they render bare (no timestamptz wrap).
+        test('inThePast completed day emits bare project-TZ boundaries (GLITCH-452)', () => {
             const filter: FilterRule<FilterOperator, unknown> = {
                 id: 'id',
                 target: { fieldId: 'fieldId' },
@@ -2789,11 +2793,12 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 settings: { unitOfTime: UnitOfTime.days, completed: true },
             };
             const sql = renderWithParam(filter, true);
-            expect(sql).toContain("AT TIME ZONE 'Asia/Tokyo'");
-            expect(sql).toContain("'2026-04-21'::timestamp");
+            expect(sql).not.toContain('AT TIME ZONE');
+            expect(sql).not.toContain('::timestamp');
+            expect(sql).toContain("'2026-04-21'");
         });
 
-        test('inTheCurrent day wraps boundaries in project TZ', () => {
+        test('inTheCurrent day emits bare project-TZ boundaries (GLITCH-452)', () => {
             const filter: FilterRule<FilterOperator, unknown> = {
                 id: 'id',
                 target: { fieldId: 'fieldId' },
@@ -2802,11 +2807,12 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 settings: { unitOfTime: UnitOfTime.days },
             };
             const sql = renderWithParam(filter, true);
-            expect(sql).toContain("AT TIME ZONE 'Asia/Tokyo'");
-            expect(sql).toContain("'2026-04-22'::timestamp");
+            expect(sql).not.toContain('AT TIME ZONE');
+            expect(sql).not.toContain('::timestamp');
+            expect(sql).toContain("'2026-04-22'");
         });
 
-        test('inTheNext day wraps boundaries in project TZ', () => {
+        test('inTheNext day emits bare project-TZ boundaries (GLITCH-452)', () => {
             const filter: FilterRule<FilterOperator, unknown> = {
                 id: 'id',
                 target: { fieldId: 'fieldId' },
@@ -2815,7 +2821,7 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 settings: { unitOfTime: UnitOfTime.days, completed: false },
             };
             const sql = renderWithParam(filter, true);
-            expect(sql).toContain("AT TIME ZONE 'Asia/Tokyo'");
+            expect(sql).not.toContain('AT TIME ZONE');
         });
 
         test('inThePast completed day leaves boundaries bare when parameter is omitted', () => {
@@ -2914,7 +2920,9 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             expect(sql).not.toContain('TIMESTAMP(');
         });
 
-        test('BigQuery: non-matching source/target preserves the wrap', () => {
+        // GLITCH-452: LHS is a real DATE regardless of source/target, so the
+        // literal is bare — there is no wrap left to preserve.
+        test('BigQuery: non-matching source/target still emits a bare literal (GLITCH-452)', () => {
             const sql = renderFilterRuleSql(
                 equalsFilter,
                 DimensionType.DATE,
@@ -2930,9 +2938,8 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 DimensionType.TIMESTAMP,
                 'UTC',
             );
-            expect(sql).toContain(
-                "TIMESTAMP('2024-01-15', 'America/New_York')",
-            );
+            expect(sql).not.toContain('TIMESTAMP(');
+            expect(sql).toContain("'2024-01-15'");
         });
 
         test('Postgres: matching source/target drops the AT TIME ZONE wrap on the literal', () => {
@@ -2974,7 +2981,7 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             expect(sql).not.toContain('toDateTime(');
         });
 
-        test('Postgres: non-matching source/target preserves the AT TIME ZONE wrap', () => {
+        test('Postgres: non-matching source/target still emits a bare literal (GLITCH-452)', () => {
             const sql = renderFilterRuleSql(
                 equalsFilter,
                 DimensionType.DATE,
@@ -2990,11 +2997,11 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 DimensionType.TIMESTAMP,
                 'UTC',
             );
-            expect(sql).toContain("AT TIME ZONE 'America/New_York'");
-            expect(sql).toContain("'2024-01-15'::timestamp");
+            expect(sql).not.toContain('AT TIME ZONE');
+            expect(sql).not.toContain('::timestamp');
         });
 
-        test('ClickHouse: non-matching source/target preserves the toDateTime wrap', () => {
+        test('ClickHouse: non-matching source/target still emits a bare literal (GLITCH-452)', () => {
             const sql = renderFilterRuleSql(
                 equalsFilter,
                 DimensionType.DATE,
@@ -3010,9 +3017,8 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 DimensionType.TIMESTAMP,
                 'UTC',
             );
-            expect(sql).toContain(
-                "toDateTime('2024-01-15', 'America/New_York')",
-            );
+            expect(sql).not.toContain('toDateTime(');
+            expect(sql).toContain("'2024-01-15'");
         });
     });
 });

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -841,12 +841,6 @@ export const renderFilterRuleSql = (
         }
         case DimensionType.DATE:
         case MetricType.DATE: {
-            // Only truncations over a TIMESTAMP base carry a timestamptz
-            // SQL expression; pure DATE columns stay bare DATE, so wrapping
-            // the literal would break BigQuery's DATE vs TIMESTAMP check.
-            const wrapLiteralAsTimestamptz =
-                !!useTimezoneAwareDateTrunc &&
-                baseTimeIntervalDimensionType === DimensionType.TIMESTAMP;
             return renderDateFilterSql({
                 dimensionSql: fieldSql,
                 filter: escapedFilterRule,
@@ -857,7 +851,11 @@ export const renderFilterRuleSql = (
                     : undefined,
                 startOfWeek,
                 baseDimensionSql,
-                useTimezoneAwareDateTrunc: wrapLiteralAsTimestamptz,
+                // GLITCH-452: day-or-coarser dims now compile to a real DATE
+                // (CAST(... AS DATE)), so the literal stays a bare date —
+                // wrapping it as a timestamptz would re-introduce the tz drift
+                // the cast removes (and break BigQuery's DATE vs TIMESTAMP check).
+                useTimezoneAwareDateTrunc: false,
                 sourceTimezone,
             });
         }

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -715,6 +715,61 @@ describe('TimeFrames', () => {
             );
         });
 
+        // GLITCH-452: with castDayGrainToDate, a day-or-coarser trunc casts the
+        // project-wall-clock value to DATE and drops the toUTC round-trip-back.
+        test('day grain with castDayGrainToDate casts the wall-clock trunc to DATE (Postgres)', () => {
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.DAY,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    tz,
+                    undefined,
+                    true, // castDayGrainToDate
+                ),
+            ).toEqual(
+                `CAST(DATE_TRUNC('DAY', (${col})::timestamptz AT TIME ZONE '${tz}') AS DATE)`,
+            );
+        });
+
+        // GLITCH-452: sub-day grains are real instants — castDayGrainToDate must
+        // not cast them; they keep the TIMESTAMP round-trip.
+        test('sub-day grain ignores castDayGrainToDate and keeps the timestamp round-trip (Postgres)', () => {
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.HOUR,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    tz,
+                    undefined,
+                    true, // castDayGrainToDate — ignored for sub-day
+                ),
+            ).toEqual(
+                `(DATE_TRUNC('HOUR', (${col})::timestamptz AT TIME ZONE '${tz}')) AT TIME ZONE '${tz}'`,
+            );
+        });
+
+        // GLITCH-452: a UTC project short-circuits the round-trip, but day-grain
+        // output must still be a real DATE.
+        test('UTC project (no round-trip) still casts day grain to DATE (Postgres)', () => {
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.DAY,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    'UTC',
+                    undefined,
+                    true, // castDayGrainToDate
+                ),
+            ).toEqual(`CAST(DATE_TRUNC('DAY', ${col}) AS DATE)`);
+        });
+
         test('TIMESTAMP dimension with timezone still gets tz round-trip (Snowflake)', () => {
             expect(
                 getSqlForTruncatedDate(

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -719,15 +719,20 @@ export const getSqlForTruncatedDate = (
     startOfWeek?: WeekDay | null,
     timezone?: string,
     sourceTimezone?: string,
+    castDayGrainToDate: boolean = false,
 ): string => {
     const wrap = resolveTimezoneWrap(type, timezone, sourceTimezone);
+    // GLITCH-452: day-or-coarser grains emit a real DATE so the warehouse type
+    // matches the metadata; sub-day grains stay TIMESTAMP.
+    const castToDate = castDayGrainToDate && !isSubDayTimeFrame(timeFrame);
     if (!wrap) {
-        return warehouseConfigs[adapterType].getSqlForTruncatedDate(
+        const bare = warehouseConfigs[adapterType].getSqlForTruncatedDate(
             timeFrame,
             originalSql,
             type,
             startOfWeek,
         );
+        return castToDate ? `CAST(${bare} AS DATE)` : bare;
     }
 
     const { toProjectTz, toUTC } = dateTruncTimezoneConversions[adapterType];
@@ -739,7 +744,11 @@ export const getSqlForTruncatedDate = (
         startOfWeek,
         wrap.timezone,
     );
-    return toUTC(truncated, wrap.timezone);
+    // Cast the project-wall-clock value to DATE and drop the toUTC round-trip;
+    // casting the UTC instant instead would be session-tz-dependent (wrong day).
+    return castToDate
+        ? `CAST(${truncated} AS DATE)`
+        : toUTC(truncated, wrap.timezone);
 };
 
 // DATE base dimensions short-circuit: no time component to shift.


### PR DESCRIPTION
### Description

**PR 2 of the GLITCH-452 stack — SQL side.** Behind `EnableTimezoneSupport` (default OFF).

Makes day / week / month / quarter / year truncations of a `TIMESTAMP` column emit a real `DATE` in the warehouse instead of a `TIMESTAMP` at project-TZ midnight:

- `getSqlForTruncatedDate` gains an opt-in `castDayGrainToDate` param — day-or-coarser grains cast the **project-wall-clock** truncated value to `DATE` and drop the `toUTC` round-trip; sub-day grains stay `TIMESTAMP`.
- `MetricQueryBuilder.getTimezoneAwareDimensionSql` passes it through (reached only when the flag is on), so day-grain **SELECT** and **WHERE-LHS** expressions become a real `DATE`.
- Filter literals for day-or-coarser dims emit **bare dates** (no `+00:00` / `::timestamptz`), matching the `DATE` LHS.

Validated by execution on all six supported warehouses (Postgres, Snowflake, BigQuery, Databricks, Trino, ClickHouse): a `15:00Z` instant buckets to the correct calendar date in UTC / `Pacific/Pago_Pago` (−11) / `Asia/Tokyo` (+9), and sub-day grains stay timestamps. The BigQuery-specific per-adapter cast correction (`DATE(expr, tz)` — its `TIMESTAMP_TRUNC` returns a UTC instant) lands in #24251, with the full cross-warehouse + downstream test matrix.

Relates: GLITCH-452

🤖 Generated with [Claude Code](https://claude.com/claude-code)
