### PR TITLE
feat(dashboard): add timezone source indicator to chart tiles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -151,6 +151,7 @@ import ExportDataModal from './ExportDataModal';
 import ExportImageModal from './ExportImageModal';
 import TileBase from './TileBase';
 import TileExecutionInfo from './TileExecutionInfo';
+import TileTimezoneInfo from './TileTimezoneInfo';
 import { UnderlyingDataMenuItem } from './UnderlyingDataMenuItem';
 
 interface ExportGoogleSheetProps {
@@ -591,6 +592,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                 appliedDashboardFilters,
                 cacheMetadata,
                 metricQuery,
+                resolvedTimezone,
                 usedParametersValues,
             },
             chart,
@@ -1434,6 +1436,10 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                         </HoverCard.Target>
                                     </HoverCard>
                                 )}
+                            <TileTimezoneInfo
+                                resolvedTimezone={resolvedTimezone}
+                                timezoneSetting={metricQuery?.timezone}
+                            />
                             <TileExecutionInfo
                                 cacheMetadata={cacheMetadata}
                                 performance={performance}

--- a/packages/frontend/src/components/DashboardTiles/TileTimezoneInfo.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileTimezoneInfo.tsx
@@ -1,0 +1,69 @@
+import {
+    FeatureFlags,
+    isTimeZone,
+    PROJECT_TIMEZONE_SETTING,
+    USER_TIMEZONE_SETTING,
+} from '@lightdash/common';
+import { ActionIcon, HoverCard, Text } from '@mantine-8/core';
+import { IconWorld } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
+import { getTimezoneSourceLabel } from '../../utils/timezoneSourceLabel';
+import MantineIcon from '../common/MantineIcon';
+
+type Props = {
+    resolvedTimezone: string | null | undefined;
+    // The chart's single `timezone` setting, used to explain where the resolved
+    // zone came from (per-viewer / pinned override).
+    timezoneSetting: string | null | undefined;
+};
+
+const TileTimezoneInfo: FC<Props> = ({ resolvedTimezone, timezoneSetting }) => {
+    const { data: timezoneSupportFlag } = useServerFeatureFlag(
+        FeatureFlags.EnableTimezoneSupport,
+    );
+    const timezoneSupportEnabled = timezoneSupportFlag?.enabled ?? false;
+
+    // Only surface the indicator when the chart opts out of the project default:
+    // either following each viewer's own zone or pinned to a specific zone.
+    const isUserTimezone = timezoneSetting === USER_TIMEZONE_SETTING;
+    const pinnedZone =
+        timezoneSetting &&
+        timezoneSetting !== PROJECT_TIMEZONE_SETTING &&
+        isTimeZone(timezoneSetting)
+            ? timezoneSetting
+            : null;
+    const timezone = resolvedTimezone ?? pinnedZone;
+
+    if (
+        !timezoneSupportEnabled ||
+        (!isUserTimezone && !pinnedZone) ||
+        !timezone
+    ) {
+        return null;
+    }
+
+    return (
+        <HoverCard
+            withArrow
+            withinPortal
+            shadow="md"
+            position="bottom-end"
+            offset={4}
+            arrowOffset={10}
+        >
+            <HoverCard.Dropdown>
+                <Text size="sm" c="ldGray.7" maw={260}>
+                    {getTimezoneSourceLabel(timezoneSetting, timezone)}
+                </Text>
+            </HoverCard.Dropdown>
+            <HoverCard.Target>
+                <ActionIcon size="sm" variant="subtle" color="gray">
+                    <MantineIcon icon={IconWorld} />
+                </ActionIcon>
+            </HoverCard.Target>
+        </HoverCard>
+    );
+};
+
+export default TileTimezoneInfo;

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
@@ -1,14 +1,9 @@
-import {
-    FeatureFlags,
-    getTimezoneLabel,
-    isTimeZone,
-    PROJECT_TIMEZONE_SETTING,
-    USER_TIMEZONE_SETTING,
-} from '@lightdash/common';
+import { FeatureFlags, getTimezoneLabel, isTimeZone } from '@lightdash/common';
 import { Badge, Tooltip } from '@mantine-8/core';
 import { IconClock } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { getTimezoneSourceLabel } from '../../../utils/timezoneSourceLabel';
 import MantineIcon from '../../common/MantineIcon';
 
 type Props = {
@@ -16,23 +11,6 @@ type Props = {
     // The saved chart's single `timezone` setting, used to explain where the
     // resolved zone came from (project default / per-viewer / override).
     timezoneSetting: string | null | undefined;
-};
-
-const getSourceLabel = (
-    timezoneSetting: string | null | undefined,
-    resolvedTimezone: string,
-): string => {
-    if (timezoneSetting === USER_TIMEZONE_SETTING) {
-        return `This chart follows each viewer's own time zone. You're seeing it in ${resolvedTimezone}.`;
-    }
-    if (
-        timezoneSetting &&
-        timezoneSetting !== PROJECT_TIMEZONE_SETTING &&
-        isTimeZone(timezoneSetting)
-    ) {
-        return `This chart is pinned to ${resolvedTimezone} and won't follow the project time zone.`;
-    }
-    return `This chart resolves in the project time zone (${resolvedTimezone}).`;
 };
 
 const VisualizationTimezone: FC<Props> = ({
@@ -53,7 +31,7 @@ const VisualizationTimezone: FC<Props> = ({
 
     return (
         <Tooltip
-            label={getSourceLabel(timezoneSetting, timezone)}
+            label={getTimezoneSourceLabel(timezoneSetting, timezone)}
             position="bottom"
             multiline
             w={260}

--- a/packages/frontend/src/utils/timezoneSourceLabel.ts
+++ b/packages/frontend/src/utils/timezoneSourceLabel.ts
@@ -1,0 +1,24 @@
+import {
+    isTimeZone,
+    PROJECT_TIMEZONE_SETTING,
+    USER_TIMEZONE_SETTING,
+} from '@lightdash/common';
+
+// Explains where a chart's resolved time zone came from, classifying its single
+// `timezone` setting as project default / per-viewer / pinned override.
+export const getTimezoneSourceLabel = (
+    timezoneSetting: string | null | undefined,
+    resolvedTimezone: string,
+): string => {
+    if (timezoneSetting === USER_TIMEZONE_SETTING) {
+        return `This chart follows each viewer's own time zone. You're seeing it in ${resolvedTimezone}.`;
+    }
+    if (
+        timezoneSetting &&
+        timezoneSetting !== PROJECT_TIMEZONE_SETTING &&
+        isTimeZone(timezoneSetting)
+    ) {
+        return `This chart is pinned to ${resolvedTimezone} and won't follow the project time zone.`;
+    }
+    return `This chart resolves in the project time zone (${resolvedTimezone}).`;
+};


### PR DESCRIPTION
Closes: GLITCH-495

### Description:

Dashboard chart tiles now show a timezone indicator (a globe icon with a HoverCard popover) when a chart pins a specific time zone or follows the viewer's own time zone; it stays hidden for charts on the project default. The whole indicator is gated behind the `EnableTimezoneSupport` flag, and the popover reuses the explorer badge's source-classification copy — which I extracted into a shared `getTimezoneSourceLabel` util so both surfaces stay in sync. The icon is styled (`subtle`/`gray` + filters-style HoverCard) to match the other tile-header icons.

<img width="1436" height="1206" alt="CleanShot 2026-06-12 at 14 26 43@2x" src="https://github.com/user-attachments/assets/9f515810-ba01-436f-8d66-d2f971e651c1" />
